### PR TITLE
docs: add developer getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ All numbers measured on Intel Core Ultra 9 285K, Java 25, AVX2 256-bit.
 | I want to... | Start here |
 |:---|:---|
 | **Use Spector** | [Quick Start](https://spectrayan.github.io/spector/getting-started/quickstart/) · [Installation](https://spectrayan.github.io/spector/getting-started/installation/) · [Configuration](https://spectrayan.github.io/spector/configuration/parameters/) |
+| **Contribute to Spector** | [Developer Guide](https://spectrayan.github.io/spector/getting-started/developer-guide/) · [Contributing](CONTRIBUTING.md) |
 | **Connect an AI agent** | [MCP Server Guide](https://spectrayan.github.io/spector/sdk-usage/mcp-server/) · [Claude Desktop Config](#claude-desktop-config) |
 | **Add cognitive memory** | [Memory Overview](https://spectrayan.github.io/spector/memory/) · [Getting Started](https://spectrayan.github.io/spector/memory/getting-started/) · [Use Cases](https://spectrayan.github.io/spector/memory/use-cases/) |
 | **Use the Java SDK** | [Java SDK Guide](https://spectrayan.github.io/spector/sdk-usage/java-client/) · [Spring AI Integration](https://spectrayan.github.io/spector/sdk-usage/spring-ai/) |

--- a/docs/docs/getting-started/developer-guide.md
+++ b/docs/docs/getting-started/developer-guide.md
@@ -1,0 +1,159 @@
+---
+title: Developer Getting Started
+description: Build Spector locally, run the node, store a first memory, and find the main code paths for contributions.
+---
+
+# Developer Getting Started
+
+This guide is for contributors who want to clone Spector, run it locally, make a focused change, and verify it before opening a pull request. If you only want to try the product, start with the [Quick Start](quickstart.md) or [Installation](installation.md) guide instead.
+
+Project-level contribution rules live in the [README](https://github.com/spectrayan/spector/blob/main/README.md) and [CONTRIBUTING](https://github.com/spectrayan/spector/blob/main/CONTRIBUTING.md) files. Read those before you push a branch; commits require a sign-off.
+
+## Prerequisites
+
+Install these tools before cloning the repository:
+
+| Tool | Required | Check |
+| ---- | -------- | ----- |
+| JDK 25 | Yes | `java -version` |
+| Maven 3.9 or newer | Yes | `mvn --version` |
+| Git | Yes | `git --version` |
+| Ollama | Optional, useful for memory and auto-embedding examples | `ollama --version` |
+| Docker | Optional, useful for container and integration workflows | `docker --version` |
+
+Use a terminal that preserves normal shell quoting. On Windows PowerShell, prefer `curl.exe` in the examples below so PowerShell does not alias `curl` to `Invoke-WebRequest`.
+
+## Clone And Build
+
+```bash
+git clone https://github.com/spectrayan/spector.git
+cd spector
+mvn clean verify
+```
+
+A successful first build ends with `BUILD SUCCESS`. For a faster compile-only check while iterating:
+
+```bash
+mvn clean compile
+```
+
+To build all modules without running tests:
+
+```bash
+mvn clean package -DskipTests
+```
+
+## Run The Local Node
+
+The node module starts the embedded Armeria REST server on port `7070` by default:
+
+```bash
+mvn exec:java -pl spector-node -Dexec.mainClass="com.spectrayan.spector.node.SpectorNode"
+```
+
+In another terminal, verify the service:
+
+```bash
+curl http://localhost:7070/health
+curl http://localhost:7070/api/v1/status
+```
+
+To use a different port, vector dimension, or API key, pass runtime arguments:
+
+```bash
+mvn exec:java -pl spector-node -Dexec.mainClass="com.spectrayan.spector.node.SpectorNode" -Dexec.args="7071 384 my-secret-key"
+```
+
+If you plan to test automatic embeddings or cognitive memory examples, start Ollama before the node:
+
+```bash
+ollama serve
+ollama pull nomic-embed-text
+```
+
+## Store A First Memory
+
+With the node running, store a semantic memory:
+
+```bash
+curl -X POST http://localhost:7070/api/v1/memory/remember \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "dev-guide-1",
+    "text": "Spector stores agent memories in semantic, episodic, working, and procedural tiers.",
+    "tier": "SEMANTIC",
+    "source": "USER_STATED",
+    "tags": "developer-guide,memory"
+  }'
+```
+
+The endpoint returns an accepted task response with the generated task id and memory id. See the [REST API reference](../api-reference/rest-endpoints.md) for the full request schema and related recall endpoints.
+
+## Architecture Map
+
+Spector is a multi-module Maven project. Start with these areas when deciding where a change belongs:
+
+| Area | Modules |
+| ---- | ------- |
+| Search and storage | `spector-core`, `spector-index`, `spector-query`, `spector-storage` |
+| Runtime composition | `spector-engine`, `spector-runtime`, `spector-node` |
+| Cognitive memory | `spector-memory`, `spector-rag`, `spector-embed-api`, `spector-embed-ollama` |
+| Integrations | `spector-mcp`, `spector-client`, `spector-cli`, `spector-spring` |
+| Support and verification | `spector-test-support`, `spector-bench`, `spector-metrics`, `spector-events` |
+
+For a deeper walkthrough, read the [architecture overview](../architecture/overview.md), [module guide](../modules/index.md), and module-specific README files.
+
+## Run Focused Tests
+
+Run the full test suite before opening a pull request when practical:
+
+```bash
+mvn test
+```
+
+For focused work, test the touched module and any required upstream modules:
+
+```bash
+mvn test -pl spector-memory -am
+mvn test -pl spector-node -am
+```
+
+To run a single test class:
+
+```bash
+mvn test -pl spector-core -Dtest=DotProductTest
+```
+
+Use `mvn clean verify` before submitting changes that touch public APIs, module boundaries, packaging, or documentation snippets that are checked during the site build.
+
+## IDE Setup
+
+IntelliJ IDEA, Eclipse, and VS Code can import the root `pom.xml` as a Maven project. Set the project SDK to JDK 25 and let Maven manage compiler flags and module dependencies.
+
+Useful defaults:
+
+- Enable automatic Maven project import.
+- Delegate build and test actions to Maven if IDE classpath resolution differs from the command line.
+- Run the node from Maven with the `spector-node` command above, or create a run configuration for `com.spectrayan.spector.node.SpectorNode`.
+- Keep generated build output under each module's `target/` directory out of commits.
+
+## Contribution Checklist
+
+Before opening a pull request:
+
+- Confirm the issue is still open and no existing pull request solves it.
+- Create a branch with a focused name, for example `docs/getting-started-developer-guide`.
+- Keep the change small enough to review in one pass.
+- Add or update tests/docs for behavior changes.
+- Run the narrowest useful check, then the broader Maven check when the change warrants it.
+- Commit with a conventional message and sign off: `git commit -s -m "docs: add developer getting started guide"`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| ------- | --- |
+| Maven uses an older JDK | Set `JAVA_HOME` to JDK 25 and reopen the terminal. |
+| `curl` behaves differently on PowerShell | Use `curl.exe` instead of `curl`. |
+| Port `7070` is already in use | Pass a different port with `-Dexec.args="7071 384"`. |
+| Memory examples fail to embed content | Start Ollama and pull `nomic-embed-text`, or inspect node logs for the configured embedding provider. |
+| A module test cannot resolve local classes | Add `-am` so Maven also builds required upstream modules. |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
   - Getting Started:
       - Quick Start: getting-started/quickstart.md
       - Installation: getting-started/installation.md
+      - Developer Guide: getting-started/developer-guide.md
       - MCP Server: sdk-usage/mcp-server.md
       - Java SDK: sdk-usage/java-client.md
       - Python SDK: sdk-usage/python-sdk.md


### PR DESCRIPTION
## Summary
- Add a developer getting-started guide for local setup, build checks, running the node, first memory storage, architecture orientation, focused tests, IDE setup, and troubleshooting.
- Add the guide to the MkDocs Getting Started navigation.
- Link the guide from the README documentation table.

Closes #47

## Verification
- `git diff --cached --check`
- Verified referenced internal docs targets exist.

Java/Maven/MkDocs builds were not run locally because the workspace shell does not expose `java`, `mvn`, or `mkdocs`.