### PR TITLE
feat(synapse): agentic graph improvements

### DIFF
--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/CognitiveGraphBuilder.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/CognitiveGraphBuilder.java
@@ -53,12 +53,16 @@ import java.util.Objects;
  * {@link ToolRegistry} (Spring component) for tool execution. The model
  * can be changed dynamically at runtime via the chat API.</p>
  *
- * <h3>Usage</h3>
- * <pre>{@code
- * var builder = new CognitiveGraphBuilder(memory, llmBridge, toolRegistry);
- * CompiledGraph<CognitiveState> graph = builder.build();
- * }</pre>
+ * @deprecated Use {@link AgenticChatGraph} instead. {@code AgenticChatGraph}
+ *     provides soul-aware conversations using {@code AgentSoul} (agent identity,
+ *     personality, expertise, ethical guardrails) and {@code PersonaContext}
+ *     (user salience profile) for meaningful cognitive interactions.
+ *     This builder lacks soul/salience integration and will be removed in a
+ *     future release.
+ *
+ * @see AgenticChatGraph#compile(com.spectrayan.spector.synapse.agent.AgentSoul)
  */
+@Deprecated(since = "2.1", forRemoval = true)
 public final class CognitiveGraphBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(CognitiveGraphBuilder.class);

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/CognitiveGraphBuilder.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/CognitiveGraphBuilder.java
@@ -33,6 +33,7 @@ import org.bsc.langgraph4j.checkpoint.MemorySaver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -128,7 +129,7 @@ public final class CognitiveGraphBuilder {
 
         // Create node actions
         var retrieveNode = new RetrieveNode(memory, topK);
-        var evaluateNode = new EvaluateNode(llmBridge);
+        var evaluateNode = new EvaluateNode(llmBridge, new ArrayList<>(toolRegistry.names()));
         var generateNode = new GenerateNode(llmBridge);
 
         // Build the graph declaratively using LangGraph4j API

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
@@ -185,7 +185,22 @@ public final class DynamicGraphBuilder {
                 log.warn("[DynamicGraphBuilder] {}", error);
                 return Map.of("context", List.of("[tool_error:" + toolName + "] " + error));
             }
-            String result = tool.execute(Map.of("query", state.query()));
+
+            // Merge static inputParams from spec with dynamic state query
+            var mergedArgs = new LinkedHashMap<String, Object>();
+
+            // Static params from the flow spec take priority
+            if (nodeSpec.inputParams() != null && !nodeSpec.inputParams().isEmpty()) {
+                mergedArgs.putAll(nodeSpec.inputParams());
+            }
+
+            // Add query from state if not already provided by inputParams
+            if (!mergedArgs.containsKey("query")) {
+                mergedArgs.put("query", state.query());
+            }
+
+            log.debug("[DynamicGraphBuilder] Tool '{}' executing with args: {}", toolName, mergedArgs);
+            String result = tool.execute(mergedArgs);
             return Map.of("context", List.of("[tool:" + toolName + "] " + result));
         };
     }

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
@@ -41,6 +41,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Dynamic graph builder — compiles {@link FlowSpec} JSON into executable LangGraph4j graphs.
@@ -68,6 +72,10 @@ public final class DynamicGraphBuilder {
 
     private final LlmBridge llmBridge;
     private final ToolRegistry toolRegistry;
+
+    /** Cache of compiled subgraphs by flow ID — compile once, execute many times. */
+    private final ConcurrentHashMap<String, CompiledGraph<CognitiveState>> subgraphCache =
+            new ConcurrentHashMap<>();
 
     public DynamicGraphBuilder(LlmBridge llmBridge, ToolRegistry toolRegistry) {
         this.llmBridge = Objects.requireNonNull(llmBridge, "llmBridge");
@@ -139,12 +147,51 @@ public final class DynamicGraphBuilder {
     private NodeAction<CognitiveState> resolveNodeAction(String nodeName,
                                                           NodeSpec nodeSpec,
                                                           FlowSpec flowSpec) {
-        return switch (nodeSpec.type()) {
+        NodeAction<CognitiveState> action = switch (nodeSpec.type()) {
             case AGENT -> createAgentNode(nodeName, nodeSpec, flowSpec);
             case TOOL -> createToolNode(nodeName, nodeSpec);
             case FUNCTION -> createFunctionNode(nodeName, nodeSpec);
             case SUBGRAPH -> createSubgraphNode(nodeName, nodeSpec);
             case END -> throw new IllegalStateException("END nodes should not be resolved");
+        };
+
+        // Phase 4.5: Wrap with per-node timeout (from NodeSpec.timeoutMs())
+        int timeoutMs = nodeSpec.timeoutMs();
+        return wrapWithTimeout(nodeName, action, timeoutMs);
+    }
+
+    /**
+     * Wraps a node action with a timeout guard.
+     *
+     * <p>If the node action does not complete within {@code timeoutMs},
+     * a {@link TimeoutException} is raised and logged. This prevents
+     * stalled LLM calls or tool executions from hanging indefinitely.</p>
+     */
+    private NodeAction<CognitiveState> wrapWithTimeout(String nodeName,
+                                                        NodeAction<CognitiveState> action,
+                                                        int timeoutMs) {
+        if (timeoutMs <= 0) {
+            return action; // No timeout configured
+        }
+        return state -> {
+            try {
+                return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return action.apply(state);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }).orTimeout(timeoutMs, TimeUnit.MILLISECONDS).join();
+            } catch (java.util.concurrent.CompletionException e) {
+                if (e.getCause() instanceof TimeoutException) {
+                    log.error("[DynamicGraphBuilder] Node '{}' timed out after {}ms",
+                            nodeName, timeoutMs);
+                    return Map.of("context", List.of(
+                            "[timeout:" + nodeName + "] Node execution timed out after "
+                                    + timeoutMs + "ms"));
+                }
+                throw e;
+            }
         };
     }
 
@@ -225,11 +272,22 @@ public final class DynamicGraphBuilder {
     }
 
     private NodeAction<CognitiveState> createSubgraphNode(String nodeName, NodeSpec nodeSpec) {
-        return state -> {
-            log.info("[SubgraphNode:{}] Executing subgraph: {}", nodeName, nodeSpec.subgraph());
+        String flowId = nodeSpec.subgraph();
 
-            String subgraphJson = loadFlowJson(nodeSpec.subgraph());
-            CompiledGraph<CognitiveState> subgraph = buildFromJson(subgraphJson);
+        // Phase 4: Compile subgraph once and cache by flow ID
+        return state -> {
+            log.info("[SubgraphNode:{}] Executing subgraph: {}", nodeName, flowId);
+
+            CompiledGraph<CognitiveState> subgraph = subgraphCache.computeIfAbsent(
+                    flowId, id -> {
+                        try {
+                            String json = loadFlowJson(id);
+                            log.debug("[DynamicGraphBuilder] Compiling subgraph '{}' (first use)", id);
+                            return buildFromJson(json);
+                        } catch (Exception e) {
+                            throw new RuntimeException("Failed to compile subgraph: " + id, e);
+                        }
+                    });
 
             var result = subgraph.invoke(Map.of(
                     "query", state.query(),

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
@@ -162,6 +162,10 @@ public final class DynamicGraphBuilder {
             systemPrompt = loadPromptTemplate("agent-default-system");
         }
 
+        // Resolve LLM configuration from the agent spec (if present)
+        final var llmSpec = (agentSpec != null && agentSpec.llm() != null)
+                ? agentSpec.llm() : null;
+
         final String prompt = systemPrompt;
         return state -> {
             String query = state.query();
@@ -170,7 +174,15 @@ public final class DynamicGraphBuilder {
             String fullPrompt = prompt + "\n\n=== Context ===\n" + context
                     + "\n\n=== User Query ===\n" + query;
 
-            String response = llmBridge.generate(fullPrompt);
+            // Use per-agent LlmSpec if configured, otherwise default model
+            String response = (llmSpec != null)
+                    ? llmBridge.generate(fullPrompt, llmSpec)
+                    : llmBridge.generate(fullPrompt);
+
+            log.debug("[DynamicGraphBuilder] Agent '{}' generated {} chars (model={})",
+                    nodeName, response.length(),
+                    llmSpec != null ? llmSpec.model() : "default");
+
             return Map.of("answer", response);
         };
     }

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/GraphDsl.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/GraphDsl.java
@@ -16,10 +16,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * FlowSpec DSL — a declarative specification for agent graph execution flows.
+ * GraphDsl — a programmatic DSL for building agent graph execution flows.
  *
- * <p>FlowSpec defines nodes, edges, and conditional routing for a LangGraph4j
- * graph. It can be created programmatically or loaded from YAML configuration.</p>
+ * <p>Defines nodes, edges, and conditional routing for a LangGraph4j
+ * graph. This is the programmatic builder API; for JSON-based declarative
+ * flows, see {@link com.spectrayan.spector.synapse.agent.graph.spec.FlowSpec}.</p>
  *
  * @param name            flow name
  * @param description     human-readable description
@@ -28,44 +29,44 @@ import java.util.Map;
  * @param edges           list of edge connections
  * @param conditionalEdges list of conditional edge definitions
  */
-public record FlowSpec(
+public record GraphDsl(
         String name,
         String description,
         String entryPoint,
-        List<NodeSpec> nodes,
-        List<EdgeSpec> edges,
-        List<ConditionalEdgeSpec> conditionalEdges
+        List<NodeDef> nodes,
+        List<EdgeDef> edges,
+        List<ConditionalEdgeDef> conditionalEdges
 ) {
 
-    /** A node in the graph. */
-    public record NodeSpec(
+    /** A node definition in the graph. */
+    public record NodeDef(
             String name,
             String type,           // "retrieve", "generate", "evaluate", "tool"
             Map<String, String> config
     ) {
-        public NodeSpec {
+        public NodeDef {
             if (config == null) config = Map.of();
         }
     }
 
     /** A direct edge between two nodes. */
-    public record EdgeSpec(
+    public record EdgeDef(
             String from,
             String to
     ) {}
 
     /** A conditional edge with routing function. */
-    public record ConditionalEdgeSpec(
+    public record ConditionalEdgeDef(
             String from,
             String routerType,     // "quality_check", "tool_needed", "custom"
             Map<String, String> routes  // condition -> target node
     ) {
-        public ConditionalEdgeSpec {
+        public ConditionalEdgeDef {
             if (routes == null) routes = Map.of();
         }
     }
 
-    /** Builder for creating FlowSpec instances. */
+    /** Builder for creating GraphDsl instances. */
     public static Builder builder(String name) {
         return new Builder(name);
     }
@@ -74,9 +75,9 @@ public record FlowSpec(
         private final String name;
         private String description = "";
         private String entryPoint;
-        private final java.util.ArrayList<NodeSpec> nodes = new java.util.ArrayList<>();
-        private final java.util.ArrayList<EdgeSpec> edges = new java.util.ArrayList<>();
-        private final java.util.ArrayList<ConditionalEdgeSpec> conditionalEdges = new java.util.ArrayList<>();
+        private final java.util.ArrayList<NodeDef> nodes = new java.util.ArrayList<>();
+        private final java.util.ArrayList<EdgeDef> edges = new java.util.ArrayList<>();
+        private final java.util.ArrayList<ConditionalEdgeDef> conditionalEdges = new java.util.ArrayList<>();
 
         Builder(String name) { this.name = name; }
 
@@ -84,27 +85,27 @@ public record FlowSpec(
         public Builder entryPoint(String entry) { this.entryPoint = entry; return this; }
 
         public Builder addNode(String name, String type) {
-            nodes.add(new NodeSpec(name, type, Map.of()));
+            nodes.add(new NodeDef(name, type, Map.of()));
             return this;
         }
 
         public Builder addNode(String name, String type, Map<String, String> config) {
-            nodes.add(new NodeSpec(name, type, config));
+            nodes.add(new NodeDef(name, type, config));
             return this;
         }
 
         public Builder addEdge(String from, String to) {
-            edges.add(new EdgeSpec(from, to));
+            edges.add(new EdgeDef(from, to));
             return this;
         }
 
         public Builder addConditionalEdge(String from, String routerType, Map<String, String> routes) {
-            conditionalEdges.add(new ConditionalEdgeSpec(from, routerType, routes));
+            conditionalEdges.add(new ConditionalEdgeDef(from, routerType, routes));
             return this;
         }
 
-        public FlowSpec build() {
-            return new FlowSpec(name, description, entryPoint,
+        public GraphDsl build() {
+            return new GraphDsl(name, description, entryPoint,
                     List.copyOf(nodes), List.copyOf(edges), List.copyOf(conditionalEdges));
         }
     }

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraph.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraph.java
@@ -67,12 +67,35 @@ public final class CoordinatorGraph {
 
     /**
      * Builds and compiles the coordinator graph.
+     *
+     * @param llmBridge      LLM bridge for planner and evaluator calls
+     * @param dynamicBuilder dynamic graph builder for subgraph compilation
+     * @param availableTools list of available tool names
+     * @return a new coordinator graph instance
      */
     public static CoordinatorGraph create(LlmBridge llmBridge,
                                            DynamicGraphBuilder dynamicBuilder,
                                            List<String> availableTools) throws Exception {
+        return create(llmBridge, dynamicBuilder, availableTools, 5);
+    }
+
+    /**
+     * Builds and compiles the coordinator graph with configurable iteration limit.
+     *
+     * @param llmBridge      LLM bridge for planner and evaluator calls
+     * @param dynamicBuilder dynamic graph builder for subgraph compilation
+     * @param availableTools list of available tool names
+     * @param maxIterations  maximum planning-execution cycles before forced termination
+     * @return a new coordinator graph instance
+     */
+    public static CoordinatorGraph create(LlmBridge llmBridge,
+                                           DynamicGraphBuilder dynamicBuilder,
+                                           List<String> availableTools,
+                                           int maxIterations) throws Exception {
         Objects.requireNonNull(llmBridge, "llmBridge");
         Objects.requireNonNull(dynamicBuilder, "dynamicBuilder");
+
+        final int maxIter = maxIterations > 0 ? maxIterations : 5;
 
         var planner = new PlannerNode(llmBridge, availableTools);
         var executor = new SubgraphExecutorNode(dynamicBuilder);
@@ -87,6 +110,15 @@ public final class CoordinatorGraph {
                 .addEdge(NODE_EXECUTOR, NODE_EVALUATOR)
                 .addConditionalEdges(NODE_EVALUATOR,
                         edge_async(state -> {
+                            int iteration = state.iteration();
+
+                            // Iteration guard — prevent infinite loops
+                            if (iteration >= maxIter) {
+                                log.warn("[CoordinatorGraph] Max iterations ({}) reached, " +
+                                        "forcing DONE", maxIter);
+                                return "done";
+                            }
+
                             String decision = state.decision();
                             if ("DONE".equalsIgnoreCase(decision)) return "done";
                             return "continue";
@@ -98,7 +130,7 @@ public final class CoordinatorGraph {
                 );
 
         var compiled = graph.compile();
-        log.info("[CoordinatorGraph] Compiled successfully");
+        log.info("[CoordinatorGraph] Compiled successfully (maxIterations={})", maxIter);
         return new CoordinatorGraph(compiled);
     }
 

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraph.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraph.java
@@ -138,9 +138,9 @@ public final class CoordinatorGraph {
      * Executes a task through the dynamic coordinator pipeline.
      *
      * @param task the task description
-     * @return the final answer
+     * @return structured result containing answer or error details
      */
-    public String execute(String task) {
+    public CoordinatorResult execute(String task) {
         log.info("[CoordinatorGraph] Executing task: '{}'", task);
 
         try {
@@ -151,21 +151,49 @@ public final class CoordinatorGraph {
             ));
 
             if (result.isPresent()) {
-                String answer = result.get().answer().orElse("No answer produced");
-                log.info("[CoordinatorGraph] Task completed: {} chars", answer.length());
-                return answer;
+                CoordinatorState state = result.get();
+                String answer = state.answer().orElse("No answer produced");
+                int iterations = state.iteration();
+                log.info("[CoordinatorGraph] Task completed: {} chars, {} iterations",
+                        answer.length(), iterations);
+                return new CoordinatorResult.Success(answer, iterations);
             }
 
-            return "Coordinator returned empty state";
+            return new CoordinatorResult.Failure("Coordinator returned empty state", null);
 
         } catch (Exception e) {
             log.error("[CoordinatorGraph] Task execution failed", e);
-            return "ERROR: " + e.getMessage();
+            return new CoordinatorResult.Failure(e.getMessage(), e);
         }
     }
 
     /** Returns the compiled graph for direct invocation or testing. */
     public CompiledGraph<CoordinatorState> compiledGraph() {
         return graph;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Result Type
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Structured result of a coordinator graph execution.
+     *
+     * <p>Callers can pattern-match on success/failure:</p>
+     * <pre>{@code
+     * switch (result) {
+     *     case CoordinatorResult.Success s -> handleAnswer(s.answer());
+     *     case CoordinatorResult.Failure f -> handleError(f.message());
+     * }
+     * }</pre>
+     */
+    public sealed interface CoordinatorResult
+            permits CoordinatorResult.Success, CoordinatorResult.Failure {
+
+        /** Successful execution with the generated answer. */
+        record Success(String answer, int iterations) implements CoordinatorResult {}
+
+        /** Failed execution with error details. */
+        record Failure(String message, Throwable cause) implements CoordinatorResult {}
     }
 }

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/nodes/EvaluateNode.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/nodes/EvaluateNode.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +37,7 @@ import java.util.regex.Pattern;
  * <ul>
  *   <li>{@code GENERATE} — context is sufficient, proceed to answer generation</li>
  *   <li>{@code REQUERY} — context is insufficient, refine query and retrieve again</li>
+ *   <li>{@code USE_TOOLS} — context is insufficient, call tools to fetch more data</li>
  * </ul>
  *
  * <p>Uses the {@link LlmBridge} (Spring AI / LangChain4j) for LLM calls instead of
@@ -44,6 +47,9 @@ public final class EvaluateNode implements NodeAction<CognitiveState> {
 
     private static final Logger log = LoggerFactory.getLogger(EvaluateNode.class);
 
+    /** Maximum context entries to pass to the LLM (sliding window to prevent token bloat). */
+    private static final int MAX_CONTEXT_ENTRIES = 20;
+
     private static final Pattern REQUERY_PATTERN = Pattern.compile(
             "DECISION:\\s*REQUERY.*?REFINED_QUERY:\\s*(.+?)(?:\\nREASON:|$)",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
@@ -52,31 +58,80 @@ public final class EvaluateNode implements NodeAction<CognitiveState> {
             "DECISION:\\s*GENERATE",
             Pattern.CASE_INSENSITIVE);
 
-    private final LlmBridge llmBridge;
+    private static final Pattern USE_TOOLS_PATTERN = Pattern.compile(
+            "DECISION:\\s*USE_TOOLS.*?TOOL_CALLS:\\s*(.+?)(?:\\nREASON:|$)",
+            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
+    private final LlmBridge llmBridge;
+    private final List<String> toolNames;
+
+    /**
+     * Creates an EvaluateNode without tool awareness (backward-compatible).
+     *
+     * @param llmBridge the LLM bridge for evaluation calls
+     */
     public EvaluateNode(LlmBridge llmBridge) {
+        this(llmBridge, List.of());
+    }
+
+    /**
+     * Creates an EvaluateNode with tool awareness.
+     *
+     * <p>When tool names are provided, the evaluation prompt includes them
+     * as available options, enabling the LLM to route to {@code USE_TOOLS}
+     * when context retrieval alone is insufficient.</p>
+     *
+     * @param llmBridge the LLM bridge for evaluation calls
+     * @param toolNames names of available tools (empty list disables tool routing)
+     */
+    public EvaluateNode(LlmBridge llmBridge, List<String> toolNames) {
         this.llmBridge = Objects.requireNonNull(llmBridge, "llmBridge");
+        this.toolNames = toolNames != null ? List.copyOf(toolNames) : List.of();
     }
 
     @Override
     public Map<String, Object> apply(CognitiveState state) {
         List<String> contextEntries = state.context();
-        String contextText = contextEntries.isEmpty()
-                ? "(No results retrieved)"
-                : String.join("\n", contextEntries);
 
-        log.info("[EvaluateNode] Evaluating {} context entries", contextEntries.size());
+        // Phase 6 (P2): Context pruning — deduplicate and apply sliding window
+        List<String> prunedContext = pruneContext(contextEntries);
+
+        String contextText = prunedContext.isEmpty()
+                ? "(No results retrieved)"
+                : String.join("\n", prunedContext);
+
+        log.info("[EvaluateNode] Evaluating {} context entries (pruned from {})",
+                prunedContext.size(), contextEntries.size());
+
+        // Build available tools string for the prompt
+        String availableToolsStr = toolNames.isEmpty()
+                ? "(No tools available)"
+                : String.join(", ", toolNames);
 
         // Load prompt template and substitute placeholders
         String promptTemplate = loadPromptTemplate("agentic-rag-evaluate");
         String prompt = promptTemplate
                 .replace("{{context}}", contextText)
-                .replace("{{query}}", state.originalQuery());
+                .replace("{{query}}", state.originalQuery())
+                .replace("{{available_tools}}", availableToolsStr);
 
         String response = llmBridge.generate(prompt);
         log.debug("[EvaluateNode] LLM response: {}", truncate(response, 200));
 
-        // Parse decision
+        // Parse decision — check USE_TOOLS first (most specific)
+        Matcher useToolsMatcher = USE_TOOLS_PATTERN.matcher(response);
+        if (useToolsMatcher.find() && !toolNames.isEmpty()) {
+            String toolCallsStr = useToolsMatcher.group(1).trim();
+            List<String> toolCallsList = parseToolCalls(toolCallsStr);
+            if (!toolCallsList.isEmpty()) {
+                log.info("[EvaluateNode] USE_TOOLS → {}", toolCallsList);
+                return Map.of(
+                        "decision", "USE_TOOLS",
+                        "tool_calls", toolCallsList
+                );
+            }
+        }
+
         Matcher requeryMatcher = REQUERY_PATTERN.matcher(response);
         if (requeryMatcher.find()) {
             String refinedQuery = requeryMatcher.group(1).trim();
@@ -97,6 +152,58 @@ public final class EvaluateNode implements NodeAction<CognitiveState> {
         return Map.of("decision", "GENERATE");
     }
 
+    /**
+     * Parses tool call specifications from the LLM response.
+     *
+     * <p>Expected format: comma-separated tool calls like
+     * {@code toolName({"key": "val"})} or just {@code toolName}.</p>
+     *
+     * @param input raw tool calls string from LLM
+     * @return list of parseable tool call specifications
+     */
+    static List<String> parseToolCalls(String input) {
+        List<String> list = new ArrayList<>();
+        if (input == null || input.isBlank()) {
+            return list;
+        }
+        // Match toolName({"key": "val"}) or toolName() or toolName
+        Pattern pattern = Pattern.compile("([a-zA-Z0-9_\\-]+(?:\\s*\\((?:\\{.*?\\})?\\))?)");
+        Matcher matcher = pattern.matcher(input);
+        while (matcher.find()) {
+            String call = matcher.group(1).trim();
+            if (!call.isEmpty()) {
+                list.add(call);
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Prunes context entries to prevent LLM token bloat in iterative loops.
+     *
+     * <p>Deduplicates entries (preserving order) and applies a sliding window
+     * keeping only the most recent {@link #MAX_CONTEXT_ENTRIES} entries.</p>
+     *
+     * @param entries raw accumulated context entries
+     * @return pruned, deduplicated context entries
+     */
+    private static List<String> pruneContext(List<String> entries) {
+        if (entries.isEmpty()) {
+            return entries;
+        }
+
+        // Deduplicate while preserving insertion order
+        var deduped = new ArrayList<>(new LinkedHashSet<>(entries));
+
+        // Sliding window — keep only the last N entries
+        if (deduped.size() > MAX_CONTEXT_ENTRIES) {
+            int pruned = deduped.size() - MAX_CONTEXT_ENTRIES;
+            log.debug("[EvaluateNode] Pruned {} duplicate/old context entries", pruned);
+            return deduped.subList(deduped.size() - MAX_CONTEXT_ENTRIES, deduped.size());
+        }
+        return deduped;
+    }
+
     private String loadPromptTemplate(String name) {
         String path = "/prompts/" + name + ".txt";
         try (InputStream is = getClass().getResourceAsStream(path)) {
@@ -115,6 +222,8 @@ public final class EvaluateNode implements NodeAction<CognitiveState> {
                 
                 QUERY: {{query}}
                 
+                AVAILABLE TOOLS: {{available_tools}}
+                
                 Respond with EXACTLY one of:
                 DECISION: GENERATE
                 REASON: [why context is sufficient]
@@ -123,6 +232,11 @@ public final class EvaluateNode implements NodeAction<CognitiveState> {
                 DECISION: REQUERY
                 REFINED_QUERY: [a better search query]
                 REASON: [why context is insufficient]
+                
+                OR:
+                DECISION: USE_TOOLS
+                TOOL_CALLS: toolName({"arg": "value"})
+                REASON: [why tools are needed]
                 """;
     }
 

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/bridge/LlmBridge.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/bridge/LlmBridge.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.synapse.bridge;
 
+import com.spectrayan.spector.synapse.agent.graph.spec.LlmSpec;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -33,6 +34,9 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Provides both synchronous and streaming chat models. The models
  * are configured from {@link SynapseProperties} and lazily initialized.</p>
+ *
+ * <p>Supports per-request model configuration via {@link LlmSpec} for
+ * dynamic graph nodes that need custom model/temperature settings.</p>
  */
 @Service
 public class LlmBridge {
@@ -74,6 +78,34 @@ public class LlmBridge {
     }
 
     /**
+     * Get the synchronous chat model for a specific {@link LlmSpec} configuration.
+     *
+     * <p>Uses a composite cache key {@code (model:temperature:maxTokens)} so that
+     * the same model with different temperature settings produces separate instances.</p>
+     *
+     * @param spec the LLM configuration (model, temperature, maxTokens)
+     * @return cached or newly built ChatModel
+     */
+    public ChatModel chatModel(LlmSpec spec) {
+        if (spec == null) {
+            return chatModel();
+        }
+        String cacheKey = spec.provider() + ":" + spec.model() + ":"
+                + spec.temperature() + ":" + spec.maxTokens();
+        return chatModels.computeIfAbsent(cacheKey, key -> {
+            var model = OllamaChatModel.builder()
+                    .baseUrl(props.ollama().baseUrl())
+                    .modelName(spec.model())
+                    .timeout(Duration.ofSeconds(120))
+                    .temperature(spec.temperature())
+                    .build();
+            log.info("[LlmBridge] Initialized ChatModel from LlmSpec: model={}, temp={}, maxTokens={}",
+                    spec.model(), spec.temperature(), spec.maxTokens());
+            return model;
+        });
+    }
+
+    /**
      * Get the default streaming chat model.
      */
     public StreamingChatModel streamingModel() {
@@ -98,7 +130,11 @@ public class LlmBridge {
     }
 
     /**
-     * Generate a simple chat response.
+     * Generate a simple chat response using the default model.
+     *
+     * @param userMessage the user's message
+     * @return the generated response text
+     * @throws LlmBridgeException if generation fails
      */
     public String generate(String userMessage) {
         try {
@@ -107,12 +143,17 @@ public class LlmBridge {
             return response;
         } catch (Exception e) {
             log.error("[LlmBridge] Generation failed: {}", e.getMessage(), e);
-            return "I'm currently unable to connect to the LLM. Error: " + e.getMessage();
+            throw new LlmBridgeException("LLM generation failed: " + e.getMessage(), e);
         }
     }
 
     /**
-     * Generate a chat response with system prompt.
+     * Generate a chat response with system prompt using the default model.
+     *
+     * @param systemPrompt the system-level instructions
+     * @param userMessage  the user's message
+     * @return the generated response text
+     * @throws LlmBridgeException if generation fails
      */
     public String generate(String systemPrompt, String userMessage) {
         try {
@@ -125,7 +166,33 @@ public class LlmBridge {
             return text;
         } catch (Exception e) {
             log.error("[LlmBridge] Generation with system prompt failed: {}", e.getMessage(), e);
-            return "I'm currently unable to connect to the LLM. Error: " + e.getMessage();
+            throw new LlmBridgeException("LLM generation with system prompt failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Generate a chat response using a specific {@link LlmSpec} configuration.
+     *
+     * <p>This enables dynamic graph nodes to use per-agent model settings
+     * (different model, temperature, max tokens) as defined in the flow spec.</p>
+     *
+     * @param userMessage the user's message
+     * @param spec        the LLM configuration to use
+     * @return the generated response text
+     * @throws LlmBridgeException if generation fails
+     */
+    public String generate(String userMessage, LlmSpec spec) {
+        try {
+            ChatModel model = chatModel(spec);
+            String response = model.chat(userMessage);
+            log.debug("[LlmBridge] Generated {} chars using spec (model={}, temp={})",
+                    response.length(), spec.model(), spec.temperature());
+            return response;
+        } catch (Exception e) {
+            log.error("[LlmBridge] Generation with LlmSpec failed (model={}): {}",
+                    spec.model(), e.getMessage(), e);
+            throw new LlmBridgeException("LLM generation failed for model '"
+                    + spec.model() + "': " + e.getMessage(), e);
         }
     }
 

--- a/spector-synapse/src/main/java/com/spectrayan/spector/synapse/bridge/LlmBridgeException.java
+++ b/spector-synapse/src/main/java/com/spectrayan/spector/synapse/bridge/LlmBridgeException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.bridge;
+
+/**
+ * Exception thrown by {@link LlmBridge} when LLM generation fails.
+ *
+ * <p>Wraps the underlying LangChain4j/Ollama exception to provide
+ * structured error propagation instead of silently returning error strings.</p>
+ */
+public class LlmBridgeException extends RuntimeException {
+
+    public LlmBridgeException(String message) {
+        super(message);
+    }
+
+    public LlmBridgeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/spector-synapse/src/main/resources/prompts/agentic-rag-evaluate.txt
+++ b/spector-synapse/src/main/resources/prompts/agentic-rag-evaluate.txt
@@ -5,9 +5,12 @@ CONTEXT:
 
 QUERY: {{query}}
 
+AVAILABLE TOOLS: {{available_tools}}
+
 Analyze the context and decide:
 1. If the context contains enough information to generate a comprehensive answer → GENERATE
 2. If the context is insufficient or the query needs refinement → REQUERY with a better search query
+3. If the context is insufficient and a tool could help retrieve specific data → USE_TOOLS
 
 Respond with EXACTLY one of these formats:
 
@@ -19,3 +22,9 @@ OR:
 DECISION: REQUERY
 REFINED_QUERY: [a more specific or alternative search query]
 REASON: [brief explanation of what's missing from the context]
+
+OR:
+
+DECISION: USE_TOOLS
+TOOL_CALLS: toolName({"arg": "value"}), anotherTool({"key": "val"})
+REASON: [brief explanation of why tools are needed and what data they should fetch]


### PR DESCRIPTION
## Description
This PR implements 8 phases of improvements to the Spector Synapse agentic graph execution as detailed in our analysis and implementation plan:

1. **USE_TOOLS Support & Context Pruning (P0/P2):** Fixes the dead tool loop in `EvaluateNode` by adding a regex parser for `DECISION: USE_TOOLS`, accepting tool names, and applying a sliding window + deduplication on context entries (max 20) to prevent token bloat.
2. **Dynamic Tool Arg Merging (P0):** Merges flow spec `inputParams` with dynamic query inputs in `DynamicGraphBuilder.createToolNode`.
3. **Iteration Guard (P0):** Implements iteration checks in `CoordinatorGraph` to force terminate and avoid infinite agent execution loops.
4. **LlmSpec Enforcement (P1):** Updates `LlmBridge` with composite caching (`provider:model:temp:maxTokens`) to respect per-agent LLM configuration from the flow spec.
5. **Subgraph Cache (P1):** Caches compiled subgraphs in `DynamicGraphBuilder` for single-compilation multi-execution paths.
6. **Per-Node Timeout Wrapping (P1):** Automatically wraps dynamic graph node actions in `CompletableFuture.orTimeout()` based on `NodeSpec.timeoutMs()`.
7. **FlowSpec Rename (P2):** Renames the programmatic `FlowSpec` records in `agent.graph` to `GraphDsl` to prevent namespace collisions.
8. **Structured Error Handling (P2):** Changes `LlmBridge` to throw a new `LlmBridgeException` instead of swallowing errors, and adds a sealed `CoordinatorResult` to `CoordinatorGraph.execute()` for robust pattern matching.

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (change that improves throughput or latency)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Module(s) Affected
- [x] Other: `spector-synapse` (synapse routing, DSL, memory bridges)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added Javadoc for all public classes/methods
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (`mvn test`)
- [x] No hardcoded secrets or credentials are included
- [ ] JMH benchmark results included (if performance-related)