### PR TITLE
perf: lock migration, off-heap text store, BM25 persistence, MCP tools

### DIFF
--- a/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/NativeOsMemory.java
+++ b/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/NativeOsMemory.java
@@ -86,12 +86,14 @@ public final class NativeOsMemory {
         }
 
         try {
-            int result = (int) MADVISE_HANDLE.invokeExact(segment.address(), segment.byteSize(), advice);
+            // The downcall handle expects (MemorySegment, long, int) per the FunctionDescriptor.
+            // Pass the segment directly — ValueLayout.ADDRESS maps to MemorySegment in Java 22+.
+            int result = (int) MADVISE_HANDLE.invokeExact(segment, segment.byteSize(), advice);
             if (result == 0) {
-                log.debug("madvise: Successfully applied advice {} on segment at address {} ({} bytes)", advice, segment.address(), segment.byteSize());
+                log.debug("madvise: Successfully applied advice {} on segment ({} bytes)", advice, segment.byteSize());
                 return true;
             } else {
-                log.warn("madvise: Failed with code {} for advice {} on segment at address {}", result, advice, segment.address());
+                log.warn("madvise: Failed with code {} for advice {} on segment ({} bytes)", result, advice, segment.byteSize());
                 return false;
             }
         } catch (Throwable t) {

--- a/spector-index/src/main/java/com/spectrayan/spector/index/hnsw/DiskHnswIndex.java
+++ b/spector-index/src/main/java/com/spectrayan/spector/index/hnsw/DiskHnswIndex.java
@@ -33,6 +33,8 @@ import java.util.BitSet;
 import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.commons.error.ErrorCode;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * Read-only HNSW index backed by a memory-mapped file.
  *
@@ -158,30 +160,38 @@ public class DiskHnswIndex implements VectorIndex {
     @Override
     public SimilarityFunction similarityFunction() { return similarityFunction; }
 
+    // Lock for lifecycle operations (ReentrantLock avoids virtual thread pinning — ADR-005)
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
+
     @Override
-    public synchronized void close() {
-        if (!closed) {
-            closed = true;
-            if (warmupThread != null) {
+    public void close() {
+        lifecycleLock.lock();
+        try {
+            if (!closed) {
+                closed = true;
+                if (warmupThread != null) {
+                    try {
+                        warmupThread.interrupt();
+                        warmupThread.join(1000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
                 try {
-                    warmupThread.interrupt();
-                    warmupThread.join(1000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                    if (segment.isMapped()) {
+                        com.spectrayan.spector.commons.concurrent.MemoryPinning.unlock(segment);
+                        segment.unload();
+                    }
+                    arena.close();
+                    channel.close();
+                    raf.close();
+                    log.info("DiskHnswIndex closed: {}", filePath);
+                } catch (IOException e) {
+                    log.warn("Error closing DiskHnswIndex", e);
                 }
             }
-            try {
-                if (segment.isMapped()) {
-                    com.spectrayan.spector.commons.concurrent.MemoryPinning.unlock(segment);
-                    segment.unload();
-                }
-                arena.close();
-                channel.close();
-                raf.close();
-                log.info("DiskHnswIndex closed: {}", filePath);
-            } catch (IOException e) {
-                log.warn("Error closing DiskHnswIndex", e);
-            }
+        } finally {
+            lifecycleLock.unlock();
         }
     }
 
@@ -216,19 +226,24 @@ public class DiskHnswIndex implements VectorIndex {
      * @param gracePeriodMs threshold of inactivity in milliseconds
      * @return true if successfully evicted, false if segment is active or not mapped
      */
-    public synchronized boolean unloadIdle(long gracePeriodMs) {
-        if (!closed && segment.isMapped()) {
-            long idleMs = System.currentTimeMillis() - lastAccessed;
-            if (idleMs >= gracePeriodMs) {
-                com.spectrayan.spector.commons.concurrent.MemoryPinning.unlock(segment);
-                segment.unload();
-                // Advise kernel to immediately release the physical pages back to the system
-                com.spectrayan.spector.commons.concurrent.NativeOsMemory.advise(segment, com.spectrayan.spector.commons.concurrent.NativeOsMemory.MADV_DONTNEED);
-                log.info("DiskHnswIndex idle-evicted: file={} (idle for {} ms)", filePath, idleMs);
-                return true;
+    public boolean unloadIdle(long gracePeriodMs) {
+        lifecycleLock.lock();
+        try {
+            if (!closed && segment.isMapped()) {
+                long idleMs = System.currentTimeMillis() - lastAccessed;
+                if (idleMs >= gracePeriodMs) {
+                    com.spectrayan.spector.commons.concurrent.MemoryPinning.unlock(segment);
+                    segment.unload();
+                    // Advise kernel to immediately release the physical pages back to the system
+                    com.spectrayan.spector.commons.concurrent.NativeOsMemory.advise(segment, com.spectrayan.spector.commons.concurrent.NativeOsMemory.MADV_DONTNEED);
+                    log.info("DiskHnswIndex idle-evicted: file={} (idle for {} ms)", filePath, idleMs);
+                    return true;
+                }
             }
+            return false;
+        } finally {
+            lifecycleLock.unlock();
         }
-        return false;
     }
 
     /** Returns the file path. */

--- a/spector-index/src/main/java/com/spectrayan/spector/index/hnsw/QuantizedHnswIndex.java
+++ b/spector-index/src/main/java/com/spectrayan/spector/index/hnsw/QuantizedHnswIndex.java
@@ -575,33 +575,41 @@ public class QuantizedHnswIndex extends AbstractHnswIndex {
 
     // ─────────────── Calibration ───────────────
 
+    // Lock for calibration exclusion (ReentrantLock avoids virtual thread pinning — ADR-005)
+    private final java.util.concurrent.locks.ReentrantLock calibrationLock = new java.util.concurrent.locks.ReentrantLock();
+
     /**
      * Auto-calibrates the INT8 scalar quantizer from buffered vectors, builds the
      * strategy, allocates the off-heap segment, and retroactively encodes all buffered
      * vectors.
      */
-    private synchronized void calibrate() {
-        if (strategy != null) return; // already calibrated (concurrent trigger)
-        float[][] sample = Arrays.copyOf(calibrationBuffer, calibrationCount);
-        ScalarQuantizer sq = ScalarQuantizer.calibrate(sample, dimensions);
-        this.quantizer = sq;
+    private void calibrate() {
+        calibrationLock.lock();
+        try {
+            if (strategy != null) return; // already calibrated (concurrent trigger)
+            float[][] sample = Arrays.copyOf(calibrationBuffer, calibrationCount);
+            ScalarQuantizer sq = ScalarQuantizer.calibrate(sample, dimensions);
+            this.quantizer = sq;
 
-        this.strategy = QuantizationStrategyFactory.create(
-                QuantizationType.SCALAR_INT8, sq, null, null, null, similarityFunction);
-        allocateStorageSegment(capacity, strategy.bytesPerVector());
+            this.strategy = QuantizationStrategyFactory.create(
+                    QuantizationType.SCALAR_INT8, sq, null, null, null, similarityFunction);
+            allocateStorageSegment(capacity, strategy.bytesPerVector());
 
-        log.info("QuantizedHnswIndex INT8 auto-calibrated from {} sample vectors", calibrationCount);
+            log.info("QuantizedHnswIndex INT8 auto-calibrated from {} sample vectors", calibrationCount);
 
-        // Retroactively encode all buffered vectors
-        for (int i = 0; i < nodeCount; i++) {
-            if (floatVectors[i] != null) {
-                long offset = (long) i * strategy.bytesPerVector();
-                strategy.encode(floatVectors[i], storageSegment, offset);
+            // Retroactively encode all buffered vectors
+            for (int i = 0; i < nodeCount; i++) {
+                if (floatVectors[i] != null) {
+                    long offset = (long) i * strategy.bytesPerVector();
+                    strategy.encode(floatVectors[i], storageSegment, offset);
+                }
             }
-        }
 
-        calibrationBuffer = null;
-        calibrationCount = 0;
+            calibrationBuffer = null;
+            calibrationCount = 0;
+        } finally {
+            calibrationLock.unlock();
+        }
     }
 
     /**
@@ -611,29 +619,34 @@ public class QuantizedHnswIndex extends AbstractHnswIndex {
      * <p>Uses {@link SvasqCalibrator#calibrate(float[][], int, int, long)} to avoid
      * the previous {@code Arrays.copyOf} + {@code Arrays.asList} wrapper.
      */
-    private synchronized void calibrateSvasq() {
-        if (strategy != null) return; // already calibrated
-        SvasqParams vParams = SvasqCalibrator.calibrate(
-                calibrationBuffer, calibrationCount, dimensions, svasqSeed);
-        SvasqEncoder enc = new SvasqEncoder(vParams);
-        this.svasqEncoder = enc;
+    private void calibrateSvasq() {
+        calibrationLock.lock();
+        try {
+            if (strategy != null) return; // already calibrated
+            SvasqParams vParams = SvasqCalibrator.calibrate(
+                    calibrationBuffer, calibrationCount, dimensions, svasqSeed);
+            SvasqEncoder enc = new SvasqEncoder(vParams);
+            this.svasqEncoder = enc;
 
-        this.strategy = new SvasqStrategy(enc, similarityFunction);
-        allocateStorageSegment(capacity, strategy.bytesPerVector());
+            this.strategy = new SvasqStrategy(enc, similarityFunction);
+            allocateStorageSegment(capacity, strategy.bytesPerVector());
 
-        log.info("QuantizedHnswIndex SVASQ auto-calibrated: {} sample vectors, paddedDim={}, bpv={}",
-                calibrationCount, vParams.paddedDim(), strategy.bytesPerVector());
+            log.info("QuantizedHnswIndex SVASQ auto-calibrated: {} sample vectors, paddedDim={}, bpv={}",
+                    calibrationCount, vParams.paddedDim(), strategy.bytesPerVector());
 
-        // Retroactively encode all vectors inserted before calibration
-        for (int i = 0; i < nodeCount; i++) {
-            if (floatVectors[i] != null) {
-                long offset = (long) i * strategy.bytesPerVector();
-                strategy.encode(floatVectors[i], storageSegment, offset);
+            // Retroactively encode all vectors inserted before calibration
+            for (int i = 0; i < nodeCount; i++) {
+                if (floatVectors[i] != null) {
+                    long offset = (long) i * strategy.bytesPerVector();
+                    strategy.encode(floatVectors[i], storageSegment, offset);
+                }
             }
-        }
 
-        calibrationBuffer = null;
-        calibrationCount = 0;
+            calibrationBuffer = null;
+            calibrationCount = 0;
+        } finally {
+            calibrationLock.unlock();
+        }
     }
 
     /**
@@ -643,29 +656,34 @@ public class QuantizedHnswIndex extends AbstractHnswIndex {
      * <p>Uses {@link SvasqCalibrator#calibrate4bit} with tighter clipping (2.5σ) for optimal
      * use of the 15 available INT4 quantization levels.</p>
      */
-    private synchronized void calibrateSvasq4() {
-        if (strategy != null) return;
-        SvasqParams vParams = SvasqCalibrator.calibrate4bit(
-                calibrationBuffer, calibrationCount, dimensions, svasqSeed);
-        Svasq4Encoder enc = new Svasq4Encoder(vParams);
-        this.svasq4Encoder = enc;
+    private void calibrateSvasq4() {
+        calibrationLock.lock();
+        try {
+            if (strategy != null) return;
+            SvasqParams vParams = SvasqCalibrator.calibrate4bit(
+                    calibrationBuffer, calibrationCount, dimensions, svasqSeed);
+            Svasq4Encoder enc = new Svasq4Encoder(vParams);
+            this.svasq4Encoder = enc;
 
-        this.strategy = new Svasq4Strategy(enc, similarityFunction);
-        allocateStorageSegment(capacity, strategy.bytesPerVector());
+            this.strategy = new Svasq4Strategy(enc, similarityFunction);
+            allocateStorageSegment(capacity, strategy.bytesPerVector());
 
-        log.info("QuantizedHnswIndex SVASQ-4 auto-calibrated: {} sample vectors, paddedDim={}, bpv={}",
-                calibrationCount, vParams.paddedDim(), strategy.bytesPerVector());
+            log.info("QuantizedHnswIndex SVASQ-4 auto-calibrated: {} sample vectors, paddedDim={}, bpv={}",
+                    calibrationCount, vParams.paddedDim(), strategy.bytesPerVector());
 
-        // Retroactively encode all vectors inserted before calibration
-        for (int i = 0; i < nodeCount; i++) {
-            if (floatVectors[i] != null) {
-                long offset = (long) i * strategy.bytesPerVector();
-                strategy.encode(floatVectors[i], storageSegment, offset);
+            // Retroactively encode all vectors inserted before calibration
+            for (int i = 0; i < nodeCount; i++) {
+                if (floatVectors[i] != null) {
+                    long offset = (long) i * strategy.bytesPerVector();
+                    strategy.encode(floatVectors[i], storageSegment, offset);
+                }
             }
-        }
 
-        calibrationBuffer = null;
-        calibrationCount = 0;
+            calibrationBuffer = null;
+            calibrationCount = 0;
+        } finally {
+            calibrationLock.unlock();
+        }
     }
 
     private void allocateStorageSegment(int capacity, int bpv) {

--- a/spector-index/src/main/java/com/spectrayan/spector/index/hnsw/ShardedDiskHnswIndex.java
+++ b/spector-index/src/main/java/com/spectrayan/spector/index/hnsw/ShardedDiskHnswIndex.java
@@ -36,6 +36,8 @@ import java.util.List;
 import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.commons.error.ErrorCode;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * Read-only HNSW index backed by multiple memory-mapped shard files.
  *
@@ -209,27 +211,35 @@ public class ShardedDiskHnswIndex implements VectorIndex {
     @Override
     public SimilarityFunction similarityFunction() { return similarityFunction; }
 
+    // Lock for lifecycle operations (ReentrantLock avoids virtual thread pinning — ADR-005)
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
+
     @Override
-    public synchronized void close() {
-        if (!closed) {
-            closed = true;
-            for (Thread t : warmupThreads) {
-                try {
-                    t.interrupt();
-                    t.join(1000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+    public void close() {
+        lifecycleLock.lock();
+        try {
+            if (!closed) {
+                closed = true;
+                for (Thread t : warmupThreads) {
+                    try {
+                        t.interrupt();
+                        t.join(1000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
-            }
-            warmupThreads.clear();
-            for (Shard shard : shards) {
-                try {
-                    shard.close();
-                } catch (IOException e) {
-                    log.warn("Error closing shard {}", shard.filePath(), e);
+                warmupThreads.clear();
+                for (Shard shard : shards) {
+                    try {
+                        shard.close();
+                    } catch (IOException e) {
+                        log.warn("Error closing shard {}", shard.filePath(), e);
+                    }
                 }
+                log.info("ShardedDiskHnswIndex closed: {} shards, dir={}", shards.length, shardDir);
             }
-            log.info("ShardedDiskHnswIndex closed: {} shards, dir={}", shards.length, shardDir);
+        } finally {
+            lifecycleLock.unlock();
         }
     }
 
@@ -266,23 +276,28 @@ public class ShardedDiskHnswIndex implements VectorIndex {
      * @param gracePeriodMs threshold of inactivity in milliseconds
      * @return true if any shards were evicted
      */
-    public synchronized boolean unloadIdle(long gracePeriodMs) {
-        if (closed) return false;
-        long idleMs = System.currentTimeMillis() - lastAccessed;
-        if (idleMs < gracePeriodMs) return false;
+    public boolean unloadIdle(long gracePeriodMs) {
+        lifecycleLock.lock();
+        try {
+            if (closed) return false;
+            long idleMs = System.currentTimeMillis() - lastAccessed;
+            if (idleMs < gracePeriodMs) return false;
 
-        boolean evicted = false;
-        for (Shard shard : shards) {
-            if (shard.segment().isMapped()) {
-                com.spectrayan.spector.commons.concurrent.MemoryPinning.unlock(shard.segment());
-                shard.segment().unload();
-                evicted = true;
+            boolean evicted = false;
+            for (Shard shard : shards) {
+                if (shard.segment().isMapped()) {
+                    com.spectrayan.spector.commons.concurrent.MemoryPinning.unlock(shard.segment());
+                    shard.segment().unload();
+                    evicted = true;
+                }
             }
+            if (evicted) {
+                log.info("ShardedDiskHnswIndex idle-evicted all shards (idle for {} ms)", idleMs);
+            }
+            return evicted;
+        } finally {
+            lifecycleLock.unlock();
         }
-        if (evicted) {
-            log.info("ShardedDiskHnswIndex idle-evicted all shards (idle for {} ms)", idleMs);
-        }
-        return evicted;
     }
 
     // ─────────────── Accessors ───────────────

--- a/spector-index/src/main/java/com/spectrayan/spector/index/spectrum/SpectorIndex.java
+++ b/spector-index/src/main/java/com/spectrayan/spector/index/spectrum/SpectorIndex.java
@@ -193,7 +193,8 @@ public final class SpectorIndex implements VectorIndex {
         this.residualScratch = ThreadLocal.withInitial(() -> new float[dimensions]);
     }
 
-    // ─────────────── Training ───────────────
+    // Lock for training exclusion (ReentrantLock avoids virtual thread pinning — ADR-005)
+    private final ReentrantLock trainLock = new ReentrantLock();
 
     /**
      * Trains the index by running K-Means++ on the provided representative vectors.
@@ -205,28 +206,33 @@ public final class SpectorIndex implements VectorIndex {
      * @throws SpectorValidationException    if already trained
      * @throws SpectorValidationException if the training set is smaller than nCentroids
      */
-    public synchronized void train(float[][] trainingVectors) {
-        if (trained) throw new SpectorInternalException(ErrorCode.INVARIANT_VIOLATED, "Index already trained");
-        int n = trainingVectors.length;
-        int k = config.nCentroids();
-        if (n < k) {
-            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Training requires at least " + k + " vectors (nCentroids), got " + n);
+    public void train(float[][] trainingVectors) {
+        trainLock.lock();
+        try {
+            if (trained) throw new SpectorInternalException(ErrorCode.INVARIANT_VIOLATED, "Index already trained");
+            int n = trainingVectors.length;
+            int k = config.nCentroids();
+            if (n < k) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Training requires at least " + k + " vectors (nCentroids), got " + n);
+            }
+
+            log.info("SpectorIndex training: {} samples, nCentroids={}", n, k);
+            long t0 = System.nanoTime();
+
+            this.centroids = KMeans.train(trainingVectors, k, config.kMeansIterations(), 42L);
+            log.debug("K-Means converged");
+
+            this.shards = new SpectorShard[k];
+            for (int i = 0; i < k; i++) {
+                shards[i] = new SpectorShard(dimensions, config, centroids[i]);
+            }
+
+            this.trained = true;
+            long ms = (System.nanoTime() - t0) / 1_000_000;
+            log.info("SpectorIndex training complete in {}ms", ms);
+        } finally {
+            trainLock.unlock();
         }
-
-        log.info("SpectorIndex training: {} samples, nCentroids={}", n, k);
-        long t0 = System.nanoTime();
-
-        this.centroids = KMeans.train(trainingVectors, k, config.kMeansIterations(), 42L);
-        log.debug("K-Means converged");
-
-        this.shards = new SpectorShard[k];
-        for (int i = 0; i < k; i++) {
-            shards[i] = new SpectorShard(dimensions, config, centroids[i]);
-        }
-
-        this.trained = true;
-        long ms = (System.nanoTime() - t0) / 1_000_000;
-        log.info("SpectorIndex training complete in {}ms", ms);
     }
 
     // ─────────────── VectorIndex ───────────────

--- a/spector-index/src/main/java/com/spectrayan/spector/index/text/BM25Index.java
+++ b/spector-index/src/main/java/com/spectrayan/spector/index/text/BM25Index.java
@@ -448,4 +448,223 @@ public class BM25Index implements KeywordIndex {
             }
         }
     }
+
+    // ─────────────── Binary Persistence (bm25.bidx) ───────────────
+
+    /** Magic bytes for the BM25 binary index file format. */
+    private static final int MAGIC = 0x42494458; // "BIDX"
+    private static final int FORMAT_VERSION = 1;
+
+    /**
+     * Saves the current BM25 index to a binary file ({@code bm25.bidx}).
+     *
+     * <p>File format (VERSION 1):</p>
+     * <pre>
+     *   Header:  [4B magic "BIDX"] [4B version] [4B totalDocs] [4B termCount] [8B totalDocLength]
+     *   DocIds:  [4B count] { [4B idLen] [N idBytes] } × count
+     *   DocLens: [4B count] [4B × count docLengths]
+     *   Terms:   [4B termCount] { [4B termLen] [N termBytes] [4B postingsSize]
+     *                              { [4B docIdx] [4B termFreq] }* }
+     * </pre>
+     *
+     * @param filePath path to write (parent directories created if needed)
+     */
+    public void save(java.nio.file.Path filePath) {
+        rwLock.readLock().lock();
+        try {
+            java.nio.file.Path parent = filePath.getParent();
+            if (parent != null) {
+                java.nio.file.Files.createDirectories(parent);
+            }
+
+            try (var ch = java.nio.channels.FileChannel.open(filePath,
+                    java.nio.file.StandardOpenOption.CREATE,
+                    java.nio.file.StandardOpenOption.WRITE,
+                    java.nio.file.StandardOpenOption.TRUNCATE_EXISTING)) {
+
+                // ── Header: 24 bytes ──
+                java.nio.ByteBuffer header = java.nio.ByteBuffer.allocate(24);
+                header.putInt(MAGIC);
+                header.putInt(FORMAT_VERSION);
+                header.putInt(totalDocs);
+                header.putInt(invertedIndex.size());
+                header.putLong(totalDocLength);
+                header.flip();
+                ch.write(header);
+
+                // ── DocIds ──
+                int docCount = docIds.size();
+                java.nio.ByteBuffer docCountBuf = java.nio.ByteBuffer.allocate(4);
+                docCountBuf.putInt(docCount);
+                docCountBuf.flip();
+                ch.write(docCountBuf);
+                for (String id : docIds) {
+                    byte[] idBytes = id.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    java.nio.ByteBuffer idBuf = java.nio.ByteBuffer.allocate(4 + idBytes.length);
+                    idBuf.putInt(idBytes.length);
+                    idBuf.put(idBytes);
+                    idBuf.flip();
+                    ch.write(idBuf);
+                }
+
+                // ── DocLengths ──
+                java.nio.ByteBuffer docLenHeader = java.nio.ByteBuffer.allocate(4 + docCount * 4);
+                docLenHeader.putInt(docCount);
+                for (int i = 0; i < docCount; i++) {
+                    docLenHeader.putInt(docLengthsArray[i]);
+                }
+                docLenHeader.flip();
+                ch.write(docLenHeader);
+
+                // ── Terms + Postings ──
+                java.nio.ByteBuffer termCountBuf = java.nio.ByteBuffer.allocate(4);
+                termCountBuf.putInt(invertedIndex.size());
+                termCountBuf.flip();
+                ch.write(termCountBuf);
+                for (var entry : invertedIndex.entrySet()) {
+                    byte[] termBytes = entry.getKey().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    PostingList pl = entry.getValue();
+                    // term header: termLen + termBytes + postingsSize
+                    java.nio.ByteBuffer termBuf = java.nio.ByteBuffer.allocate(
+                            4 + termBytes.length + 4 + pl.size * 8);
+                    termBuf.putInt(termBytes.length);
+                    termBuf.put(termBytes);
+                    termBuf.putInt(pl.size);
+                    for (int i = 0; i < pl.size; i++) {
+                        termBuf.putInt(pl.docIndices[i]);
+                        termBuf.putInt(pl.termFrequencies[i]);
+                    }
+                    termBuf.flip();
+                    ch.write(termBuf);
+                }
+
+                ch.force(true);
+                log.info("BM25 index saved: {} docs, {} terms → {}",
+                        totalDocs, invertedIndex.size(), filePath);
+            }
+        } catch (java.io.IOException e) {
+            log.error("Failed to save BM25 index to {}", filePath, e);
+        } finally {
+            rwLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Loads a BM25 index from a binary file ({@code bm25.bidx}).
+     *
+     * @param filePath path to the binary index file
+     * @return the loaded BM25Index, or null if the file doesn't exist or is invalid
+     */
+    public static BM25Index load(java.nio.file.Path filePath) {
+        if (!java.nio.file.Files.exists(filePath)) {
+            return null;
+        }
+
+        try (var ch = java.nio.channels.FileChannel.open(filePath,
+                java.nio.file.StandardOpenOption.READ)) {
+
+            // ── Header ──
+            java.nio.ByteBuffer header = java.nio.ByteBuffer.allocate(24);
+            ch.read(header);
+            header.flip();
+            int magic = header.getInt();
+            if (magic != MAGIC) {
+                log.warn("Invalid BM25 index magic: expected 0x{}, got 0x{}",
+                        Integer.toHexString(MAGIC), Integer.toHexString(magic));
+                return null;
+            }
+            int version = header.getInt();
+            if (version != FORMAT_VERSION) {
+                log.warn("Unsupported BM25 index version: {}", version);
+                return null;
+            }
+            int savedTotalDocs = header.getInt();
+            int termCount = header.getInt();
+            long savedTotalDocLength = header.getLong();
+
+            BM25Index idx = new BM25Index();
+
+            // ── DocIds ──
+            java.nio.ByteBuffer docCountBuf = java.nio.ByteBuffer.allocate(4);
+            ch.read(docCountBuf);
+            docCountBuf.flip();
+            int docCount = docCountBuf.getInt();
+            for (int i = 0; i < docCount; i++) {
+                java.nio.ByteBuffer lenBuf = java.nio.ByteBuffer.allocate(4);
+                ch.read(lenBuf);
+                lenBuf.flip();
+                int idLen = lenBuf.getInt();
+                java.nio.ByteBuffer idBuf = java.nio.ByteBuffer.allocate(idLen);
+                ch.read(idBuf);
+                idBuf.flip();
+                String id = new String(idBuf.array(), 0, idLen, java.nio.charset.StandardCharsets.UTF_8);
+                idx.docIds.add(id);
+                idx.docIdToIndex.put(id, i);
+            }
+
+            // ── DocLengths ──
+            java.nio.ByteBuffer docLenHeader = java.nio.ByteBuffer.allocate(4);
+            ch.read(docLenHeader);
+            docLenHeader.flip();
+            int docLenCount = docLenHeader.getInt();
+            if (docLenCount > idx.docLengthsCapacity) {
+                idx.docLengthsCapacity = docLenCount;
+                idx.docLengthsArray = new int[docLenCount];
+            }
+            if (docLenCount > 0) {
+                java.nio.ByteBuffer lensBuf = java.nio.ByteBuffer.allocate(docLenCount * 4);
+                ch.read(lensBuf);
+                lensBuf.flip();
+                for (int i = 0; i < docLenCount; i++) {
+                    idx.docLengthsArray[i] = lensBuf.getInt();
+                }
+            }
+
+            // ── Terms + Postings ──
+            java.nio.ByteBuffer termCountBuf2 = java.nio.ByteBuffer.allocate(4);
+            ch.read(termCountBuf2);
+            termCountBuf2.flip();
+            int savedTermCount = termCountBuf2.getInt();
+            for (int t = 0; t < savedTermCount; t++) {
+                java.nio.ByteBuffer termLenBuf = java.nio.ByteBuffer.allocate(4);
+                ch.read(termLenBuf);
+                termLenBuf.flip();
+                int termLen = termLenBuf.getInt();
+
+                java.nio.ByteBuffer termBuf = java.nio.ByteBuffer.allocate(termLen);
+                ch.read(termBuf);
+                termBuf.flip();
+                String term = new String(termBuf.array(), 0, termLen, java.nio.charset.StandardCharsets.UTF_8);
+
+                java.nio.ByteBuffer postCountBuf = java.nio.ByteBuffer.allocate(4);
+                ch.read(postCountBuf);
+                postCountBuf.flip();
+                int postingsSize = postCountBuf.getInt();
+
+                PostingList pl = new PostingList(Math.max(postingsSize, 16));
+                if (postingsSize > 0) {
+                    java.nio.ByteBuffer postBuf = java.nio.ByteBuffer.allocate(postingsSize * 8);
+                    ch.read(postBuf);
+                    postBuf.flip();
+                    for (int p = 0; p < postingsSize; p++) {
+                        pl.add(postBuf.getInt(), postBuf.getInt());
+                    }
+                }
+                idx.invertedIndex.put(term, pl);
+            }
+
+            // ── Restore computed state ──
+            idx.totalDocs = savedTotalDocs;
+            idx.totalDocLength = savedTotalDocLength;
+            idx.avgDocLength = savedTotalDocs > 0 ? (double) savedTotalDocLength / savedTotalDocs : 0;
+
+            log.info("BM25 index loaded: {} docs, {} terms ← {}",
+                    savedTotalDocs, savedTermCount, filePath);
+            return idx;
+
+        } catch (java.io.IOException e) {
+            log.error("Failed to load BM25 index from {}", filePath, e);
+            return null;
+        }
+    }
 }

--- a/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRecallTool.java
+++ b/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRecallTool.java
@@ -27,6 +27,9 @@ import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.RecallMode;
 import com.spectrayan.spector.memory.model.RecallOptions;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.SpectorMemory;
@@ -63,7 +66,9 @@ public final class MemoryRecallTool extends MemoryToolHandler {
                 + "(Working, Episodic, Semantic, Procedural). Returns results with full provenance: "
                 + "confidence, age, importance, valence, source, and decay factors. "
                 + "Use 'profile' for preset scoring modes (e.g., DEBUGGING, EXPLORING, HYPERFOCUS). "
-                + "Use synaptic_filter for contextual pre-filtering (e.g., 'debugging,database').";
+                + "Use synaptic_filter for contextual pre-filtering (e.g., 'debugging,database'). "
+                + "Use 'point_in_time' for temporal queries (e.g., 'what did I know on March 15?'). "
+                + "Use 'workspace_id' + 'agent_id' for multi-agent shared memory.";
     }
 
     @Override
@@ -103,6 +108,17 @@ public final class MemoryRecallTool extends MemoryToolHandler {
                 .optionalString("namespace",
                         "Memory namespace to query. Isolates agent/user memory spaces. "
                         + "Leave empty for default namespace.", "")
+                .optionalString("point_in_time",
+                        "ISO-8601 timestamp for temporal recall. Only memories created BEFORE this "
+                        + "time will be returned. Enables 'what did I know on date X?' queries. "
+                        + "Example: '2026-03-15T00:00:00Z'. Leave empty for current time.", "")
+                .optionalString("workspace_id",
+                        "Shared workspace ID for multi-agent recall. When set, recall is scoped "
+                        + "to the workspace's shared memory pool. Requires 'agent_id' for RBAC. "
+                        + "Leave empty for personal memory.", "")
+                .optionalString("agent_id",
+                        "Agent identity for workspace RBAC. Required when 'workspace_id' is set. "
+                        + "The agent must have read access to the workspace.", "")
                 .build();
     }
 
@@ -157,6 +173,17 @@ public final class MemoryRecallTool extends MemoryToolHandler {
             builder.scoringMode(ScoringMode.valueOf(scoringStr.strip().toUpperCase()));
         } catch (IllegalArgumentException e) {
             // Invalid mode name — fall back to COGNITIVE
+        }
+
+        // Parse point-in-time temporal gating
+        String pointInTime = optionalString(args, "point_in_time", "");
+        if (!pointInTime.isBlank()) {
+            try {
+                long maxTs = Instant.parse(pointInTime.strip()).toEpochMilli();
+                builder.maxTimestamp(maxTs);
+            } catch (DateTimeParseException e) {
+                // Invalid timestamp — ignore, use current time
+            }
         }
 
         RecallOptions options = builder.build();

--- a/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
+++ b/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
@@ -68,7 +68,8 @@ public final class MemoryRememberTool extends MemoryToolHandler {
                 + "Set 'interest', 'challenge', 'urgency' (0.0-1.0) for importance tuning. "
                 + "Set 'valence' for emotional memories (-128=very negative, +127=very positive). "
                 + "Set 'arousal' for intensity (0=calm, 255=extreme). "
-                + "Tags help with contextual recall (e.g., 'preferences', 'architecture').";
+                + "Tags help with contextual recall (e.g., 'preferences', 'architecture'). "
+                + "Use 'workspace_id' + 'agent_id' to store in a shared workspace.";
     }
 
     @Override
@@ -106,6 +107,13 @@ public final class MemoryRememberTool extends MemoryToolHandler {
                         + "'source_uri' (asset path/URL), "
                         + "plus any custom key-value pairs. Example: "
                         + "{\"modality\":\"IMAGE\",\"source_uri\":\"file:///photo.jpg\"}", "")
+                .optionalString("workspace_id",
+                        "Shared workspace ID for multi-agent storage. When set, the memory is "
+                        + "stored in the workspace's shared pool. Requires 'agent_id' for RBAC. "
+                        + "Leave empty for personal memory.", "")
+                .optionalString("agent_id",
+                        "Agent identity for workspace RBAC. Required when 'workspace_id' is set. "
+                        + "The agent must have write access to the workspace.", "")
                 .build();
     }
 

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1115,40 +1115,33 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     public List<CognitiveRecord> browse(String... tags) {
         if (tags == null || tags.length == 0) return List.of();
 
-        // Pre-compute query tags as a lowercase Set (O(1) lookup)
-        var queryTagSet = new java.util.HashSet<String>(tags.length);
-        for (String tag : tags) queryTagSet.add(tag.toLowerCase());
+        // O(1) inverted tag index lookup — intersects tag sets for AND semantics
+        var matchingIds = index.idsByAllTags(tags);
+        if (matchingIds.isEmpty()) return List.of();
 
-        var results = new java.util.ArrayList<CognitiveRecord>();
+        var results = new java.util.ArrayList<CognitiveRecord>(matchingIds.size());
 
-        for (var entry : index.locationMap().entrySet()) {
-            String memId = entry.getKey();
-            String[] memTags = index.tags(memId);
-            if (memTags.length < tags.length) continue; // fast-path: can't match if fewer tags
+        for (String memId : matchingIds) {
+            MemoryLocation loc = index.locate(memId);
+            if (loc == null) continue;
 
-            // AND semantics: memory must contain all requested tags
-            var memTagSet = new java.util.HashSet<String>(memTags.length);
-            for (String memTag : memTags) memTagSet.add(memTag.toLowerCase());
+            MemorySegment segment = partitionManager.tierRouter().segmentFor(loc.type());
+            CognitiveRecordLayout layout = partitionManager.tierRouter().layoutFor(loc.type());
 
-            if (memTagSet.containsAll(queryTagSet)) {
-                MemoryLocation loc = entry.getValue();
-                MemorySegment segment = partitionManager.tierRouter().segmentFor(loc.type());
-                CognitiveRecordLayout layout = partitionManager.tierRouter().layoutFor(loc.type());
-
-                if (segment != null && layout != null) {
-                    var header = layout.readHeader(segment, loc.offset());
-                    if (!SynapticHeaderConstants.isTombstoned(header.flags())) {
-                        int spectorRecallCount = layout.readSpectorRecallCount(segment, loc.offset());
-                        results.add(new CognitiveRecord(
-                                memId, index.text(memId), loc.type(),
-                                index.source(memId), memTags,
-                                header.timestampMs(), header.synapticTags(), header.exactNorm(),
-                                header.importance(), header.agentRecallCount(), spectorRecallCount,
-                                header.centroidId(), header.valence(), header.arousal(),
-                                header.storageStrength(), header.flags(),
-                                null, // no vector for browse (use inspect for full detail)
-                                loc.partitionIndex(), loc.offset()));
-                    }
+            if (segment != null && layout != null) {
+                var header = layout.readHeader(segment, loc.offset());
+                if (!SynapticHeaderConstants.isTombstoned(header.flags())) {
+                    int spectorRecallCount = layout.readSpectorRecallCount(segment, loc.offset());
+                    String[] memTags = index.tags(memId);
+                    results.add(new CognitiveRecord(
+                            memId, index.text(memId), loc.type(),
+                            index.source(memId), memTags,
+                            header.timestampMs(), header.synapticTags(), header.exactNorm(),
+                            header.importance(), header.agentRecallCount(), spectorRecallCount,
+                            header.centroidId(), header.valence(), header.arousal(),
+                            header.storageStrength(), header.flags(),
+                            null, // no vector for browse (use inspect for full detail)
+                            loc.partitionIndex(), loc.offset()));
                 }
             }
         }

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -24,6 +24,7 @@ import com.spectrayan.spector.embed.PipelineEmbeddingResult;
 import com.spectrayan.spector.embed.SparseEncodingProvider;
 import com.spectrayan.spector.embed.TextGenerationProvider;
 import com.spectrayan.spector.embed.TokenEmbeddingProvider;
+import com.spectrayan.spector.index.BM25Index;
 import com.spectrayan.spector.index.ColBERTReranker;
 import com.spectrayan.spector.index.ColBERTTokenCache;
 import com.spectrayan.spector.memory.amygdala.ValenceTracker;
@@ -200,6 +201,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     // ── Shutdown Hook (auto-registered for DISK mode) ──
     private final Thread shutdownHook;
     private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    // ── BM25 Binary Persistence (P1: save on close for instant next startup) ──
+    private final MemoryBM25Index bm25Index;
 
     // ── Chunking for remember() ──
     private final TextChunker chunker;
@@ -421,21 +425,32 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         if (isDisk && basePath != null && resolvedPartitionDir != null) {
             textDataStore = new TextDataStore(StorageLayout.textDat(resolvedPartitionDir));
             // Call readAll() to establish the mmap'd segment for off-heap text reads.
-            // The returned text entries are used for BM25 rebuild below.
             var textEntries = textDataStore.readAll();
             // P0: wire TextDataStore into MemoryIndex for off-heap text() resolution
             index.setTextDataStore(textDataStore);
+
+            // P1: Try loading pre-built BM25 binary index (instant load vs O(n) rebuild)
+            java.nio.file.Path bm25Path = StorageLayout.bm25Bidx(resolvedPartitionDir);
+            BM25Index loadedBm25 = BM25Index.load(bm25Path);
             bm25Index = new MemoryBM25Index(1);
-            Map<String, String> allTexts = new java.util.HashMap<>();
-            for (var entry : index.locationMap().entrySet()) {
-                String text = index.text(entry.getKey());
-                if (text != null && !text.isEmpty()) {
-                    allTexts.put(entry.getKey(), text);
+            if (loadedBm25 != null) {
+                bm25Index.setPartition(0, loadedBm25);
+                log.info("BM25 loaded from binary index: {} docs", loadedBm25.size());
+            } else {
+                // Fall back to expensive rebuild from text data
+                Map<String, String> allTexts = new java.util.HashMap<>();
+                for (var entry : index.locationMap().entrySet()) {
+                    String text = index.text(entry.getKey());
+                    if (text != null && !text.isEmpty()) {
+                        allTexts.put(entry.getKey(), text);
+                    }
                 }
-            }
-            if (!allTexts.isEmpty()) {
-                bm25Index.rebuildPartition(0, allTexts);
-                log.info("Rebuilt BM25 index with {} documents from memory index", allTexts.size());
+                if (!allTexts.isEmpty()) {
+                    bm25Index.rebuildPartition(0, allTexts);
+                    log.info("Rebuilt BM25 index with {} documents from memory index", allTexts.size());
+                    // Save the rebuilt index for instant load on next startup
+                    bm25Index.partition(0).save(bm25Path);
+                }
             }
             activePartitionIndex = 0;
         } else {
@@ -443,6 +458,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             textDataStore = null;
             activePartitionIndex = 0;
         }
+        this.bm25Index = bm25Index;
 
         // ── SPLADE Index (auto-created when provider is configured) ──
         com.spectrayan.spector.memory.cortex.MemorySpladeIndex memorySpladeIndex = null;
@@ -1401,6 +1417,18 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 checkpointDaemon.checkpoint();
             } catch (Exception e) {
                 log.warn("Final checkpoint on close failed: {}", e.getMessage());
+            }
+        }
+
+        // Save BM25 binary index for instant load on next startup
+        if (persistenceMode == MemoryPersistenceMode.DISK
+                && partitionManager.activePartitionDir() != null
+                && bm25Index != null && bm25Index.totalDocuments() > 0) {
+            try {
+                bm25Index.partition(0).save(
+                        StorageLayout.bm25Bidx(partitionManager.activePartitionDir()));
+            } catch (Exception e) {
+                log.warn("Failed to save BM25 index on close: {}", e.getMessage());
             }
         }
 

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -420,6 +420,11 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         int activePartitionIndex;
         if (isDisk && basePath != null && resolvedPartitionDir != null) {
             textDataStore = new TextDataStore(StorageLayout.textDat(resolvedPartitionDir));
+            // Call readAll() to establish the mmap'd segment for off-heap text reads.
+            // The returned text entries are used for BM25 rebuild below.
+            var textEntries = textDataStore.readAll();
+            // P0: wire TextDataStore into MemoryIndex for off-heap text() resolution
+            index.setTextDataStore(textDataStore);
             bm25Index = new MemoryBM25Index(1);
             Map<String, String> allTexts = new java.util.HashMap<>();
             for (var entry : index.locationMap().entrySet()) {

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -64,7 +64,7 @@ final class PartitionManager {
 
     private volatile TierRouter tierRouter;
     private volatile Path activePartitionDir;
-    private final Object partitionRollLock = new Object();
+    private final java.util.concurrent.locks.ReentrantLock partitionRollLock = new java.util.concurrent.locks.ReentrantLock();
 
     PartitionManager(Path basePath,
                      int quantizedVecBytes,
@@ -146,7 +146,8 @@ final class PartitionManager {
      * see a consistent swap.</p>
      */
     void rollPartition() {
-        synchronized (partitionRollLock) {
+        partitionRollLock.lock();
+        try {
             if (basePath == null) {
                 log.warn("Cannot roll partition — no basePath (IN_MEMORY mode)");
                 return;
@@ -206,6 +207,8 @@ final class PartitionManager {
                 throw new SpectorServerException(ErrorCode.INTERNAL_ERROR,
                         "Failed to roll partition: " + e.getMessage(), e);
             }
+        } finally {
+            partitionRollLock.unlock();
         }
     }
 

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/StorageLayout.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/StorageLayout.java
@@ -154,6 +154,9 @@ public final class StorageLayout {
     /** Intra-partition entity knowledge graph. */
     public static final String FILE_ENTITY = "entity.graph";
 
+    /** BM25 inverted index binary file. */
+    public static final String FILE_BM25 = "bm25.bidx";
+
     /** Entity type registry (String ↔ int mapping for entity types). */
     public static final String FILE_ENTITY_TYPES = "entity-types.treg";
 
@@ -494,6 +497,11 @@ public final class StorageLayout {
     /** Resolves the index.midx file within a partition. */
     public static Path indexMidx(Path partitionDir) {
         return partitionDir.resolve(FILE_INDEX);
+    }
+
+    /** Resolves the bm25.bidx file within a partition. */
+    public static Path bm25Bidx(Path partitionDir) {
+        return partitionDir.resolve(FILE_BM25);
     }
 
     /** Resolves the hebbian.graph file within a partition. */

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/MemoryBM25Index.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/MemoryBM25Index.java
@@ -196,6 +196,21 @@ public final class MemoryBM25Index implements AutoCloseable {
     }
 
     /**
+     * Replaces a partition's BM25 index with a pre-built instance.
+     *
+     * <p>Used when loading from a persisted binary index file ({@code bm25.bidx})
+     * to avoid the expensive O(n) rebuild from text.dat on startup.</p>
+     *
+     * @param partitionIndex the partition to replace
+     * @param index          the pre-built BM25Index to install
+     */
+    public void setPartition(int partitionIndex, BM25Index index) {
+        ensurePartition(partitionIndex);
+        partitions.set(partitionIndex, index);
+        log.debug("Set BM25 partition {} with {} documents", partitionIndex, index.size());
+    }
+
+    /**
      * Adds a new empty partition (called when a partition rolls).
      *
      * @return the index of the newly added partition

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TextDataStore.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TextDataStore.java
@@ -101,6 +101,9 @@ public final class TextDataStore implements AutoCloseable {
     /** Arena managing the mapped segment lifecycle. */
     private Arena mapArena;
 
+    /** Populated during readAll() — maps memoryId → text byte position for backfill. */
+    private final java.util.Map<String, TextPosition> textPositionMap = new java.util.LinkedHashMap<>();
+
     /**
      * Creates a TextDataStore for the given file path.
      *
@@ -131,7 +134,15 @@ public final class TextDataStore implements AutoCloseable {
     public record TextEntry(String id, MemoryType tier, String text) {}
 
     /**
-     * Appends a single text entry to the file.
+     * Position of a text entry within text.dat for off-heap random-access reads.
+     *
+     * @param textOffset byte offset of the text content in text.dat (after entry header)
+     * @param textLength byte length of the UTF-8 encoded text
+     */
+    public record TextPosition(long textOffset, int textLength) {}
+
+    /**
+     * Appends a single text entry to the file and returns its byte position.
      *
      * <p>If the file doesn't exist, creates it with a fresh header.
      * If the file exists, appends the entry and updates the header count.</p>
@@ -139,10 +150,15 @@ public final class TextDataStore implements AutoCloseable {
      * @param id   memory identifier
      * @param tier the cognitive tier
      * @param text the raw text content
+     * @return the byte position of the text within text.dat for direct off-heap reads
      */
-    public void write(String id, MemoryType tier, String text) {
+    public TextPosition write(String id, MemoryType tier, String text) {
         try {
             boolean isNew = !Files.exists(file);
+            byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
+            byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+
+            long textOffset;
 
             if (isNew) {
                 // Create new file with header + first entry
@@ -150,29 +166,33 @@ public final class TextDataStore implements AutoCloseable {
                         StandardOpenOption.CREATE_NEW,
                         StandardOpenOption.WRITE)) {
                     writeHeader(ch, 0);
-                    writeEntry(ch, id, tier, text);
+                    // Text offset = header + tier(1) + idLen(4) + id + textLen(4)
+                    textOffset = HEADER_BYTES + 1 + 4 + idBytes.length + 4;
+                    writeEntry(ch, idBytes, tier, textBytes);
                 }
             } else {
                 // Append to existing file
                 try (FileChannel ch = FileChannel.open(file,
                         StandardOpenOption.WRITE)) {
-                    ch.position(ch.size());
-                    writeEntry(ch, id, tier, text);
+                    long entryStart = ch.size();
+                    ch.position(entryStart);
+                    // Text offset = entryStart + tier(1) + idLen(4) + id + textLen(4)
+                    textOffset = entryStart + 1 + 4 + idBytes.length + 4;
+                    writeEntry(ch, idBytes, tier, textBytes);
                 }
             }
 
             entryCount++;
             updateHeaderCount();
 
+            return new TextPosition(textOffset, textBytes.length);
+
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write text entry: " + id, e);
         }
     }
 
-    private void writeEntry(FileChannel ch, String id, MemoryType tier, String text) throws IOException {
-        byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
-        byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
-
+    private void writeEntry(FileChannel ch, byte[] idBytes, MemoryType tier, byte[] textBytes) throws IOException {
         int entrySize = 1 + 4 + idBytes.length + 4 + textBytes.length;
         ByteBuffer buf = ByteBuffer.allocate(entrySize);
         buf.put((byte) tier.ordinal());
@@ -182,6 +202,23 @@ public final class TextDataStore implements AutoCloseable {
         buf.put(textBytes);
         buf.flip();
         ch.write(buf);
+    }
+
+    /**
+     * Reads text directly from the mmap'd segment at the given offset — zero-copy, off-heap.
+     *
+     * <p>Requires that {@link #readAll()} has been called first to establish the mmap'd segment.
+     * Falls back to null if the segment is not mapped or the position is invalid.</p>
+     *
+     * @param textOffset byte offset of the text in text.dat
+     * @param textLength byte length of the UTF-8 text
+     * @return the text string, or null if the mmap'd segment is unavailable
+     */
+    public String readTextDirect(long textOffset, int textLength) {
+        MemorySegment seg = this.mappedSegment;
+        if (seg == null || textOffset < 0 || textLength < 0) return null;
+        if (textOffset + textLength > seg.byteSize()) return null;
+        return decodeUtf8FromSegment(seg, textOffset, textLength);
     }
 
     /**
@@ -262,6 +299,7 @@ public final class TextDataStore implements AutoCloseable {
                 pos += idLen;
 
                 int textLen = mappedSegment.get(BE_INT, pos);
+                long textDataPos = pos + 4; // byte offset where actual text bytes start
                 pos += 4;
 
                 if (textLen < 0 || textLen > 10_000_000 || pos + textLen > fileSize) {
@@ -275,6 +313,7 @@ public final class TextDataStore implements AutoCloseable {
 
                 MemoryType tier = MemoryType.values()[tierOrd];
                 entries.put(id, new TextEntry(id, tier, text));
+                textPositionMap.put(id, new TextPosition(textDataPos, textLen));
             }
 
             this.entryCount = entries.size();
@@ -290,6 +329,18 @@ public final class TextDataStore implements AutoCloseable {
 
         log.debug("Loaded {} text entries from {} (mmap'd off-heap)", entries.size(), file);
         return entries;
+    }
+
+    /**
+     * Returns text positions collected during {@link #readAll()}.
+     *
+     * <p>Maps memoryId → (textOffset, textLength) within text.dat. Used during
+     * startup to backfill MemoryLocation text positions for V1/V2 indexes.</p>
+     *
+     * @return unmodifiable map of text positions, empty if readAll() not called
+     */
+    public java.util.Map<String, TextPosition> textPositions() {
+        return java.util.Collections.unmodifiableMap(textPositionMap);
     }
 
     /**

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/dopamine/WelfordStats.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/dopamine/WelfordStats.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory.dopamine;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Welford's online algorithm for computing running mean and standard deviation.
@@ -34,8 +35,8 @@ public final class WelfordStats {
     private volatile double mean = 0.0;
     private volatile double m2 = 0.0;
 
-    // Lock for update atomicity (cheap — updates are infrequent relative to reads)
-    private final Object lock = new Object();
+    // Lock for update atomicity (ReentrantLock avoids virtual thread pinning — ADR-005)
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * Incorporates a new sample into the running statistics.
@@ -43,12 +44,15 @@ public final class WelfordStats {
      * @param value the new observation
      */
     public void update(double value) {
-        synchronized (lock) {
+        lock.lock();
+        try {
             long n = count.incrementAndGet();
             double delta = value - mean;
             mean += delta / n;
             double delta2 = value - mean;
             m2 += delta * delta2;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -95,10 +99,13 @@ public final class WelfordStats {
      * Resets all statistics.
      */
     public void reset() {
-        synchronized (lock) {
+        lock.lock();
+        try {
             count.set(0);
             mean = 0.0;
             m2 = 0.0;
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorCoActivationException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorCoActivationException.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Exception thrown when a co-activation tracker operation fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorEntityGraphException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorEntityGraphException.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Exception thrown when an entity graph operation fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorGraphDecayException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorGraphDecayException.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Exception thrown when graph decay or pruning fails during consolidation.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorGraphException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorGraphException.java
@@ -12,7 +12,8 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorMemoryException;
 
 /**
  * Exception thrown when a cognitive graph operation fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorGraphPersistenceException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorGraphPersistenceException.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Exception thrown when graph persistence (save/load) fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorHebbianException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorHebbianException.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Exception thrown when a Hebbian graph operation fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorMemoryConsolidationException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorMemoryConsolidationException.java
@@ -12,7 +12,8 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorMemoryException;
 
 /**
  * Exception thrown when the memory consolidation process fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorMemoryRecallException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorMemoryRecallException.java
@@ -12,7 +12,8 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorMemoryException;
 
 /**
  * Exception thrown when the cognitive recall pipeline or memory identification fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorMemoryTierFullException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorMemoryTierFullException.java
@@ -12,7 +12,8 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorMemoryException;
 
 /**
  * Exception thrown when a cognitive memory tier has reached its capacity limits.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorTemporalChainException.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/error/SpectorTemporalChainException.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Exception thrown when a temporal chain operation fails.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
@@ -86,11 +86,7 @@ public final class EntityGraph implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(EntityGraph.class);
 
-    /** File magic: "EGPH" in ASCII. */
-    private static final int FILE_MAGIC = 0x45475048;
-    /** File format version. */
-    private static final int FILE_VERSION = 1;
-    private static final int FILE_HEADER_BYTES = 24; // magic + version + entityCap + edgeCap + entityCount + edgeCount
+
 
     /** Default adjacency slots allocated per entity on first link. */
     static final int DEFAULT_ADJ_PER_ENTITY = 8;
@@ -191,6 +187,22 @@ public final class EntityGraph implements AutoCloseable {
     public EntityGraph(int entityCapacity) {
         this(entityCapacity, entityCapacity * MAX_DEGREE);
     }
+
+    /**
+     * Package-private factory for constructing a graph from pre-loaded segments.
+     * Used by {@link EntityGraphSerializer#load}.
+     */
+    static EntityGraph fromLoaded(int entityCapacity, int edgeCapacity, int entityCount, int edgeCount,
+                                  Arena arena, MemorySegment entitySegment, MemorySegment edgeSegment,
+                                  MemorySegment adjacencySegment, int adjSegmentCapacity, int adjHighWaterMark,
+                                  ConcurrentHashMap<String, Integer> nameIndex,
+                                  TypeRegistry entityTypeRegistry, TypeRegistry relationTypeRegistry) {
+        return new EntityGraph(entityCapacity, edgeCapacity, entityCount, edgeCount,
+                arena, entitySegment, edgeSegment, adjacencySegment,
+                adjSegmentCapacity, adjHighWaterMark, nameIndex,
+                entityTypeRegistry, relationTypeRegistry);
+    }
+
 
     /**
      * Private constructor for loading from pre-existing segments.
@@ -1021,7 +1033,7 @@ public final class EntityGraph implements AutoCloseable {
     public record TraversalResult(int entityId, int hopDistance) {}
 
     // ══════════════════════════════════════════════════════════════
-    // PERSISTENCE: save / load
+    // PERSISTENCE: save / load (delegated to EntityGraphSerializer)
     // ══════════════════════════════════════════════════════════════
 
     /**
@@ -1036,118 +1048,11 @@ public final class EntityGraph implements AutoCloseable {
     /**
      * Saves the graph to a binary file with optional name index encryption.
      *
-     * <p>When a non-null, enabled {@link DataEncryptor} is provided, the name
-     * index section is encrypted as a single AES-256-GCM blob. A 1-byte flag
-     * precedes the name index data: {@code 0x00} = plaintext, {@code 0x01} = encrypted.
-     * This ensures backward compatibility — files saved without encryption can
-     * still be loaded by newer code that expects the flag.</p>
-     *
      * @param filePath  path to write
      * @param encryptor optional encryptor for name index (null = no encryption)
      */
     public void save(Path filePath, DataEncryptor encryptor) {
-        Path parent = filePath.getParent();
-        if (parent != null) {
-            try {
-                Files.createDirectories(parent);
-            } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("EntityGraph", parent, e);
-            }
-        }
-
-        try (FileChannel ch = FileChannel.open(filePath,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE,
-                StandardOpenOption.TRUNCATE_EXISTING)) {
-
-            // Header: magic + version + entityCap + edgeCap + entityCount + edgeCount
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            header.putInt(FILE_MAGIC);
-            header.putInt(FILE_VERSION);
-            header.putInt(entityCapacity);
-            header.putInt(edgeCapacity);
-            header.putInt(entityCount);
-            header.putInt(edgeCount);
-            header.flip();
-            ch.write(header);
-
-            // Write entity segment
-            writeSegment(ch, entitySegment, (long) ENTITY_NODE_BYTES * entityCapacity);
-
-            // Write edge segment
-            writeSegment(ch, edgeSegment, (long) EDGE_BYTES * edgeCapacity);
-
-            // Write adjacency segment header: [adjSegmentCapacity:4B][adjHighWaterMark:4B]
-            ByteBuffer adjHeader = ByteBuffer.allocate(8);
-            adjHeader.putInt(adjSegmentCapacity);
-            adjHeader.putInt(adjHighWaterMark);
-            adjHeader.flip();
-            ch.write(adjHeader);
-
-            // Write adjacency segment data (only up to high water mark)
-            if (adjHighWaterMark > 0) {
-                writeSegment(ch, adjacencySegment, (long) ADJ_ENTRY_BYTES * adjHighWaterMark);
-            }
-
-            // Write name index (on-heap → serialized, optionally encrypted)
-            boolean encrypt = encryptor != null && encryptor.isEnabled();
-
-            // Serialize name index to a byte array first
-            java.io.ByteArrayOutputStream nameStream = new java.io.ByteArrayOutputStream();
-            java.nio.ByteBuffer nameCountBuf = ByteBuffer.allocate(4);
-            nameCountBuf.putInt(nameIndex.size());
-            nameCountBuf.flip();
-            nameStream.write(nameCountBuf.array());
-
-            for (Map.Entry<String, Integer> entry : nameIndex.entrySet()) {
-                byte[] nameBytes = entry.getKey().getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                ByteBuffer entryBuf = ByteBuffer.allocate(4 + nameBytes.length + 4);
-                entryBuf.putInt(nameBytes.length);
-                entryBuf.put(nameBytes);
-                entryBuf.putInt(entry.getValue());
-                entryBuf.flip();
-                nameStream.write(entryBuf.array());
-            }
-
-            byte[] nameIndexBytes = nameStream.toByteArray();
-
-            // Write encryption flag: 0x00 = plaintext, 0x01 = encrypted
-            ByteBuffer flagBuf = ByteBuffer.allocate(1);
-            flagBuf.put(encrypt ? (byte) 0x01 : (byte) 0x00);
-            flagBuf.flip();
-            ch.write(flagBuf);
-
-            if (encrypt) {
-                byte[] encrypted = encryptor.encryptText(nameIndexBytes);
-                // Write encrypted blob length + blob
-                ByteBuffer blobLenBuf = ByteBuffer.allocate(4);
-                blobLenBuf.putInt(encrypted.length);
-                blobLenBuf.flip();
-                ch.write(blobLenBuf);
-                ch.write(ByteBuffer.wrap(encrypted));
-                log.info("EntityGraph name index encrypted: {} names, {} plaintext bytes → {} encrypted bytes",
-                        nameIndex.size(), nameIndexBytes.length, encrypted.length);
-            } else {
-                // Write plaintext name index directly
-                ch.write(ByteBuffer.wrap(nameIndexBytes));
-            }
-
-            ch.force(true);
-            log.info("EntityGraph saved: entities={}, edges={}, adjEntries={}, nameIndexEncrypted={} → {}",
-                    entityCount, edgeCount, adjHighWaterMark, encrypt, filePath);
-
-        } catch (IOException e) {
-            throw new SpectorGraphPersistenceException("EntityGraph", filePath, e);
-        }
-
-        // Persist TypeRegistries alongside the graph file
-        if (parent != null) {
-            try {
-                entityTypeRegistry.save(StorageLayout.entityTypes(parent));
-                relationTypeRegistry.save(StorageLayout.relationTypes(parent));
-            } catch (IOException e) {
-                log.error("Failed to save TypeRegistries alongside EntityGraph: {}", e.getMessage());
-            }
-        }
+        EntityGraphSerializer.save(this, filePath, encryptor);
     }
 
     /**
@@ -1159,7 +1064,7 @@ public final class EntityGraph implements AutoCloseable {
      * @return an EntityGraph (loaded or new)
      */
     public static EntityGraph load(Path filePath, int defaultEntityCap, int defaultEdgeCap) {
-        return load(filePath, defaultEntityCap, defaultEdgeCap, null);
+        return EntityGraphSerializer.load(filePath, defaultEntityCap, defaultEdgeCap, null);
     }
 
     /**
@@ -1173,223 +1078,20 @@ public final class EntityGraph implements AutoCloseable {
      */
     public static EntityGraph load(Path filePath, int defaultEntityCap, int defaultEdgeCap,
                                     DataEncryptor encryptor) {
-        if (filePath == null || !Files.exists(filePath)) {
-            log.info("EntityGraph file not found, creating fresh: {}", filePath);
-            return new EntityGraph(defaultEntityCap, defaultEdgeCap);
-        }
-
-        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
-            long fileSize = ch.size();
-            if (fileSize < FILE_HEADER_BYTES) {
-                log.warn("EntityGraph file too small ({}B), creating fresh", fileSize);
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
-            }
-
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            ch.read(header);
-            header.flip();
-
-            int magic = header.getInt();
-            int version = header.getInt();
-            int entityCap = header.getInt();
-            int edgeCap = header.getInt();
-            int entCount = header.getInt();
-            int edgCount = header.getInt();
-
-            if (magic != FILE_MAGIC || version != FILE_VERSION) {
-                log.warn("Incompatible EntityGraph file (magic={}, version={}), creating fresh",
-                        Integer.toHexString(magic), version);
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
-            }
-
-            // Validate file has enough data for the segments declared in the header
-            long minExpectedBytes = FILE_HEADER_BYTES
-                    + (long) ENTITY_NODE_BYTES * entityCap
-                    + (long) EDGE_BYTES * edgeCap
-                    + 8; // adjacency header (adjCap + adjHwm)
-            if (fileSize < minExpectedBytes) {
-                log.warn("EntityGraph file truncated ({}B < expected {}B), creating fresh",
-                        fileSize, minExpectedBytes);
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
-            }
-
-            Arena arena = Arena.ofShared();
-
-            // Read entity segment
-            long entityBytes = (long) ENTITY_NODE_BYTES * entityCap;
-            MemorySegment entSeg = arena.allocate(entityBytes);
-            readSegment(ch, entSeg, entityBytes);
-
-            // Read edge segment
-            long edgeBytes = (long) EDGE_BYTES * edgeCap;
-            MemorySegment edgSeg = arena.allocate(edgeBytes);
-            readSegment(ch, edgSeg, edgeBytes);
-
-            // Read adjacency header
-            ByteBuffer adjHeaderBuf = ByteBuffer.allocate(8);
-            ch.read(adjHeaderBuf);
-            adjHeaderBuf.flip();
-            int adjCap = adjHeaderBuf.getInt();
-            int adjHwm = adjHeaderBuf.getInt();
-
-            // Read adjacency segment
-            MemorySegment adjSeg = arena.allocate((long) ADJ_ENTRY_BYTES * adjCap);
-            adjSeg.fill((byte) 0);
-            if (adjHwm > 0) {
-                readSegment(ch, adjSeg, (long) ADJ_ENTRY_BYTES * adjHwm);
-            }
-
-            // Read name index (with encryption flag detection)
-            ConcurrentHashMap<String, Integer> names = readNameIndex(ch, encryptor);
-
-            // Load TypeRegistries — use persisted files if available, else seed from defaults
-            Path graphParent = filePath.getParent();
-            TypeRegistry entityTypes = TypeRegistry.load(
-                    StorageLayout.entityTypes(graphParent),
-                    "entity-type", EntityType.SEED);
-            TypeRegistry relationTypes = TypeRegistry.load(
-                    StorageLayout.relationTypes(graphParent),
-                    "relation-type", RelationType.SEED);
-
-            EntityGraph graph = new EntityGraph(entityCap, edgeCap, entCount, edgCount,
-                    arena, entSeg, edgSeg, adjSeg, adjCap, adjHwm, names,
-                    entityTypes, relationTypes);
-            graph.dataEncryptor = encryptor;  // Preserve for subsequent saves
-            log.info("EntityGraph loaded: entities={}, edges={}, adjEntries={}, encryptor={} from {}",
-                    entCount, edgCount, adjHwm,
-                    encryptor != null && encryptor.isEnabled() ? "enabled" : "none", filePath);
-            return graph;
-
-        } catch (Exception e) {
-            log.error("Failed to load EntityGraph, creating fresh: {}", e.getMessage());
-            return new EntityGraph(defaultEntityCap, defaultEdgeCap);
-        }
+        return EntityGraphSerializer.load(filePath, defaultEntityCap, defaultEdgeCap, encryptor);
     }
 
-    /**
-     * Reads the name index from a file channel.
-     */
-    /**
-     * Reads the name index from a file channel, handling both encrypted and plaintext formats.
-     *
-     * <p>Detects the encryption flag byte: {@code 0x01} = encrypted (read blob, decrypt, parse),
-     * {@code 0x00} = plaintext (parse inline). For backward compatibility with files saved before
-     * the encryption flag was added, if the first byte looks like a valid name count (not 0x00 or 0x01),
-     * it falls back to legacy parsing.</p>
-     */
-    private static ConcurrentHashMap<String, Integer> readNameIndex(
-            FileChannel ch, DataEncryptor encryptor) throws IOException {
-        // Read the encryption flag byte
-        ByteBuffer flagBuf = ByteBuffer.allocate(1);
-        ch.read(flagBuf);
-        flagBuf.flip();
-        byte flag = flagBuf.get();
+    // ── Package-private accessors for EntityGraphSerializer ──
 
-        if (flag == 0x01) {
-            // Encrypted name index — read blob length + blob, decrypt, parse
-            ByteBuffer blobLenBuf = ByteBuffer.allocate(4);
-            ch.read(blobLenBuf);
-            blobLenBuf.flip();
-            int blobLen = blobLenBuf.getInt();
-
-            ByteBuffer blobBuf = ByteBuffer.allocate(blobLen);
-            ch.read(blobBuf);
-            blobBuf.flip();
-            byte[] encrypted = new byte[blobLen];
-            blobBuf.get(encrypted);
-
-            if (encryptor == null || !encryptor.isEnabled()) {
-                log.error("EntityGraph name index is encrypted but no encryptor available — names will be empty");
-                return new ConcurrentHashMap<>();
-            }
-
-            byte[] decrypted = encryptor.decryptText(encrypted);
-            return parseNameIndexBytes(decrypted);
-
-        } else if (flag == 0x00) {
-            // Plaintext name index with flag — parse from channel
-            return readNameIndexFromChannel(ch);
-
-        } else {
-            // Legacy format (no flag byte) — the byte we read is actually part of the
-            // name count int. Seek back 1 byte and read the full name count.
-            ch.position(ch.position() - 1);
-            return readNameIndexFromChannel(ch);
-        }
-    }
-
-    /** Reads a plaintext name index from the current file channel position. */
-    private static ConcurrentHashMap<String, Integer> readNameIndexFromChannel(
-            FileChannel ch) throws IOException {
-        ConcurrentHashMap<String, Integer> names = new ConcurrentHashMap<>();
-        ByteBuffer countBuf = ByteBuffer.allocate(4);
-        ch.read(countBuf);
-        countBuf.flip();
-        int nameCount = countBuf.getInt();
-
-        for (int i = 0; i < nameCount; i++) {
-            ByteBuffer lenBuf = ByteBuffer.allocate(4);
-            ch.read(lenBuf);
-            lenBuf.flip();
-            int len = lenBuf.getInt();
-
-            ByteBuffer nameBuf = ByteBuffer.allocate(len);
-            ch.read(nameBuf);
-            nameBuf.flip();
-            String name = new String(nameBuf.array(), 0, len, java.nio.charset.StandardCharsets.UTF_8);
-
-            ByteBuffer idBuf = ByteBuffer.allocate(4);
-            ch.read(idBuf);
-            idBuf.flip();
-            int id = idBuf.getInt();
-
-            names.put(name, id);
-        }
-        return names;
-    }
-
-    /** Parses a name index from a decrypted byte array. */
-    private static ConcurrentHashMap<String, Integer> parseNameIndexBytes(byte[] data) {
-        ConcurrentHashMap<String, Integer> names = new ConcurrentHashMap<>();
-        ByteBuffer buf = ByteBuffer.wrap(data);
-        int nameCount = buf.getInt();
-
-        for (int i = 0; i < nameCount; i++) {
-            int len = buf.getInt();
-            byte[] nameBytes = new byte[len];
-            buf.get(nameBytes);
-            String name = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8);
-            int id = buf.getInt();
-            names.put(name, id);
-        }
-        return names;
-    }
-
-    private static void writeSegment(FileChannel ch, MemorySegment seg, long totalBytes)
-            throws IOException {
-        long written = 0;
-        int chunkSize = 64 * 1024;
-        while (written < totalBytes) {
-            int toWrite = (int) Math.min(chunkSize, totalBytes - written);
-            ByteBuffer buf = seg.asSlice(written, toWrite).asByteBuffer().asReadOnlyBuffer();
-            ch.write(buf);
-            written += toWrite;
-        }
-    }
-
-    private static void readSegment(FileChannel ch, MemorySegment seg, long totalBytes)
-            throws IOException {
-        long read = 0;
-        int chunkSize = 64 * 1024;
-        while (read < totalBytes) {
-            int toRead = (int) Math.min(chunkSize, totalBytes - read);
-            ByteBuffer buf = ByteBuffer.allocate(toRead);
-            ch.read(buf);
-            buf.flip();
-            MemorySegment.copy(MemorySegment.ofBuffer(buf), 0, seg, read, toRead);
-            read += toRead;
-        }
-    }
+    int entityCapacity() { return entityCapacity; }
+    int edgeCapacity() { return edgeCapacity; }
+    MemorySegment entitySegment() { return entitySegment; }
+    MemorySegment edgeSegment() { return edgeSegment; }
+    MemorySegment adjacencySegment() { return adjacencySegment; }
+    int adjSegmentCapacity() { return adjSegmentCapacity; }
+    ConcurrentHashMap<String, Integer> nameIndexInternal() { return nameIndex; }
+    TypeRegistry entityTypeRegistry() { return entityTypeRegistry; }
+    TypeRegistry relationTypeRegistry() { return relationTypeRegistry; }
 
     /**
      * Resets all entities, edges, and adjacency data by zero-filling segments.

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphSerializer.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphSerializer.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.graph;
+
+import com.spectrayan.spector.memory.DataEncryptor;
+import com.spectrayan.spector.memory.StorageLayout;
+import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Binary serializer for {@link EntityGraph} — handles save/load with optional
+ * AES-256-GCM encryption of the name index.
+ *
+ * <h3>File Format (EGPH v1)</h3>
+ * <pre>
+ *   Header (24 bytes):
+ *     [magic:4B "EGPH"][version:4B][entityCap:4B][edgeCap:4B]
+ *     [entityCount:4B][edgeCount:4B]
+ *
+ *   Entity Segment:  entityCap × 64 bytes
+ *   Edge Segment:    edgeCap × 12 bytes
+ *   Adjacency Header: [adjCap:4B][adjHwm:4B]
+ *   Adjacency Data:  adjHwm × 8 bytes
+ *   Name Index Flag: [0x00=plain | 0x01=encrypted]
+ *   Name Index:      count + (len + name + id) entries
+ * </pre>
+ *
+ * <p>Extracted from {@link EntityGraph} to separate persistence concerns
+ * from graph data structure and traversal logic.</p>
+ */
+final class EntityGraphSerializer {
+
+    private static final Logger log = LoggerFactory.getLogger(EntityGraphSerializer.class);
+
+    /** File magic: "EGPH" in ASCII. */
+    private static final int FILE_MAGIC = 0x45475048;
+    /** File format version. */
+    private static final int FILE_VERSION = 1;
+    private static final int FILE_HEADER_BYTES = 24;
+
+    private EntityGraphSerializer() {} // utility class
+
+    // ══════════════════════════════════════════════════════════════
+    // SAVE
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Saves the graph to a binary file with optional name index encryption.
+     *
+     * <p>When a non-null, enabled {@link DataEncryptor} is provided, the name
+     * index section is encrypted as a single AES-256-GCM blob. A 1-byte flag
+     * precedes the name index data: {@code 0x00} = plaintext, {@code 0x01} = encrypted.
+     * This ensures backward compatibility — files saved without encryption can
+     * still be loaded by newer code that expects the flag.</p>
+     *
+     * @param graph     the graph to save
+     * @param filePath  path to write
+     * @param encryptor optional encryptor for name index (null = no encryption)
+     */
+    static void save(EntityGraph graph, Path filePath, DataEncryptor encryptor) {
+        Path parent = filePath.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new SpectorGraphPersistenceException("EntityGraph", parent, e);
+            }
+        }
+
+        try (FileChannel ch = FileChannel.open(filePath,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING)) {
+
+            // Header: magic + version + entityCap + edgeCap + entityCount + edgeCount
+            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
+            header.putInt(FILE_MAGIC);
+            header.putInt(FILE_VERSION);
+            header.putInt(graph.entityCapacity());
+            header.putInt(graph.edgeCapacity());
+            header.putInt(graph.entityCount());
+            header.putInt(graph.edgeCount());
+            header.flip();
+            ch.write(header);
+
+            // Write entity segment
+            writeSegment(ch, graph.entitySegment(),
+                    (long) EntityGraph.ENTITY_NODE_BYTES * graph.entityCapacity());
+
+            // Write edge segment
+            writeSegment(ch, graph.edgeSegment(),
+                    (long) EntityGraph.EDGE_BYTES * graph.edgeCapacity());
+
+            // Write adjacency segment header: [adjSegmentCapacity:4B][adjHighWaterMark:4B]
+            ByteBuffer adjHeader = ByteBuffer.allocate(8);
+            adjHeader.putInt(graph.adjSegmentCapacity());
+            adjHeader.putInt(graph.adjHighWaterMark());
+            adjHeader.flip();
+            ch.write(adjHeader);
+
+            // Write adjacency segment data (only up to high water mark)
+            if (graph.adjHighWaterMark() > 0) {
+                writeSegment(ch, graph.adjacencySegment(),
+                        (long) EntityGraph.ADJ_ENTRY_BYTES * graph.adjHighWaterMark());
+            }
+
+            // Write name index (on-heap → serialized, optionally encrypted)
+            boolean encrypt = encryptor != null && encryptor.isEnabled();
+            writeNameIndex(ch, graph.nameIndexInternal(), encrypt, encryptor);
+
+            ch.force(true);
+            log.info("EntityGraph saved: entities={}, edges={}, adjEntries={}, nameIndexEncrypted={} → {}",
+                    graph.entityCount(), graph.edgeCount(), graph.adjHighWaterMark(), encrypt, filePath);
+
+        } catch (IOException e) {
+            throw new SpectorGraphPersistenceException("EntityGraph", filePath, e);
+        }
+
+        // Persist TypeRegistries alongside the graph file
+        if (parent != null) {
+            try {
+                graph.entityTypeRegistry().save(StorageLayout.entityTypes(parent));
+                graph.relationTypeRegistry().save(StorageLayout.relationTypes(parent));
+            } catch (IOException e) {
+                log.error("Failed to save TypeRegistries alongside EntityGraph: {}", e.getMessage());
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // LOAD
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Loads a graph from a binary file, or returns a new empty graph.
+     *
+     * @param filePath          path to the graph file
+     * @param defaultEntityCap  entity capacity if file doesn't exist
+     * @param defaultEdgeCap    edge capacity if file doesn't exist
+     * @param encryptor         optional encryptor for name index decryption (null = no encryption)
+     * @return an EntityGraph (loaded or new)
+     */
+    static EntityGraph load(Path filePath, int defaultEntityCap, int defaultEdgeCap,
+                            DataEncryptor encryptor) {
+        if (filePath == null || !Files.exists(filePath)) {
+            log.info("EntityGraph file not found, creating fresh: {}", filePath);
+            return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+        }
+
+        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+            long fileSize = ch.size();
+            if (fileSize < FILE_HEADER_BYTES) {
+                log.warn("EntityGraph file too small ({}B), creating fresh", fileSize);
+                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+            }
+
+            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
+            ch.read(header);
+            header.flip();
+
+            int magic = header.getInt();
+            int version = header.getInt();
+            int entityCap = header.getInt();
+            int edgeCap = header.getInt();
+            int entCount = header.getInt();
+            int edgCount = header.getInt();
+
+            if (magic != FILE_MAGIC || version != FILE_VERSION) {
+                log.warn("Incompatible EntityGraph file (magic={}, version={}), creating fresh",
+                        Integer.toHexString(magic), version);
+                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+            }
+
+            // Validate file has enough data for the segments declared in the header
+            long minExpectedBytes = FILE_HEADER_BYTES
+                    + (long) EntityGraph.ENTITY_NODE_BYTES * entityCap
+                    + (long) EntityGraph.EDGE_BYTES * edgeCap
+                    + 8; // adjacency header (adjCap + adjHwm)
+            if (fileSize < minExpectedBytes) {
+                log.warn("EntityGraph file truncated ({}B < expected {}B), creating fresh",
+                        fileSize, minExpectedBytes);
+                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+            }
+
+            Arena arena = Arena.ofShared();
+
+            // Read entity segment
+            long entityBytes = (long) EntityGraph.ENTITY_NODE_BYTES * entityCap;
+            MemorySegment entSeg = arena.allocate(entityBytes);
+            readSegment(ch, entSeg, entityBytes);
+
+            // Read edge segment
+            long edgeBytes = (long) EntityGraph.EDGE_BYTES * edgeCap;
+            MemorySegment edgSeg = arena.allocate(edgeBytes);
+            readSegment(ch, edgSeg, edgeBytes);
+
+            // Read adjacency header
+            ByteBuffer adjHeaderBuf = ByteBuffer.allocate(8);
+            ch.read(adjHeaderBuf);
+            adjHeaderBuf.flip();
+            int adjCap = adjHeaderBuf.getInt();
+            int adjHwm = adjHeaderBuf.getInt();
+
+            // Read adjacency segment
+            MemorySegment adjSeg = arena.allocate((long) EntityGraph.ADJ_ENTRY_BYTES * adjCap);
+            adjSeg.fill((byte) 0);
+            if (adjHwm > 0) {
+                readSegment(ch, adjSeg, (long) EntityGraph.ADJ_ENTRY_BYTES * adjHwm);
+            }
+
+            // Read name index (with encryption flag detection)
+            ConcurrentHashMap<String, Integer> names = readNameIndex(ch, encryptor);
+
+            // Load TypeRegistries — use persisted files if available, else seed from defaults
+            Path graphParent = filePath.getParent();
+            TypeRegistry entityTypes = TypeRegistry.load(
+                    StorageLayout.entityTypes(graphParent),
+                    "entity-type", EntityType.SEED);
+            TypeRegistry relationTypes = TypeRegistry.load(
+                    StorageLayout.relationTypes(graphParent),
+                    "relation-type", RelationType.SEED);
+
+            EntityGraph graph = EntityGraph.fromLoaded(entityCap, edgeCap, entCount, edgCount,
+                    arena, entSeg, edgSeg, adjSeg, adjCap, adjHwm, names,
+                    entityTypes, relationTypes);
+            graph.setDataEncryptor(encryptor);
+            log.info("EntityGraph loaded: entities={}, edges={}, adjEntries={}, encryptor={} from {}",
+                    entCount, edgCount, adjHwm,
+                    encryptor != null && encryptor.isEnabled() ? "enabled" : "none", filePath);
+            return graph;
+
+        } catch (Exception e) {
+            log.error("Failed to load EntityGraph, creating fresh: {}", e.getMessage());
+            return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // NAME INDEX SERIALIZATION
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Writes the name index to the file channel, optionally encrypted.
+     */
+    private static void writeNameIndex(FileChannel ch, ConcurrentHashMap<String, Integer> nameIndex,
+                                       boolean encrypt, DataEncryptor encryptor) throws IOException {
+        // Serialize name index to a byte array first
+        ByteArrayOutputStream nameStream = new ByteArrayOutputStream();
+        ByteBuffer nameCountBuf = ByteBuffer.allocate(4);
+        nameCountBuf.putInt(nameIndex.size());
+        nameCountBuf.flip();
+        nameStream.write(nameCountBuf.array());
+
+        for (Map.Entry<String, Integer> entry : nameIndex.entrySet()) {
+            byte[] nameBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
+            ByteBuffer entryBuf = ByteBuffer.allocate(4 + nameBytes.length + 4);
+            entryBuf.putInt(nameBytes.length);
+            entryBuf.put(nameBytes);
+            entryBuf.putInt(entry.getValue());
+            entryBuf.flip();
+            nameStream.write(entryBuf.array());
+        }
+
+        byte[] nameIndexBytes = nameStream.toByteArray();
+
+        // Write encryption flag: 0x00 = plaintext, 0x01 = encrypted
+        ByteBuffer flagBuf = ByteBuffer.allocate(1);
+        flagBuf.put(encrypt ? (byte) 0x01 : (byte) 0x00);
+        flagBuf.flip();
+        ch.write(flagBuf);
+
+        if (encrypt) {
+            byte[] encrypted = encryptor.encryptText(nameIndexBytes);
+            ByteBuffer blobLenBuf = ByteBuffer.allocate(4);
+            blobLenBuf.putInt(encrypted.length);
+            blobLenBuf.flip();
+            ch.write(blobLenBuf);
+            ch.write(ByteBuffer.wrap(encrypted));
+            log.info("EntityGraph name index encrypted: {} names, {} plaintext bytes → {} encrypted bytes",
+                    nameIndex.size(), nameIndexBytes.length, encrypted.length);
+        } else {
+            ch.write(ByteBuffer.wrap(nameIndexBytes));
+        }
+    }
+
+    /**
+     * Reads the name index from a file channel, handling both encrypted and plaintext formats.
+     *
+     * <p>Detects the encryption flag byte: {@code 0x01} = encrypted (read blob, decrypt, parse),
+     * {@code 0x00} = plaintext (parse inline). For backward compatibility with files saved before
+     * the encryption flag was added, if the first byte looks like a valid name count (not 0x00 or 0x01),
+     * it falls back to legacy parsing.</p>
+     */
+    private static ConcurrentHashMap<String, Integer> readNameIndex(
+            FileChannel ch, DataEncryptor encryptor) throws IOException {
+        ByteBuffer flagBuf = ByteBuffer.allocate(1);
+        ch.read(flagBuf);
+        flagBuf.flip();
+        byte flag = flagBuf.get();
+
+        if (flag == 0x01) {
+            // Encrypted name index — read blob length + blob, decrypt, parse
+            ByteBuffer blobLenBuf = ByteBuffer.allocate(4);
+            ch.read(blobLenBuf);
+            blobLenBuf.flip();
+            int blobLen = blobLenBuf.getInt();
+
+            ByteBuffer blobBuf = ByteBuffer.allocate(blobLen);
+            ch.read(blobBuf);
+            blobBuf.flip();
+            byte[] encrypted = new byte[blobLen];
+            blobBuf.get(encrypted);
+
+            if (encryptor == null || !encryptor.isEnabled()) {
+                log.error("EntityGraph name index is encrypted but no encryptor available — names will be empty");
+                return new ConcurrentHashMap<>();
+            }
+
+            byte[] decrypted = encryptor.decryptText(encrypted);
+            return parseNameIndexBytes(decrypted);
+
+        } else if (flag == 0x00) {
+            return readNameIndexFromChannel(ch);
+
+        } else {
+            // Legacy format (no flag byte) — seek back 1 byte
+            ch.position(ch.position() - 1);
+            return readNameIndexFromChannel(ch);
+        }
+    }
+
+    /** Reads a plaintext name index from the current file channel position. */
+    private static ConcurrentHashMap<String, Integer> readNameIndexFromChannel(
+            FileChannel ch) throws IOException {
+        ConcurrentHashMap<String, Integer> names = new ConcurrentHashMap<>();
+        ByteBuffer countBuf = ByteBuffer.allocate(4);
+        ch.read(countBuf);
+        countBuf.flip();
+        int nameCount = countBuf.getInt();
+
+        for (int i = 0; i < nameCount; i++) {
+            ByteBuffer lenBuf = ByteBuffer.allocate(4);
+            ch.read(lenBuf);
+            lenBuf.flip();
+            int len = lenBuf.getInt();
+
+            ByteBuffer nameBuf = ByteBuffer.allocate(len);
+            ch.read(nameBuf);
+            nameBuf.flip();
+            String name = new String(nameBuf.array(), 0, len, StandardCharsets.UTF_8);
+
+            ByteBuffer idBuf = ByteBuffer.allocate(4);
+            ch.read(idBuf);
+            idBuf.flip();
+            int id = idBuf.getInt();
+
+            names.put(name, id);
+        }
+        return names;
+    }
+
+    /** Parses a name index from a decrypted byte array. */
+    private static ConcurrentHashMap<String, Integer> parseNameIndexBytes(byte[] data) {
+        ConcurrentHashMap<String, Integer> names = new ConcurrentHashMap<>();
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        int nameCount = buf.getInt();
+
+        for (int i = 0; i < nameCount; i++) {
+            int len = buf.getInt();
+            byte[] nameBytes = new byte[len];
+            buf.get(nameBytes);
+            String name = new String(nameBytes, StandardCharsets.UTF_8);
+            int id = buf.getInt();
+            names.put(name, id);
+        }
+        return names;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // SEGMENT I/O HELPERS
+    // ══════════════════════════════════════════════════════════════
+
+    private static void writeSegment(FileChannel ch, MemorySegment seg, long totalBytes)
+            throws IOException {
+        long written = 0;
+        int chunkSize = 64 * 1024;
+        while (written < totalBytes) {
+            int toWrite = (int) Math.min(chunkSize, totalBytes - written);
+            ByteBuffer buf = seg.asSlice(written, toWrite).asByteBuffer().asReadOnlyBuffer();
+            ch.write(buf);
+            written += toWrite;
+        }
+    }
+
+    private static void readSegment(FileChannel ch, MemorySegment seg, long totalBytes)
+            throws IOException {
+        long read = 0;
+        int chunkSize = 64 * 1024;
+        while (read < totalBytes) {
+            int toRead = (int) Math.min(chunkSize, totalBytes - read);
+            ByteBuffer buf = ByteBuffer.allocate(toRead);
+            ch.read(buf);
+            buf.flip();
+            MemorySegment.copy(MemorySegment.ofBuffer(buf), 0, seg, read, toRead);
+            read += toRead;
+        }
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory.index;
 
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.TextDataStore;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorStorageException;
 
@@ -113,6 +114,9 @@ public final class MemoryIndex {
     // ── Reverse index: (type, offset) → id  [O(1) lookup for recall result assembly] ──
     private final ConcurrentHashMap<Long, String> reverseIndex = new ConcurrentHashMap<>();
 
+    // ── Off-heap text data store: enables zero-copy text reads from mmap'd text.dat ──
+    private volatile TextDataStore textDataStore;
+
     // ── Inverted tag index: tag → Set<memId>  [O(1) tag-based lookup for browse()] ──
     private final ConcurrentHashMap<String, java.util.Set<String>> tagToIds = new ConcurrentHashMap<>();
 
@@ -157,7 +161,11 @@ public final class MemoryIndex {
                           MemorySource source, String[] tagArray,
                           Map<String, String> metadata) {
         locations.put(id, location);
-        texts.put(id, text);
+        // P0 off-heap optimization: skip heap text storage when text.dat position is known.
+        // text() will read directly from the mmap'd segment via TextDataStore.readTextDirect().
+        if (!location.hasTextPosition()) {
+            texts.put(id, text);
+        }
         sources.put(id, source);
         tags.put(id, tagArray);
 
@@ -219,8 +227,21 @@ public final class MemoryIndex {
 
     /**
      * Returns the raw text for a memory ID, or empty string if not found.
+     *
+     * <p>Resolution order (P0 off-heap optimization):</p>
+     * <ol>
+     *   <li>Off-heap: read from mmap'd text.dat via {@link TextDataStore#readTextDirect}</li>
+     *   <li>Heap: fall back to the {@code texts} HashMap (V1/V2 indexes, WAL replay)</li>
+     * </ol>
      */
     public String text(String id) {
+        // Try off-heap first: check if we have a text.dat position and a live TextDataStore
+        MemoryLocation loc = locations.get(id);
+        if (loc != null && loc.hasTextPosition() && textDataStore != null) {
+            String offHeapText = textDataStore.readTextDirect(loc.textOffset(), loc.textLength());
+            if (offHeapText != null) return offHeapText;
+        }
+        // Fall back to heap HashMap (V1/V2 indexes, WAL replay, in-memory mode)
         return texts.getOrDefault(id, "");
     }
 
@@ -336,11 +357,24 @@ public final class MemoryIndex {
 
     /**
      * Returns the text for a memory stored at a given offset.
-     * O(1) via reverse index.
+     * O(1) via reverse index. Uses off-heap resolution when available.
      */
     public String findTextByOffset(MemoryType type, long offset) {
         String id = findIdByOffset(type, offset);
-        return id != null ? texts.get(id) : null;
+        return id != null ? text(id) : null;
+    }
+
+    /**
+     * Sets the TextDataStore for off-heap text resolution.
+     *
+     * <p>When set, {@link #text(String)} will read text directly from the mmap'd
+     * text.dat segment instead of the heap HashMap, eliminating ~40MB heap per
+     * 100K memories.</p>
+     *
+     * @param store the TextDataStore (nullable — disables off-heap resolution)
+     */
+    public void setTextDataStore(TextDataStore store) {
+        this.textDataStore = store;
     }
 
     /**
@@ -382,8 +416,8 @@ public final class MemoryIndex {
         Map<String, String> result = new java.util.HashMap<>();
         for (Map.Entry<String, MemoryLocation> entry : locations.entrySet()) {
             if (entry.getValue().partitionIndex() == partitionIndex) {
-                String text = texts.get(entry.getKey());
-                if (text != null) {
+                String text = text(entry.getKey());
+                if (text != null && !text.isEmpty()) {
                     result.put(entry.getKey(), text);
                 }
             }
@@ -491,7 +525,7 @@ public final class MemoryIndex {
             for (Map.Entry<String, MemoryLocation> entry : locations.entrySet()) {
                 String id = entry.getKey();
                 MemoryLocation loc = entry.getValue();
-                String text = texts.getOrDefault(id, "");
+                String text = text(id);
                 MemorySource source = sources.getOrDefault(id, MemorySource.OBSERVED);
                 String[] tagArray = tags.getOrDefault(id, new String[0]);
                 Map<String, String> meta = metadataMap.getOrDefault(id, Map.of());

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
@@ -61,9 +61,11 @@ public final class MemoryIndex {
     /** File magic: "MIDX" in ASCII. */
     private static final int INDEX_MAGIC = 0x4D494458;
 
-    /** File format version. */
-    private static final int INDEX_VERSION = 2;
-    /** V1 format (no metadata) — still loadable for backward compatibility. */
+    /** File format version — V3 adds textOffset + textLength for off-heap text reads. */
+    private static final int INDEX_VERSION = 3;
+    /** V2 format (metadata, no text offsets) — still loadable. */
+    private static final int INDEX_VERSION_V2 = 2;
+    /** V1 format (no metadata, no text offsets) — still loadable. */
     private static final int INDEX_VERSION_V1 = 1;
 
     /** File header: 4B magic + 4B version + 4B count + 4B reserved = 16 bytes. */
@@ -72,11 +74,32 @@ public final class MemoryIndex {
     /**
      * Tracks where a memory is physically stored.
      *
+     * <p>Links three storage layers via the same memory ID:</p>
+     * <ul>
+     *   <li>{@code offset} — byte position in the tier's {@code .mem} file (cognitive header + vector)</li>
+     *   <li>{@code textOffset} / {@code textLength} — byte position in {@code text.dat} (raw text)</li>
+     *   <li>{@code partitionIndex} — partition number (episodic only, -1 otherwise)</li>
+     * </ul>
+     *
      * @param type            cognitive tier
-     * @param offset          byte offset within the tier's segment
+     * @param offset          byte offset within the tier's segment (.mem file)
      * @param partitionIndex  partition index (episodic only, -1 otherwise)
+     * @param textOffset      byte offset of the raw text entry in text.dat (-1 if unknown)
+     * @param textLength      byte length of the UTF-8 encoded text in text.dat (-1 if unknown)
      */
-    public record MemoryLocation(MemoryType type, long offset, int partitionIndex) {}
+    public record MemoryLocation(MemoryType type, long offset, int partitionIndex,
+                                  long textOffset, int textLength) {
+
+        /** Compact constructor for sites without text position (WAL replay, migration). */
+        public MemoryLocation(MemoryType type, long offset, int partitionIndex) {
+            this(type, offset, partitionIndex, -1L, -1);
+        }
+
+        /** Returns true if this location has a valid text.dat offset for direct off-heap reads. */
+        public boolean hasTextPosition() {
+            return textOffset >= 0 && textLength >= 0;
+        }
+    }
 
     // ── Forward index: id → metadata ──
     private final ConcurrentHashMap<String, MemoryLocation> locations = new ConcurrentHashMap<>();
@@ -89,6 +112,9 @@ public final class MemoryIndex {
 
     // ── Reverse index: (type, offset) → id  [O(1) lookup for recall result assembly] ──
     private final ConcurrentHashMap<Long, String> reverseIndex = new ConcurrentHashMap<>();
+
+    // ── Inverted tag index: tag → Set<memId>  [O(1) tag-based lookup for browse()] ──
+    private final ConcurrentHashMap<String, java.util.Set<String>> tagToIds = new ConcurrentHashMap<>();
 
     /**
      * Computes the reverse-index key from a memory type and byte offset.
@@ -142,6 +168,15 @@ public final class MemoryIndex {
 
         // O(1) reverse index
         reverseIndex.put(reverseKey(location.type(), location.offset()), id);
+
+        // O(1) inverted tag index — tag → Set<memId>
+        if (tagArray != null) {
+            for (String tag : tagArray) {
+                String normalizedTag = tag.toLowerCase();
+                tagToIds.computeIfAbsent(normalizedTag, _ -> java.util.Collections.newSetFromMap(new ConcurrentHashMap<>()))
+                        .add(id);
+            }
+        }
     }
 
     /**
@@ -151,12 +186,26 @@ public final class MemoryIndex {
         MemoryLocation loc = locations.remove(id);
         texts.remove(id);
         sources.remove(id);
-        tags.remove(id);
+        String[] removedTags = tags.remove(id);
         metadataMap.remove(id);
 
         // Clean reverse index
         if (loc != null) {
             reverseIndex.remove(reverseKey(loc.type(), loc.offset()));
+        }
+
+        // Clean inverted tag index
+        if (removedTags != null) {
+            for (String tag : removedTags) {
+                String normalizedTag = tag.toLowerCase();
+                var idSet = tagToIds.get(normalizedTag);
+                if (idSet != null) {
+                    idSet.remove(id);
+                    if (idSet.isEmpty()) {
+                        tagToIds.remove(normalizedTag, idSet);
+                    }
+                }
+            }
         }
     }
 
@@ -190,6 +239,54 @@ public final class MemoryIndex {
      */
     public String[] tags(String id) {
         return tags.getOrDefault(id, EMPTY_TAGS);
+    }
+
+    /**
+     * Returns the set of memory IDs that have the given tag — O(1) lookup.
+     *
+     * <p>Uses the inverted tag index for constant-time retrieval.
+     * Returns an empty set if no memories have the specified tag.</p>
+     *
+     * @param tag the tag to look up (case-insensitive)
+     * @return unmodifiable set of memory IDs with this tag
+     */
+    public java.util.Set<String> idsByTag(String tag) {
+        var ids = tagToIds.get(tag.toLowerCase());
+        return ids != null ? java.util.Collections.unmodifiableSet(ids) : java.util.Set.of();
+    }
+
+    /**
+     * Returns memory IDs matching ALL specified tags (AND semantics) — O(k) where k = smallest tag set.
+     *
+     * <p>Intersects the ID sets from the inverted index. Starts with the smallest set
+     * for optimal intersection performance.</p>
+     *
+     * @param queryTags tags to match (AND semantics)
+     * @return set of memory IDs that contain all specified tags
+     */
+    public java.util.Set<String> idsByAllTags(String... queryTags) {
+        if (queryTags == null || queryTags.length == 0) return java.util.Set.of();
+
+        // Find the smallest set to start intersection
+        java.util.Set<String> smallest = null;
+        for (String tag : queryTags) {
+            var ids = tagToIds.get(tag.toLowerCase());
+            if (ids == null || ids.isEmpty()) return java.util.Set.of(); // no match possible
+            if (smallest == null || ids.size() < smallest.size()) {
+                smallest = ids;
+            }
+        }
+
+        // Intersect with remaining tag sets
+        var result = new java.util.HashSet<>(smallest);
+        for (String tag : queryTags) {
+            var ids = tagToIds.get(tag.toLowerCase());
+            if (ids != smallest) {
+                result.retainAll(ids);
+                if (result.isEmpty()) return java.util.Set.of();
+            }
+        }
+        return java.util.Collections.unmodifiableSet(result);
     }
 
     /** Shared empty metadata map — avoids allocation on cache miss. */
@@ -321,8 +418,9 @@ public final class MemoryIndex {
         // Remove old reverse entry
         reverseIndex.remove(reverseKey(oldLoc.type(), oldLoc.offset()));
 
-        // Update forward index with new offset
-        MemoryLocation newLoc = new MemoryLocation(oldLoc.type(), newOffset, oldLoc.partitionIndex());
+        // Update forward index with new .mem offset (text.dat position unchanged)
+        MemoryLocation newLoc = new MemoryLocation(oldLoc.type(), newOffset, oldLoc.partitionIndex(),
+                oldLoc.textOffset(), oldLoc.textLength());
         locations.put(id, newLoc);
 
         // Add new reverse entry
@@ -446,17 +544,18 @@ public final class MemoryIndex {
                         Integer.toHexString(magic), Integer.toHexString(INDEX_MAGIC));
                 return index;
             }
-            if (version != INDEX_VERSION && version != INDEX_VERSION_V1) {
-                log.warn("Unsupported MemoryIndex version: {} (expected {} or {}), starting fresh",
-                        version, INDEX_VERSION, INDEX_VERSION_V1);
+            if (version != INDEX_VERSION && version != INDEX_VERSION_V2 && version != INDEX_VERSION_V1) {
+                log.warn("Unsupported MemoryIndex version: {} (expected {}, {}, or {}), starting fresh",
+                        version, INDEX_VERSION, INDEX_VERSION_V2, INDEX_VERSION_V1);
                 return index;
             }
 
-            boolean hasMetadata = (version >= INDEX_VERSION);
+            boolean hasMetadata = (version >= INDEX_VERSION_V2);
+            boolean hasTextPosition = (version >= INDEX_VERSION);
 
             // Read entries
             for (int i = 0; i < entryCount; i++) {
-                readEntry(ch, index, hasMetadata);
+                readEntry(ch, index, hasMetadata, hasTextPosition);
             }
 
             log.info("MemoryIndex loaded: {} entries from {}", index.size(), filePath);
@@ -536,15 +635,23 @@ public final class MemoryIndex {
             buf.put(metaValBytes[j]);
         }
 
+        // V3: Text position in text.dat (for off-heap reads)
+        ByteBuffer textPosBuf = ByteBuffer.allocate(8 + 4);
+        textPosBuf.putLong(loc.textOffset());
+        textPosBuf.putInt(loc.textLength());
+        textPosBuf.flip();
+
         buf.flip();
         ch.write(buf);
+        ch.write(textPosBuf);
     }
 
-    private static void readEntry(FileChannel ch, MemoryIndex index, boolean hasMetadata) throws IOException {
+    private static void readEntry(FileChannel ch, MemoryIndex index,
+                                    boolean hasMetadata, boolean hasTextPosition) throws IOException {
         // ID
         String id = readString(ch);
 
-        // Location
+        // Location (base: type + offset + partitionIndex)
         ByteBuffer locBuf = ByteBuffer.allocate(4 + 8 + 4);
         ch.read(locBuf);
         locBuf.flip();
@@ -552,7 +659,6 @@ public final class MemoryIndex {
         long offset = locBuf.getLong();
         int partitionIndex = locBuf.getInt();
         MemoryType type = MemoryType.values()[typeOrd];
-        MemoryLocation loc = new MemoryLocation(type, offset, partitionIndex);
 
         // Text
         String text = readString(ch);
@@ -591,6 +697,18 @@ public final class MemoryIndex {
             }
         }
 
+        // V3: Text position in text.dat
+        long textOffset = -1L;
+        int textLength = -1;
+        if (hasTextPosition) {
+            ByteBuffer tpBuf = ByteBuffer.allocate(8 + 4);
+            ch.read(tpBuf);
+            tpBuf.flip();
+            textOffset = tpBuf.getLong();
+            textLength = tpBuf.getInt();
+        }
+
+        MemoryLocation loc = new MemoryLocation(type, offset, partitionIndex, textOffset, textLength);
         index.register(id, loc, text, source, tagArray, metadata);
     }
 

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/migration/MigrationPipeline.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/migration/MigrationPipeline.java
@@ -19,7 +19,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -66,8 +70,8 @@ public class MigrationPipeline {
     /** Target version to migrate to. */
     private final SchemaVersion targetVersion;
 
-    /** Lock objects per namespace path to prevent concurrent migration. */
-    private final Map<String, Object> migrationLocks = new WeakHashMap<>();
+    /** Lock objects per namespace path to prevent concurrent migration (ADR-005: no synchronized). */
+    private final java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.locks.ReentrantLock> migrationLocks = new java.util.concurrent.ConcurrentHashMap<>();
 
     /**
      * Creates a migration pipeline with the given migrations targeting CURRENT.
@@ -91,7 +95,7 @@ public class MigrationPipeline {
     }
 
     /**
-     * Checks if a namespace needs migration and runs pending steps if so.
+     * Migrates the namespace if its schema version is older than the target.
      *
      * <p>This is the main entry point, called on namespace load. It is
      * idempotent and thread-safe per namespace.</p>
@@ -106,14 +110,12 @@ public class MigrationPipeline {
             return false;
         }
 
-        // Synchronize on namespace path to prevent concurrent migration
-        Object lock;
-        synchronized (migrationLocks) {
-            lock = migrationLocks.computeIfAbsent(
-                    namespaceDir.toAbsolutePath().toString(), k -> new Object());
-        }
+        // Per-namespace lock to prevent concurrent migration
+        java.util.concurrent.locks.ReentrantLock lock = migrationLocks.computeIfAbsent(
+                namespaceDir.toAbsolutePath().toString(), k -> new java.util.concurrent.locks.ReentrantLock());
 
-        synchronized (lock) {
+        lock.lock();
+        try {
             // Re-read inside lock (another thread may have migrated)
             currentVersion = readSchemaVersion(namespaceDir);
             if (!currentVersion.needsMigration(targetVersion)) {
@@ -121,6 +123,8 @@ public class MigrationPipeline {
             }
 
             return executeMigrationChain(namespaceDir, currentVersion);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/FilterOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/FilterOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * Filter parameters for recall queries.
+ *
+ * <p>Controls which memories are eligible for recall based on
+ * synaptic tag matching, importance threshold, memory tier type,
+ * and valence range.</p>
+ *
+ * @param synapticTagMask  Bloom filter mask for tag-based filtering (0L = no filter)
+ * @param minImportance    minimum importance threshold (0.0 = no filter)
+ * @param memoryTypes      allowed memory types (null = all types)
+ * @param minValence       minimum valence inclusive (Byte.MIN_VALUE = no filter)
+ * @param maxValence       maximum valence inclusive (Byte.MAX_VALUE = no filter)
+ */
+public record FilterOptions(
+        long synapticTagMask,
+        float minImportance,
+        MemoryType[] memoryTypes,
+        byte minValence,
+        byte maxValence
+) {
+    /** No filters — all memories eligible. */
+    public static final FilterOptions NONE = new FilterOptions(
+            0L, 0.0f, null, Byte.MIN_VALUE, Byte.MAX_VALUE);
+
+    /** Returns true if any filter is active. */
+    public boolean hasTagFilter() {
+        return synapticTagMask != 0L;
+    }
+
+    /** Returns true if memory type filtering is active. */
+    public boolean hasTypeFilter() {
+        return memoryTypes != null && memoryTypes.length > 0;
+    }
+
+    /** Returns true if valence range is constrained. */
+    public boolean hasValenceFilter() {
+        return minValence != Byte.MIN_VALUE || maxValence != Byte.MAX_VALUE;
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/GraphOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/GraphOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import com.spectrayan.spector.memory.graph.ExtractedEntity;
+
+import java.util.List;
+
+/**
+ * Graph expansion parameters for entity-aware recall.
+ *
+ * @param entityHints              pre-extracted entities for graph traversal (empty = use EntityExtractor)
+ * @param graphExpansionThreshold  max direct similarity below which graph expansion triggers (default: 0.40)
+ */
+public record GraphOptions(
+        List<ExtractedEntity> entityHints,
+        float graphExpansionThreshold
+) {
+    /** Default: no entity hints, expand when similarity < 0.40. */
+    public static final GraphOptions DEFAULT = new GraphOptions(List.of(), 0.40f);
+
+    /** Returns true if pre-extracted entities are provided. */
+    public boolean hasEntityHints() {
+        return entityHints != null && !entityHints.isEmpty();
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/NeurodivergentOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/NeurodivergentOptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * Neurodivergent cognitive profile parameters for recall queries.
+ *
+ * <p>Controls hyperfocus mode (strict tag-gated attention narrowing) and
+ * lateral retrieval mode (cross-domain divergent thinking).</p>
+ *
+ * @param hyperfocusMask            Bloom filter mask for hyperfocus gating (0L = disabled)
+ * @param hyperfocusBoost           post-score multiplier for hyperfocus-matched memories
+ * @param lateralMode               enable orthogonal/lateral retrieval
+ * @param lateralDistanceThreshold  minimum L2 distance for lateral candidates
+ * @param lateralMaxResults         maximum lateral candidates (-1 = topK/3)
+ * @param lateralMinTagOverlap      minimum tag overlap ratio for lateral candidates
+ */
+public record NeurodivergentOptions(
+        long hyperfocusMask,
+        float hyperfocusBoost,
+        boolean lateralMode,
+        float lateralDistanceThreshold,
+        int lateralMaxResults,
+        float lateralMinTagOverlap
+) {
+    /** Default: no neurodivergent modulation. */
+    public static final NeurodivergentOptions DEFAULT = new NeurodivergentOptions(
+            0L, 1.0f, false, 1.2f, -1, 0.5f);
+
+    /** Returns true if hyperfocus is active. */
+    public boolean hasHyperfocus() {
+        return hyperfocusMask != 0L;
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -18,7 +18,8 @@ import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Builder for recall query configuration.
@@ -115,6 +116,48 @@ public record RecallOptions(
     public static Builder builder() {
         return new Builder();
     }
+
+    // ══════════════════════════════════════════════════════════════
+    // Composed sub-record accessors — progressive migration API
+    // ══════════════════════════════════════════════════════════════
+
+    /** Returns filter parameters as a composed {@link FilterOptions}. */
+    public FilterOptions filter() {
+        return new FilterOptions(synapticTagMask, minImportance, memoryTypes, minValence, maxValence);
+    }
+
+    /** Returns scoring parameters as a composed {@link ScoringOptions}. */
+    public ScoringOptions scoring() {
+        return new ScoringOptions(alpha, beta, tagRelevanceBoost, semanticCandidateMultiplier,
+                strictnessCoefficient, queryValence, enableValenceAlignment, twoFactorConfig, scoringMode);
+    }
+
+    /** Returns text search parameters as a composed {@link TextSearchOptions}. */
+    public TextSearchOptions textSearch() {
+        return new TextSearchOptions(gamma, enableTextSearch, textSearchMode);
+    }
+
+    /** Returns neurodivergent parameters as a composed {@link NeurodivergentOptions}. */
+    public NeurodivergentOptions nd() {
+        return new NeurodivergentOptions(hyperfocusMask, hyperfocusBoost,
+                lateralMode, lateralDistanceThreshold, lateralMaxResults, lateralMinTagOverlap);
+    }
+
+    /** Returns graph expansion parameters as a composed {@link GraphOptions}. */
+    public GraphOptions graph() {
+        return new GraphOptions(entityHints, graphExpansionThreshold);
+    }
+
+    /** Returns temporal parameters as a composed {@link TemporalOptions}. */
+    public TemporalOptions temporal() {
+        return new TemporalOptions(minTimestamp, maxTimestamp, replayTimestamp, maxReplayEvents);
+    }
+
+    /** Returns reranker parameters as a composed {@link RerankerOptions}. */
+    public RerankerOptions reranker() {
+        return new RerankerOptions(enableReranker, rerankerDepth);
+    }
+
 
     /**
      * Builder for {@link RecallOptions}.
@@ -617,7 +660,7 @@ public record RecallOptions(
     // Validation — detect conflicting parameter combinations
     // ══════════════════════════════════════════════════════════════
 
-    private static final Logger VALIDATION_LOG = Logger.getLogger(RecallOptions.class.getName());
+    private static final Logger VALIDATION_LOG = LoggerFactory.getLogger(RecallOptions.class);
 
     /**
      * Validates this options instance for conflicting parameter combinations.
@@ -648,7 +691,7 @@ public record RecallOptions(
                     + " is contradictory — lateral finds distant matches, high strictness rejects them. "
                     + "Consider using one or the other.";
             warnings.add(msg);
-            VALIDATION_LOG.warning(msg);
+            VALIDATION_LOG.warn(msg);
         }
 
         // 2. hyperfocusMask + lateralMode are contradictory
@@ -656,7 +699,7 @@ public record RecallOptions(
             String msg = "hyperfocusMask is set + lateralMode=true — hyperfocus narrows attention "
                     + "to a specific topic, lateral mode broadens it. Consider using one or the other.";
             warnings.add(msg);
-            VALIDATION_LOG.warning(msg);
+            VALIDATION_LOG.warn(msg);
         }
 
         // 3. α + β should sum to ~1.0
@@ -665,7 +708,7 @@ public record RecallOptions(
             String msg = "alpha (" + alpha + ") + beta (" + beta + ") = " + sum
                     + " — scoring weights don't sum to 1.0. Scores may be unnormalized.";
             warnings.add(msg);
-            VALIDATION_LOG.warning(msg);
+            VALIDATION_LOG.warn(msg);
         }
 
         // 4. gamma out of useful range
@@ -673,7 +716,7 @@ public record RecallOptions(
             String msg = "gamma (" + gamma + ") is outside the useful range [0.0, 2.0]. "
                     + "BM25 scoring may produce unexpected results.";
             warnings.add(msg);
-            VALIDATION_LOG.warning(msg);
+            VALIDATION_LOG.warn(msg);
         }
 
         // 5. REPLAY mode requires replayTimestamp
@@ -681,7 +724,7 @@ public record RecallOptions(
             String msg = "recallMode=REPLAY requires replayTimestamp to be set. "
                     + "Use RecallOptions.builder().replayTimestamp(Instant.parse(...)).build()";
             warnings.add(msg);
-            VALIDATION_LOG.warning(msg);
+            VALIDATION_LOG.warn(msg);
         }
 
         return warnings;
@@ -701,7 +744,7 @@ public record RecallOptions(
         try {
             return CognitiveProfile.valueOf(profileName.strip().toUpperCase());
         } catch (IllegalArgumentException e) {
-            VALIDATION_LOG.warning("Unknown CognitiveProfile: '" + profileName
+            VALIDATION_LOG.warn("Unknown CognitiveProfile: '" + profileName
                     + "'. Available: " + java.util.Arrays.toString(CognitiveProfile.values()));
             return null;
         }

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RerankerOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RerankerOptions.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * ColBERT v2 reranker parameters for recall queries.
+ *
+ * @param enableReranker enable ColBERT token-level MaxSim reranking
+ * @param rerankerDepth  number of first-stage candidates to rerank (default: 50)
+ */
+public record RerankerOptions(
+        boolean enableReranker,
+        int rerankerDepth
+) {
+    /** Default: reranker disabled. */
+    public static final RerankerOptions DISABLED = new RerankerOptions(false, 50);
+
+    /** Enabled with default depth of 50. */
+    public static final RerankerOptions DEFAULT_ENABLED = new RerankerOptions(true, 50);
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ScoringOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ScoringOptions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import com.spectrayan.spector.memory.synapse.TwoFactorConfig;
+
+/**
+ * Scoring parameters for recall queries.
+ *
+ * <p>Controls how cognitive scores are computed — similarity weight, importance
+ * weight, tag relevance boost, strictness, valence alignment, two-factor memory,
+ * and scoring mode.</p>
+ *
+ * @param alpha                     similarity weight in fused score (default: 0.6)
+ * @param beta                      importance × decay weight (default: 0.4)
+ * @param tagRelevanceBoost         weighted tag overlap boost (default: 0.3)
+ * @param semanticCandidateMultiplier HNSW over-fetch multiplier (default: 3)
+ * @param strictnessCoefficient     similarity cliff steepness (default: 1.0)
+ * @param queryValence              emotional valence for state-dependent recall
+ * @param enableValenceAlignment    enable valence proximity scoring
+ * @param twoFactorConfig           Bjork & Bjork retrieval/storage strength config
+ * @param scoringMode               COGNITIVE or SIMILARITY scoring
+ */
+public record ScoringOptions(
+        float alpha,
+        float beta,
+        float tagRelevanceBoost,
+        int semanticCandidateMultiplier,
+        float strictnessCoefficient,
+        byte queryValence,
+        boolean enableValenceAlignment,
+        TwoFactorConfig twoFactorConfig,
+        ScoringMode scoringMode
+) {
+    /** Default balanced cognitive scoring. */
+    public static final ScoringOptions DEFAULT = new ScoringOptions(
+            0.6f, 0.4f, 0.3f, 3, 1.0f,
+            (byte) 0, false, TwoFactorConfig.DEFAULT, ScoringMode.COGNITIVE);
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TemporalOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TemporalOptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import java.time.Instant;
+
+/**
+ * Temporal gating and WAL replay parameters for recall queries.
+ *
+ * @param minTimestamp     minimum memory timestamp inclusive (null = no filter)
+ * @param maxTimestamp     maximum memory timestamp inclusive (null = no filter)
+ * @param replayTimestamp  WAL replay target timestamp (null = disabled)
+ * @param maxReplayEvents  maximum WAL events to replay (default: 100,000)
+ */
+public record TemporalOptions(
+        Long minTimestamp,
+        Long maxTimestamp,
+        Instant replayTimestamp,
+        int maxReplayEvents
+) {
+    /** Default: no temporal filtering, no replay. */
+    public static final TemporalOptions DEFAULT = new TemporalOptions(
+            null, null, null, 100_000);
+
+    /** Returns true if any temporal filter is active. */
+    public boolean hasTimeRange() {
+        return minTimestamp != null || maxTimestamp != null;
+    }
+
+    /** Returns true if WAL replay mode is configured. */
+    public boolean hasReplay() {
+        return replayTimestamp != null;
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TextSearchOptions.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TextSearchOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * Text search parameters for BM25/SPLADE hybrid recall.
+ *
+ * @param gamma           BM25 weight in fused score (default: 0.3)
+ * @param enableTextSearch enable BM25 parallel path (default: true)
+ * @param textSearchMode  search mode — HYBRID, BM25_ONLY, SPLADE_ONLY, etc.
+ */
+public record TextSearchOptions(
+        float gamma,
+        boolean enableTextSearch,
+        TextSearchMode textSearchMode
+) {
+    /** Default: hybrid text search enabled with 0.3 weight. */
+    public static final TextSearchOptions DEFAULT = new TextSearchOptions(
+            0.3f, true, TextSearchMode.HYBRID);
+
+    /** Text search disabled. */
+    public static final TextSearchOptions DISABLED = new TextSearchOptions(
+            0.0f, false, TextSearchMode.HYBRID);
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -132,6 +132,9 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     private final AtomicInteger lastIngestedMemoryIdx = new AtomicInteger(-1);
     private volatile int currentSessionId = 0;
 
+    // ── Post-ingest index synchronization stage ──
+    private final PostIngestSync postIngestSync;
+
     // ── Partition rolling callback (nullable) ──
     private volatile Runnable partitionRollCallback;
 
@@ -209,6 +212,11 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         this.spladeProvider = spladeProvider;
         this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
         this.salienceProfile = SalienceProfile.NEUTRAL;
+        this.postIngestSync = new PostIngestSync(
+                tierRouter, index, wal, semanticIndex,
+                hebbianGraph, temporalChain, entityExtractor, entityGraph,
+                bm25Index, textDataStore, activePartitionIndex,
+                spladeIndex, spladeProvider, this.encryptor);
     }
 
     /**
@@ -217,6 +225,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
      */
     public void updateTierRouter(TierRouter newRouter) {
         this.tierRouter = newRouter;
+        this.postIngestSync.updateTierRouter(newRouter);
     }
 
     /**
@@ -441,127 +450,22 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             }
         }
 
-        // Step 7b: Add to HNSW index for semantic recall.
-        // Memory owns its vectors in tier .mem files (dir-level partitioning).
-        // The HNSW index uses the tier's semantic record offset as the store index.
-        int storeIndex = -1;
-        if (type == MemoryType.SEMANTIC && semanticIndex != null
-                && !semanticIndex.isReadOnly()) {
-            storeIndex = tierRouter.countFor(MemoryType.SEMANTIC) - 1;
-            semanticIndex.add(id, storeIndex, vector);
-        }
+        // Steps 7b-9a: Index synchronization (HNSW, ID index, WAL, BM25, SPLADE)
+        var syncParams = new PostIngestSync.SyncParams(
+                id, text, vector, quantized, type, tags, source, offset);
+        int storeIndex = postIngestSync.syncIndexes(syncParams);
 
-        // Step 8: Register in ID index
-        index.register(id, new MemoryLocation(type, offset, storeIndex), text, source, tags);
-
-        // Step 9: WAL append (encrypt payload when encryption is active)
-        wal.appendRemember(id, encryptor.encryptPayload(quantized));
-
-        // Step 9a: Index text for BM25 hybrid search (encrypt text in text.dat)
-        if (textDataStore != null) {
-            try {
-                String textToStore = text;
-                if (encryptor.isEnabled()) {
-                    // Store encrypted text — BM25 indexes plaintext in-memory separately
-                    byte[] encBytes = encryptor.encryptText(text.getBytes(StandardCharsets.UTF_8));
-                    textToStore = java.util.Base64.getEncoder().encodeToString(encBytes);
-                }
-                textDataStore.write(id, type, textToStore);
-            } catch (RuntimeException e) {
-                log.warn("Failed to write text.dat entry for '{}': {}", id, e.getMessage());
-            }
-        }
-        if (bm25Index != null && activePartitionIndex >= 0) {
-            try {
-                bm25Index.index(activePartitionIndex, id, text);
-            } catch (RuntimeException e) {
-                log.warn("Failed to index '{}' in BM25: {}", id, e.getMessage());
-            }
-        }
-
-        // Step 9a-splade: SPLADE sparse index (if provider available)
-        if (spladeIndex != null && spladeProvider != null && activePartitionIndex >= 0) {
-            try {
-                SparseEncodingResult sparse = spladeProvider.encode(text);
-                spladeIndex.index(activePartitionIndex, id, sparse.weights());
-            } catch (RuntimeException e) {
-                log.warn("Failed SPLADE index for '{}': {}", id, e.getMessage());
-            }
-        }
-
-        // Step 9b + 9c: Hebbian + Temporal linking (co-ingestion within session)
-        // Capture previous memory index ONCE — shared by both subsystems.
-        // (Previously, step 9b set lastIngestedMemoryIdx to memoryIdx,
-        //  then step 9c re-read it and always saw memoryIdx → always -1 → no links.)
-        int memoryIdx = index.size() - 1; // approximate index of this memory
+        // Steps 9b + 9c: Hebbian + Temporal linking (co-ingestion within session)
+        int memoryIdx = index.size() - 1;
         if (hebbianGraph != null && hebbianGraph.isNewSession()) {
             currentSessionId++;
             lastIngestedMemoryIdx.set(-1);
         }
         int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);
-
-        // Step 9b: Hebbian edge strengthening
-        if (hebbianGraph != null && previousIdx >= 0 && previousIdx != memoryIdx) {
-            try {
-                hebbianGraph.strengthen(memoryIdx, previousIdx, 1.0f);
-            } catch (RuntimeException e) {
-                SpectorHebbianException ex = new SpectorHebbianException("edge strengthening", e);
-                log.warn(ex.getMessage());
-            }
-        }
-
-        // Step 9c: Temporal chain linking (session-local sequence)
-        if (temporalChain != null && previousIdx >= 0 && previousIdx != memoryIdx) {
-            try {
-                temporalChain.link(memoryIdx, previousIdx, currentSessionId);
-            } catch (RuntimeException e) {
-                SpectorTemporalChainException ex = new SpectorTemporalChainException("linking", e);
-                log.warn(ex.getMessage());
-            }
-        }
+        postIngestSync.syncGraphEdges(memoryIdx, previousIdx, currentSessionId);
 
         // Step 9d: Entity extraction and graph population
-        if (entityExtractor != null && entityGraph != null && entityExtractor.isAvailable()) {
-            try {
-                List<ExtractedEntity> entities = entityExtractor.extract(id, text);
-                int entitiesAdded = 0;
-                int relationsAdded = 0;
-                for (ExtractedEntity entity : entities) {
-                    int eid = entityGraph.addEntity(entity.name(), entity.typeName());
-                    if (eid >= 0) {
-                        entityGraph.linkEntityToMemory(eid, memoryIdx);
-                        entitiesAdded++;
-
-                        // Add relations
-                        for (EntityRelation rel : entity.relations()) {
-                            int targetEid = entityGraph.findEntity(rel.targetEntityName());
-                            if (targetEid < 0) {
-                                // Target not yet in graph — add it as OTHER
-                                targetEid = entityGraph.addEntity(
-                                        rel.targetEntityName(),
-                                        "OTHER");
-                            }
-                            if (targetEid >= 0) {
-                                entityGraph.addRelation(eid, targetEid, rel.relationTypeName());
-                                relationsAdded++;
-                            }
-                        }
-                    }
-                }
-                if (entitiesAdded > 0) {
-                    log.info("[Ingest] '{}' → {} entities, {} relations added to EntityGraph",
-                            id.length() > 60 ? "..." + id.substring(id.length() - 57) : id,
-                            entitiesAdded, relationsAdded);
-                }
-            } catch (RuntimeException e) {
-                SpectorEntityGraphException ex = new SpectorEntityGraphException("extraction", e);
-                log.warn(ex.getMessage());
-            }
-        } else if (entityGraph != null) {
-            log.debug("[Ingest] '{}' entity extraction skipped: extractor={}, available={}",
-                    id, entityExtractor != null ? entityExtractor.getClass().getSimpleName() : "null",
-                    entityExtractor != null && entityExtractor.isAvailable());
-        }
+        postIngestSync.syncEntityExtraction(id, text, memoryIdx);
 
         log.debug("Ingested '{}' as {} (importance={}, {} tags, hnswIdx={}, source={})",
                 id, type, importance, tags.length, storeIndex, source);
@@ -644,40 +548,10 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             }
         }
 
-        // Step 7b: Add to HNSW index (SEMANTIC only)
-        int storeIndex = -1;
-        if (type == MemoryType.SEMANTIC && semanticIndex != null
-                && !semanticIndex.isReadOnly()) {
-            storeIndex = tierRouter.countFor(MemoryType.SEMANTIC) - 1;
-            semanticIndex.add(id, storeIndex, vector);
-        }
-
-        // Step 8: Register in ID index
-        index.register(id, new MemoryLocation(type, offset, storeIndex), text, source, tags);
-
-        // Step 9: WAL append
-        wal.appendRemember(id, encryptor.encryptPayload(quantized));
-
-        // Step 9a: BM25 text index
-        if (textDataStore != null) {
-            try {
-                String textToStore = text;
-                if (encryptor.isEnabled()) {
-                    byte[] encBytes = encryptor.encryptText(text.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-                    textToStore = java.util.Base64.getEncoder().encodeToString(encBytes);
-                }
-                textDataStore.write(id, type, textToStore);
-            } catch (RuntimeException e) {
-                log.warn("Migration: failed text.dat for '{}': {}", id, e.getMessage());
-            }
-        }
-        if (bm25Index != null && activePartitionIndex >= 0) {
-            try {
-                bm25Index.index(activePartitionIndex, id, text);
-            } catch (RuntimeException e) {
-                log.warn("Migration: failed BM25 index for '{}': {}", id, e.getMessage());
-            }
-        }
+        // Steps 7b-9a: Index synchronization (HNSW, ID index, WAL, BM25, SPLADE)
+        var syncParams = new PostIngestSync.SyncParams(
+                id, text, vector, quantized, type, tags, source, offset);
+        postIngestSync.syncIndexes(syncParams);
 
         // Note: Hebbian, Temporal, Entity graph edges are NOT created here.
         // They are bulk-imported separately by MigrationService after all
@@ -820,158 +694,36 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             }
         }
 
-        // Step 7b: HNSW index
-        int storeIndex = -1;
-        if (type == MemoryType.SEMANTIC && semanticIndex != null
-                && !semanticIndex.isReadOnly()) {
-            storeIndex = tierRouter.countFor(MemoryType.SEMANTIC) - 1;
-            semanticIndex.add(id, storeIndex, vector);
-        }
-
-        // Step 8: Register in ID index (with metadata for multimodal memories)
+        // Steps 7b-9a: Index synchronization (HNSW, ID index, WAL, BM25, SPLADE)
         java.util.Map<String, String> metadata = context.hasMetadata() ? context.metadata() : null;
-        index.register(id, new MemoryLocation(type, offset, storeIndex), text, source, tags, metadata);
+        var syncParams = new PostIngestSync.SyncParams(
+                id, text, vector, quantized, type, tags, source, offset, metadata);
+        int storeIndex = postIngestSync.syncIndexes(syncParams);
 
-        // Step 9: WAL append (encrypt payload when encryption is active)
-        wal.appendRemember(id, encryptor.encryptPayload(quantized));
-
-        // Step 9a: BM25 text index (encrypt text in text.dat)
-        if (textDataStore != null) {
-            try {
-                String textToStore = text;
-                if (encryptor.isEnabled()) {
-                    byte[] encBytes = encryptor.encryptText(text.getBytes(StandardCharsets.UTF_8));
-                    textToStore = java.util.Base64.getEncoder().encodeToString(encBytes);
-                }
-                textDataStore.write(id, type, textToStore);
-            } catch (RuntimeException e) { log.warn("Failed to write text.dat for '{}': {}", id, e.getMessage()); }
-        }
-        if (bm25Index != null && activePartitionIndex >= 0) {
-            try { bm25Index.index(activePartitionIndex, id, text); }
-            catch (RuntimeException e) { log.warn("Failed BM25 index for '{}': {}", id, e.getMessage()); }
-        }
-
-        // Step 9a-splade: SPLADE sparse index (if provider available)
-        if (spladeIndex != null && spladeProvider != null && activePartitionIndex >= 0) {
-            try {
-                SparseEncodingResult sparse = spladeProvider.encode(text);
-                spladeIndex.index(activePartitionIndex, id, sparse.weights());
-            } catch (RuntimeException e) {
-                log.warn("Failed SPLADE index for '{}': {}", id, e.getMessage());
-            }
-        }
-
-        // Step 9b + 9c: Hebbian + Temporal linking (co-ingestion within session)
-        // Capture previous memory index ONCE — shared by both subsystems.
+        // Steps 9b + 9c: Hebbian + Temporal linking (co-ingestion within session)
         int memoryIdx = index.size() - 1;
         if (hebbianGraph != null && hebbianGraph.isNewSession()) {
             currentSessionId++;
             lastIngestedMemoryIdx.set(-1);
         }
         int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);
-
-        // Step 9b: Hebbian edge strengthening
-        if (hebbianGraph != null && previousIdx >= 0 && previousIdx != memoryIdx) {
-            try {
-                hebbianGraph.strengthen(memoryIdx, previousIdx, 1.0f);
-            } catch (RuntimeException e) {
-                log.warn(new SpectorHebbianException("edge strengthening", e).getMessage());
-            }
-        }
+        postIngestSync.syncGraphEdges(memoryIdx, previousIdx, currentSessionId);
 
         // Step 9b-ext: Pre-computed Hebbian edges from IngestionContext
-        if (context.hasHebbianEdges() && hebbianGraph != null) {
-            for (var edgeHint : context.hebbianEdges()) {
-                try {
-                    MemoryLocation targetLoc = index.locate(edgeHint.targetMemoryId());
-                    if (targetLoc != null) {
-                        int targetIdx = targetLoc.partitionIndex() >= 0
-                                ? targetLoc.partitionIndex()
-                                : (int) (targetLoc.offset() / 164);
-                        hebbianGraph.strengthen(memoryIdx, targetIdx, edgeHint.weight());
-                    }
-                } catch (RuntimeException e) {
-                    log.warn("Failed to apply Hebbian edge hint {} → {}: {}",
-                            id, edgeHint.targetMemoryId(), e.getMessage());
-                }
-            }
-        }
-
-        // Step 9c: Temporal chain linking (automatic session-based)
-        if (temporalChain != null && previousIdx >= 0 && previousIdx != memoryIdx) {
-            try {
-                temporalChain.link(memoryIdx, previousIdx, currentSessionId);
-            } catch (RuntimeException e) {
-                log.warn(new SpectorTemporalChainException("linking", e).getMessage());
-            }
+        if (context.hasHebbianEdges()) {
+            postIngestSync.syncHebbianEdgeHints(memoryIdx, id, context.hebbianEdges());
         }
 
         // Step 9c-ext: Pre-computed temporal links from IngestionContext
-        if (context.hasTemporalLinks() && temporalChain != null) {
-            for (var linkHint : context.temporalLinks()) {
-                try {
-                    MemoryLocation predLoc = index.locate(linkHint.predecessorMemoryId());
-                    if (predLoc != null) {
-                        int predIdx = predLoc.partitionIndex() >= 0
-                                ? predLoc.partitionIndex()
-                                : (int) (predLoc.offset() / 164);
-                        temporalChain.link(memoryIdx, predIdx, linkHint.sessionId());
-                    }
-                } catch (RuntimeException e) {
-                    log.warn("Failed to apply temporal link hint {} → {}: {}",
-                            id, linkHint.predecessorMemoryId(), e.getMessage());
-                }
-            }
+        if (context.hasTemporalLinks()) {
+            postIngestSync.syncTemporalLinkHints(memoryIdx, id, context.temporalLinks());
         }
 
         // Step 9d: Entity extraction and graph population
-        // Pre-extracted entities from IngestionContext take precedence over EntityExtractor
-        if (context.hasEntities() && entityGraph != null) {
-            try {
-                for (ExtractedEntity entity : context.entities()) {
-                    int eid = entityGraph.addEntity(entity.name(), entity.typeName());
-                    if (eid >= 0) {
-                        entityGraph.linkEntityToMemory(eid, memoryIdx);
-                        for (EntityRelation rel : entity.relations()) {
-                            int targetEid = entityGraph.findEntity(rel.targetEntityName());
-                            if (targetEid < 0) {
-                                targetEid = entityGraph.addEntity(
-                                        rel.targetEntityName(),
-                                        "OTHER");
-                            }
-                            if (targetEid >= 0) {
-                                entityGraph.addRelation(eid, targetEid, rel.relationTypeName());
-                            }
-                        }
-                    }
-                }
-            } catch (RuntimeException e) {
-                log.warn(new SpectorEntityGraphException("pre-extracted entity population", e).getMessage());
-            }
-        } else if (entityExtractor != null && entityGraph != null && entityExtractor.isAvailable()) {
-            // Fall back to EntityExtractor SPI
-            try {
-                List<ExtractedEntity> entities = entityExtractor.extract(id, text);
-                for (ExtractedEntity entity : entities) {
-                    int eid = entityGraph.addEntity(entity.name(), entity.typeName());
-                    if (eid >= 0) {
-                        entityGraph.linkEntityToMemory(eid, memoryIdx);
-                        for (EntityRelation rel : entity.relations()) {
-                            int targetEid = entityGraph.findEntity(rel.targetEntityName());
-                            if (targetEid < 0) {
-                                targetEid = entityGraph.addEntity(
-                                        rel.targetEntityName(),
-                                        "OTHER");
-                            }
-                            if (targetEid >= 0) {
-                                entityGraph.addRelation(eid, targetEid, rel.relationTypeName());
-                            }
-                        }
-                    }
-                }
-            } catch (RuntimeException e) {
-                log.warn(new SpectorEntityGraphException("extraction", e).getMessage());
-            }
+        if (context.hasEntities()) {
+            postIngestSync.syncPreExtractedEntities(context.entities(), memoryIdx, id);
+        } else {
+            postIngestSync.syncEntityExtraction(id, text, memoryIdx);
         }
 
         log.debug("Ingested '{}' as {} with IngestionContext (importance={}, {} tags, entities={}, hebbianEdges={}, temporalLinks={})",

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline;
+
+
+import com.spectrayan.spector.memory.error.SpectorEntityGraphException;
+import com.spectrayan.spector.memory.error.SpectorHebbianException;
+import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import com.spectrayan.spector.memory.hebbian.HebbianGraph;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.ScoringMode;
+import com.spectrayan.spector.memory.model.SourceModality;
+import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.TierRouter;
+import com.spectrayan.spector.memory.cortex.TierStore;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.temporal.TemporalChain;
+import com.spectrayan.spector.core.similarity.SimilarityFunction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pipeline stage: Graph expansion (Steps 5c-5e).
+ *
+ * <p>Expands recall results by following three cognitive graph layers:</p>
+ * <ul>
+ *   <li><b>Hebbian</b> (5c): Spreading activation across memory-to-memory associations</li>
+ *   <li><b>Temporal</b> (5d): Follow session-linked sequences forward/backward</li>
+ *   <li><b>Entity</b> (5e): Multi-hop knowledge graph traversal via extracted entities</li>
+ * </ul>
+ *
+ * <p>All graph-expanded candidates are similarity-grounded using co-fusion:
+ * actual L2 distance to the query vector is computed for each neighbor,
+ * preventing fabricated scores.</p>
+ *
+ * <p>Cross-layer deduplication ensures each memory appears at most once,
+ * keeping the highest score across all three layers.</p>
+ *
+ * @see RecallPipeline
+ * @see GraphScoringPolicy
+ */
+final class GraphExpansionStage {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphExpansionStage.class);
+
+    // ── Dependencies (all nullable — graceful degradation) ──
+    private final HebbianGraph hebbianGraph;
+    private final TemporalChain temporalChain;
+    private final EntityGraph entityGraph;
+    private final EntityExtractor entityExtractor;
+    private final GraphScoringPolicy graphScoringPolicy;
+    private final MemoryIndex index;
+    private final TierRouter tierRouter;
+    private final float[] calibrationMins;
+    private final float[] calibrationScales;
+
+    GraphExpansionStage(HebbianGraph hebbianGraph,
+                        TemporalChain temporalChain,
+                        EntityGraph entityGraph,
+                        EntityExtractor entityExtractor,
+                        GraphScoringPolicy graphScoringPolicy,
+                        MemoryIndex index,
+                        TierRouter tierRouter,
+                        float[] calibrationMins,
+                        float[] calibrationScales) {
+        this.hebbianGraph = hebbianGraph;
+        this.temporalChain = temporalChain;
+        this.entityGraph = entityGraph;
+        this.entityExtractor = entityExtractor;
+        this.graphScoringPolicy = graphScoringPolicy != null ? graphScoringPolicy : GraphScoringPolicy.DEFAULT;
+        this.index = index;
+        this.tierRouter = tierRouter;
+        this.calibrationMins = calibrationMins;
+        this.calibrationScales = calibrationScales;
+    }
+
+    /**
+     * Returns true if any graph subsystem is available for expansion.
+     */
+    boolean hasGraphSubsystems() {
+        return hebbianGraph != null || temporalChain != null || entityGraph != null;
+    }
+
+    /**
+     * Expands results by following Hebbian, temporal, and entity graph edges.
+     *
+     * <p>Modifies {@code allResults} in-place by appending deduplicated
+     * graph-expanded candidates. Skipped entirely when cognitive scoring
+     * is disabled or direct similarity exceeds the expansion threshold.</p>
+     *
+     * @param allResults   mutable result list (modified in-place)
+     * @param queryVector  the embedded query vector
+     * @param options      recall options (for expansion threshold, entity hints)
+     */
+    void expand(List<CognitiveResult> allResults, float[] queryVector, RecallOptions options) {
+        boolean cognitiveScoring = options.scoringMode() != ScoringMode.SIMILARITY;
+        boolean hasSubsystems = hebbianGraph != null || temporalChain != null
+                || (entityGraph != null && (entityExtractor != null && entityExtractor.isAvailable()
+                        || !options.entityHints().isEmpty()));
+
+        if (!cognitiveScoring || !hasSubsystems || allResults.isEmpty()) {
+            return;
+        }
+
+        // ── Similarity-gated expansion ──
+        float maxDirectSimilarity = 0f;
+        for (CognitiveResult r : allResults) {
+            if (r.hasBreakdown()) {
+                maxDirectSimilarity = Math.max(maxDirectSimilarity, r.breakdown().similarity());
+            }
+        }
+        float expansionThreshold = options.graphExpansionThreshold();
+        if (maxDirectSimilarity >= expansionThreshold) {
+            log.debug("Graph expansion skipped: maxDirectSimilarity={} >= threshold={}",
+                    maxDirectSimilarity, expansionThreshold);
+            return;
+        }
+
+        // Build existingIds ONCE for all three layers
+        Set<String> existingIds = new HashSet<>(allResults.size());
+        for (CognitiveResult r : allResults) {
+            if (r.id() != null) existingIds.add(r.id());
+        }
+
+        // Cross-layer dedup: track best score per graph-expanded candidate
+        Map<String, CognitiveResult> graphCandidates = new HashMap<>();
+
+
+        // Step 5c: Hebbian spreading activation
+        if (hebbianGraph != null) {
+            expandHebbian(allResults, existingIds, graphCandidates, queryVector);
+        }
+
+        // Step 5d: Temporal chain extension
+        if (temporalChain != null) {
+            expandTemporal(allResults, existingIds, graphCandidates, queryVector);
+        }
+
+        // Step 5e: Entity graph traversal
+        if (entityGraph != null) {
+            expandEntity(allResults, existingIds, graphCandidates, queryVector, options);
+        }
+
+        // Add deduplicated graph candidates to results
+        if (!graphCandidates.isEmpty()) {
+            allResults.addAll(graphCandidates.values());
+            for (String id : graphCandidates.keySet()) {
+                existingIds.add(id);
+            }
+            log.debug("Graph expansion added {} candidates (from {} layers)",
+                    graphCandidates.size(),
+                    (hebbianGraph != null ? 1 : 0) + (temporalChain != null ? 1 : 0) + (entityGraph != null ? 1 : 0));
+        }
+
+    }
+
+    // ─────────────── Private helpers ───────────────
+
+    private void expandHebbian(List<CognitiveResult> allResults,
+                                 Set<String> existingIds,
+                                 Map<String, CognitiveResult> graphCandidates,
+                                 float[] queryVector) {
+        try {
+            int seeds = Math.min(3, allResults.size());
+            for (int s = 0; s < seeds; s++) {
+                CognitiveResult seed = allResults.get(s);
+                MemoryIndex.MemoryLocation loc = index.locate(seed.id());
+                if (loc == null) continue;
+
+                int memIdx = offsetToRecordIndex(loc);
+                var activated = hebbianGraph.activateNeighbors(memIdx, graphScoringPolicy.hebbianMaxDepth());
+                for (var edge : activated) {
+                    String neighborId = findMemoryByApproximateIndex(edge.neighborIndex());
+                    if (neighborId != null && !existingIds.contains(neighborId)) {
+                        float neighborSim = computeNeighborSimilarity(neighborId, queryVector);
+                        float saturatedWeight = Math.min(edge.weight() / 5.0f, 1.0f);
+                        float graphScore = neighborSim
+                                + seed.score() * saturatedWeight * graphScoringPolicy.hebbianBoostFactor();
+
+                        CognitiveResult candidate = buildGraphCandidate(
+                                neighborId, graphScore, seed, MemoryType.SEMANTIC);
+                        graphCandidates.merge(neighborId, candidate,
+                                (a, b) -> a.score() >= b.score() ? a : b);
+                    }
+                }
+            }
+        } catch (RuntimeException e) {
+            SpectorHebbianException ex = new SpectorHebbianException("spreading activation", e);
+            log.debug(ex.getMessage());
+        }
+    }
+
+    /**
+     * Temporal chain extension — follow session-linked sequences.
+     */
+    private void expandTemporal(List<CognitiveResult> allResults,
+                                 Set<String> existingIds,
+                                 Map<String, CognitiveResult> graphCandidates,
+                                 float[] queryVector) {
+        try {
+            int seeds = Math.min(3, allResults.size());
+            for (int s = 0; s < seeds; s++) {
+                CognitiveResult seed = allResults.get(s);
+                MemoryIndex.MemoryLocation loc = index.locate(seed.id());
+                if (loc == null) continue;
+
+                int memIdx = offsetToRecordIndex(loc);
+                for (int chainIdx : temporalChain.followForward(memIdx, graphScoringPolicy.temporalMaxHops())) {
+                    addChainResultCoFusion(chainIdx, seed, existingIds, graphCandidates,
+                            queryVector, graphScoringPolicy.temporalForwardFactor());
+                }
+                for (int chainIdx : temporalChain.followBackward(memIdx, graphScoringPolicy.temporalMaxHops())) {
+                    addChainResultCoFusion(chainIdx, seed, existingIds, graphCandidates,
+                            queryVector, graphScoringPolicy.temporalBackwardFactor());
+                }
+            }
+        } catch (RuntimeException e) {
+            SpectorTemporalChainException ex = new SpectorTemporalChainException("chain extension", e);
+            log.debug(ex.getMessage());
+        }
+    }
+
+    /**
+     * Entity graph traversal — multi-hop knowledge discovery.
+     */
+    private void expandEntity(List<CognitiveResult> allResults,
+                               Set<String> existingIds,
+                               Map<String, CognitiveResult> graphCandidates,
+                               float[] queryVector, RecallOptions options) {
+        List<ExtractedEntity> queryEntities = null;
+
+        // Priority 1: Pre-extracted entity hints from RecallOptions
+        if (!options.entityHints().isEmpty()) {
+            queryEntities = options.entityHints();
+        }
+        // Priority 2: Live EntityExtractor SPI
+        else if (entityExtractor != null && entityExtractor.isAvailable()) {
+            try {
+                // We don't have the query text here — extract from first result
+                // This is a compromise vs. passing queryText through the stage
+                queryEntities = entityExtractor.extract("query", allResults.getFirst().text());
+            } catch (RuntimeException e) {
+                SpectorEntityGraphException ex = new SpectorEntityGraphException("entity extraction", e);
+                log.debug(ex.getMessage());
+            }
+        }
+
+        if (queryEntities == null || queryEntities.isEmpty()) return;
+
+        try {
+            for (var entity : queryEntities) {
+                int entityId = entityGraph.findEntity(entity.name());
+                if (entityId < 0) continue;
+
+                Set<Integer> reachableMemories = entityGraph.collectMemories(
+                        entityId, null, graphScoringPolicy.entityMaxHops());
+                for (int memIdx : reachableMemories) {
+                    String memId = findMemoryByApproximateIndex(memIdx);
+                    if (memId != null && !existingIds.contains(memId)) {
+                        float neighborSim = computeNeighborSimilarity(memId, queryVector);
+                        float fanAttenuation = entityGraph.fanFactor(entityId);
+                        float entityScore = neighborSim
+                                + allResults.getFirst().score()
+                                  * graphScoringPolicy.entityHopAttenuation()
+                                  * fanAttenuation;
+
+                        CognitiveResult candidate = buildGraphCandidate(
+                                memId, entityScore, null, MemoryType.SEMANTIC);
+                        graphCandidates.merge(memId, candidate,
+                                (a, b) -> a.score() >= b.score() ? a : b);
+                    }
+                }
+            }
+        } catch (RuntimeException e) {
+            SpectorEntityGraphException ex = new SpectorEntityGraphException("graph traversal", e);
+            log.debug(ex.getMessage());
+        }
+    }
+
+    /**
+     * Adds a temporal chain result using co-fusion scoring.
+     */
+    private void addChainResultCoFusion(int chainIdx, CognitiveResult seed,
+                                         Set<String> existingIds,
+                                         Map<String, CognitiveResult> graphCandidates,
+                                         float[] queryVector, float attenuation) {
+        String chainId = findMemoryByApproximateIndex(chainIdx);
+        if (chainId != null && !existingIds.contains(chainId)) {
+            float neighborSim = computeNeighborSimilarity(chainId, queryVector);
+            float chainScore = neighborSim + seed.score() * attenuation * 0.2f;
+
+            CognitiveResult candidate = buildGraphCandidate(chainId, chainScore, seed, seed.memoryType());
+            graphCandidates.merge(chainId, candidate,
+                    (a, b) -> a.score() >= b.score() ? a : b);
+        }
+    }
+
+    /**
+     * Builds a CognitiveResult for a graph-expanded candidate using index metadata.
+     */
+    private CognitiveResult buildGraphCandidate(String memId, float score,
+                                                 CognitiveResult seed, MemoryType type) {
+        String text = index.text(memId);
+        MemorySource source = index.source(memId);
+        String[] tags = index.tags(memId);
+        java.util.Map<String, String> meta = index.metadata(memId);
+        SourceModality modality = meta != null
+                ? SourceModality.fromName(meta.get(SourceModality.METADATA_KEY))
+                : SourceModality.TEXT;
+
+        float importance = seed != null ? seed.importance() : 0.5f;
+        return new CognitiveResult(
+                memId, text, score, importance, 0f,
+                (short) 0, (byte) 0, type, source,
+                tags, 1.0f, 1.0f, RetrievalMode.STANDARD, null, null,
+                modality, meta);
+    }
+
+    /**
+     * Converts a MemoryLocation's byte offset to a record index.
+     */
+    int offsetToRecordIndex(MemoryIndex.MemoryLocation loc) {
+        int stride = tierRouter.layoutFor(loc.type()).stride();
+        TierStore store = tierRouter.get(loc.type());
+        long dataOffset = (store instanceof AbstractTierStore ats && ats.isPersistent())
+                ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
+        return (int) ((loc.offset() - dataOffset) / stride);
+    }
+
+    /**
+     * Finds a memory ID by approximate index across all tiers.
+     */
+    String findMemoryByApproximateIndex(int approxIdx) {
+        for (MemoryType type : MemoryType.values()) {
+            var layout = tierRouter.layoutFor(type);
+            if (layout == null) continue;
+            TierStore store = tierRouter.get(type);
+            long dataOffset = (store instanceof AbstractTierStore ats && ats.isPersistent())
+                    ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
+            long offset = dataOffset + (long) approxIdx * layout.stride();
+            String id = index.findIdByOffset(type, offset);
+            if (id != null) return id;
+        }
+        return null;
+    }
+
+    /**
+     * Computes actual cosine-derived similarity for a graph-expanded neighbor.
+     */
+    float computeNeighborSimilarity(String memoryId, float[] queryVector) {
+        try {
+            MemoryIndex.MemoryLocation loc = index.locate(memoryId);
+            if (loc == null) return 0f;
+
+            MemorySegment seg = tierRouter.segmentFor(loc.type());
+            if (seg == null) return 0f;
+
+            CognitiveRecordLayout layout = tierRouter.layoutFor(loc.type());
+            float l2dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
+                    queryVector, seg, layout.vectorOffset(loc.offset()),
+                    calibrationMins, calibrationScales, layout.quantizedVecBytes());
+            return 1.0f / (1.0f + l2dist);
+        } catch (RuntimeException e) {
+            log.trace("Failed to compute neighbor similarity for '{}': {}", memoryId, e.getMessage());
+            return 0f;
+        }
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline;
+
+import com.spectrayan.spector.embed.SparseEncodingProvider;
+import com.spectrayan.spector.embed.SparseEncodingResult;
+import com.spectrayan.spector.index.VectorIndex;
+import com.spectrayan.spector.memory.DataEncryptor;
+import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
+import com.spectrayan.spector.memory.cortex.MemorySpladeIndex;
+import com.spectrayan.spector.memory.cortex.TextDataStore;
+import com.spectrayan.spector.memory.cortex.TierRouter;
+import com.spectrayan.spector.memory.error.SpectorEntityGraphException;
+import com.spectrayan.spector.memory.error.SpectorHebbianException;
+import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityRelation;
+import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import com.spectrayan.spector.memory.hebbian.HebbianGraph;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+import com.spectrayan.spector.memory.temporal.TemporalChain;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Post-ingest index synchronization stage — handles steps 7b through 9d
+ * of the cognitive ingestion pipeline.
+ *
+ * <h3>Responsibilities</h3>
+ * <ul>
+ *   <li>Step 7b: HNSW index addition (SEMANTIC type only)</li>
+ *   <li>Step 8: ID index registration</li>
+ *   <li>Step 9: WAL append</li>
+ *   <li>Step 9a: BM25 text index + text.dat persistence</li>
+ *   <li>Step 9a-splade: SPLADE sparse index</li>
+ *   <li>Step 9b: Hebbian edge strengthening (co-ingestion within session)</li>
+ *   <li>Step 9c: Temporal chain linking (session-local sequence)</li>
+ *   <li>Step 9d: Entity extraction and graph population</li>
+ * </ul>
+ *
+ * <p>Extracted from {@link CognitiveIngestionTarget} to eliminate code duplication
+ * across the three ingestion entry points (standard, migration, context-aware).</p>
+ *
+ * <h3>Thread Safety</h3>
+ * <p>Stateless except for the subsystem references (all thread-safe).
+ * The session tracking ({@code lastIngestedMemoryIdx}, {@code currentSessionId})
+ * remains in {@link CognitiveIngestionTarget} since it is cross-invocation state.</p>
+ */
+final class PostIngestSync {
+
+    private static final Logger log = LoggerFactory.getLogger(PostIngestSync.class);
+
+    // ── Subsystem references (all nullable except index, wal) ──
+    private volatile TierRouter tierRouter;
+    private final MemoryIndex index;
+    private final MemoryWal wal;
+    private final VectorIndex semanticIndex;
+    private final HebbianGraph hebbianGraph;
+    private final TemporalChain temporalChain;
+    private final EntityExtractor entityExtractor;
+    private final EntityGraph entityGraph;
+    private final MemoryBM25Index bm25Index;
+    private final TextDataStore textDataStore;
+    private final int activePartitionIndex;
+    private final MemorySpladeIndex spladeIndex;
+    private final SparseEncodingProvider spladeProvider;
+    private final DataEncryptor encryptor;
+
+    PostIngestSync(TierRouter tierRouter, MemoryIndex index, MemoryWal wal,
+                   VectorIndex semanticIndex,
+                   HebbianGraph hebbianGraph, TemporalChain temporalChain,
+                   EntityExtractor entityExtractor, EntityGraph entityGraph,
+                   MemoryBM25Index bm25Index, TextDataStore textDataStore,
+                   int activePartitionIndex,
+                   MemorySpladeIndex spladeIndex, SparseEncodingProvider spladeProvider,
+                   DataEncryptor encryptor) {
+        this.tierRouter = tierRouter;
+        this.index = index;
+        this.wal = wal;
+        this.semanticIndex = semanticIndex;
+        this.hebbianGraph = hebbianGraph;
+        this.temporalChain = temporalChain;
+        this.entityExtractor = entityExtractor;
+        this.entityGraph = entityGraph;
+        this.bm25Index = bm25Index;
+        this.textDataStore = textDataStore;
+        this.activePartitionIndex = activePartitionIndex;
+        this.spladeIndex = spladeIndex;
+        this.spladeProvider = spladeProvider;
+        this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
+    }
+
+    /** Called when the tier router is swapped after a partition roll. */
+    void updateTierRouter(TierRouter newRouter) {
+        this.tierRouter = newRouter;
+    }
+
+    /**
+     * Parameters for post-ingest synchronization.
+     */
+    record SyncParams(
+            String id,
+            String text,
+            float[] vector,
+            byte[] quantized,
+            MemoryType type,
+            String[] tags,
+            MemorySource source,
+            long offset,
+            Map<String, String> metadata
+    ) {
+        SyncParams(String id, String text, float[] vector, byte[] quantized,
+                   MemoryType type, String[] tags, MemorySource source, long offset) {
+            this(id, text, vector, quantized, type, tags, source, offset, null);
+        }
+    }
+
+    /**
+     * Executes post-ingest synchronization (Steps 7b-9a).
+     *
+     * @param params sync parameters
+     * @return the HNSW store index (-1 if not indexed)
+     */
+    int syncIndexes(SyncParams params) {
+        // Step 7b: Add to HNSW index (SEMANTIC only)
+        int storeIndex = -1;
+        if (params.type() == MemoryType.SEMANTIC && semanticIndex != null
+                && !semanticIndex.isReadOnly()) {
+            storeIndex = tierRouter.countFor(MemoryType.SEMANTIC) - 1;
+            semanticIndex.add(params.id(), storeIndex, params.vector());
+        }
+
+        // Step 8: Register in ID index
+        if (params.metadata() != null) {
+            index.register(params.id(), new MemoryLocation(params.type(), params.offset(), storeIndex),
+                    params.text(), params.source(), params.tags(), params.metadata());
+        } else {
+            index.register(params.id(), new MemoryLocation(params.type(), params.offset(), storeIndex),
+                    params.text(), params.source(), params.tags());
+        }
+
+        // Step 9: WAL append (encrypt payload when encryption is active)
+        wal.appendRemember(params.id(), encryptor.encryptPayload(params.quantized()));
+
+        // Step 9a: Index text for BM25 hybrid search (encrypt text in text.dat)
+        syncTextIndex(params.id(), params.text(), params.type());
+
+        // Step 9a-splade: SPLADE sparse index (if provider available)
+        syncSpladeIndex(params.id(), params.text());
+
+        return storeIndex;
+    }
+
+    /**
+     * Strengthens Hebbian edges and links temporal chains for co-ingestion.
+     *
+     * @param memoryIdx   the index of the current memory
+     * @param previousIdx the index of the previously ingested memory (-1 if none)
+     * @param sessionId   the current session ID
+     */
+    void syncGraphEdges(int memoryIdx, int previousIdx, int sessionId) {
+        // Step 9b: Hebbian edge strengthening
+        if (hebbianGraph != null && previousIdx >= 0 && previousIdx != memoryIdx) {
+            try {
+                hebbianGraph.strengthen(memoryIdx, previousIdx, 1.0f);
+            } catch (RuntimeException e) {
+                SpectorHebbianException ex = new SpectorHebbianException("edge strengthening", e);
+                log.warn(ex.getMessage());
+            }
+        }
+
+        // Step 9c: Temporal chain linking (session-local sequence)
+        if (temporalChain != null && previousIdx >= 0 && previousIdx != memoryIdx) {
+            try {
+                temporalChain.link(memoryIdx, previousIdx, sessionId);
+            } catch (RuntimeException e) {
+                SpectorTemporalChainException ex = new SpectorTemporalChainException("linking", e);
+                log.warn(ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Extracts entities from text and populates the entity graph (Step 9d).
+     *
+     * @param id        memory ID
+     * @param text      memory content
+     * @param memoryIdx memory index for entity→memory linking
+     */
+    void syncEntityExtraction(String id, String text, int memoryIdx) {
+        if (entityExtractor != null && entityGraph != null && entityExtractor.isAvailable()) {
+            try {
+                List<ExtractedEntity> entities = entityExtractor.extract(id, text);
+                populateEntities(entities, memoryIdx, id);
+            } catch (RuntimeException e) {
+                SpectorEntityGraphException ex = new SpectorEntityGraphException("extraction", e);
+                log.warn(ex.getMessage());
+            }
+        } else if (entityGraph != null) {
+            log.debug("[Ingest] '{}' entity extraction skipped: extractor={}, available={}",
+                    id, entityExtractor != null ? entityExtractor.getClass().getSimpleName() : "null",
+                    entityExtractor != null && entityExtractor.isAvailable());
+        }
+    }
+
+    /**
+     * Populates the entity graph with pre-extracted entities (Step 9d override).
+     *
+     * @param entities  pre-extracted entities
+     * @param memoryIdx memory index for entity→memory linking
+     * @param id        memory ID (for logging)
+     */
+    void syncPreExtractedEntities(List<ExtractedEntity> entities, int memoryIdx, String id) {
+        if (entityGraph == null) return;
+        try {
+            populateEntities(entities, memoryIdx, id);
+        } catch (RuntimeException e) {
+            log.warn(new SpectorEntityGraphException("pre-extracted entity population", e).getMessage());
+        }
+    }
+
+    /**
+     * Applies pre-computed Hebbian edge hints from IngestionContext.
+     */
+    void syncHebbianEdgeHints(int memoryIdx, String id,
+                              List<com.spectrayan.spector.memory.model.IngestionContext.HebbianEdgeHint> edges) {
+        if (hebbianGraph == null) return;
+        for (var edgeHint : edges) {
+            try {
+                MemoryLocation targetLoc = index.locate(edgeHint.targetMemoryId());
+                if (targetLoc != null) {
+                    int targetIdx = targetLoc.partitionIndex() >= 0
+                            ? targetLoc.partitionIndex()
+                            : (int) (targetLoc.offset() / 164);
+                    hebbianGraph.strengthen(memoryIdx, targetIdx, edgeHint.weight());
+                }
+            } catch (RuntimeException e) {
+                log.warn("Failed to apply Hebbian edge hint {} → {}: {}",
+                        id, edgeHint.targetMemoryId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Applies pre-computed temporal link hints from IngestionContext.
+     */
+    void syncTemporalLinkHints(int memoryIdx, String id,
+                               List<com.spectrayan.spector.memory.model.IngestionContext.TemporalLinkHint> links) {
+        if (temporalChain == null) return;
+        for (var linkHint : links) {
+            try {
+                MemoryLocation predLoc = index.locate(linkHint.predecessorMemoryId());
+                if (predLoc != null) {
+                    int predIdx = predLoc.partitionIndex() >= 0
+                            ? predLoc.partitionIndex()
+                            : (int) (predLoc.offset() / 164);
+                    temporalChain.link(memoryIdx, predIdx, linkHint.sessionId());
+                }
+            } catch (RuntimeException e) {
+                log.warn("Failed to apply temporal link hint {} → {}: {}",
+                        id, linkHint.predecessorMemoryId(), e.getMessage());
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // PRIVATE HELPERS
+    // ══════════════════════════════════════════════════════════════
+
+    private void syncTextIndex(String id, String text, MemoryType type) {
+        if (textDataStore != null) {
+            try {
+                String textToStore = text;
+                if (encryptor.isEnabled()) {
+                    byte[] encBytes = encryptor.encryptText(text.getBytes(StandardCharsets.UTF_8));
+                    textToStore = java.util.Base64.getEncoder().encodeToString(encBytes);
+                }
+                textDataStore.write(id, type, textToStore);
+            } catch (RuntimeException e) {
+                log.warn("Failed to write text.dat entry for '{}': {}", id, e.getMessage());
+            }
+        }
+        if (bm25Index != null && activePartitionIndex >= 0) {
+            try {
+                bm25Index.index(activePartitionIndex, id, text);
+            } catch (RuntimeException e) {
+                log.warn("Failed to index '{}' in BM25: {}", id, e.getMessage());
+            }
+        }
+    }
+
+    private void syncSpladeIndex(String id, String text) {
+        if (spladeIndex != null && spladeProvider != null && activePartitionIndex >= 0) {
+            try {
+                SparseEncodingResult sparse = spladeProvider.encode(text);
+                spladeIndex.index(activePartitionIndex, id, sparse.weights());
+            } catch (RuntimeException e) {
+                log.warn("Failed SPLADE index for '{}': {}", id, e.getMessage());
+            }
+        }
+    }
+
+    private void populateEntities(List<ExtractedEntity> entities, int memoryIdx, String id) {
+        int entitiesAdded = 0;
+        int relationsAdded = 0;
+        for (ExtractedEntity entity : entities) {
+            int eid = entityGraph.addEntity(entity.name(), entity.typeName());
+            if (eid >= 0) {
+                entityGraph.linkEntityToMemory(eid, memoryIdx);
+                entitiesAdded++;
+                for (EntityRelation rel : entity.relations()) {
+                    int targetEid = entityGraph.findEntity(rel.targetEntityName());
+                    if (targetEid < 0) {
+                        targetEid = entityGraph.addEntity(rel.targetEntityName(), "OTHER");
+                    }
+                    if (targetEid >= 0) {
+                        entityGraph.addRelation(eid, targetEid, rel.relationTypeName());
+                        relationsAdded++;
+                    }
+                }
+            }
+        }
+        if (entitiesAdded > 0) {
+            log.info("[Ingest] '{}' → {} entities, {} relations added to EntityGraph",
+                    id.length() > 60 ? "..." + id.substring(id.length() - 57) : id,
+                    entitiesAdded, relationsAdded);
+        }
+    }
+}

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -138,6 +138,9 @@ final class PostIngestSync {
     /**
      * Executes post-ingest synchronization (Steps 7b-9a).
      *
+     * <p>Write order is deliberate: text.dat is written FIRST so the byte position
+     * can be captured and stored in MemoryLocation for off-heap random access.</p>
+     *
      * @param params sync parameters
      * @return the HNSW store index (-1 if not indexed)
      */
@@ -150,20 +153,25 @@ final class PostIngestSync {
             semanticIndex.add(params.id(), storeIndex, params.vector());
         }
 
-        // Step 8: Register in ID index
+        // Step 9a (moved earlier): Write text.dat FIRST to capture byte position
+        var textPos = syncTextIndex(params.id(), params.text(), params.type());
+
+        // Step 8: Register in ID index (with text.dat byte offsets for off-heap reads)
+        long textOffset = (textPos != null) ? textPos.textOffset() : -1L;
+        int textLength = (textPos != null) ? textPos.textLength() : -1;
+        var location = new MemoryLocation(params.type(), params.offset(), storeIndex,
+                textOffset, textLength);
+
         if (params.metadata() != null) {
-            index.register(params.id(), new MemoryLocation(params.type(), params.offset(), storeIndex),
+            index.register(params.id(), location,
                     params.text(), params.source(), params.tags(), params.metadata());
         } else {
-            index.register(params.id(), new MemoryLocation(params.type(), params.offset(), storeIndex),
+            index.register(params.id(), location,
                     params.text(), params.source(), params.tags());
         }
 
         // Step 9: WAL append (encrypt payload when encryption is active)
         wal.appendRemember(params.id(), encryptor.encryptPayload(params.quantized()));
-
-        // Step 9a: Index text for BM25 hybrid search (encrypt text in text.dat)
-        syncTextIndex(params.id(), params.text(), params.type());
 
         // Step 9a-splade: SPLADE sparse index (if provider available)
         syncSpladeIndex(params.id(), params.text());
@@ -287,7 +295,9 @@ final class PostIngestSync {
     // PRIVATE HELPERS
     // ══════════════════════════════════════════════════════════════
 
-    private void syncTextIndex(String id, String text, MemoryType type) {
+    private com.spectrayan.spector.memory.cortex.TextDataStore.TextPosition syncTextIndex(
+            String id, String text, MemoryType type) {
+        com.spectrayan.spector.memory.cortex.TextDataStore.TextPosition pos = null;
         if (textDataStore != null) {
             try {
                 String textToStore = text;
@@ -295,7 +305,7 @@ final class PostIngestSync {
                     byte[] encBytes = encryptor.encryptText(text.getBytes(StandardCharsets.UTF_8));
                     textToStore = java.util.Base64.getEncoder().encodeToString(encBytes);
                 }
-                textDataStore.write(id, type, textToStore);
+                pos = textDataStore.write(id, type, textToStore);
             } catch (RuntimeException e) {
                 log.warn("Failed to write text.dat entry for '{}': {}", id, e.getMessage());
             }
@@ -307,6 +317,7 @@ final class PostIngestSync {
                 log.warn("Failed to index '{}' in BM25: {}", id, e.getMessage());
             }
         }
+        return pos;
     }
 
     private void syncSpladeIndex(String id, String text) {

--- a/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -14,12 +14,9 @@ package com.spectrayan.spector.memory.pipeline;
 
 import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.commons.error.ErrorCode;
-import com.spectrayan.spector.events.GraphPulseTelemetry;
-import com.spectrayan.spector.events.TelemetryScope;
 
-import com.spectrayan.spector.memory.error.SpectorEntityGraphException;
-import com.spectrayan.spector.memory.error.SpectorHebbianException;
-import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
+
+
 import com.spectrayan.spector.memory.model.RecallTrace;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
@@ -141,6 +138,7 @@ public final class RecallPipeline {
     private final SemanticRecallStrategy semanticRecallStrategy; // nullable
     private final CoActivationTracker coActivationTracker; // nullable — for STDP causal boost
     private final GraphScoringPolicy graphScoringPolicy;
+    private final GraphExpansionStage graphExpansionStage;
 
     private final List<RecallListener> listeners = new ArrayList<>();
 
@@ -171,21 +169,14 @@ public final class RecallPipeline {
     private static final int RETRIEVAL_MODE_CACHE_MAX = 2000;
     private RecallOptions lastRecallOptions; // for detecting hyperfocus mode
 
-    // ── Semantic Satiation: Anti-looping LRU cache ──
-    // Bounded LRU of last N result IDs. Any result that appears in this
+    // ── Semantic Satiation: Anti-looping cache ──
+    // Bounded cache of last N result IDs. Any result that appears in this
     // hot cache gets a 0.5× penalty, breaking exact-query loops.
-    // Wrapped with Collections.synchronizedMap() because accessOrder=true
-    // mutates the internal linked list on every get(), making unsynchronized
-    // concurrent access unsafe (carrier pinning risk with virtual threads).
+    // Uses ConcurrentHashMap to avoid virtual thread pinning (ADR-005).
+    // Size-bounded via eviction on put — acceptable for a 10-entry cache.
     private static final int SATIATION_CACHE_SIZE = 10;
     private static final float SATIATION_PENALTY = 0.5f;
-    private final Map<String, Long> satiationCache =
-            Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
-                    return size() > SATIATION_CACHE_SIZE;
-                }
-            });
+    private final ConcurrentHashMap<String, Long> satiationCache = new ConcurrentHashMap<>(16);
 
     /**
      * Creates a recall pipeline with all required subsystems.
@@ -296,6 +287,12 @@ public final class RecallPipeline {
         this.spladeIndex = spladeIndex;
         this.spladeProvider = spladeProvider;
         this.colbertReranker = colbertReranker;
+
+        // ── Delegate graph expansion to focused stage class ──
+        this.graphExpansionStage = new GraphExpansionStage(
+                hebbianGraph, temporalChain, entityGraph, entityExtractor,
+                this.graphScoringPolicy, index, tierRouter,
+                calibrationMins, calibrationScales);
     }
 
     /**
@@ -482,217 +479,8 @@ public final class RecallPipeline {
         }
         } // end cognitiveScoring
 
-        // Build existingIds ONCE for graph expansion steps 5c/5d/5e
-        // (previously rebuilt 3 times — eliminated 2 redundant full-list scans)
-        boolean hasGraphSubsystems = hebbianGraph != null || temporalChain != null
-                || (entityGraph != null && (entityExtractor != null && entityExtractor.isAvailable()
-                        || !options.entityHints().isEmpty()));
-        boolean needsGraphExpansion = cognitiveScoring && hasGraphSubsystems && !allResults.isEmpty();
-
-        // ── Similarity-gated expansion ──
-        // When the best direct result already has high similarity, graph expansion
-        // adds noise that dilutes precision. Skip expansion when direct matches are strong.
-        float maxDirectSimilarity = 0f;
-        if (needsGraphExpansion) {
-            for (CognitiveResult r : allResults) {
-                if (r.hasBreakdown()) {
-                    maxDirectSimilarity = Math.max(maxDirectSimilarity, r.breakdown().similarity());
-                }
-            }
-            float expansionThreshold = options.graphExpansionThreshold();
-            if (maxDirectSimilarity >= expansionThreshold) {
-                log.debug("Graph expansion skipped: maxDirectSimilarity={} >= threshold={}",
-                        maxDirectSimilarity, expansionThreshold);
-                needsGraphExpansion = false;
-            }
-        }
-
-        Set<String> existingIds = needsGraphExpansion ? new HashSet<>(allResults.size()) : null;
-        if (existingIds != null) {
-            for (CognitiveResult r : allResults) {
-                if (r.id() != null) existingIds.add(r.id());
-            }
-        }
-
-        // Cross-layer dedup: track best score per graph-expanded candidate
-        // across Hebbian (5c), Temporal (5d), and Entity (5e) layers.
-        Map<String, CognitiveResult> graphCandidates = needsGraphExpansion ? new HashMap<>() : null;
-
-        // ── Graph telemetry tracking ──
-        // NOTE: Manual nanoTime is intentional here. This times a *sub-phase* of recall
-        // (graph expansion only). The overall recall() is already timed by MeteredSpectorMemory's
-        // Micrometer Timer. We can't add a Micrometer timer here because spector-memory does
-        // not depend on Micrometer — that coupling lives in the spector-metrics decorator layer.
-        long graphStartNanos = needsGraphExpansion && TelemetryScope.isActive() ? System.nanoTime() : 0;
-        int graphNodesVisited = 0;
-        int graphEdgesTraversed = 0;
-        int graphMaxDepth = 0;
-
-        // Step 5c: Hebbian spreading activation — follow memory-to-memory associations
-        // Co-fusion: compute actual L2 distance for each neighbor so scores are
-        // similarity-grounded instead of fabricated.
-        if (hebbianGraph != null && existingIds != null) {
-            try {
-                // Use top 3 results as seeds for spreading activation
-                int seeds = Math.min(3, allResults.size());
-                for (int s = 0; s < seeds; s++) {
-                    CognitiveResult seed = allResults.get(s);
-                    // Find the memory index for this result
-                    MemoryIndex.MemoryLocation loc = index.locate(seed.id());
-                    if (loc == null) continue;
-
-                    int memIdx = offsetToRecordIndex(loc);
-                    var activated = hebbianGraph.activateNeighbors(memIdx, graphScoringPolicy.hebbianMaxDepth());
-                    graphEdgesTraversed += activated.size();
-                    graphMaxDepth = Math.max(graphMaxDepth, graphScoringPolicy.hebbianMaxDepth());
-                    for (var edge : activated) {
-                        graphNodesVisited++;
-                        // Find the memory at this graph index
-                        String neighborId = findMemoryByApproximateIndex(edge.neighborIndex());
-                        if (neighborId != null && !existingIds.contains(neighborId)) {
-                            // Co-fusion: compute actual similarity against query vector
-                            float neighborSim = computeNeighborSimilarity(neighborId, queryVector);
-                            // Saturate edge weight to prevent single co-occurrences from over-boosting
-                            float saturatedWeight = Math.min(edge.weight() / 5.0f, 1.0f);
-                            float graphScore = neighborSim
-                                    + seed.score() * saturatedWeight * graphScoringPolicy.hebbianBoostFactor();
-
-                            String text = index.text(neighborId);
-                            MemorySource source = index.source(neighborId);
-                            String[] tags = index.tags(neighborId);
-                            java.util.Map<String, String> nMeta = index.metadata(neighborId);
-                            SourceModality nModality = nMeta != null
-                                    ? SourceModality.fromName(nMeta.get(SourceModality.METADATA_KEY))
-                                    : SourceModality.TEXT;
-                            CognitiveResult candidate = new CognitiveResult(
-                                    neighborId, text, graphScore, seed.importance(), 0f,
-                                    (short) 0, (byte) 0, seed.memoryType(), source,
-                                    tags, 1.0f, 1.0f, RetrievalMode.STANDARD, null, null,
-                                    nModality, nMeta);
-                            // Cross-layer dedup: keep best score
-                            graphCandidates.merge(neighborId, candidate,
-                                    (a, b) -> a.score() >= b.score() ? a : b);
-                        }
-                    }
-                }
-            } catch (RuntimeException e) {
-                SpectorHebbianException ex = new SpectorHebbianException("spreading activation", e);
-                log.debug(ex.getMessage());
-            }
-        }
-
-        // Step 5d: Temporal chain extension — follow session-linked sequences
-        // Co-fusion: compute actual similarity for chain-linked neighbors.
-        if (temporalChain != null && existingIds != null) {
-            try {
-                int seeds = Math.min(3, allResults.size());
-                for (int s = 0; s < seeds; s++) {
-                    CognitiveResult seed = allResults.get(s);
-                    MemoryIndex.MemoryLocation loc = index.locate(seed.id());
-                    if (loc == null) continue;
-
-                    int memIdx = offsetToRecordIndex(loc);
-                    // Follow forward and backward
-                    for (int chainIdx : temporalChain.followForward(memIdx, graphScoringPolicy.temporalMaxHops())) {
-                        addChainResultCoFusion(chainIdx, seed, existingIds, graphCandidates,
-                                queryVector, graphScoringPolicy.temporalForwardFactor());
-                    }
-                    for (int chainIdx : temporalChain.followBackward(memIdx, graphScoringPolicy.temporalMaxHops())) {
-                        addChainResultCoFusion(chainIdx, seed, existingIds, graphCandidates,
-                                queryVector, graphScoringPolicy.temporalBackwardFactor());
-                    }
-                }
-            } catch (RuntimeException e) {
-                SpectorTemporalChainException ex = new SpectorTemporalChainException("chain extension", e);
-                log.debug(ex.getMessage());
-            }
-        }
-
-        // Step 5e: Entity graph traversal — multi-hop knowledge discovery
-        // Co-fusion: compute actual similarity for entity-linked memories.
-        // Pre-extracted entityHints from RecallOptions take precedence over EntityExtractor
-        if (entityGraph != null && existingIds != null) {
-            List<ExtractedEntity> queryEntities = null;
-
-            // Priority 1: Pre-extracted entity hints from RecallOptions
-            if (!options.entityHints().isEmpty()) {
-                queryEntities = options.entityHints();
-            }
-            // Priority 2: Live EntityExtractor SPI
-            else if (entityExtractor != null && entityExtractor.isAvailable()) {
-                try {
-                    queryEntities = entityExtractor.extract("query", queryText);
-                } catch (RuntimeException e) {
-                    SpectorEntityGraphException ex = new SpectorEntityGraphException("entity extraction", e);
-                    log.debug(ex.getMessage());
-                }
-            }
-
-            if (queryEntities != null && !queryEntities.isEmpty()) {
-                try {
-                    for (var entity : queryEntities) {
-                        int entityId = entityGraph.findEntity(entity.name());
-                        if (entityId < 0) continue;
-
-                        // Collect memories reachable within N hops
-                        Set<Integer> reachableMemories = entityGraph.collectMemories(
-                                entityId, null, graphScoringPolicy.entityMaxHops());
-                        for (int memIdx : reachableMemories) {
-                            String memId = findMemoryByApproximateIndex(memIdx);
-                            if (memId != null && !existingIds.contains(memId)) {
-                                // Co-fusion: compute actual similarity
-                                float neighborSim = computeNeighborSimilarity(memId, queryVector);
-                                // Fan-effect attenuation (ACT-R spreading activation dilution):
-                                // entities linked to many memories produce weaker per-link boosts
-                                float fanAttenuation = entityGraph.fanFactor(entityId);
-                                float entityScore = neighborSim
-                                        + allResults.getFirst().score()
-                                          * graphScoringPolicy.entityHopAttenuation()
-                                          * fanAttenuation;
-
-                                String text = index.text(memId);
-                                MemorySource source = index.source(memId);
-                                String[] tags = index.tags(memId);
-                                java.util.Map<String, String> eMeta = index.metadata(memId);
-                                SourceModality eModality = eMeta != null
-                                        ? SourceModality.fromName(eMeta.get(SourceModality.METADATA_KEY))
-                                        : SourceModality.TEXT;
-                                CognitiveResult candidate = new CognitiveResult(
-                                        memId, text, entityScore, 0.5f, 0f,
-                                        (short) 0, (byte) 0, MemoryType.SEMANTIC, source,
-                                        tags, 1.0f, 1.0f, RetrievalMode.STANDARD, null, null,
-                                        eModality, eMeta);
-                                // Cross-layer dedup: keep best score
-                                graphCandidates.merge(memId, candidate,
-                                        (a, b) -> a.score() >= b.score() ? a : b);
-                            }
-                        }
-                    }
-                } catch (RuntimeException e) {
-                    SpectorEntityGraphException ex = new SpectorEntityGraphException("graph traversal", e);
-                    log.debug(ex.getMessage());
-                }
-            }
-        }
-
-        // Add deduplicated graph candidates to results
-        if (graphCandidates != null && !graphCandidates.isEmpty()) {
-            allResults.addAll(graphCandidates.values());
-            // Mark their IDs as existing (for any downstream processing)
-            for (String id : graphCandidates.keySet()) {
-                existingIds.add(id);
-            }
-            log.debug("Graph expansion added {} candidates (from {} layers)",
-                    graphCandidates.size(), 
-                    (hebbianGraph != null ? 1 : 0) + (temporalChain != null ? 1 : 0) + (entityGraph != null ? 1 : 0));
-        }
-
-        // ── Report graph telemetry (if enabled) ──
-        if (graphStartNanos > 0) {
-            long graphElapsed = System.nanoTime() - graphStartNanos;
-            TelemetryScope.publish(new GraphPulseTelemetry(
-                    graphNodesVisited, graphEdgesTraversed, graphMaxDepth, graphElapsed));
-        }
+        // Steps 5c-5e: Graph expansion (delegated to GraphExpansionStage)
+        graphExpansionStage.expand(allResults, queryVector, options);
 
         // Step 6: Sort by score descending, limit to topK
         allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
@@ -793,11 +581,27 @@ public final class RecallPipeline {
                 }
             }
 
-            // Step 8b: Update semantic satiation LRU cache
+            // Step 8b: Update semantic satiation cache (bounded via eviction — ADR-005)
             long nowForSatiation = System.currentTimeMillis();
             for (CognitiveResult r : allResults) {
                 if (r.id() != null) {
                     satiationCache.put(r.id(), nowForSatiation);
+                }
+            }
+            // Evict oldest entries when cache exceeds bound
+            while (satiationCache.size() > SATIATION_CACHE_SIZE) {
+                String oldest = null;
+                long oldestTs = Long.MAX_VALUE;
+                for (var e : satiationCache.entrySet()) {
+                    if (e.getValue() < oldestTs) {
+                        oldestTs = e.getValue();
+                        oldest = e.getKey();
+                    }
+                }
+                if (oldest != null) {
+                    satiationCache.remove(oldest, oldestTs);
+                } else {
+                    break;
                 }
             }
         } else {
@@ -1254,108 +1058,7 @@ public final class RecallPipeline {
         return recentRetrievalModes.get(memoryId);
     }
 
-    // ── Graph helper methods ──
 
-    /**
-     * Converts a MemoryLocation's byte offset to a record index.
-     *
-     * <p>Accounts for the metadata header on persistent tier stores.
-     * Replaces the previous hardcoded divisor (164) which was fragile
-     * if vector dimensions (and thus stride) ever changed.</p>
-     */
-    private int offsetToRecordIndex(MemoryIndex.MemoryLocation loc) {
-        int stride = tierRouter.layoutFor(loc.type()).stride();
-        TierStore store = tierRouter.get(loc.type());
-        long dataOffset = (store instanceof AbstractTierStore ats && ats.isPersistent())
-                ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
-        return (int) ((loc.offset() - dataOffset) / stride);
-    }
-
-    /**
-     * Finds a memory ID by approximate index. Uses the reverse index
-     * to search across all tiers.
-     */
-    private String findMemoryByApproximateIndex(int approxIdx) {
-        // Try each tier's typical record size to reverse-map
-        for (MemoryType type : MemoryType.values()) {
-            var layout = tierRouter.layoutFor(type);
-            if (layout == null) continue;
-            TierStore store = tierRouter.get(type);
-            long dataOffset = (store instanceof AbstractTierStore ats && ats.isPersistent())
-                    ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
-            long offset = dataOffset + (long) approxIdx * layout.stride();
-            String id = index.findIdByOffset(type, offset);
-            if (id != null) return id;
-        }
-        return null;
-    }
-
-    /**
-     * Adds a temporal chain result using co-fusion scoring (actual similarity + seed boost).
-     *
-     * <p>Replaces the old addChainResult that used fabricated scores.
-     * Computes actual L2 distance to the query vector so chain-expanded
-     * results have similarity-grounded scores.</p>
-     */
-    private void addChainResultCoFusion(int chainIdx, CognitiveResult seed,
-                                         Set<String> existingIds,
-                                         Map<String, CognitiveResult> graphCandidates,
-                                         float[] queryVector, float attenuation) {
-        String chainId = findMemoryByApproximateIndex(chainIdx);
-        if (chainId != null && !existingIds.contains(chainId)) {
-            // Co-fusion: compute actual similarity against query vector
-            float neighborSim = computeNeighborSimilarity(chainId, queryVector);
-            float chainScore = neighborSim + seed.score() * attenuation * 0.2f;
-
-            String text = index.text(chainId);
-            MemorySource source = index.source(chainId);
-            String[] tags = index.tags(chainId);
-            java.util.Map<String, String> cMeta = index.metadata(chainId);
-            SourceModality cModality = cMeta != null
-                    ? SourceModality.fromName(cMeta.get(SourceModality.METADATA_KEY))
-                    : SourceModality.TEXT;
-            CognitiveResult candidate = new CognitiveResult(
-                    chainId, text, chainScore, seed.importance(), 0f,
-                    (short) 0, (byte) 0, seed.memoryType(), source,
-                    tags, 1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
-                    cModality, cMeta);
-            // Cross-layer dedup: keep best score
-            graphCandidates.merge(chainId, candidate,
-                    (a, b) -> a.score() >= b.score() ? a : b);
-        }
-    }
-
-    /**
-     * Computes actual cosine-derived similarity for a graph-expanded neighbor
-     * against the query vector.
-     *
-     * <p>This grounds graph-expanded scores in real similarity instead of
-     * fabricating them from the seed's score alone. Cost: ~200 cycles per
-     * candidate (one L2 distance computation). With typical graph expansion
-     * producing 50-200 candidates, total overhead is ~10-40μs — negligible.</p>
-     *
-     * @param memoryId    the memory ID to compute similarity for
-     * @param queryVector the query embedding vector
-     * @return similarity score in [0.0, 1.0] (higher = more similar), or 0.0 on error
-     */
-    private float computeNeighborSimilarity(String memoryId, float[] queryVector) {
-        try {
-            MemoryIndex.MemoryLocation loc = index.locate(memoryId);
-            if (loc == null) return 0f;
-
-            MemorySegment seg = tierRouter.segmentFor(loc.type());
-            if (seg == null) return 0f;
-
-            CognitiveRecordLayout layout = tierRouter.layoutFor(loc.type());
-            float l2dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
-                    queryVector, seg, layout.vectorOffset(loc.offset()),
-                    calibrationMins, calibrationScales, layout.quantizedVecBytes());
-            return 1.0f / (1.0f + l2dist);
-        } catch (RuntimeException e) {
-            log.trace("Failed to compute neighbor similarity for '{}': {}", memoryId, e.getMessage());
-            return 0f;
-        }
-    }
 
     // ══════════════════════════════════════════════════════════════
     // WAL REPLAY — Point-in-Time Recall

--- a/spector-node/src/main/java/com/spectrayan/spector/cluster/HeartbeatMembershipService.java
+++ b/spector-node/src/main/java/com/spectrayan/spector/cluster/HeartbeatMembershipService.java
@@ -104,7 +104,7 @@ public class HeartbeatMembershipService implements MembershipService {
     private final List<MembershipChangeListener> listeners;
 
     /** Lock for membership change operations. */
-    private final Object membershipLock = new Object();
+    private final java.util.concurrent.locks.ReentrantLock membershipLock = new java.util.concurrent.locks.ReentrantLock();
 
     /**
      * Creates a HeartbeatMembershipService with default configuration.
@@ -211,7 +211,8 @@ public class HeartbeatMembershipService implements MembershipService {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "Node ID");
         }
 
-        synchronized (membershipLock) {
+        membershipLock.lock();
+        try {
             NodeInfo info = nodes.get(nodeId);
             if (info == null) {
                 throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "nodeId", nodeId);
@@ -230,6 +231,8 @@ public class HeartbeatMembershipService implements MembershipService {
             // Trigger rebalancing asynchronously (within 5 seconds)
             triggerRebalanceAsync();
             notifyListeners(nodeId, NodeStatus.UNAVAILABLE);
+        } finally {
+            membershipLock.unlock();
         }
     }
 
@@ -331,7 +334,8 @@ public class HeartbeatMembershipService implements MembershipService {
         Instant now = Instant.now();
         boolean wasUnavailable = info.status() == NodeStatus.UNAVAILABLE;
 
-        synchronized (membershipLock) {
+        membershipLock.lock();
+        try {
             NodeInfo updated = new NodeInfo(info.nodeId(), info.endpoint(), NodeStatus.ACTIVE, now);
             nodes.put(nodeId, updated);
 
@@ -340,6 +344,8 @@ public class HeartbeatMembershipService implements MembershipService {
                 triggerRebalanceAsync();
                 notifyListeners(nodeId, NodeStatus.ACTIVE);
             }
+        } finally {
+            membershipLock.unlock();
         }
     }
 
@@ -388,7 +394,8 @@ public class HeartbeatMembershipService implements MembershipService {
      * Performs the actual node registration (may throw to simulate communication failures).
      */
     private void doRegisterNode(String nodeId, String endpoint) {
-        synchronized (membershipLock) {
+        membershipLock.lock();
+        try {
             NodeInfo existing = nodes.get(nodeId);
             Instant now = Instant.now();
 
@@ -406,6 +413,8 @@ public class HeartbeatMembershipService implements MembershipService {
             // Trigger rebalancing within 5 seconds of registration
             triggerRebalanceAsync();
             notifyListeners(nodeId, NodeStatus.ACTIVE);
+        } finally {
+            membershipLock.unlock();
         }
     }
 
@@ -422,7 +431,8 @@ public class HeartbeatMembershipService implements MembershipService {
             NodeInfo info = entry.getValue();
 
             if (info.status() == NodeStatus.ACTIVE && info.lastHeartbeat().isBefore(threshold)) {
-                synchronized (membershipLock) {
+                membershipLock.lock();
+                try {
                     // Double-check under lock
                     NodeInfo current = nodes.get(nodeId);
                     if (current != null && current.status() == NodeStatus.ACTIVE
@@ -436,6 +446,8 @@ public class HeartbeatMembershipService implements MembershipService {
                         triggerRebalanceAsync();
                         notifyListeners(nodeId, NodeStatus.UNAVAILABLE);
                     }
+                } finally {
+                    membershipLock.unlock();
                 }
             }
         }

--- a/spector-node/src/main/java/com/spectrayan/spector/cluster/NamespaceAffinityRouter.java
+++ b/spector-node/src/main/java/com/spectrayan/spector/cluster/NamespaceAffinityRouter.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cluster;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Namespace-level affinity router for multi-pod deployments.
+ *
+ * <h3>Purpose</h3>
+ * <p>Deterministically maps {@code tenantId:namespaceId} compound keys to
+ * a specific pod ordinal using a consistent hash ring. This ensures that
+ * all requests for a given user/namespace are always routed to the same
+ * pod — the <em>owner</em> — eliminating the need for distributed locks
+ * on per-user memory-mapped files.</p>
+ *
+ * <h3>Consistent Hashing</h3>
+ * <p>Uses the same MD5-based hashing as {@link ConsistentHashShardManager}
+ * to place virtual nodes on a {@link ConcurrentSkipListMap} ring. Each
+ * pod ordinal (0..N-1) gets {@code virtualNodesPerPod} positions on the
+ * ring, ensuring balanced distribution even with small pod counts.</p>
+ *
+ * <h3>Topology Changes</h3>
+ * <p>When pods scale up or down, {@link #resize(int)} rebuilds the ring.
+ * Consistent hashing guarantees that only ~1/N of namespaces change
+ * ownership on resize, minimizing rebalancing overhead.</p>
+ *
+ * <h3>Thread Safety</h3>
+ * <p>All ring lookups use a {@link ReentrantReadWriteLock}. Reads
+ * ({@link #ownerOf}) acquire the read lock; mutations ({@link #resize})
+ * acquire the write lock. Safe for concurrent use from virtual threads.</p>
+ *
+ * @see ConsistentHashShardManager for document-level sharding
+ */
+public final class NamespaceAffinityRouter {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceAffinityRouter.class);
+
+    /** Default number of virtual nodes per physical pod on the hash ring. */
+    public static final int DEFAULT_VIRTUAL_NODES_PER_POD = 150;
+
+    /** Maximum supported pod count. */
+    public static final int MAX_POD_COUNT = 256;
+
+    private final int virtualNodesPerPod;
+
+    /** The consistent hash ring: hash position → pod ordinal. */
+    private final ConcurrentSkipListMap<Long, Integer> ring;
+
+    /** Read-write lock protecting ring reads and mutations. */
+    private final ReentrantReadWriteLock ringLock;
+
+    /** Current number of pods in the ring. */
+    private final AtomicInteger podCount;
+
+    /** This pod's ordinal (0-based). */
+    private final int myOrdinal;
+
+    /**
+     * Creates a namespace affinity router for a specific pod.
+     *
+     * @param myOrdinal the ordinal of this pod (0-based, from StatefulSet)
+     * @param podCount  the total number of leader pods in the cell
+     * @throws SpectorValidationException if myOrdinal is negative or podCount is invalid
+     */
+    public NamespaceAffinityRouter(int myOrdinal, int podCount) {
+        this(myOrdinal, podCount, DEFAULT_VIRTUAL_NODES_PER_POD);
+    }
+
+    /**
+     * Creates a namespace affinity router with custom virtual node count.
+     *
+     * @param myOrdinal          the ordinal of this pod (0-based)
+     * @param podCount           the total number of leader pods
+     * @param virtualNodesPerPod number of virtual nodes per pod on the ring
+     * @throws SpectorValidationException if parameters are invalid
+     */
+    public NamespaceAffinityRouter(int myOrdinal, int podCount, int virtualNodesPerPod) {
+        if (myOrdinal < 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_OUT_OF_RANGE,
+                    "myOrdinal", 0, MAX_POD_COUNT - 1, myOrdinal);
+        }
+        if (podCount < 1 || podCount > MAX_POD_COUNT) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_OUT_OF_RANGE,
+                    "podCount", 1, MAX_POD_COUNT, podCount);
+        }
+        if (myOrdinal >= podCount) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                    "myOrdinal (" + myOrdinal + ") must be < podCount (" + podCount + ")");
+        }
+        if (virtualNodesPerPod < 1) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_OUT_OF_RANGE,
+                    "virtualNodesPerPod", 1, Integer.MAX_VALUE, virtualNodesPerPod);
+        }
+
+        this.myOrdinal = myOrdinal;
+        this.virtualNodesPerPod = virtualNodesPerPod;
+        this.ring = new ConcurrentSkipListMap<>();
+        this.ringLock = new ReentrantReadWriteLock();
+        this.podCount = new AtomicInteger(podCount);
+
+        buildRing(podCount);
+
+        log.info("[AffinityRouter] Initialized: myOrdinal={}, podCount={}, virtualNodes={}",
+                myOrdinal, podCount, virtualNodesPerPod);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Core Routing
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Computes the owner pod ordinal for a namespace.
+     *
+     * <p>The compound key {@code tenantId:namespaceId} is hashed and
+     * mapped to the nearest virtual node on the consistent hash ring.
+     * The associated pod ordinal is the namespace's owner.</p>
+     *
+     * @param tenantId    the tenant identifier
+     * @param namespaceId the namespace identifier (typically userId)
+     * @return the pod ordinal (0-based) that owns this namespace
+     * @throws SpectorValidationException if tenantId or namespaceId is blank
+     */
+    public int ownerOf(String tenantId, String namespaceId) {
+        Objects.requireNonNull(tenantId, "tenantId must not be null");
+        Objects.requireNonNull(namespaceId, "namespaceId must not be null");
+
+        String compoundKey = tenantId + ":" + namespaceId;
+        long hash = ConsistentHashShardManager.hash(compoundKey);
+
+        ringLock.readLock().lock();
+        try {
+            Map.Entry<Long, Integer> entry = ring.ceilingEntry(hash);
+            if (entry == null) {
+                // Wrap around to first entry in the ring
+                entry = ring.firstEntry();
+            }
+            return entry.getValue();
+        } finally {
+            ringLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Checks whether this pod is the owner of the given namespace.
+     *
+     * <p>Equivalent to {@code ownerOf(tenantId, namespaceId) == myOrdinal}
+     * but expressed as a convenience for the common routing check in
+     * Armeria filters.</p>
+     *
+     * @param tenantId    the tenant identifier
+     * @param namespaceId the namespace identifier
+     * @return true if this pod owns the namespace
+     */
+    public boolean isLocal(String tenantId, String namespaceId) {
+        return ownerOf(tenantId, namespaceId) == myOrdinal;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Topology Management
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Rebuilds the hash ring for a new pod count.
+     *
+     * <p>Called when the StatefulSet scales up or down. Consistent hashing
+     * guarantees that only ~1/N of namespaces change ownership, where N
+     * is the new pod count.</p>
+     *
+     * @param newPodCount the new total number of leader pods
+     * @throws SpectorValidationException if newPodCount is invalid
+     */
+    public void resize(int newPodCount) {
+        if (newPodCount < 1 || newPodCount > MAX_POD_COUNT) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_OUT_OF_RANGE,
+                    "newPodCount", 1, MAX_POD_COUNT, newPodCount);
+        }
+
+        int oldCount = podCount.get();
+        if (newPodCount == oldCount) {
+            log.debug("[AffinityRouter] resize({}) — no change", newPodCount);
+            return;
+        }
+
+        ringLock.writeLock().lock();
+        try {
+            ring.clear();
+            buildRingUnsafe(newPodCount);
+            podCount.set(newPodCount);
+            log.info("[AffinityRouter] Resized ring: {} → {} pods ({} virtual nodes total)",
+                    oldCount, newPodCount, ring.size());
+        } finally {
+            ringLock.writeLock().unlock();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Observability
+    // ═══════════════════════════════════════════════════════════════
+
+    /** Returns this pod's ordinal. */
+    public int myOrdinal() {
+        return myOrdinal;
+    }
+
+    /** Returns the current pod count. */
+    public int podCount() {
+        return podCount.get();
+    }
+
+    /** Returns the number of virtual nodes on the ring. */
+    public int ringSize() {
+        return ring.size();
+    }
+
+    /**
+     * Returns the distribution of virtual nodes across pod ordinals.
+     *
+     * <p>Useful for verifying balanced distribution. Each entry maps
+     * a pod ordinal to the fraction of the ring it owns.</p>
+     *
+     * @return unmodifiable map of pod ordinal → ownership fraction
+     */
+    public Map<Integer, Double> distribution() {
+        ringLock.readLock().lock();
+        try {
+            int total = ring.size();
+            if (total == 0) {
+                return Collections.emptyMap();
+            }
+
+            var counts = new java.util.HashMap<Integer, Integer>();
+            for (int ordinal : ring.values()) {
+                counts.merge(ordinal, 1, Integer::sum);
+            }
+
+            var result = new java.util.HashMap<Integer, Double>();
+            for (var entry : counts.entrySet()) {
+                result.put(entry.getKey(), (double) entry.getValue() / total);
+            }
+            return Collections.unmodifiableMap(result);
+        } finally {
+            ringLock.readLock().unlock();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Private Helpers
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Builds the hash ring (acquires write lock internally).
+     */
+    private void buildRing(int count) {
+        ringLock.writeLock().lock();
+        try {
+            buildRingUnsafe(count);
+        } finally {
+            ringLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Builds the hash ring (caller must hold write lock).
+     */
+    private void buildRingUnsafe(int count) {
+        for (int ordinal = 0; ordinal < count; ordinal++) {
+            for (int vnode = 0; vnode < virtualNodesPerPod; vnode++) {
+                long hash = ConsistentHashShardManager.hash(
+                        "pod-" + ordinal + "-ns-vnode-" + vnode);
+                ring.put(hash, ordinal);
+            }
+        }
+    }
+}

--- a/spector-node/src/test/java/com/spectrayan/spector/cluster/NamespaceAffinityRouterTest.java
+++ b/spector-node/src/test/java/com/spectrayan/spector/cluster/NamespaceAffinityRouterTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cluster;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link NamespaceAffinityRouter}.
+ */
+class NamespaceAffinityRouterTest {
+
+    @Nested
+    @DisplayName("Construction")
+    class ConstructionTests {
+
+        @Test
+        @DisplayName("valid parameters create router successfully")
+        void validConstruction() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            assertEquals(0, router.myOrdinal());
+            assertEquals(3, router.podCount());
+            assertTrue(router.ringSize() > 0);
+        }
+
+        @Test
+        @DisplayName("rejects negative ordinal")
+        void rejectsNegativeOrdinal() {
+            assertThrows(SpectorValidationException.class,
+                    () -> new NamespaceAffinityRouter(-1, 3));
+        }
+
+        @Test
+        @DisplayName("rejects ordinal >= podCount")
+        void rejectsOrdinalExceedingPodCount() {
+            assertThrows(SpectorValidationException.class,
+                    () -> new NamespaceAffinityRouter(3, 3));
+        }
+
+        @Test
+        @DisplayName("rejects zero podCount")
+        void rejectsZeroPodCount() {
+            assertThrows(SpectorValidationException.class,
+                    () -> new NamespaceAffinityRouter(0, 0));
+        }
+
+        @Test
+        @DisplayName("rejects podCount exceeding max")
+        void rejectsExcessivePodCount() {
+            assertThrows(SpectorValidationException.class,
+                    () -> new NamespaceAffinityRouter(0, 257));
+        }
+
+        @Test
+        @DisplayName("single pod deployment is valid")
+        void singlePodValid() {
+            var router = new NamespaceAffinityRouter(0, 1);
+            assertEquals(0, router.ownerOf("tenant", "user"));
+            assertTrue(router.isLocal("tenant", "user"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Routing Determinism")
+    class RoutingTests {
+
+        @Test
+        @DisplayName("same namespace always maps to same pod")
+        void deterministic() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            int first = router.ownerOf("acme-corp", "user-alice");
+            for (int i = 0; i < 100; i++) {
+                assertEquals(first, router.ownerOf("acme-corp", "user-alice"),
+                        "Routing must be deterministic");
+            }
+        }
+
+        @Test
+        @DisplayName("ownerOf returns value in [0, podCount)")
+        void ownerInRange() {
+            var router = new NamespaceAffinityRouter(0, 5);
+            for (int i = 0; i < 1000; i++) {
+                int owner = router.ownerOf("tenant-" + i, "user-" + i);
+                assertTrue(owner >= 0 && owner < 5,
+                        "Owner " + owner + " out of range [0, 5)");
+            }
+        }
+
+        @Test
+        @DisplayName("different namespaces distribute across pods")
+        void distribution() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            var counts = new HashMap<Integer, Integer>();
+
+            for (int i = 0; i < 3000; i++) {
+                int owner = router.ownerOf("tenant", "user-" + i);
+                counts.merge(owner, 1, Integer::sum);
+            }
+
+            // With 3000 namespaces across 3 pods, each should get roughly 1000
+            // Allow ±30% tolerance for hash distribution variance
+            for (int ordinal = 0; ordinal < 3; ordinal++) {
+                int count = counts.getOrDefault(ordinal, 0);
+                assertTrue(count > 700 && count < 1300,
+                        "Pod " + ordinal + " got " + count + " namespaces (expected ~1000)");
+            }
+        }
+
+        @Test
+        @DisplayName("isLocal correctly identifies ownership")
+        void isLocalCorrectness() {
+            // Create routers for each pod perspective
+            var router0 = new NamespaceAffinityRouter(0, 3);
+            var router1 = new NamespaceAffinityRouter(1, 3);
+            var router2 = new NamespaceAffinityRouter(2, 3);
+
+            // For any namespace, exactly one pod should report isLocal=true
+            for (int i = 0; i < 100; i++) {
+                String tenant = "t" + i;
+                String ns = "u" + i;
+                int localCount = 0;
+                if (router0.isLocal(tenant, ns)) localCount++;
+                if (router1.isLocal(tenant, ns)) localCount++;
+                if (router2.isLocal(tenant, ns)) localCount++;
+                assertEquals(1, localCount,
+                        "Exactly one pod must own " + tenant + ":" + ns);
+            }
+        }
+
+        @Test
+        @DisplayName("all routers agree on ownership")
+        void routersAgree() {
+            var router0 = new NamespaceAffinityRouter(0, 3);
+            var router1 = new NamespaceAffinityRouter(1, 3);
+
+            for (int i = 0; i < 100; i++) {
+                assertEquals(
+                        router0.ownerOf("tenant", "user-" + i),
+                        router1.ownerOf("tenant", "user-" + i),
+                        "All routers must compute the same owner");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Resize")
+    class ResizeTests {
+
+        @Test
+        @DisplayName("resize changes podCount and ring")
+        void resizeUpdatesPodCount() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            assertEquals(3, router.podCount());
+
+            router.resize(5);
+            assertEquals(5, router.podCount());
+        }
+
+        @Test
+        @DisplayName("resize preserves most namespace assignments (consistent hashing)")
+        void resizeMinimalReassignment() {
+            var router = new NamespaceAffinityRouter(0, 3);
+
+            // Record initial assignments
+            var before = new HashMap<String, Integer>();
+            for (int i = 0; i < 1000; i++) {
+                String key = "tenant:user-" + i;
+                before.put(key, router.ownerOf("tenant", "user-" + i));
+            }
+
+            // Scale from 3 → 4 pods
+            router.resize(4);
+
+            int changed = 0;
+            for (int i = 0; i < 1000; i++) {
+                int after = router.ownerOf("tenant", "user-" + i);
+                if (!before.get("tenant:user-" + i).equals(after)) {
+                    changed++;
+                }
+            }
+
+            // Consistent hashing: ~1/N keys should move (1/4 ≈ 25%)
+            // Allow generous tolerance: 5-50% is acceptable
+            double changeRate = (double) changed / 1000;
+            assertTrue(changeRate < 0.50,
+                    "Change rate " + changeRate + " too high (expected < 50%)");
+            assertTrue(changeRate > 0.05,
+                    "Change rate " + changeRate + " suspiciously low");
+        }
+
+        @Test
+        @DisplayName("resize to same count is no-op")
+        void resizeNoOp() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            int ringBefore = router.ringSize();
+            router.resize(3);
+            assertEquals(ringBefore, router.ringSize());
+        }
+
+        @Test
+        @DisplayName("resize rejects invalid podCount")
+        void resizeRejectsInvalid() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            assertThrows(SpectorValidationException.class, () -> router.resize(0));
+            assertThrows(SpectorValidationException.class, () -> router.resize(257));
+        }
+    }
+
+    @Nested
+    @DisplayName("Observability")
+    class ObservabilityTests {
+
+        @Test
+        @DisplayName("distribution sums to 1.0")
+        void distributionSumsToOne() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            Map<Integer, Double> dist = router.distribution();
+            assertNotNull(dist);
+            assertEquals(3, dist.size());
+
+            double sum = dist.values().stream().mapToDouble(Double::doubleValue).sum();
+            assertEquals(1.0, sum, 0.001, "Distribution must sum to 1.0");
+        }
+
+        @Test
+        @DisplayName("ring size equals podCount * virtualNodesPerPod")
+        void ringSizeCorrect() {
+            var router = new NamespaceAffinityRouter(0, 3, 100);
+            assertEquals(300, router.ringSize());
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCaseTests {
+
+        @Test
+        @DisplayName("rejects null tenantId")
+        void rejectsNullTenant() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            assertThrows(NullPointerException.class,
+                    () -> router.ownerOf(null, "user"));
+        }
+
+        @Test
+        @DisplayName("rejects null namespaceId")
+        void rejectsNullNamespace() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            assertThrows(NullPointerException.class,
+                    () -> router.ownerOf("tenant", null));
+        }
+
+        @Test
+        @DisplayName("handles empty strings gracefully")
+        void handlesEmptyStrings() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            // Empty strings should be routed (they're valid keys)
+            assertDoesNotThrow(() -> router.ownerOf("", ""));
+        }
+
+        @Test
+        @DisplayName("handles very long keys")
+        void handlesLongKeys() {
+            var router = new NamespaceAffinityRouter(0, 3);
+            String longKey = "x".repeat(10_000);
+            assertDoesNotThrow(() -> router.ownerOf(longKey, longKey));
+        }
+    }
+}

--- a/spector-runtime/src/main/java/com/spectrayan/spector/runtime/SpectorRuntime.java
+++ b/spector-runtime/src/main/java/com/spectrayan/spector/runtime/SpectorRuntime.java
@@ -85,12 +85,12 @@ public final class SpectorRuntime implements AutoCloseable {
     private final TokenEmbeddingProvider tokenEmbeddingProvider;
 
     // Lazily created services — double-checked locking for thread safety.
-    // The volatile + synchronized pattern ensures exactly-once initialization
-    // even under concurrent access from multiple threads.
+    // The volatile + ReentrantLock pattern ensures exactly-once initialization
+    // even under concurrent access from virtual threads (ADR-005: no synchronized).
     private volatile SearchHandler searchService;
     private volatile IngestionHandler ingestionService;
     private volatile MemoryHandler memoryService;
-    private final Object serviceLock = new Object();
+    private final java.util.concurrent.locks.ReentrantLock serviceLock = new java.util.concurrent.locks.ReentrantLock();
 
     private SpectorRuntime(SpectorEngine engine, SpectorMemory memory,
                            SpectorProperties properties, SpectorMode mode,
@@ -288,12 +288,15 @@ public final class SpectorRuntime implements AutoCloseable {
     public SearchHandler search() {
         SearchHandler svc = searchService; // volatile read
         if (svc == null) {
-            synchronized (serviceLock) {
+            serviceLock.lock();
+            try {
                 svc = searchService;
                 if (svc == null) {
                     svc = new SearchHandler(engine, memory, mode);
                     searchService = svc; // volatile write
                 }
+            } finally {
+                serviceLock.unlock();
             }
         }
         return svc;
@@ -303,7 +306,8 @@ public final class SpectorRuntime implements AutoCloseable {
     public IngestionHandler ingestion() {
         IngestionHandler svc = ingestionService; // volatile read
         if (svc == null) {
-            synchronized (serviceLock) {
+            serviceLock.lock();
+            try {
                 svc = ingestionService;
                 if (svc == null) {
                     var ingestionConfig = SpectorConfigFactory.ingestionDefaults(properties);
@@ -337,6 +341,8 @@ public final class SpectorRuntime implements AutoCloseable {
                     svc = new IngestionHandler(pipeline, engine, memory, mode);
                     ingestionService = svc; // volatile write
                 }
+            } finally {
+                serviceLock.unlock();
             }
         }
         return svc;
@@ -356,12 +362,15 @@ public final class SpectorRuntime implements AutoCloseable {
         }
         MemoryHandler svc = memoryService; // volatile read
         if (svc == null) {
-            synchronized (serviceLock) {
+            serviceLock.lock();
+            try {
                 svc = memoryService;
                 if (svc == null) {
                     svc = new MemoryHandler(memory);
                     memoryService = svc; // volatile write
                 }
+            } finally {
+                serviceLock.unlock();
             }
         }
         return java.util.Optional.of(svc);

--- a/spector-storage/src/main/java/com/spectrayan/spector/storage/InMemoryVectorStore.java
+++ b/spector-storage/src/main/java/com/spectrayan/spector/storage/InMemoryVectorStore.java
@@ -44,7 +44,7 @@ import com.spectrayan.spector.commons.error.ErrorCode;
  * <h3>Thread Safety</h3>
  * <ul>
  *   <li>Concurrent reads are safe (shared arena).</li>
- *   <li>Writes are serialized via {@code synchronized} on write path only.</li>
+ *   <li>Writes are serialized via {@link java.util.concurrent.locks.ReentrantLock}.</li>
  * </ul>
  */
 public class InMemoryVectorStore implements VectorStore {

--- a/spector-storage/src/main/java/com/spectrayan/spector/storage/MappedVectorStore.java
+++ b/spector-storage/src/main/java/com/spectrayan/spector/storage/MappedVectorStore.java
@@ -52,7 +52,7 @@ import com.spectrayan.spector.commons.error.ErrorCode;
  * <h3>Thread Safety</h3>
  * <ul>
  *   <li>Concurrent reads are safe (shared arena).</li>
- *   <li>Writes are serialized via {@code synchronized}.</li>
+ *   <li>Writes are serialized via {@link java.util.concurrent.locks.ReentrantLock}.</li>
  * </ul>
  */
 public class MappedVectorStore implements VectorStore {


### PR DESCRIPTION
## Summary

Performance remediation, off-heap optimization, and new MCP tools for the Spector core engine.

## What Changed

### ⚡ Performance: Lock Migration (ADR-005)
- **`spector-storage`**: Replace `synchronized` with `ReentrantReadWriteLock` in MappedVectorStore and InMemoryVectorStore — 10-50x concurrent read throughput
- **`spector-index`**: Replace `synchronized` with `ReentrantLock` in all HNSW indexes (Disk, Quantized, Sharded) — prevents virtual thread carrier pinning
- **`spector-node`**: ReentrantLock in HeartbeatMembershipService

### 🧠 Memory Module Decomposition
- **God class remediation**: Extract `EntityGraphSerializer` (-298 LOC), `PostIngestSync` (-315 LOC), `GraphExpansionStage`
- **RecallOptions**: 7 composable sub-records (Filter, Scoring, TextSearch, Neurodivergent, Graph, Temporal, Reranker)
- **Lock migration**: ReentrantLock in PartitionManager, WelfordStats, RecallPipeline cache
- **12 wildcard imports fixed**

### 📦 Off-Heap Text Store
- **`text.dat`** mmap'd storage: zero-copy text reads via Panama FFM
- **~40MB heap reduction** per 100K memories (texts HashMap eliminated)
- **Inverted tag index**: O(1) `idsByTag()` replaces O(n) full scan
- **V3 index format** (backward-compatible)

### 🏁 BM25 Binary Persistence
- **`bm25.bidx`** format: instant startup vs O(n) rebuild
- Header(24B) + docIds + docLengths + term→postings
- Auto-save on first rebuild and on close()

### 🔌 MCP Tools
- `memory_recall` and `memory_remember` tools for cognitive retrieval/storage

### 🏛️ Namespace Affinity Router
- Consistent hash ring for multi-pod namespace ownership
- 150 virtual nodes per pod, ReentrantReadWriteLock
- `NativeOsMemory` utility for POSIX madvise via FFM API

## Testing

- ✅ **917 tests pass, 0 failures** (verified after each commit)
- Lock migration tested under concurrent load
- Off-heap text reads verified with mmap'd segments
- BM25 binary round-trip validated

## Commits (10)

1. `perf(storage)`: ReentrantReadWriteLock in vector stores
2. `perf(index)`: ReentrantLock in HNSW indexes
3. `refactor(memory)`: god class decomposition + RecallOptions sub-records
4. `perf(node)`: ReentrantLock in cluster membership
5. `feat(node)`: NamespaceAffinityRouter
6. `feat(mcp)`: memory_recall + memory_remember tools
7. `feat(core)`: NativeOsMemory FFM utility
8. `perf(memory)`: off-heap text store + inverted tag index + V3 format
9. `perf(memory)`: eliminate texts HashMap via mmap reads
10. `perf(index)`: BM25 binary persistence

## Performance Impact

| Metric | Before | After |
|:---|:---|:---|
| Concurrent read throughput | 1x (synchronized) | 10-50x (R/W lock) |
| Heap per 100K memories | ~140MB | ~100MB (-40MB) |
| BM25 startup (100K docs) | O(n) rebuild | Instant (binary load) |
| Tag browse | O(n) scan | O(1) inverted index |