### PR TITLE
feat: single-image deployment — stateless MCP, LLM entity extraction, CORS and deploy fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,14 +13,14 @@
 
 # Node (cortex source not needed — we copy pre-built dist)
 **/node_modules
-spector-cortex/.angular
-spector-cortex/src
-spector-cortex/public
+cortex/spector-cortex/.angular
+cortex/spector-cortex/src
+cortex/spector-cortex/public
 
 # Maven build output (rebuilt in container)
 **/target
 # Exception: allow pre-built Synapse fat JAR for local deployment
-!spector-synapse/target/spector-synapse-*.jar
+!synapse/spector-synapse/target/spector-synapse-*.jar
 
 # Top-level documentation (not source code)
 ACKNOWLEDGMENTS.md

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -58,7 +58,7 @@ graph TD
 
     subgraph run_layer ["Runtime Layer"]
         runtime[spector-runtime]
-        node[spector-node]
+        synapse[spector-synapse]
         mcp[spector-mcp]
         cli[spector-cli]
         client[spector-client]
@@ -131,7 +131,7 @@ graph TD
     *   `spector-events`: Reactive publishing-subscription model.
 5.  **Runtime Layer**
     *   `spector-runtime`: Combines `spector-memory` and `spector-engine` peers.
-    *   `spector-node`: Orchestrates clustering and replication.
+    *   `spector-synapse`: Unified API gateway, Spring Boot application, and clustering/replication coordinator.
     *   `spector-mcp`: Anthropic Model Context Protocol server.
     *   `spector-cli` / `spector-client`: User interfaces and client libraries.
 6.  **Infrastructure Layer**
@@ -184,4 +184,4 @@ The **Cortex dashboard** and full-stack product features have been extracted to 
 *   Cortex Dashboard — Angular 22 neural visualization (migrated from `spector-cortex/`)
 *   Single-port architecture — everything on port 7070 via Armeria
 
-Enterprise **depends on** `spector-node` and always starts the core engine.
+Enterprise **depends on** `spector-synapse` and always starts the core engine.

--- a/cortex/spector-cortex/Dockerfile
+++ b/cortex/spector-cortex/Dockerfile
@@ -2,9 +2,9 @@
 FROM node:24-alpine AS builder
 
 WORKDIR /app/spector-cortex
-COPY spector-cortex/package*.json ./
+COPY cortex/spector-cortex/package*.json ./
 RUN npm ci --prefer-offline
-COPY spector-cortex/ .
+COPY cortex/spector-cortex/ .
 RUN npx ng build --configuration=production
 
 # ── Stage 2: Serve with Nginx ──

--- a/cortex/spector-cortex/angular.json
+++ b/cortex/spector-cortex/angular.json
@@ -35,6 +35,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/cortex/spector-cortex/src/app/core/services/event-stream.service.ts
+++ b/cortex/spector-cortex/src/app/core/services/event-stream.service.ts
@@ -144,6 +144,11 @@ export class EventStreamService implements OnDestroy {
             currentData = line.substring(5).trim();
           } else if (line === '' && currentEventType && currentData) {
             // End of event — dispatch
+            if (currentEventType === 'heartbeat' || currentData === '::heartbeat::') {
+              currentEventType = '';
+              currentData = '';
+              continue;
+            }
             try {
               const data = JSON.parse(currentData);
               data.eventType = currentEventType;

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,65 +1,66 @@
 # ═══════════════════════════════════════════════════════════════════
-# Spector — Backend-Only Docker Image
+# Spector OSS — Single Docker Image (Spring Boot 4 + Nginx)
 # ═══════════════════════════════════════════════════════════════════
 #
-# SpectorNode backend only (REST/gRPC/MCP-SSE/Prometheus) on :7070
+# Packages pre-built artifacts (built on host) into a runtime image:
+#   - Spector Synapse (Spring Boot 4 fat JAR — cognitive memory engine)
+#   - Nginx serving Angular Cortex dashboard + reverse proxy on :3000
 #
-# The Cortex dashboard has been moved to spector-enterprise.
-# This image runs the headless cognitive memory engine only.
+# Prerequisites (done by deploy.ps1):
+#   1. mvn package -DskipTests   (builds Spring Boot fat JAR)
+#   2. npm run build             (builds Angular production bundle)
 #
 # Build:
 #   docker build -f deploy/docker/Dockerfile -t spector .
 #
 # ═══════════════════════════════════════════════════════════════════
 
-# ── Stage 1: Build backend ────────────────────────────────────────
-FROM eclipse-temurin:25-jdk AS build
-
-# Install Maven
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz \
-       | tar xz -C /opt \
-    && ln -s /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /src
-COPY . .
-
-# Build the full reactor (skip tests for speed)
-# BuildKit cache mount avoids re-downloading on retries
-RUN --mount=type=cache,target=/root/.m2/repository \
-    mvn install -DskipTests -B -q \
-    && mkdir -p /app/lib \
-    && cp spector-node/target/spector-node-*.jar /app/spector-node.jar \
-    && mvn dependency:copy-dependencies -pl spector-node \
-         -DoutputDirectory=/app/lib -DincludeScope=runtime -B -q
-
-# ── Stage 2: Runtime ──────────────────────────────────────────────
 FROM eclipse-temurin:25-jre-alpine
+
+# Install Nginx and tini for proper signal handling
+RUN apk add --no-cache nginx tini
 
 # Create non-root user
 RUN addgroup -S spector && adduser -S spector -G spector
 
 WORKDIR /app
 
-# Copy backend
-COPY --from=build /app/spector-node.jar /app/spector-node.jar
-COPY --from=build /app/lib/             /app/lib/
+# Copy pre-built Spring Boot fat JAR (self-contained)
+COPY synapse/spector-synapse/target/spector-synapse-*.jar /app/spector-synapse.jar
 
 # Copy YAML config
 COPY deploy/docker/spector-docker.yml /app/spector.yml
 
-# Copy entrypoint
+# Copy frontend (Angular dist — built on host)
+COPY cortex/spector-cortex/dist/spector-cortex/browser/ /usr/share/nginx/html/
+
+# Copy Nginx config
+RUN rm -f /etc/nginx/http.d/default.conf
+COPY deploy/docker/nginx.conf /etc/nginx/http.d/spector.conf
+
+# Copy entrypoint (sed strips Windows CRLF — critical for Windows-built images)
 COPY deploy/docker/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+
+# Set data root to Docker volume mount point
+ENV SPECTOR_DATA_DIR=/data
+
+# JVM tuning — right-sized for Panama + Virtual Threads
+ENV JAVA_OPTS="-Xms512m -Xmx1536m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 \
+-XX:G1HeapRegionSize=8m -XX:MaxDirectMemorySize=2g \
+--enable-preview --add-modules=jdk.incubator.vector \
+--enable-native-access=ALL-UNNAMED -Djava.io.tmpdir=/data/tmp"
 
 # Create data directories
-RUN mkdir -p /data/index /data/memory && chown -R spector:spector /data /app
+RUN mkdir -p /data/index /data/memory /data/tmp \
+    && chown -R spector:spector /data /app
 
-EXPOSE 7070
+# Fix Nginx PID directory permissions
+RUN mkdir -p /run/nginx
+
+EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=3 \
-    CMD wget -qO- http://localhost:7070/health || exit 1
+    CMD wget -qO- http://localhost:7070/actuator/health || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/deploy/docker/Dockerfile.cortex-local
+++ b/deploy/docker/Dockerfile.cortex-local
@@ -2,7 +2,7 @@
 FROM nginx:alpine
 
 # Copy pre-built Angular dist
-COPY spector-cortex/dist/spector-cortex/browser /usr/share/nginx/html
+COPY cortex/spector-cortex/dist/spector-cortex/browser /usr/share/nginx/html
 
 # Nginx config for SPA routing + API proxy
 RUN echo 'server { \

--- a/deploy/docker/Dockerfile.synapse-local
+++ b/deploy/docker/Dockerfile.synapse-local
@@ -11,7 +11,7 @@ RUN groupadd -r spector && useradd -r -g spector spector && \
 WORKDIR /app
 
 # Copy pre-built fat JAR
-COPY spector-synapse/target/spector-synapse-*.jar app.jar
+COPY synapse/spector-synapse/target/spector-synapse-*.jar app.jar
 
 # Data directory
 RUN mkdir -p /data && chown -R spector:spector /data /app

--- a/deploy/docker/deploy.ps1
+++ b/deploy/docker/deploy.ps1
@@ -179,7 +179,7 @@ function Invoke-Run {
         -e "SPECTOR_OLLAMA_BASE_URL=http://host.docker.internal:11434" `
         -e "SPECTOR_OLLAMA_EMBED_MODEL=qwen3-embedding:0.6b" `
         -e "SPECTOR_OLLAMA_MODEL=spector-extractor:small" `
-        -e "SPECTOR_CORS_ORIGINS=http://localhost:4200,http://localhost:7700,http://localhost:3000" `
+        -e "SPECTOR_CORS_ORIGINS=http://localhost:4200,http://localhost:7700,http://localhost:3000,*" `
         --add-host=host.docker.internal:host-gateway `
         --restart unless-stopped `
         $ImageName

--- a/deploy/docker/deploy.ps1
+++ b/deploy/docker/deploy.ps1
@@ -30,7 +30,7 @@ param(
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = "Continue"
 
 # ── Configuration ──────────────────────────────────────────────────
 $ImageName     = "spector"
@@ -68,6 +68,36 @@ function Invoke-Build {
         Write-Err "Dockerfile not found at $Dockerfile"
         exit 1
     }
+
+    # 1. Build Spring Boot fat JAR on Host
+    Write-Log "Building backend (Maven - Spring Boot fat JAR)..."
+    mvn package '-DskipTests' -B -q
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Maven backend build failed"
+        exit $LASTEXITCODE
+    }
+    Write-Ok "Backend built successfully (Spring Boot fat JAR)."
+
+    # 2. Build Angular Frontend on Host
+    Write-Log "Building Angular Cortex Frontend..."
+    $uiPath = Join-Path $ProjectRoot "cortex/spector-cortex"
+    Push-Location $uiPath
+    try {
+        Write-Log "Running npm install to ensure all dependencies are present..."
+        npm install 2>&1 | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err "npm install failed"
+            exit $LASTEXITCODE
+        }
+        npm run build 2>&1 | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err "Angular frontend build failed"
+            exit $LASTEXITCODE
+        }
+    } finally {
+        Pop-Location
+    }
+    Write-Ok "Angular frontend built successfully."
 
     $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
     $versionTag = "v$timestamp"
@@ -143,6 +173,13 @@ function Invoke-Run {
         -p "${HostPortHttp}:3000" `
         -p "${HostPortApi}:7070" `
         -v "${DataVolume}:/data" `
+        -e "SPECTOR_DATA_DIR=/data" `
+        -e "SPECTOR_DB_ENCRYPT=false" `
+        -e "SPECTOR_DIMENSIONS=1024" `
+        -e "SPECTOR_OLLAMA_BASE_URL=http://host.docker.internal:11434" `
+        -e "SPECTOR_OLLAMA_EMBED_MODEL=qwen3-embedding:0.6b" `
+        -e "SPECTOR_OLLAMA_MODEL=spector-extractor:small" `
+        -e "SPECTOR_CORS_ORIGINS=http://localhost:4200,http://localhost:7700,http://localhost:3000" `
         --add-host=host.docker.internal:host-gateway `
         --restart unless-stopped `
         $ImageName

--- a/deploy/docker/deploy.sh
+++ b/deploy/docker/deploy.sh
@@ -20,6 +20,7 @@ IMAGE_NAME="spector"
 CONTAINER_NAME="spector"
 DOCKERFILE="deploy/docker/Dockerfile"
 DATA_VOLUME="spector-data"
+HOST_PORT_HTTP=7700
 HOST_PORT_API=7070
 
 # Colors
@@ -49,6 +50,20 @@ build() {
         err "Docker is not installed or not in PATH"
         exit 1
     fi
+
+    # 1. Build Spring Boot fat JAR on Host
+    log "Building backend (Maven - Spring Boot fat JAR)..."
+    mvn package -DskipTests -B -q
+    ok "Backend built successfully (Spring Boot fat JAR)."
+
+    # 2. Build Angular Frontend on Host
+    log "Building Angular Cortex Frontend..."
+    pushd cortex/spector-cortex >/dev/null
+    log "Running npm install to ensure all dependencies are present..."
+    npm install
+    npm run build
+    popd >/dev/null
+    ok "Angular frontend built successfully."
 
     local timestamp="$(date +%Y%m%d_%H%M%S)"
     local version_tag="v${timestamp}"
@@ -112,14 +127,22 @@ run() {
     docker volume create "$DATA_VOLUME" > /dev/null 2>&1 || true
 
     log "Starting container '${CONTAINER_NAME}'..."
-    log "  API (SpectorNode) → http://localhost:${HOST_PORT_API}"
+    log "  Dashboard (Nginx) → http://localhost:${HOST_PORT_HTTP}"
+    log "  API Backend       → http://localhost:${HOST_PORT_API}"
     log "  Data volume       → ${DATA_VOLUME}"
-    log "  Note: This is the headless engine. For the dashboard, use spector-enterprise."
 
     docker run -d \
         --name "$CONTAINER_NAME" \
+        -p "${HOST_PORT_HTTP}:3000" \
         -p "${HOST_PORT_API}:7070" \
         -v "${DATA_VOLUME}:/data" \
+        -e "SPECTOR_DATA_DIR=/data" \
+        -e "SPECTOR_DB_ENCRYPT=false" \
+        -e "SPECTOR_DIMENSIONS=1024" \
+        -e "SPECTOR_OLLAMA_BASE_URL=http://host.docker.internal:11434" \
+        -e "SPECTOR_OLLAMA_EMBED_MODEL=qwen3-embedding:0.6b" \
+        -e "SPECTOR_OLLAMA_MODEL=spector-extractor:small" \
+        -e "SPECTOR_CORS_ORIGINS=http://localhost:4200,http://localhost:7700,http://localhost:3000" \
         --add-host=host.docker.internal:host-gateway \
         --restart unless-stopped \
         "$IMAGE_NAME"

--- a/deploy/docker/deploy.sh
+++ b/deploy/docker/deploy.sh
@@ -142,7 +142,7 @@ run() {
         -e "SPECTOR_OLLAMA_BASE_URL=http://host.docker.internal:11434" \
         -e "SPECTOR_OLLAMA_EMBED_MODEL=qwen3-embedding:0.6b" \
         -e "SPECTOR_OLLAMA_MODEL=spector-extractor:small" \
-        -e "SPECTOR_CORS_ORIGINS=http://localhost:4200,http://localhost:7700,http://localhost:3000" \
+        -e "SPECTOR_CORS_ORIGINS=http://localhost:4200,http://localhost:7700,http://localhost:3000,*" \
         --add-host=host.docker.internal:host-gateway \
         --restart unless-stopped \
         "$IMAGE_NAME"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,23 +1,33 @@
 #!/bin/sh
-# â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
-# Spector â€” Container Entrypoint (Backend Only)
-# Starts SpectorNode in foreground.
-#
-# The Cortex dashboard has been moved to spector-enterprise.
-# This container runs the headless cognitive memory engine only.
+# ═══════════════════════════════════════════════════════════════════
+# Spector OSS — Container Entrypoint (Nginx + Backend)
+# ═══════════════════════════════════════════════════════════════════
+# Starts Nginx (background) + Spector Synapse Server (foreground)
 #
 # Graceful Shutdown:
 #   On SIGTERM (docker stop), the JVM receives the signal directly
-#   and runs its shutdown hook to persist graphs and flush data.
-# â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
+#   and runs its shutdown hook to persist data.
+#   Nginx is stopped first, then we wait for the JVM to finish.
+# ═══════════════════════════════════════════════════════════════════
 
 set -e
+
+# Ensure data directories exist
+mkdir -p /data/index /data/memory /data/tmp
+
+# Start Nginx in background (serves dashboard + proxies API)
+echo "[Spector] Starting Nginx..."
+nginx
 
 # Trap signals for graceful shutdown
 cleanup() {
     echo "[Spector] Received shutdown signal, draining..."
+    # Stop accepting new HTTP connections
+    nginx -s quit 2>/dev/null || true
+    # Forward SIGTERM to Java (triggers JVM shutdown hook)
     if [ -n "$JAVA_PID" ]; then
         kill -TERM "$JAVA_PID" 2>/dev/null || true
+        # Wait for Java to finish shutdown
         wait "$JAVA_PID" 2>/dev/null || true
     fi
     echo "[Spector] Shutdown complete"
@@ -25,20 +35,19 @@ cleanup() {
 }
 trap cleanup TERM INT
 
-# Start SpectorNode in background so trap can catch signals
-echo "[Spector] Starting SpectorNode (backend only, no UI)..."
-echo "[Spector] API â†’ http://localhost:7070"
+# Start Spector Synapse in background so trap can catch signals
+echo "[Spector] Starting Spector Synapse..."
+echo "[Spector] Dashboard → http://localhost:3000"
+echo "[Spector] API Backend → http://localhost:7070"
 java \
-    --add-modules jdk.incubator.vector \
-    --enable-preview \
-    --enable-native-access=ALL-UNNAMED \
-    -cp "/app/spector-node.jar:/app/lib/*" \
-    -Dspector.config=/app/spector.yml \
-    com.spectrayan.spector.node.SpectorNode &
+    ${JAVA_OPTS:---enable-preview --add-modules=jdk.incubator.vector --enable-native-access=ALL-UNNAMED} \
+    -jar /app/spector-synapse.jar \
+    --spring.config.additional-location=optional:file:/app/spector.yml &
 
 JAVA_PID=$!
 
-# Wait for Java process
+# Wait for Java process (if it exits on its own, we exit too)
+# The 'wait' will be interrupted by SIGTERM, which triggers cleanup()
 wait "$JAVA_PID"
 exit_code=$?
 echo "[Spector] Java process exited with code $exit_code"

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -1,0 +1,137 @@
+# ═══════════════════════════════════════════════════════════════════
+# Spector OSS — Nginx Reverse Proxy + SPA
+# ═══════════════════════════════════════════════════════════════════
+# Serves Angular Cortex dashboard and proxies API/MCP to backend.
+#
+# Backend runs on port 7070. Nginx exposes port 3000.
+# ═══════════════════════════════════════════════════════════════════
+
+upstream synapse_backend {
+    server 127.0.0.1:7070;
+    keepalive 32;
+}
+
+server {
+    listen 3000;
+    server_name _;
+
+    # ── Gzip Compression ─────────────────────────────────────────
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        image/svg+xml;
+
+    # ── Static Files (Angular SPA) ───────────────────────────────
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Cache static assets aggressively (hashed filenames)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # ── ALL API Endpoints → Synapse Backend (7070) ───────────────
+    location /api/ {
+        proxy_pass http://synapse_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "keep-alive";
+
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
+    # ── SSE Event Stream → Synapse Backend (NO buffering) ────────
+    location /sse/ {
+        proxy_pass http://synapse_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+
+        # Critical for SSE: disable all buffering
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        chunked_transfer_encoding off;
+        gzip off;
+    }
+
+    # Legacy SSE path /api/v1/events
+    location /api/v1/events {
+        proxy_pass http://synapse_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        chunked_transfer_encoding off;
+        gzip off;
+    }
+
+    # ── MCP Streamable HTTP → Synapse Backend ────────────────────
+    location /mcp {
+        proxy_pass http://synapse_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+
+        # MCP responses can be SSE streams — disable buffering
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        chunked_transfer_encoding off;
+        gzip off;
+    }
+
+    # ── Health Checks → Synapse Backend ──────────────────────────
+    location /actuator/health {
+        proxy_pass http://synapse_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+
+    location /health {
+        proxy_pass http://synapse_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+
+    # ── Angular SPA Fallback ─────────────────────────────────────
+    # Must be last — serves index.html for all unmatched routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/docker/spector-docker.yml
+++ b/deploy/docker/spector-docker.yml
@@ -15,7 +15,7 @@ spector:
 
   engine:
     dimensions: 1024
-    capacity: 10000
+    capacity: 100
     similarity: COSINE
     index-type: HNSW
     persistence-mode: DISK
@@ -61,6 +61,6 @@ spector:
     skip-dirs: ".git,node_modules,target"
     chunk-size: 2500
     chunk-overlap: 200
-    parallelism: 2
+    parallelism: 1
     max-retries: 3
     retry-delay-ms: 2000

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,8 +5,8 @@
 # Uses pre-built artifacts from the host (no multi-stage Maven/npm
 # builds inside Docker). Requires:
 #   1. mvn install -DskipTests          (core reactor)
-#   2. mvn package -DskipTests -f spector-synapse/pom.xml (synapse)
-#   3. cd spector-cortex && npm run build (cortex)
+#   2. mvn package -DskipTests -f synapse/spector-synapse/pom.xml (synapse)
+#   3. cd cortex/spector-cortex && npm run build (cortex)
 #
 # Usage:
 #   docker compose -f docker-compose.local.yml up --build

--- a/docker-compose.synapse.yml
+++ b/docker-compose.synapse.yml
@@ -25,7 +25,7 @@ services:
   synapse:
     build:
       context: .
-      dockerfile: spector-synapse/Dockerfile
+      dockerfile: synapse/spector-synapse/Dockerfile
     container_name: spector-synapse
     ports:
       - "7070:7070"
@@ -69,7 +69,7 @@ services:
   cortex:
     build:
       context: .
-      dockerfile: spector-cortex/Dockerfile
+      dockerfile: cortex/spector-cortex/Dockerfile
     container_name: spector-cortex
     ports:
       - "4200:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@
 #
 # Prerequisites:
 #   - Docker Desktop with Docker Compose v2
-#   - Pre-built Angular frontend (npm run build in spector-cortex)
+#   - Pre-built Angular frontend (npm run build in cortex/spector-cortex)
 #   - (Optional) Ollama running on host at localhost:11434
 # ═══════════════════════════════════════════════════════════════════
 

--- a/docs/docs/configuration/parameters.md
+++ b/docs/docs/configuration/parameters.md
@@ -163,10 +163,8 @@ var config = SpectorConfig.DEFAULT
 | `corsOrigins` | * | Allowed CORS origins |
 
 ```bash
-# Format: port dimensions apiKey
-mvn exec:java -pl spector-node \
-  -Dexec.mainClass="com.spectrayan.spector.server.SpectorNode" \
-  -Dexec.args="7070 384 my-secret-key"
+# Start Spector Synapse server on port 7070 with custom API key
+SPECTOR_API_KEY=my-secret-key mvn -Psynapse -pl synapse/spector-synapse spring-boot:run
 ```
 
 ---

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -216,7 +216,7 @@ java \
   --enable-native-access=ALL-UNNAMED \
   -XX:+UseZGC -XX:+ZGenerational \
   -Xmx4g -Xms4g \
-  -jar spector-node.jar
+  -jar spector.jar
 ```
 
 ---
@@ -238,8 +238,11 @@ java \
 **Yes.** Set an API key at server startup:
 
 ```bash
-mvn exec:java -pl spector-node \
-  -Dexec.args="7070 384 my-secret-key"
+# via environment variable
+SPECTOR_API_KEY=my-secret-key mvn -Psynapse -pl synapse/spector-synapse spring-boot:run
+
+# or via Spring Boot argument
+mvn -Psynapse -pl synapse/spector-synapse spring-boot:run -- --spector.api-key=my-secret-key
 ```
 
 Clients include `X-API-Key: my-secret-key` in requests. Without a key configured, all requests are allowed.

--- a/docs/docs/operations/contributing.md
+++ b/docs/docs/operations/contributing.md
@@ -63,8 +63,8 @@ graph LR
 
     subgraph "⚡ Applications"
         engine["spector-engine<br/>Unified facade"]
-        server["spector-node<br/>REST API"]
-        cluster["spector-node<br/>Distributed gRPC"]
+        server["spector-synapse<br/>REST / Spring Web"]
+        cluster["spector-synapse<br/>Distributed coordination"]
         cli["spector-cli<br/>CLI tool"]
         client["spector-client<br/>Java SDK"]
         spring["spector-spring<br/>Spring AI"]

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacade.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacade.java
@@ -121,7 +121,9 @@ public final class CognitiveGraphFacade {
      */
     public GraphNeighborhood overview(int maxNodes, Function<String, CognitiveRecord> inspector) {
         try {
-            var allIds = index.allIds().stream().limit(maxNodes).toList();
+            List<String> allIds = new java.util.ArrayList<>(index.allIds());
+            java.util.Collections.reverse(allIds);
+            allIds = allIds.stream().limit(maxNodes).toList();
             if (allIds.isEmpty()) return GraphNeighborhood.empty(null);
             var allIdsSet = new HashSet<>(allIds);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -365,6 +365,11 @@ final class PostIngestSync {
             // Create hyperedge for multi-entity co-occurrence (if >= 2 entities in this memory)
             if (hyperEntityGraph != null && entityIds.size() >= 2) {
                 int[] vertexArr = entityIds.stream().mapToInt(Integer::intValue).toArray();
+                if (vertexArr.length > HyperEntityGraph.MAX_VERTICES_PER_EDGE) {
+                    int[] truncated = new int[HyperEntityGraph.MAX_VERTICES_PER_EDGE];
+                    System.arraycopy(vertexArr, 0, truncated, 0, HyperEntityGraph.MAX_VERTICES_PER_EDGE);
+                    vertexArr = truncated;
+                }
                 int[] roles = new int[vertexArr.length];
                 // First entity gets SUBJECT role, rest get CONTEXT
                 roles[0] = HyperEntityGraph.ROLE_SUBJECT;

--- a/scripts/benchmark-beir.ps1
+++ b/scripts/benchmark-beir.ps1
@@ -8,7 +8,7 @@ param(
     [string]$Dataset = "scifact",
     [string]$DataDir = "datasets",
     [string]$Config  = "spector-local.yml",
-    [string]$Jar     = "spector-dist/target/spector.jar",
+    [string]$Jar     = "synapse/spector-dist/target/spector.jar",
     [int]$TopK       = 10,
     [string]$SearchMode = "HYBRID",  # HYBRID, VECTOR_ONLY, KEYWORD_ONLY
     [string]$ScoringMode = "COGNITIVE",  # COGNITIVE, SIMILARITY

--- a/scripts/ingest-docs.bat
+++ b/scripts/ingest-docs.bat
@@ -8,7 +8,7 @@ REM  Usage: scripts\ingest-docs.bat [--pattern "**\*.java"] [--root path]
 REM ═══════════════════════════════════════════════════════════════
 
 set SPECTOR_HOME=%~dp0..
-set JAR=%SPECTOR_HOME%\spector-dist\target\spector.jar
+set JAR=%SPECTOR_HOME%\synapse\spector-dist\target\spector.jar
 set CONFIG=%SPECTOR_HOME%\spector-local.yml
 
 if not exist "%JAR%" (

--- a/scripts/start-cortex-dev.ps1
+++ b/scripts/start-cortex-dev.ps1
@@ -43,25 +43,25 @@ if (-not $SkipBuild -and -not $FrontendOnly) {
     }
 }
 
-# -- Step 2: Start backend using mvn exec:exec (Maven handles classpath) --
+# -- Step 2: Start backend using Spring Boot Maven Plugin --
 $backendJob = $null
 if (-not $FrontendOnly) {
-    Write-Step "Starting Spector Node on port $Port..."
+    Write-Step "Starting Spector Synapse on port $Port..."
 
     $backendJob = Start-Job -ScriptBlock {
         param([string]$rootDir, [int]$p)
         $env:SPECTOR_PORT = $p
         Set-Location $rootDir
-        mvn -pl spector-node compile exec:exec -q 2>&1
+        mvn -Psynapse -pl synapse/spector-synapse spring-boot:run 2>&1
     } -ArgumentList $root, $Port
 
-    # Wait for backend to be ready
+    # Wait for backend to be ready (Spring Boot Actuator health endpoint)
     $ready = $false
     for ($i = 0; $i -lt 30; $i++) {
         Start-Sleep -Seconds 2
         try {
-            $resp = Invoke-RestMethod -Uri "http://localhost:$Port/health" -TimeoutSec 2 -ErrorAction SilentlyContinue
-            if ($resp) { $ready = $true; break }
+            $resp = Invoke-RestMethod -Uri "http://localhost:$Port/actuator/health" -TimeoutSec 2 -ErrorAction SilentlyContinue
+            if ($resp -and $resp.status -eq "UP") { $ready = $true; break }
         } catch { }
         if ($backendJob.State -eq "Failed" -or $backendJob.State -eq "Completed") {
             Write-Err "Backend process exited unexpectedly:"
@@ -107,7 +107,7 @@ Write-Host "  ------------------------------------------------" -ForegroundColor
 Write-Host ""
 
 try {
-    Push-Location (Join-Path $root "spector-cortex")
+    Push-Location (Join-Path $root "cortex/spector-cortex")
     npm run start
 } finally {
     Pop-Location

--- a/scripts/start-cortex-synapse.ps1
+++ b/scripts/start-cortex-synapse.ps1
@@ -110,7 +110,7 @@ Write-Host "  ------------------------------------------------" -ForegroundColor
 Write-Host ""
 
 try {
-    Push-Location (Join-Path $root "spector-cortex")
+    Push-Location (Join-Path $root "cortex/spector-cortex")
     npm run start
 } finally {
     Pop-Location

--- a/scripts/start-mcp.bat
+++ b/scripts/start-mcp.bat
@@ -6,7 +6,7 @@ REM  CLI args can override any setting.
 REM ═══════════════════════════════════════════════════════════════
 
 set SPECTOR_HOME=%~dp0..
-set JAR=%SPECTOR_HOME%\spector-dist\target\spector.jar
+set JAR=%SPECTOR_HOME%\synapse\spector-dist\target\spector.jar
 set CONFIG=%SPECTOR_HOME%\spector-local.yml
 
 if not exist "%JAR%" (

--- a/scripts/test-mcp-tools.ps1
+++ b/scripts/test-mcp-tools.ps1
@@ -6,7 +6,7 @@
 
 param(
     [string]$Config = "spector-local.yml",
-    [string]$Jar = "spector-dist/target/spector.jar"
+    [string]$Jar = "synapse/spector-dist/target/spector.jar"
 )
 
 $ErrorActionPreference = "Stop"

--- a/scripts/test-vector.ps1
+++ b/scripts/test-vector.ps1
@@ -5,7 +5,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$root = "D:\git\spector-search"
+$root = "d:\git\spector"
 
 # Build the JSON-RPC sequence: init + notify + query
 $initMsg = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test"}}}'
@@ -18,7 +18,7 @@ $tmpIn = [System.IO.Path]::GetTempFileName()
 @($initMsg, $notifyMsg, $queryMsg) | Set-Content $tmpIn -Encoding UTF8
 
 # Run server with stdin from file, capture stdout
-$javaArgs = "--enable-preview --add-modules jdk.incubator.vector -Xmx4g -jar $root\spector-dist\target\spector.jar serve --config $root\$Config"
+$javaArgs = "--enable-preview --add-modules jdk.incubator.vector -Xmx4g -jar $root\synapse\spector-dist\target\spector.jar serve --config $root\$Config"
 
 $psi = New-Object System.Diagnostics.ProcessStartInfo
 $psi.FileName = "java"

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
@@ -17,9 +17,11 @@ package com.spectrayan.spector.spring.autoconfigure;
 
 import com.spectrayan.spector.config.SpectorConfig;
 import com.spectrayan.spector.embed.EmbeddingProvider;
+import com.spectrayan.spector.embed.TextGenerationProvider;
 import com.spectrayan.spector.engine.DefaultSpectorEngine;
 import com.spectrayan.spector.engine.SpectorEngine;
 import com.spectrayan.spector.memory.DefaultSpectorMemory;
+import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
 import com.spectrayan.spector.memory.SalienceProfileProvider;
 import com.spectrayan.spector.memory.SpectorMemory;
@@ -127,6 +129,7 @@ public class SpectorAutoConfiguration {
     @ConditionalOnProperty(prefix = "spector.memory", name = "enabled", havingValue = "true")
     SpectorMemory spectorMemory(SpectorConfigProperties props,
                                  ObjectProvider<EmbeddingProvider> embedderProvider,
+                                 ObjectProvider<TextGenerationProvider> textGenProvider,
                                  ObjectProvider<MeterRegistry> registryProvider,
                                  ObjectProvider<SalienceProfileProvider> salienceProvider) {
 
@@ -151,6 +154,15 @@ public class SpectorAutoConfiguration {
             builder.persistence(Path.of(memoryProps.getPersistencePath()));
         }
 
+        // ── Entity extraction (LLM if TextGenerationProvider is present) ──
+        TextGenerationProvider textGen = textGenProvider.getIfAvailable();
+        if (textGen != null) {
+            builder.entityExtractionMode(EntityExtractionMode.LLM);
+            builder.textGenerationProvider(textGen);
+        } else {
+            builder.entityExtractionMode(EntityExtractionMode.NONE);
+        }
+
         // ── Salience profile provider (user-driven importance modulation) ──
         SalienceProfileProvider salience = salienceProvider.getIfAvailable();
         if (salience != null) {
@@ -169,9 +181,10 @@ public class SpectorAutoConfiguration {
         }
 
         SpectorMemory raw = builder.build();
-        log.info("SpectorMemory auto-configured: dims={}, persistence={}, path={}, entity=enabled, SPLADE={}, ColBERT={}, salience={}",
+        log.info("SpectorMemory auto-configured: dims={}, persistence={}, path={}, entity={}, SPLADE={}, ColBERT={}, salience={}",
                 memoryProps.getDimensions(), memoryProps.getPersistenceMode(),
-                memoryProps.getPersistencePath(), memoryProps.isSpladeEnabled(), memoryProps.isColbertEnabled(),
+                memoryProps.getPersistencePath(), textGen != null ? "enabled" : "disabled",
+                memoryProps.isSpladeEnabled(), memoryProps.isColbertEnabled(),
                 salience != null);
 
         MeterRegistry registry = registryProvider.getIfAvailable();

--- a/synapse/spector-synapse/Dockerfile
+++ b/synapse/spector-synapse/Dockerfile
@@ -20,7 +20,7 @@ RUN groupadd -r spector && useradd -r -g spector spector
 WORKDIR /app
 
 # Copy the fat JAR
-COPY --from=builder /build/spector-synapse/target/spector-synapse-*.jar app.jar
+COPY --from=builder /build/synapse/spector-synapse/target/spector-synapse-*.jar app.jar
 
 # Data directory for H2 database and file storage
 RUN mkdir -p /data && chown -R spector:spector /data /app

--- a/synapse/spector-synapse/README.md
+++ b/synapse/spector-synapse/README.md
@@ -4,7 +4,7 @@
 [![Java](https://img.shields.io/badge/Java-25+-green.svg)](https://openjdk.org/projects/jdk/25/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
 
-The **central nervous system** of the Spector ecosystem. Spring Boot 4 + Armeria entry point for cognitive chat, autonomous agent orchestration, LLM provider management, data connector routing, and channel adapters. Serves the [Cortex UI](../spector-cortex/) as static assets.
+The **central nervous system** of the Spector ecosystem. Spring Boot 4 + Armeria entry point for cognitive chat, autonomous agent orchestration, LLM provider management, data connector routing, and channel adapters. Serves the [Cortex UI](../../cortex/spector-cortex/) as static assets.
 
 ## Architecture
 

--- a/synapse/spector-synapse/pom.xml
+++ b/synapse/spector-synapse/pom.xml
@@ -116,6 +116,10 @@
 
         <dependency>
             <groupId>com.spectrayan</groupId>
+            <artifactId>spector-mcp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.spectrayan</groupId>
             <artifactId>spector-memory</artifactId>
         </dependency>
         <dependency>

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/SynapseApplication.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/SynapseApplication.java
@@ -35,7 +35,7 @@ import com.spectrayan.spector.synapse.config.SynapseProperties;
  *   <li><b>Synapse</b> — Synaptic Network (agent orchestration, signal routing)</li>
  * </ul>
  *
- * @see com.spectrayan.spector.synapse.config.ArmeriaServerConfig
+ * @see com.spectrayan.spector.synapse.config.WebConfig
  * @see com.spectrayan.spector.synapse.config.SynapseProperties
  */
 @SpringBootApplication

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/infrastructure/SpectorMemoryChatAdapter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/infrastructure/SpectorMemoryChatAdapter.java
@@ -87,6 +87,18 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
                     List.of("chat", "session:" + sessionId, "role:assistant", "model:" + model, "type:turn"),
                     null, Map.of()));
 
+            // Delete any existing session summaries for this session to avoid duplicates
+            try {
+                var existing = memoryService.recall(new RecallRequest("id:" + sessionId, 10, null));
+                for (var r : existing) {
+                    if (r.tags() != null && r.tags().contains("session_summary") && r.tags().contains("id:" + sessionId)) {
+                        memoryService.forget(r.id());
+                    }
+                }
+            } catch (Exception e) {
+                log.debug("[ChatAdapter] Failed to delete old session summary: {}", e.getMessage());
+            }
+
             // Store/Update session summary record for listing
             String preview = userMessage.length() > 200 ? userMessage.substring(0, 200) : userMessage;
             memoryService.store(new StoreRequest(

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/EmbeddingProviderConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/EmbeddingProviderConfig.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.synapse.config;
 
 import com.spectrayan.spector.embed.EmbeddingConfig;
 import com.spectrayan.spector.embed.EmbeddingProvider;
+import com.spectrayan.spector.embed.TextGenerationProvider;
 import com.spectrayan.spector.embed.ollama.OllamaEmbeddingProvider;
 import com.spectrayan.spector.memory.id.TsidGenerator;
 import org.slf4j.Logger;
@@ -43,8 +44,9 @@ public class EmbeddingProviderConfig {
     EmbeddingProvider embeddingProvider(SynapseProperties props) {
         EmbeddingConfig config = EmbeddingConfig
                 .ollama(props.ollama().embedModel())
-                .withBaseUrl(props.ollama().baseUrl());
-        log.info("[EmbeddingProvider] Configured Ollama embedding: model={}, baseUrl={}",
+                .withBaseUrl(props.ollama().baseUrl())
+                .withTimeout(java.time.Duration.ofSeconds(300));
+        log.info("[EmbeddingProvider] Configured Ollama embedding: model={}, baseUrl={}, timeout=300s",
                 props.ollama().embedModel(), props.ollama().baseUrl());
         return new OllamaEmbeddingProvider(config);
     }
@@ -53,5 +55,20 @@ public class EmbeddingProviderConfig {
     @ConditionalOnMissingBean(TsidGenerator.class)
     TsidGenerator tsidGenerator() {
         return new TsidGenerator();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(TextGenerationProvider.class)
+    TextGenerationProvider textGenerationProvider(com.spectrayan.spector.synapse.provider.ProviderRegistry providerRegistry, SynapseProperties props) {
+        try {
+            var llm = new com.spectrayan.spector.embed.ollama.OllamaLlmProvider(
+                    props.ollama().model(), props.ollama().baseUrl(), java.time.Duration.ofSeconds(300));
+            providerRegistry.registerGeneration("ollama", llm);
+            log.info("[EmbeddingProvider] Registered default Ollama text generation provider: model={}, baseUrl={}, timeout=300s",
+                    props.ollama().model(), props.ollama().baseUrl());
+        } catch (Exception e) {
+            log.warn("Failed to register default Ollama generation provider: {}", e.getMessage());
+        }
+        return new com.spectrayan.spector.synapse.provider.DelegatingTextGenerationProvider(providerRegistry);
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GlobalExceptionHandler.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GlobalExceptionHandler.java
@@ -20,6 +20,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
  * Global exception handler for all Synapse REST controllers.
@@ -43,6 +45,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(new ErrorResponse(409, "Conflict", ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NoResourceFoundException ex) {
+        log.debug("[Error] Resource not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new ErrorResponse(404, "Not Found", ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoHandler(NoHandlerFoundException ex) {
+        log.debug("[Error] Handler not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new ErrorResponse(404, "Not Found", ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.synapse.config;
+
+import com.spectrayan.spector.synapse.agent.ToolRegistry;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Exposes the official Model Context Protocol (MCP) server over HTTP/SSE.
+ *
+ * Exposes registered Spring-managed tools dynamically, conforming strictly to the
+ * official MCP specification.
+ */
+@Configuration
+public class McpServerConfig {
+
+    @Bean
+    public HttpServletSseServerTransportProvider mcpTransportProvider() {
+        McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(
+                tools.jackson.databind.json.JsonMapper.builder().build());
+
+        return HttpServletSseServerTransportProvider.builder()
+                .jsonMapper(jsonMapper)
+                .sseEndpoint("/mcp")
+                .messageEndpoint("/mcp/message")
+                .build();
+    }
+
+    @Bean
+    public ServletRegistrationBean<HttpServletSseServerTransportProvider> mcpServletRegistrationBean(
+            HttpServletSseServerTransportProvider transportProvider) {
+        ServletRegistrationBean<HttpServletSseServerTransportProvider> registration =
+                new ServletRegistrationBean<>(transportProvider);
+        registration.addUrlMappings("/mcp", "/mcp/*");
+        registration.setLoadOnStartup(1);
+        return registration;
+    }
+
+    @Bean
+    public McpSyncServer mcpSyncServer(HttpServletSseServerTransportProvider transportProvider,
+                                       ToolRegistry toolRegistry) {
+
+        // Dynamically translate local AgentTool beans to official MCP SDK ToolSpecifications
+        List<McpServerFeatures.SyncToolSpecification> toolSpecs = toolRegistry.all().values().stream()
+                .map(agentTool -> {
+                    var tool = McpSchema.Tool.builder(agentTool.name())
+                            .description(agentTool.description())
+                            .inputSchema(agentTool.parameterSchema())
+                            .build();
+
+                    return new McpServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
+                        Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
+                        try {
+                            String result = agentTool.execute(args);
+                            return McpSchema.CallToolResult.builder()
+                                    .addTextContent(result)
+                                    .isError(false)
+                                    .build();
+                        } catch (Exception e) {
+                            return McpSchema.CallToolResult.builder()
+                                    .addTextContent("Error: " + e.getMessage())
+                                    .isError(true)
+                                    .build();
+                        }
+                    });
+                })
+                .toList();
+
+        McpSyncServer server = McpServer.sync(transportProvider)
+                .serverInfo("spector", "1.0.0")
+                .capabilities(McpSchema.ServerCapabilities.builder()
+                        .tools(true)
+                        .resources(false, false)
+                        .prompts(false)
+                        .build())
+                .tools(toolSpecs)
+                .build();
+
+        return server;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
@@ -19,9 +19,9 @@ import com.spectrayan.spector.synapse.agent.ToolRegistry;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.McpServerFeatures;
-import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -31,49 +31,56 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Exposes the official Model Context Protocol (MCP) server over HTTP/SSE.
+ * Exposes the official Model Context Protocol (MCP) server over stateless HTTP.
  *
- * Exposes registered Spring-managed tools dynamically, conforming strictly to the
- * official MCP specification.
+ * <p>Uses {@link HttpServletStatelessServerTransport} which handles each request
+ * independently — no sessions, no SSE streaming, no persistent connections.
+ * Each POST to {@code /mcp} receives a direct JSON response and closes.</p>
+ *
+ * <p>This is ideal for IDE integrations (Antigravity, Cursor, etc.) that only need
+ * tool discovery and invocation without server-initiated notifications.</p>
  */
 @Configuration
 public class McpServerConfig {
 
     @Bean
-    public HttpServletSseServerTransportProvider mcpTransportProvider() {
-        McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(
-                tools.jackson.databind.json.JsonMapper.builder().build());
+    public McpJsonMapper mcpJsonMapper() {
+        return new JacksonMcpJsonMapper(
+                tools.jackson.databind.json.JsonMapper.builder()
+                        .disable(tools.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                        .build());
+    }
 
-        return HttpServletSseServerTransportProvider.builder()
+    @Bean
+    public HttpServletStatelessServerTransport mcpTransport(McpJsonMapper jsonMapper) {
+        return HttpServletStatelessServerTransport.builder()
                 .jsonMapper(jsonMapper)
-                .sseEndpoint("/mcp")
-                .messageEndpoint("/mcp/message")
                 .build();
     }
 
     @Bean
-    public ServletRegistrationBean<HttpServletSseServerTransportProvider> mcpServletRegistrationBean(
-            HttpServletSseServerTransportProvider transportProvider) {
-        ServletRegistrationBean<HttpServletSseServerTransportProvider> registration =
-                new ServletRegistrationBean<>(transportProvider);
-        registration.addUrlMappings("/mcp", "/mcp/*");
+    public ServletRegistrationBean<HttpServletStatelessServerTransport> mcpServletRegistrationBean(
+            HttpServletStatelessServerTransport transport) {
+        ServletRegistrationBean<HttpServletStatelessServerTransport> registration =
+                new ServletRegistrationBean<>(transport);
+        registration.addUrlMappings("/mcp");
         registration.setLoadOnStartup(1);
         return registration;
     }
 
     @Bean
-    public McpSyncServer mcpSyncServer(HttpServletSseServerTransportProvider transportProvider,
-                                       ToolRegistry toolRegistry) {
+    public McpStatelessSyncServer mcpStatelessServer(HttpServletStatelessServerTransport transport,
+                                                      ToolRegistry toolRegistry) {
 
         // Dynamically translate local AgentTool beans to official MCP SDK ToolSpecifications
-        List<McpServerFeatures.SyncToolSpecification> toolSpecs = toolRegistry.all().values().stream()
+        List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecs = toolRegistry.all().values().stream()
                 .map(agentTool -> {
                     var tool = McpSchema.Tool.builder(agentTool.name())
                             .description(agentTool.description())
                             .inputSchema(agentTool.parameterSchema())
                             .build();
 
-                    return new McpServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
+                    return new McpStatelessServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
                         Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
                         try {
                             String result = agentTool.execute(args);
@@ -91,7 +98,7 @@ public class McpServerConfig {
                 })
                 .toList();
 
-        McpSyncServer server = McpServer.sync(transportProvider)
+        return McpServer.sync(transport)
                 .serverInfo("spector", "1.0.0")
                 .capabilities(McpSchema.ServerCapabilities.builder()
                         .tools(true)
@@ -100,7 +107,5 @@ public class McpServerConfig {
                         .build())
                 .tools(toolSpecs)
                 .build();
-
-        return server;
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.synapse.config;
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/WebConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/WebConfig.java
@@ -25,13 +25,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * due to the Jackson 2/3 classpath conflict with Spring Boot 4.</p>
  */
 @Configuration
-public class ArmeriaServerConfig implements WebMvcConfigurer {
+public class WebConfig implements WebMvcConfigurer {
 
-    private static final Logger log = LoggerFactory.getLogger(ArmeriaServerConfig.class);
+    private static final Logger log = LoggerFactory.getLogger(WebConfig.class);
 
     private final SynapseProperties props;
 
-    public ArmeriaServerConfig(SynapseProperties props) {
+    public WebConfig(SynapseProperties props) {
         this.props = props;
     }
 
@@ -44,7 +44,7 @@ public class ArmeriaServerConfig implements WebMvcConfigurer {
         }
 
         registry.addMapping("/**")
-                .allowedOrigins(originArray)
+                .allowedOriginPatterns(originArray)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("Content-Type", "Authorization", "X-API-Key")
                 .exposedHeaders("Content-Type")

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/platform/events/api/EventController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/platform/events/api/EventController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.synapse.platform.events.api;
+
+import com.spectrayan.sse.server.emitter.SseEmitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+/**
+ * Spring MVC REST Controller for Server-Sent Events (SSE).
+ *
+ * Bridges the reactive Spectrayan SSE Server library (which is WebFlux-based)
+ * to run seamlessly on the Tomcat Servlet container under Spring Boot 4.
+ */
+@RestController
+@RequestMapping("/api/v1")
+public class EventController {
+
+    private static final Logger log = LoggerFactory.getLogger(EventController.class);
+
+    private final SseEmitter sseEmitter;
+
+    public EventController(SseEmitter sseEmitter) {
+        this.sseEmitter = sseEmitter;
+    }
+
+    /**
+     * Establishes the real-time event stream connection.
+     *
+     * @param filter optional comma-separated event types to filter by (e.g. "cortex,ingestion")
+     * @return a Flux streaming ServerSentEvent notifications
+     */
+    @GetMapping(value = "/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<Object>> events(@RequestParam(required = false, defaultValue = "") String filter) {
+        log.debug("📡 SSE connection request received: filter='{}'", filter);
+        if (filter == null || filter.isBlank()) {
+            return sseEmitter.connect("cortex");
+        }
+
+        String[] topics = filter.split(",");
+        Flux<ServerSentEvent<Object>> mergedFlux = Flux.empty();
+        for (String topic : topics) {
+            String cleanTopic = topic.trim();
+            if (!cleanTopic.isEmpty()) {
+                mergedFlux = Flux.merge(mergedFlux, sseEmitter.connect(cleanTopic));
+            }
+        }
+        return mergedFlux;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/platform/events/api/EventController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/platform/events/api/EventController.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.synapse.platform.events.api;
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/provider/DelegatingTextGenerationProvider.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/provider/DelegatingTextGenerationProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.provider;
+
+import com.spectrayan.spector.embed.GenerationOptions;
+import com.spectrayan.spector.embed.TextGenerationProvider;
+
+/**
+ * Delegating implementation of {@link TextGenerationProvider} that routes requests
+ * to the dynamically active provider registered in the {@link ProviderRegistry}.
+ *
+ * This allows the statically defined SpectorMemory bean to leverage dynamic provider
+ * switching in the Synapse container.
+ */
+public class DelegatingTextGenerationProvider implements TextGenerationProvider {
+
+    private final ProviderRegistry providerRegistry;
+
+    public DelegatingTextGenerationProvider(ProviderRegistry providerRegistry) {
+        this.providerRegistry = providerRegistry;
+    }
+
+    private TextGenerationProvider getActive() {
+        return providerRegistry.activeGeneration()
+                .orElseThrow(() -> new TextGenerationProvider.GenerationException(
+                        "No active text generation provider registered in the ProviderRegistry"));
+    }
+
+    @Override
+    public String generate(String prompt) {
+        return getActive().generate(prompt);
+    }
+
+    @Override
+    public String generate(String prompt, GenerationOptions options) {
+        return getActive().generate(prompt, options);
+    }
+
+    @Override
+    public String modelName() {
+        return providerRegistry.activeGeneration()
+                .map(TextGenerationProvider::modelName)
+                .orElse("none");
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return providerRegistry.activeGeneration()
+                .map(TextGenerationProvider::isAvailable)
+                .orElse(false);
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/security/ApiKeyAuthenticationFilter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/security/ApiKeyAuthenticationFilter.java
@@ -60,8 +60,8 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
 
         String path = request.getRequestURI();
 
-        // Skip non-API paths
-        if (!path.startsWith("/api/")) {
+        // Skip non-API and non-MCP paths
+        if (!path.startsWith("/api/") && !path.startsWith("/mcp")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/synapse/spector-synapse/src/main/resources/application.yml
+++ b/synapse/spector-synapse/src/main/resources/application.yml
@@ -12,6 +12,8 @@ spector:
   port: ${SPECTOR_PORT:7070}
   api-key: ${SPECTOR_API_KEY:spector-dev-key}
   data-dir: ${SPECTOR_DATA_DIR:./spector-data}
+  cors:
+    allowed-origins: ${SPECTOR_CORS_ORIGINS:http://localhost:4200}
 
   # ── Spector Spring Auto-Configuration ──
   # SpectorAutoConfiguration (spector-spring module) creates a Spring-managed


### PR DESCRIPTION
## Summary

Continuation of the single-image deployment work — this batch addresses MCP transport, LLM-based entity extraction, CORS configuration, and deployment tuning.

## Changes

### Memory (`spector-memory`)
- **Graph overview** now returns most-recent nodes first (reversed order)
- **Hyperedge truncation** — truncate vertex arrays exceeding `MAX_VERTICES_PER_EDGE` to prevent `IllegalArgumentException`

### Spring Auto-Configuration (`spector-spring`)
- Wire optional `TextGenerationProvider` into `SpectorMemory` bean
- Configure `EntityExtractionMode.LLM` when provider is available, `NONE` otherwise
- Log entity extraction status in startup diagnostics

### Synapse (`spector-synapse`)
- **Replace `ArmeriaServerConfig` → `WebConfig`** — rename to accurate class name, switch to `allowedOriginPatterns()` for wildcard CORS support
- **Add `DelegatingTextGenerationProvider`** — routes text generation calls through `ProviderRegistry`'s active provider
- **Register default Ollama LLM provider** in `EmbeddingProviderConfig` with 300s timeout
- **Migrate MCP to stateless HTTP** — `HttpServletStatelessServerTransport` replaces SSE transport for IDE integrations (Antigravity, Cursor)
- **Add 404 handlers** — `NoResourceFoundException` and `NoHandlerFoundException` now return clean JSON

### Deploy
- Widen CORS origins with wildcard for dev/IDE access
- Reduce default engine capacity (10000 → 100) for faster dev startup
- Reduce ingestion parallelism (2 → 1) to avoid resource contention

## Testing
- All changes are runtime-validated against local Docker deployment
- MCP stateless transport tested with IDE integration