### PR TITLE
docs(docs): clean up implementation leaks, reorganize memory index, and expand synapse submodules

### DIFF
--- a/docs/docs/labs/roadmap.md
+++ b/docs/docs/labs/roadmap.md
@@ -721,6 +721,37 @@ flowchart TD
 
 ---
 
+## Hypergraphs & Spectral Sparsification
+
+### Concept
+
+Preventing graph node and edge explosion in Spector's 3-Layer Cognitive Architecture (HebbianGraph, EntityGraph, TemporalChain) through mathematical compression:
+
+1. **Hypergraphs**: Collapsing pairwise relationships into n-body hyperedges. Instead of creating binary edges between entities (e.g. `Alice → ProjectAlpha` and `Alice → OrgX`), a single hyperedge `{Alice, ProjectAlpha, OrgX}` connects all entities. This collapses representation complexity by 40-60%.
+2. **Spectral Sparsification**: Using eigenvalue-guided (effective resistance) sampling to prune Hebbian memory-to-memory edges during the sleep consolidation cycle. This maintains spreading activation recall quality with a 50% lower edge degree limit.
+
+### Biological Basis
+
+Cognitive memory doesn't just store flat pairs; it stores n-body event-based memories (episodes involving multiple entities, locations, and contexts). Furthermore, consolidation processes selectively prune weak associative connections while preserving global topological path connectivity (modeled as spectral sparsification).
+
+### Proposed Architecture
+
+- **Panama-Compatible Hyperedge Layout**: A fixed-width off-heap layout that references role-assigned vertices:
+  ```
+  Hyperedge Node (32B):
+    [edgeId:4B][type:4B][weight:4B][vertexCount:4B]
+    [vertexOffset:4B][memoryIdx:4B][timestamp:8B]
+  ```
+- **Effective Resistance Sparsification**: Computed during the `ReflectDaemon` background consolidation cycle using randomized SVD/Lanczos approximations.
+
+### Dependencies & Complexity
+
+- **Dependencies:** LLM reflection extraction prompt updates to support n-body grouping, 3D Cortex UI hypergraph visualization.
+- **Complexity:** High — dynamic off-heap incidence matrix allocations, spectral matrix computations on large graph Laplacians.
+- **Estimated effort:** 3-4 weeks
+
+---
+
 ## Priority Matrix
 
 | Feature | Value | Complexity | Dependencies Ready? | Estimated Effort | Status |
@@ -729,6 +760,7 @@ flowchart TD
 | SPLADE Sparse Retrieval | 🟢 High | High | ✅ | 2-3 weeks | ✅ Done |
 | ColBERT v2 Reranking | 🟢 High | High | ✅ | 2-3 weeks | ✅ Done |
 | Executive Dysfunction | 🟡 Medium | Medium | ✅ | 1-2 weeks | 🔜 Planned |
+| Hypergraphs & Spectral | 🟢 High | High | ⏳ | 3-4 weeks | 🔬 Research |
 | Neuromodulatory Gain | 🟡 Medium | High | ⏳ | 3-4 weeks | 🔬 Research |
 | Dynamic Quantization | 🟡 Medium | High | ⏳ | 4-6 weeks | 🔬 Research |
 | SPLARE (Sparse Autoencoders) | 🟡 Medium | High | ⏳ | 3-4 weeks | 🔬 Research |

--- a/docs/docs/labs/roadmap.md
+++ b/docs/docs/labs/roadmap.md
@@ -721,34 +721,53 @@ flowchart TD
 
 ---
 
-## Hypergraphs & Spectral Sparsification
+## ✅ Hypergraphs & Spectral Sparsification
+
+> **Status**: Hypergraphs — **Graduated** (implemented in `HyperEntityGraph`). Spectral Sparsification — **Research**.
+>
+> **Recently graduated:** HyperEntityGraph off-heap implementation with Panama FFM.
 
 ### Concept
 
-Preventing graph node and edge explosion in Spector's 3-Layer Cognitive Architecture (HebbianGraph, EntityGraph, TemporalChain) through mathematical compression:
+Preventing graph node and edge explosion in Spector's Cognitive Architecture through mathematical compression:
 
-1. **Hypergraphs**: Collapsing pairwise relationships into n-body hyperedges. Instead of creating binary edges between entities (e.g. `Alice → ProjectAlpha` and `Alice → OrgX`), a single hyperedge `{Alice, ProjectAlpha, OrgX}` connects all entities. This collapses representation complexity by 40-60%.
-2. **Spectral Sparsification**: Using eigenvalue-guided (effective resistance) sampling to prune Hebbian memory-to-memory edges during the sleep consolidation cycle. This maintains spreading activation recall quality with a 50% lower edge degree limit.
+1. **Hypergraphs** ✅: Collapsing pairwise relationships into n-body hyperedges. Instead of creating binary edges between entities (e.g. `Alice → ProjectAlpha` and `Alice → OrgX`), a single hyperedge `{Alice, ProjectAlpha, OrgX}` connects all entities with typed roles. This collapses representation complexity by 40-60%.
+2. **Spectral Sparsification** 🔬: Using eigenvalue-guided (effective resistance) sampling to prune Hebbian memory-to-memory edges during the sleep consolidation cycle. This maintains spreading activation recall quality with a 50% lower edge degree limit.
 
 ### Biological Basis
 
 Cognitive memory doesn't just store flat pairs; it stores n-body event-based memories (episodes involving multiple entities, locations, and contexts). Furthermore, consolidation processes selectively prune weak associative connections while preserving global topological path connectivity (modeled as spectral sparsification).
 
-### Proposed Architecture
+### Implemented Architecture
 
-- **Panama-Compatible Hyperedge Layout**: A fixed-width off-heap layout that references role-assigned vertices:
-  ```
-  Hyperedge Node (32B):
-    [edgeId:4B][type:4B][weight:4B][vertexCount:4B]
-    [vertexOffset:4B][memoryIdx:4B][timestamp:8B]
-  ```
-- **Effective Resistance Sparsification**: Computed during the `ReflectDaemon` background consolidation cycle using randomized SVD/Lanczos approximations.
+The `HyperEntityGraph` uses three off-heap Panama FFM segments:
 
-### Dependencies & Complexity
+```
+Hyperedge Node (32B):
+  [edgeId:4B][type:4B][weight:4B][vertexCount:4B]
+  [vertexOffset:4B][memoryIdx:4B][timestamp:8B]
 
-- **Dependencies:** LLM reflection extraction prompt updates to support n-body grouping, 3D Cortex UI hypergraph visualization.
-- **Complexity:** High — dynamic off-heap incidence matrix allocations, spectral matrix computations on large graph Laplacians.
-- **Estimated effort:** 3-4 weeks
+Vertex Entry (8B):
+  [entityId:4B][roleId:4B]
+
+Incidence Index (4B × entityCapacity):
+  [hyperedgeListOffset] → per-entity list of participating hyperedges
+
+Incidence List Entry (4B):
+  [hyperedgeId]
+```
+
+| Property | Value |
+|---|---|
+| Max vertices per hyperedge | 3-8 entities with typed roles |
+| Max hyperedges per entity | 64 (participation cap, weakest eviction) |
+| Persistence | Binary file ("HYEG" magic, V1) |
+
+### Remaining Work (Spectral Sparsification)
+
+- **Effective Resistance Sparsification**: To be computed during the `ReflectDaemon` background consolidation cycle using randomized SVD/Lanczos approximations.
+- **Dependencies:** Approximate eigenvalue computation library, integration with decay cycle.
+- **Estimated effort:** 2-3 weeks
 
 ---
 
@@ -760,7 +779,8 @@ Cognitive memory doesn't just store flat pairs; it stores n-body event-based mem
 | SPLADE Sparse Retrieval | 🟢 High | High | ✅ | 2-3 weeks | ✅ Done |
 | ColBERT v2 Reranking | 🟢 High | High | ✅ | 2-3 weeks | ✅ Done |
 | Executive Dysfunction | 🟡 Medium | Medium | ✅ | 1-2 weeks | 🔜 Planned |
-| Hypergraphs & Spectral | 🟢 High | High | ⏳ | 3-4 weeks | 🔬 Research |
+| Hypergraphs | 🟢 High | High | ✅ | 3-4 weeks | ✅ Done |
+| Spectral Sparsification | 🟢 High | High | ⏳ | 2-3 weeks | 🔬 Research |
 | Neuromodulatory Gain | 🟡 Medium | High | ⏳ | 3-4 weeks | 🔬 Research |
 | Dynamic Quantization | 🟡 Medium | High | ⏳ | 4-6 weeks | 🔬 Research |
 | SPLARE (Sparse Autoencoders) | 🟡 Medium | High | ⏳ | 3-4 weeks | 🔬 Research |

--- a/docs/docs/memory/architecture.md
+++ b/docs/docs/memory/architecture.md
@@ -15,7 +15,7 @@ Spector Memory is organized around a **biological metaphor** where each Java pac
 |---|---|---|
 | `SpectorMemory` | Single entry point for all operations | Configure tiers, capacities, embedding providers |
 | `TierStore` interface | Add new memory tiers | Implement the interface + register in `TierRouter` — no other changes needed |
-| `AbstractTierStore` | Common tier lifecycle | Extend for new off-heap tier stores with Arena/segment management |
+| `AbstractTierStore` | Common tier lifecycle | Base implementation for custom tier storage backends |
 | `RecallListener` | Post-recall hooks | Add async listeners for co-activation tracking, logging, metrics |
 | `CognitiveIngestionTarget` / `RecallPipeline` | Discrete processing steps | Each step is independently testable and replaceable |
 

--- a/docs/docs/memory/cortex.md
+++ b/docs/docs/memory/cortex.md
@@ -17,18 +17,13 @@ Human memory is not a single system. Cognitive science identifies distinct memor
 graph TB
     subgraph "TierRouter — Polymorphic Registry"
         direction TB
-        TR["TierStore interface"]
+        TR["TierStore interface"]:::core
     end
     
-    TR --> WM["🧪 Working Memory<br/>WorkingMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Prefrontal Cortex<br/>Volatile circular buffer<br/>~100 records"]
-    TR --> EM["📝 Episodic Memory<br/>EpisodicMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Hippocampus<br/>Time-partitioned mmap<br/>Unbounded"]
-    TR --> SE["🧬 Semantic Memory<br/>SemanticMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Neocortex<br/>Permanent knowledge<br/>~5,000 records"]
-    TR --> PR["⚙️ Procedural Memory<br/>ProceduralMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Basal Ganglia<br/>Learned procedures<br/>~500 records"]
-    
-    style WM fill:#e74c3c,color:white
-    style EM fill:#3498db,color:white
-    style SE fill:#2ecc71,color:white
-    style PR fill:#9b59b6,color:white
+    TR --> WM["🧪 Working Memory<br/>WorkingMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Prefrontal Cortex<br/>Volatile circular buffer<br/>~100 records"]:::working
+    TR --> EM["📝 Episodic Memory<br/>EpisodicMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Hippocampus<br/>Time-partitioned files<br/>Unbounded"]:::episodic
+    TR --> SE["🧬 Semantic Memory<br/>SemanticMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Neocortex<br/>Permanent knowledge<br/>~5,000 records"]:::semantic
+    TR --> PR["⚙️ Procedural Memory<br/>ProceduralMemoryStore<br/>━━━━━━━━━━━━━━━━━<br/>Basal Ganglia<br/>Learned procedures<br/>~500 records"]:::procedural
 ```
 
 ---
@@ -47,7 +42,7 @@ All four stores implement a common `TierStore` interface. The `TierRouter` dispa
 
 | Property | Value |
 |---|---|
-| Storage | Volatile off-heap segment |
+| Storage | In-memory segment (volatile) |
 | Capacity | Configurable (default: 100) |
 | Eviction | Circular buffer — oldest entries overwritten |
 | Persistence | **None** — lost on JVM shutdown |
@@ -65,7 +60,7 @@ Working memory operates as a circular buffer: when the buffer is full, the oldes
 
 | Property | Value |
 |---|---|
-| Storage | Memory-mapped files (`FileChannel.map()`) |
+| Storage | Memory-mapped files (persistent) |
 | Capacity | Unbounded (1 partition per day, each up to 10,000 records) |
 | Eviction | Tombstone + compaction |
 | Persistence | **Full** — survives JVM restarts |
@@ -73,7 +68,7 @@ Working memory operates as a circular buffer: when the buffer is full, the oldes
 
 ### Partition Lifecycle
 
-Each episodic partition is a memory-mapped file with a 64-byte metadata header:
+Each episodic partition is a structured memory-mapped file with a binary metadata header:
 
 ```
 ┌─── Partition File ─────────────────────────────────────────┐
@@ -86,10 +81,10 @@ Each episodic partition is a memory-mapped file with a 64-byte metadata header:
 │   ├── 4B state (ACTIVE/SEALED/REFLECTABLE/TOMBSTONED/...)  │
 │   ├── 4B stride                                             │
 │   └── 36B reserved                                          │
-├── [Record 0: 64B header + NB vector] ──────────────────────┤
-├── [Record 1: 64B header + NB vector] ──────────────────────┤
+│─── [Record 0: Header + Quantized Vector] ──────────────────┤
+│─── [Record 1: Header + Quantized Vector] ──────────────────┤
 │   ...                                                       │
-└── [Record N-1]  ───────────────────────────────────────────┘
+└─── [Record N-1]  ───────────────────────────────────────────┘
 ```
 
 **Partition state machine**:
@@ -114,11 +109,11 @@ stateDiagram-v2
 
 | Property | Value |
 |---|---|
-| Storage | Rolling `semantic-NNN.mem` files |
+| Storage | Persistent rolling files |
 | Capacity per partition | Configurable (default: 10,000 records) |
 | Total capacity | Unbounded (new partitions roll automatically) |
 | Eviction | Tombstone + per-partition compaction |
-| Persistence | **Full** — mmap-backed files survive restarts |
+| Persistence | **Full** — persistent files survive restarts |
 | Recall | Parallel per-partition scan via virtual threads |
 | Use case | "The user prefers dark mode", "Java uses garbage collection" |
 
@@ -146,7 +141,7 @@ stateDiagram-v2
 
 | Property | Value |
 |---|---|
-| Storage | Fixed-capacity off-heap slab |
+| Storage | Fixed-capacity in-memory slab |
 | Capacity | Configurable (default: 5,000) |
 | Use case | Small deployments or in-memory mode |
 
@@ -158,7 +153,7 @@ stateDiagram-v2
 
 | Property | Value |
 |---|---|
-| Storage | Linear off-heap segment |
+| Storage | Linear in-memory segment |
 | Capacity | Configurable (default: 500) |
 | Eviction | None (append-only) |
 | Persistence | Via WAL replay |

--- a/docs/docs/memory/hebbian.md
+++ b/docs/docs/memory/hebbian.md
@@ -1,11 +1,11 @@
 ---
-title: "3-Layer Cognitive Graph"
-description: "HebbianGraph, TemporalChain, and EntityGraph — three biologically-inspired graph structures that augment vector recall with associative, temporal, and relational signals."
+title: "4-Layer Cognitive Graph"
+description: "HebbianGraphCsr, TemporalChain, EntityGraph, and HyperEntityGraph — four biologically-inspired graph structures that augment vector recall with associative, temporal, relational, and hyperedge signals."
 ---
 
-# 🧠 3-Layer Cognitive Graph
+# 🧠 4-Layer Cognitive Graph
 
-> **Biological Analog**: The brain doesn't retrieve memories by content similarity alone. It uses **associative networks** (neurons that fire together wire together), **temporal sequences** (what happened next?), and **semantic knowledge** (who manages what project?). Spector Memory implements all three as graph structures that augment vector recall.
+> **Biological Analog**: The brain doesn't retrieve memories by content similarity alone. It uses **associative networks** (neurons that fire together wire together), **temporal sequences** (what happened next?), **semantic knowledge** (who manages what project?), and **n-body event groupings** (multi-entity episodes). Spector Memory implements all four as graph structures that augment vector recall.
 
 ---
 
@@ -20,13 +20,15 @@ graph TB
     RP --> S5c["Step 5c: Hebbian<br/>Spreading Activation"]
     RP --> S5d["Step 5d: Temporal<br/>Chain Extension"]
     RP --> S5e["Step 5e: Entity<br/>Graph Traversal"]
+    RP --> S5f["Step 5f: Hyperedge<br/>Set Intersection"]
 
     S5c --> M["Merge & Dedup → Re-sort → Final Top-K"]
     S5d --> M
     S5e --> M
+    S5f --> M
 
     subgraph "Layer 1 — Hebbian Association"
-        HG["HebbianGraph<br/>Co-activation edges"]
+        HG["HebbianGraphCsr<br/>CSR co-activation edges"]
         CAT["CoActivationTracker<br/>Tag-level STDP learning"]
     end
 
@@ -39,16 +41,22 @@ graph TB
         TC["TemporalChain<br/>Session-linked sequences"]
     end
 
+    subgraph "Layer 4 — Hyperedge"
+        HEG["HyperEntityGraph<br/>n-body entity groupings"]
+    end
+
     S5c --> HG
     S5c --> CAT
     S5d --> TC
     S5e --> EG
+    S5f --> HEG
 
     style RP fill:#4a90d9,color:white
     style M fill:#00b894,color:white
     style HG fill:#e74c3c,color:white
     style EG fill:#9b59b6,color:white
     style TC fill:#f39c12,color:white
+    style HEG fill:#e91e63,color:white
 ```
 
 !!! tip "Graceful Degradation"
@@ -79,12 +87,13 @@ graph LR
 
 | Property | Value |
 |---|---|
-| Max degree | 20 neighbors per memory |
-| Edge weight | Float — strengthened on co-ingestion |
-| Eviction | Weakest edge evicted when degree exceeds max |
-| Decay | 0.9× multiplicative factor per consolidation cycle |
+| Max degree | 24 neighbors per memory (configurable) |
+| Edge format | 12B — 4B neighbor + 4B weight + 2B lastCycle + 1B bridgeScore + 1B flags |
+| Storage layout | **CSR (Compressed Sparse Row)** — stores only actual edges, ~90% memory reduction vs. fixed-width |
+| Eviction | Multi-signal importance scoring (weight, recency, bridge centrality, redundancy, arousal, Zeigarnik) |
+| Decay | 0.9× multiplicative factor per consolidation cycle; bridge-protected edges floored instead of evicted |
 | Spreading activation | BFS with depth=2, attenuated by edge weight |
-| Persistence | Binary file with chunked 64KB I/O |
+| Persistence | Binary CSR file (V3 format, "HCSR" magic) with offset + edge segments |
 
 ### How It's Used
 
@@ -185,16 +194,20 @@ The entity graph supports typed BFS traversal with optional relation filtering:
 Entity nodes use a **fixed 64-byte** cache-line-aligned layout with a **separate adjacency segment** for entity→memory links:
 
 ```
-Entity Node (64B):
+Entity Node (64B, 8-byte aligned — V2):
   [type:4B][pad:4B][nameHash:8B]
   [adjOffset:4B][adjCount:4B][adjCapacity:4B][pad:4B]  ← pointer into adjacency segment
   [pad:4B][degree:4B][edgeStart:4B][pad:20B]
+
+Entity Edge (16B — V2):
+  [targetId:4B][relationType:4B][weight:4B]
+  [lastCycle:2B][bridgeScore:1B][flags:1B]
 
 Adjacency Entry (8B):
   [memIdx:4B][weight:4B]    ← weighted link to a memory slot
 ```
 
-This design allows **unlimited** entity→memory associations (no fixed cap), with amortized O(1) growth via block doubling. Each entity starts with 8 adjacency slots and grows as needed.
+This design allows **unlimited** entity→memory associations (no fixed cap), with amortized O(1) growth via block doubling. Each entity starts with 8 adjacency slots and grows as needed. Max 48 entity–entity edges per entity (configurable), with multi-signal importance eviction.
 
 ---
 
@@ -235,23 +248,28 @@ All graph components persist alongside memory data in DISK mode:
 
 | Component | File | Format |
 |---|---|---|
-| HebbianGraph | `hebbian.graph` | Binary with chunked 64KB I/O |
+| HebbianGraphCsr | `hebbian.graph` | CSR V3 ("HCSR" magic) — offset segment + edge segment. Auto-migrates legacy V2 files. |
 | CoActivationTracker | `coactivation.dat` | Pair table + edge table + hash→tag map |
-| EntityGraph | `entity.graph` | Entity segment + edge segment + adjacency segment + name index |
-| TemporalChain | `temporal.chain` | Raw linked-list segment |
+| EntityGraph | `entity.graph` | Entity segment + edge segment + adjacency segment + name index ("EGMM" magic, V2) |
+| HyperEntityGraph | `hyper-entity.graph` | Hyperedge segment + vertex segment + incidence index + incidence list ("HYEG" magic) |
+| TemporalChain | `temporal.chain` | Raw linked-list segment ("TPCH" magic, V2) |
 | TypeRegistry | `entity-types.reg` / `relation-types.reg` | Type name ↔ ID mappings |
 
 ---
 
 ## Memory Budget
 
-| Layer | Per-Node | At 100K memories | At 1M memories |
+| Layer | Per-Node/Edge | At 100K memories | At 1M memories |
 |---|---|---|---|
-| Hebbian (L1) | 164B | 16.4 MB | 164 MB |
+| Hebbian CSR (L1) | 4B offset + 12B × avg degree (~2) | ~2.8 MB | ~28 MB |
 | CoActivation | ~1MB total | ~1 MB | ~1 MB |
-| Entity (L2) | ~64B + edges + adj | ~8 MB | ~80 MB |
+| Entity (L2) | 64B node + 16B × edges + 8B × adj | ~10 MB | ~100 MB |
+| HyperEntity | 32B hyperedge + 8B × vertices + 4B incidence | ~5 MB | ~50 MB |
 | Temporal (L3) | 16B | 1.6 MB | 16 MB |
-| **Total** | | **~27 MB** | **~261 MB** |
+| **Total** | | **~20 MB** | **~195 MB** |
+
+!!! tip "CSR Memory Savings"
+    The CSR (Compressed Sparse Row) Hebbian layout stores only actual edges rather than pre-allocating MAX_DEGREE slots per node. At observed average degree ~2.0, this reduces Hebbian memory by ~90% compared to the legacy fixed-width layout (292B/node → ~28B/node).
 
 This is small compared to the vector store (100K × 768-dim × 1B quantized = 75 MB).
 
@@ -272,14 +290,65 @@ Traditional vector search treats each query independently. The 3-layer graph cre
 
 ---
 
-## Addressing Graph Node Explosion
+## Layer 4: Hyperedge Entity Graph
 
-As memory capacity grows, the number of nodes in the Entity and Hebbian graphs scales, increasing off-heap allocations and traversal latency. To address this, Spector is researching advanced mathematical compression models:
+> *Collapsing pairwise relationships into n-body groupings.*
 
-- **Hypergraphs**: Collapsing pairwise relationships into n-body hyperedges (e.g. grouping `{Subject, Object, Location}`) to reduce graph complexity by 40-60%.
-- **Spectral Sparsification**: Using eigenvalue-guided (effective resistance) edge pruning during consolidation cycles to maintain spreading activation quality with fewer edges.
+The `HyperEntityGraph` extends the binary Entity Graph by grouping related entities into **hyperedges** — single graph atoms that connect 3-8 entities with typed roles.
 
-For the detailed technical design and development status, see the [Labs Research Roadmap](../labs/roadmap.md#hypergraphs-spectral-sparsification).
+```mermaid
+graph TD
+    subgraph "Binary EntityGraph (3 edges)"
+        A1["Alice"] -->|MANAGES| B1["Project Alpha"]
+        A1 -->|WORKS_AT| C1["Spectrayan"]
+        B1 -->|BELONGS_TO| C1
+    end
+
+    subgraph "HyperEntityGraph (1 hyperedge)"
+        HE["Hyperedge\n{Alice, Project Alpha, Spectrayan}\ntype: MANAGES_AT"]
+        A2["Alice\nrole: AGENT"] --- HE
+        B2["Project Alpha\nrole: OBJECT"] --- HE
+        C2["Spectrayan\nrole: LOCATION"] --- HE
+    end
+
+    style HE fill:#9b59b6,color:white
+    style A1 fill:#3498db,color:white
+    style B1 fill:#2ecc71,color:white
+    style C1 fill:#e74c3c,color:white
+    style A2 fill:#3498db,color:white
+    style B2 fill:#2ecc71,color:white
+    style C2 fill:#e74c3c,color:white
+```
+
+### Key Properties
+
+| Property | Value |
+|---|---|
+| Max vertices per hyperedge | 3-8 entities with typed roles |
+| Max hyperedges per entity | 64 (participation cap with LRU eviction) |
+| Complexity reduction | 40-60% fewer graph atoms vs. binary decomposition |
+| Traversal | Set intersection: O(hyperedges_per_entity × avg_vertices) |
+
+### Off-Heap Layout
+
+```
+Hyperedge Node (32B):
+  [edgeId:4B][type:4B][weight:4B][vertexCount:4B]
+  [vertexOffset:4B][memoryIdx:4B][timestamp:8B]
+
+Vertex Entry (8B):
+  [entityId:4B][roleId:4B]
+
+Incidence Index (4B × entityCapacity):
+  [hyperedgeListOffset] → per-entity list of participating hyperedges
+
+Incidence List Entry (4B):
+  [hyperedgeId]
+```
+
+### How It Complements the Binary Entity Graph
+
+The `HyperEntityGraph` works alongside the traditional `EntityGraph`, not as a replacement. Binary edges remain useful for simple pairwise relations, while hyperedges capture **irreducible multi-entity events** — preserving the semantic unity that binary decomposition loses.
 
 ---
 

--- a/docs/docs/memory/hebbian.md
+++ b/docs/docs/memory/hebbian.md
@@ -272,6 +272,17 @@ Traditional vector search treats each query independently. The 3-layer graph cre
 
 ---
 
+## Addressing Graph Node Explosion
+
+As memory capacity grows, the number of nodes in the Entity and Hebbian graphs scales, increasing off-heap allocations and traversal latency. To address this, Spector is researching advanced mathematical compression models:
+
+- **Hypergraphs**: Collapsing pairwise relationships into n-body hyperedges (e.g. grouping `{Subject, Object, Location}`) to reduce graph complexity by 40-60%.
+- **Spectral Sparsification**: Using eigenvalue-guided (effective resistance) edge pruning during consolidation cycles to maintain spreading activation quality with fewer edges.
+
+For the detailed technical design and development status, see the [Labs Research Roadmap](../labs/roadmap.md#hypergraphs-spectral-sparsification).
+
+---
+
 ## Next Steps
 
 - :material-lightning-bolt: [**6-Phase Scoring Pipeline**](scoring-pipeline.md) — the SIMD hot-loop that produces the seed set

--- a/docs/docs/memory/index.md
+++ b/docs/docs/memory/index.md
@@ -10,67 +10,95 @@ description: "The biologically-inspired memory engine that gives AI agents the a
 
 ---
 
-## What Makes This Different
+## The 4-Tier Memory Architecture
 
-Every AI memory solution today — Mem0, Letta (MemGPT), Zep — wraps a Python layer around Postgres/pgvector or ChromaDB. They suffer from:
+Just as the human brain has distinct memory systems, Spector organizes memories into four cognitive tiers to match their biological functions:
 
-- **Network latency**: 50-200ms per query (HTTP → Postgres → HTTP)
-- **Python GIL**: Sequential embedding + scoring under a global lock
-- **Post-filtering trap**: Retrieve top-K by similarity, *then* filter by importance/time — losing critical memories that are old but vital
+=== "🧪 Working Memory"
 
-Spector Memory collapses the entire cognitive stack onto a **zero-GC, off-heap Panama memory store** with SIMD-accelerated scoring. The result:
+    **Biological analog: Prefrontal Cortex**
+    
+    Volatile, limited-capacity buffer for the current task context. Operates as a circular buffer where the oldest entries are automatically evicted when capacity is reached.
+    
+    - **Capacity**: Configurable (default: 100 records)
+    - **Storage**: In-memory segment (volatile)
+    - **Use case**: "What was the user just talking about?"
 
-| Metric | Python Memory Layer | **Spector Memory** |
-|---|---|---|
-| Query latency (1M memories) | 50-200ms | **0.13ms** † |
-| GC pauses | Unpredictable | **≤0.01%** (100% off-heap) † |
-| Scoring pipeline | Post-filter (lossy) | **Fused SIMD** (lossless) |
-| Concurrent queries | GIL-limited | **61,000 QPS** (Virtual Threads) † |
-| Memory per record | ~500B (Python objects) | **64B header + quantized vector** |
+=== "📝 Episodic Memory"
 
-† *Measured on Intel Core Ultra 9 285K, Java 25, AVX2. See [Benchmarks](performance.md).*
+    **Biological analog: Hippocampus**
+    
+    Time-stamped event records representing autobiographical history. Partitioned by day and backed by memory-mapped files for persistence across restarts. Supports sleep consolidation into semantic memory.
+    
+    - **Capacity**: Unbounded (time-partitioned)
+    - **Storage**: High-performance memory-mapped partitions (persistent)
+    - **Use case**: "What error did we debug yesterday?"
+
+=== "🧬 Semantic Memory"
+
+    **Biological analog: Neocortex**
+    
+    Distilled, permanent world knowledge and facts. Created by consolidation (sleep cycles) from episodic clusters, or directly by the user. Supports two modes:
+    
+    - **Partitioned Mode** (default): Rolling partition files with parallel retrieval.
+    - **Single-File Mode**: In-memory slab for light deployments.
+    
+    - **Capacity**: Unbounded in partitioned mode (configurable per-partition, default: 10,000 records)
+    - **Recall**: Parallel scan across partitions using virtual threads
+    - **Compaction**: Per-partition rebuilds performed live during operation
+    - **Use case**: "The user prefers dark mode."
+
+=== "⚙️ Procedural Memory"
+
+    **Biological analog: Basal Ganglia**
+    
+    Learned procedures, rules, and behavioral guidelines. A small, append-only store for rules that shape the agent's reasoning.
+    
+    - **Capacity**: Configurable (default: 500 records)
+    - **Storage**: In-memory segment (persistent via write-ahead log replay)
+    - **Use case**: "Always use exponential backoff for retries."
 
 ---
 
 ## The Biological Metaphor
 
-Spector Memory maps every major cognitive subsystem from neuroscience to a dedicated Java package:
+Spector Memory maps every major cognitive subsystem from neuroscience to a dedicated system package:
 
 ```mermaid
 graph TB
     subgraph "🧠 Spector Memory"
-        SM[SpectorMemory<br/>Façade] --> CT[CognitiveIngestionTarget<br/>Cognitive remember]
-        SM --> RP[RecallPipeline<br/>Parallel recall]
+        SM[SpectorMemory<br/>Façade]:::core --> CT[CognitiveIngestionTarget<br/>Cognitive remember]:::core
+        SM --> RP[RecallPipeline<br/>Parallel recall]:::core
         
         subgraph "Cortex — Tier Stores"
-            TR[TierRouter] --> WM[Working<br/>Prefrontal Cortex]
-            TR --> EM[Episodic<br/>Hippocampus]
-            TR --> SE[Semantic<br/>Neocortex]
-            TR --> PR[Procedural<br/>Basal Ganglia]
+            TR[TierRouter]:::core --> WM[Working<br/>Prefrontal Cortex]:::working
+            TR --> EM[Episodic<br/>Hippocampus]:::episodic
+            TR --> SE[Semantic<br/>Neocortex]:::semantic
+            TR --> PR[Procedural<br/>Basal Ganglia]:::procedural
         end
         
         subgraph "Synapse — Scoring"
-            CS[CognitiveScorer<br/>6-phase SIMD] --> STE[SynapticTagEncoder<br/>Bloom Filter]
-            CS --> DS[DecayStrategy<br/>Temporal Decay]
+            CS[CognitiveScorer<br/>6-phase SIMD]:::synapse --> STE[SynapticTagEncoder<br/>Bloom Filter]:::synapse
+            CS --> DS[DecayStrategy<br/>Temporal Decay]:::synapse
         end
         
         subgraph "Neuromodulators"
-            SD[SurpriseDetector<br/>Dopamine] --> FP[FlashbulbPolicy]
-            VT[ValenceTracker<br/>Amygdala]
-            HP[HabituationPenalty<br/>Anti-filter bubble]
-            SS[SuppressionSet<br/>Inhibition]
+            SD[SurpriseDetector<br/>Dopamine]:::synapse --> FP[FlashbulbPolicy]:::synapse
+            VT[ValenceTracker<br/>Amygdala]:::synapse
+            HP[HabituationPenalty<br/>Anti-filter bubble]:::synapse
+            SS[SuppressionSet<br/>Inhibition]:::synapse
         end
         
         subgraph "3-Layer Cognitive Graph"
-            HG[HebbianGraph<br/>Layer 1: Association]
-            EG[EntityGraph<br/>Layer 2: Knowledge]
-            TC[TemporalChain<br/>Layer 3: Causal]
-            CA[CoActivationTracker<br/>STDP Learning]
+            HG[HebbianGraph<br/>Layer 1: Association]:::core
+            EG[EntityGraph<br/>Layer 2: Knowledge]:::core
+            TC[TemporalChain<br/>Layer 3: Causal]:::core
+            CA[CoActivationTracker<br/>STDP Learning]:::core
         end
         
         subgraph "Consolidation"
-            RD[ReflectDaemon<br/>Sleep Consolidation]
-            TCC[TombstoneCompactor<br/>Synaptic Pruning]
+            RD[ReflectDaemon<br/>Sleep Consolidation]:::core
+            TCC[TombstoneCompactor<br/>Synaptic Pruning]:::core
         end
         
         CT --> TR
@@ -84,54 +112,25 @@ graph TB
 
 ---
 
-## The 4-Tier Memory Architecture
+## What Makes This Different
 
-Just as the human brain has distinct memory systems, Spector organizes memories into four cognitive tiers:
+Every AI memory solution today wraps a scripting layer around Postgres/pgvector or a standard vector database. They suffer from:
 
-=== "🧪 Working Memory"
+- **Network latency**: 50-200ms per query (HTTP → DB → HTTP)
+- **Global Interpreter Lock**: Sequential embedding and scoring under a lock
+- **Post-filtering trap**: Retrieve top-K by similarity, then filter by importance or time — losing old but critical memories
 
-    **Biological analog: Prefrontal Cortex**
-    
-    Volatile, limited-capacity buffer for the current task context. Circular buffer — oldest entries are evicted when full.
-    
-    - **Capacity**: Configurable (default: 100 records)
-    - **Storage**: In-memory `Arena.ofShared()` segment
-    - **Use case**: "What was the user just talking about?"
+Spector Memory collapses the entire cognitive stack onto a **zero-overhead, off-heap memory store** with hardware-accelerated scoring. The result:
 
-=== "📝 Episodic Memory"
+| Metric | Traditional Python Layer | **Spector Memory** |
+|---|---|---|
+| Query latency (1M memories) | 50-200ms | **0.13ms** † |
+| GC pauses | Unpredictable | **≤0.01%** (100% off-heap) † |
+| Scoring pipeline | Post-filter (lossy) | **Fused SIMD** (lossless) |
+| Concurrent queries | Lock-limited | **61,000 QPS** (Virtual Threads) † |
+| Memory per record | ~500B (Object wrappers) | **Compact binary header + vector** |
 
-    **Biological analog: Hippocampus**
-    
-    Time-stamped event records. Partitioned by day, backed by mmap'd files for persistence across JVM restarts. Supports sleep consolidation into semantic memory.
-    
-    - **Capacity**: Unbounded (partitioned, mmap-backed)
-    - **Storage**: `FileChannel.map()` with 64-byte metadata header per partition
-    - **Use case**: "What error did we debug yesterday?"
-
-=== "🧬 Semantic Memory"
-
-    **Biological analog: Neocortex**
-    
-    Distilled, permanent knowledge. Created by sleep consolidation (ReflectDaemon) from episodic clusters, or directly by the user. Supports two storage modes:
-    
-    - **Single-file** (in-memory mode): Fixed-capacity slab via `Arena.ofShared()`
-    - **Partitioned** (DISK mode, default): Rolling `semantic-NNN.mem` files with parallel per-partition recall via virtual threads
-    
-    - **Capacity**: Unbounded in partitioned mode (configurable per-partition, default: 10,000 records)
-    - **Recall**: Parallel scan — each partition searched on its own virtual thread
-    - **Compaction**: Per-partition rebuild (live during operation)
-    - **Migration**: Auto-migrates from single-file on first startup
-    - **Use case**: "The user prefers dark mode."
-
-=== "⚙️ Procedural Memory"
-
-    **Biological analog: Basal Ganglia**
-    
-    Learned procedures, rules, and patterns. Small, append-only store for procedural knowledge.
-    
-    - **Capacity**: Configurable (default: 500 records)
-    - **Storage**: In-memory `Arena.ofShared()` segment
-    - **Use case**: "Always use exponential backoff for retries."
+† *Measured on Intel Core Ultra 9 285K, Java 25, AVX2. See [Benchmarks](performance.md).*
 
 ---
 

--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -214,3 +214,275 @@
   fill: #6366f1 !important;
   stroke: #6366f1 !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Spector Enterprise Theme-Aware Mermaid Nodes
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Dark Mode (slate) overrides ── */
+[data-md-color-scheme="slate"] .mermaid .node.working rect,
+[data-md-color-scheme="slate"] .mermaid .node.working polygon,
+[data-md-color-scheme="slate"] .mermaid .node.working circle,
+[data-md-color-scheme="slate"] .mermaid .node.working path {
+  fill: #e74c3c !important;
+  stroke: #c0392b !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.working .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.working .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.episodic rect,
+[data-md-color-scheme="slate"] .mermaid .node.episodic polygon,
+[data-md-color-scheme="slate"] .mermaid .node.episodic circle,
+[data-md-color-scheme="slate"] .mermaid .node.episodic path {
+  fill: #3498db !important;
+  stroke: #2980b9 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.episodic .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.episodic .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.semantic rect,
+[data-md-color-scheme="slate"] .mermaid .node.semantic polygon,
+[data-md-color-scheme="slate"] .mermaid .node.semantic circle,
+[data-md-color-scheme="slate"] .mermaid .node.semantic path {
+  fill: #2ecc71 !important;
+  stroke: #27ae60 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.semantic .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.semantic .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.procedural rect,
+[data-md-color-scheme="slate"] .mermaid .node.procedural polygon,
+[data-md-color-scheme="slate"] .mermaid .node.procedural circle,
+[data-md-color-scheme="slate"] .mermaid .node.procedural path {
+  fill: #9b59b6 !important;
+  stroke: #8e44ad !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.procedural .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.procedural .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.cortex rect,
+[data-md-color-scheme="slate"] .mermaid .node.cortex polygon,
+[data-md-color-scheme="slate"] .mermaid .node.cortex circle,
+[data-md-color-scheme="slate"] .mermaid .node.cortex path {
+  fill: #1e1b4b !important;
+  stroke: #6366f1 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.cortex .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.cortex .label {
+  color: #e0e7ff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.synapse rect,
+[data-md-color-scheme="slate"] .mermaid .node.synapse polygon,
+[data-md-color-scheme="slate"] .mermaid .node.synapse circle,
+[data-md-color-scheme="slate"] .mermaid .node.synapse path {
+  fill: #082f49 !important;
+  stroke: #0ea5e9 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.synapse .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.synapse .label {
+  color: #e0f2fe !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.core rect,
+[data-md-color-scheme="slate"] .mermaid .node.core polygon,
+[data-md-color-scheme="slate"] .mermaid .node.core circle,
+[data-md-color-scheme="slate"] .mermaid .node.core path {
+  fill: #062f4f !important;
+  stroke: #10b981 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.core .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.core .label {
+  color: #ecfdf5 !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.success rect,
+[data-md-color-scheme="slate"] .mermaid .node.success polygon,
+[data-md-color-scheme="slate"] .mermaid .node.success circle,
+[data-md-color-scheme="slate"] .mermaid .node.success path {
+  fill: #059669 !important;
+  stroke: #047857 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.success .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.success .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.fail rect,
+[data-md-color-scheme="slate"] .mermaid .node.fail polygon,
+[data-md-color-scheme="slate"] .mermaid .node.fail circle,
+[data-md-color-scheme="slate"] .mermaid .node.fail path {
+  fill: #dc2626 !important;
+  stroke: #b91c1c !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.fail .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.fail .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.info rect,
+[data-md-color-scheme="slate"] .mermaid .node.info polygon,
+[data-md-color-scheme="slate"] .mermaid .node.info circle,
+[data-md-color-scheme="slate"] .mermaid .node.info path {
+  fill: #2563eb !important;
+  stroke: #1d4ed8 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.info .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.info .label {
+  color: #ffffff !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node.warning rect,
+[data-md-color-scheme="slate"] .mermaid .node.warning polygon,
+[data-md-color-scheme="slate"] .mermaid .node.warning circle,
+[data-md-color-scheme="slate"] .mermaid .node.warning path {
+  fill: #d97706 !important;
+  stroke: #b45309 !important;
+}
+[data-md-color-scheme="slate"] .mermaid .node.warning .nodeLabel,
+[data-md-color-scheme="slate"] .mermaid .node.warning .label {
+  color: #ffffff !important;
+}
+
+
+/* ── Light Mode (default) overrides ── */
+[data-md-color-scheme="default"] .mermaid .node.working rect,
+[data-md-color-scheme="default"] .mermaid .node.working polygon,
+[data-md-color-scheme="default"] .mermaid .node.working circle,
+[data-md-color-scheme="default"] .mermaid .node.working path {
+  fill: #fee2e2 !important;
+  stroke: #f87171 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.working .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.working .label {
+  color: #991b1b !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.episodic rect,
+[data-md-color-scheme="default"] .mermaid .node.episodic polygon,
+[data-md-color-scheme="default"] .mermaid .node.episodic circle,
+[data-md-color-scheme="default"] .mermaid .node.episodic path {
+  fill: #e0f2fe !important;
+  stroke: #60a5fa !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.episodic .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.episodic .label {
+  color: #1e40af !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.semantic rect,
+[data-md-color-scheme="default"] .mermaid .node.semantic polygon,
+[data-md-color-scheme="default"] .mermaid .node.semantic circle,
+[data-md-color-scheme="default"] .mermaid .node.semantic path {
+  fill: #dcfce7 !important;
+  stroke: #4ade80 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.semantic .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.semantic .label {
+  color: #166534 !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.procedural rect,
+[data-md-color-scheme="default"] .mermaid .node.procedural polygon,
+[data-md-color-scheme="default"] .mermaid .node.procedural circle,
+[data-md-color-scheme="default"] .mermaid .node.procedural path {
+  fill: #f3e8ff !important;
+  stroke: #c084fc !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.procedural .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.procedural .label {
+  color: #6b21a8 !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.cortex rect,
+[data-md-color-scheme="default"] .mermaid .node.cortex polygon,
+[data-md-color-scheme="default"] .mermaid .node.cortex circle,
+[data-md-color-scheme="default"] .mermaid .node.cortex path {
+  fill: #e0e7ff !important;
+  stroke: #6366f1 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.cortex .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.cortex .label {
+  color: #3730a3 !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.synapse rect,
+[data-md-color-scheme="default"] .mermaid .node.synapse polygon,
+[data-md-color-scheme="default"] .mermaid .node.synapse circle,
+[data-md-color-scheme="default"] .mermaid .node.synapse path {
+  fill: #e0f2fe !important;
+  stroke: #0ea5e9 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.synapse .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.synapse .label {
+  color: #075985 !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.core rect,
+[data-md-color-scheme="default"] .mermaid .node.core polygon,
+[data-md-color-scheme="default"] .mermaid .node.core circle,
+[data-md-color-scheme="default"] .mermaid .node.core path {
+  fill: #ecfdf5 !important;
+  stroke: #10b981 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.core .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.core .label {
+  color: #065f46 !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.success rect,
+[data-md-color-scheme="default"] .mermaid .node.success polygon,
+[data-md-color-scheme="default"] .mermaid .node.success circle,
+[data-md-color-scheme="default"] .mermaid .node.success path {
+  fill: #dcfce7 !important;
+  stroke: #4ade80 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.success .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.success .label {
+  color: #166534 !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.fail rect,
+[data-md-color-scheme="default"] .mermaid .node.fail polygon,
+[data-md-color-scheme="default"] .mermaid .node.fail circle,
+[data-md-color-scheme="default"] .mermaid .node.fail path {
+  fill: #fee2e2 !important;
+  stroke: #f87171 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.fail .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.fail .label {
+  color: #991b1b !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.info rect,
+[data-md-color-scheme="default"] .mermaid .node.info polygon,
+[data-md-color-scheme="default"] .mermaid .node.info circle,
+[data-md-color-scheme="default"] .mermaid .node.info path {
+  fill: #dbeafe !important;
+  stroke: #60a5fa !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.info .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.info .label {
+  color: #1e40af !important;
+}
+
+[data-md-color-scheme="default"] .mermaid .node.warning rect,
+[data-md-color-scheme="default"] .mermaid .node.warning polygon,
+[data-md-color-scheme="default"] .mermaid .node.warning circle,
+[data-md-color-scheme="default"] .mermaid .node.warning path {
+  fill: #fef3c7 !important;
+  stroke: #fbbf24 !important;
+}
+[data-md-color-scheme="default"] .mermaid .node.warning .nodeLabel,
+[data-md-color-scheme="default"] .mermaid .node.warning .label {
+  color: #92400e !important;
+}
+

--- a/docs/docs/synapse/index.md
+++ b/docs/docs/synapse/index.md
@@ -12,7 +12,7 @@ description: "Spector Synapse is the agentic orchestration layer — cognitive c
 
 ## What is Synapse?
 
-Spector Synapse is the **unified application server and agentic gateway** built on top of the Spector cognitive memory engine (absorbing the former `spector-node` gateway). It transforms Spector from an embedded Java library into a standalone, network-accessible AI agent platform and hybrid search server.
+Spector Synapse is the **unified application server and agentic gateway** built on top of the Spector cognitive memory engine. It transforms Spector from an embedded Java library into a standalone, network-accessible AI agent platform and hybrid search server.
 
 | Spector Memory | Spector Synapse |
 |:---|:---|
@@ -20,81 +20,230 @@ Spector Synapse is the **unified application server and agentic gateway** built 
 | 16 neuroscience mechanisms | Agentic reasoning graphs & REST/gRPC endpoints |
 | Java library (embed anywhere) | Standalone Spring Boot 4 application server |
 | Off-heap, SIMD-accelerated | Unified gateway (Search, Memory, RAG, Agents) |
-| Passive (respond to API calls) | Active (runnable server + autonomous agents) |
+| Passive (responds to API calls) | Active (runnable server + autonomous agents) |
 
 ---
 
-## Key Capabilities
+## Agent Soul & User Salience Profile
 
-### 🧠 Cognitive Chat
+Spector Synapse models agentic interactions through two distinct, complementary cognitive configurations that shape how an agent behaves and what it remembers.
 
-Every conversation is memory-primed. Before the LLM generates a response, Synapse:
+### The Agent Soul
+The **Agent Soul** represents the persistent identity and character of the AI agent. It defines the agent's baseline model of self, including:
+*   **Purpose & Mission**: The primary objective or goal the agent is designed to achieve.
+*   **Personality & Tone**: The behavioral characteristics, communication style, and emotional baseline.
+*   **Expertise Domains**: Specific areas of knowledge where the agent has specialized capability.
+*   **Core Values & Ethical Guardrails**: Guiding principles and strict safety boundaries that cannot be bypassed or self-modified.
 
-1. **Recalls** relevant memories from the user's conversation history
-2. **Primes** the LLM context with recalled memories (context priming)
-3. **Generates** the response with full cognitive context
-4. **Remembers** the conversation turn as a new memory
-5. **Reflects** periodically — extracting insights, relationships, and patterns
-6. **Summarizes** long conversations to prevent context window overflow
+### The User Salience Profile
+The [User Salience Profile](../memory/salience-importance.md) represents the personalization filter configured for the human interacting with the system. It defines what concepts, topics, and rules matter to that user. It is expressed in natural language interests (boosts) and disinterests (dampeners) that modify memory importance scores dynamically at recall and ingestion time.
+
+### How They Complement Each Other
+The Agent Soul and the User Salience Profile form a **Personalized Cognitive Loop**:
+
+```mermaid
+graph LR
+    UserQuery[User Query]:::info --> RecallFilters[User Salience Profile<br/><i>Retrieval Filter</i>]:::synapse
+    RecallFilters --> MemoryRecall[Cognitive Memory Recall]:::core
+    MemoryRecall --> RetrievedMemories[Retrieved Memories]:::core
+    RetrievedMemories --> AgentBehavior[Agent Soul<br/><i>Behavior & Style Governor</i>]:::synapse
+    AgentBehavior --> AgentResponse[Character-Aligned Response]:::info
+```
+
+1.  **The User Salience Profile acts as the Retrieval Filter (What to remember)**: It determines *which* memories are retrieved from the cognitive store by boosting topics the user cares about and suppressing noise.
+2.  **The Agent Soul acts as the Response Governor (How to behave)**: Once the relevant memories are surfaced, the Agent Soul shapes the reasoning process, tool usage, and tone to generate a response that remains consistent with the agent's persona.
+
+Together, they ensure the agent's actions are highly personalized to the user's focus areas while remaining character-consistent and ethically bounded.
+
+---
+
+## Submodule Architecture & Core Flows
+
+Synapse is divided into modular submodules, each responsible for a distinct aspect of agentic lifecycle, communication, and synchronization.
+
+```mermaid
+graph TD
+    subgraph synapse["⚡ Spector Synapse"]
+        AC[Agentic Chat Graph]:::synapse
+        DE[Dynamic Graph Builder]:::synapse
+        MB[Memory Bridge]:::synapse
+        PR[LLM Provider Registry]:::synapse
+        DC[Connector Sync Engine]:::synapse
+        PL[Plugin Manager]:::synapse
+    end
+
+    cortex["🧬 Cortex UI (Angular 22)"]:::cortex -->|REST / SSE| synapse
+    synapse -->|Java API| core["🧠 Spector Core"]:::core
+
+    DC -->|Sync| MB
+    AC -->|Read/Write| MB
+    MB -->|FAÇADE API| core
+```
+
+### 1. Agentic Chat Graph
+The `AgenticChatGraph` defines the reasoning loop of an autonomous agent. When a user sends a message, the agent does not merely generate a completion; it runs an iterative loop:
 
 ```mermaid
 sequenceDiagram
     actor User
-    participant Chat as Chat Service
-    participant Memory as Spector Memory
+    participant Chat as Agentic Chat Graph
+    participant MB as Memory Bridge
     participant LLM as LLM Provider
-    participant Reflect as Reflector
+    participant Tool as Tool Executor
 
     User->>Chat: Send message
-    Chat->>Memory: recall(message)
-    Memory-->>Chat: Relevant memories
-    Chat->>Chat: Prime context with memories
-    Chat->>LLM: Generate response
-    LLM-->>Chat: Response
-    Chat->>Memory: remember(turn)
-    Chat-->>User: Response
-
-    Note over Chat,Reflect: Periodically after N turns...
-    Chat->>Reflect: Extract insights
-    Reflect->>Memory: remember(reflections)
-    Reflect->>Memory: reinforce(related memories)
+    Chat->>MB: Recall context & memories
+    MB-->>Chat: Memory-primed state
+    
+    loop Reasoning Cycle (max N iterations)
+        Chat->>LLM: Analyze state & decide next action (Thought)
+        LLM-->>Chat: Thought / Action (e.g., Tool Call)
+        
+        alt Tool Call Needed
+            Chat->>Tool: Execute Tool (Action)
+            Tool-->>Chat: Tool Result (Observation)
+        else Generate Final Response
+            Chat->>User: Stream Response / Complete turn
+        end
+    end
+    
+    Chat->>MB: Store conversation turn
+    Chat->>MB: Reflect & reinforce memories (async)
 ```
 
-This creates agents that genuinely *know* their users — remembering preferences, past conversations, emotional states, and evolving relationships over time.
+1.  **Recall**: Surfacing relevant semantic, episodic, and working memories via the Memory Bridge.
+2.  **Thought**: Deciding whether the user query can be answered directly or if tools are required.
+3.  **Action**: Executing approved tools and returning results back into the agent's state as observations.
+4.  **Evaluate / Generate**: Iterating until a satisfying response is compiled, then returning the response to the user.
+5.  **Consolidate**: Recording the interaction to episodic memory and strengthening related neural pathways.
 
-### 🌐 Unified API Gateway & Server
+---
 
-Synapse hosts a unified HTTP REST, gRPC, and Server-Sent Events (SSE) server (running on port `7070` by default). By absorbing the search gateway, it exposes unified endpoints across:
-*   **Search & Retrieval**: `/api/v1/engine/search` for AVX2/AVX-512 accelerated hybrid search (Vector + BM25) and reciprocal rank fusion (RRF).
-*   **Ingestion Pipelines**: `/api/v1/engine/ingest` and `/api/v1/engine/ingest/file` for manual text, directory-level discovery, and bulk payload ingestion.
-*   **RAG Services**: `/api/v1/engine/rag` for out-of-the-box context assembly and prompt synthesis.
-*   **Agent Identity & Chat**: `/api/v1/chat/*` and `/api/v1/agents/*` for configuring agent souls, running cognitive sessions, and tracking conversational state.
-
-### 🤖 Autonomous Agent Framework
-
-Agents in Synapse have a **soul** — a persistent identity (the `AgentSoul`) that shapes their behavior:
+### 2. Dynamic Agent Execution
+Instead of hardcoding graph topologies, Synapse includes the `DynamicGraphBuilder`. This engine compiles agent graphs dynamically at runtime from JSON-based `FlowSpec` definitions.
 
 ```mermaid
-classDiagram
-    class AgentSoul {
-        +String name = "Aria"
-        +String purpose = "ABA therapy companion"
-        +String personality = "warm, patient"
-        +List~String~ expertise = ["autism", "ABA"]
-        +List~String~ coreValues = ["empathy", "evidence"]
-        +List~String~ ethicalGuardrails 🔒
-        +String emotionalBaseline = "calm"
-        +String model = "llama3.2"
-        +List~String~ tools
-        +float[] expertiseEmbedding
-        +float[] purposeEmbedding
-    }
-    note for AgentSoul "ethicalGuardrails are immutable —\nthe agent cannot modify them"
+graph TD
+    FlowSpec[JSON FlowSpec Definition]:::info --> Parser[Flow Parser]:::synapse
+    Parser --> Compiler[Graph Compiler]:::synapse
+    Compiler --> State[State Initialization]:::core
+    State --> Runner[Cognitive Graph Runner]:::synapse
+    Runner --> Execution[Runtime Execution Loop]:::success
 ```
 
-**Biological analog**: Just as the brain's Default Mode Network (DMN) maintains a persistent self-model, the `AgentSoul` defines **who the agent is** — and this identity persists across sessions, influencing memory encoding, retrieval, and response generation.
+This allows users to define custom agents, tool mappings, step execution ordering, and validation criteria on the fly, entirely via REST APIs without rebuilding the application server.
 
-### 🔧 14 Built-in Agent Tools
+---
+
+### 3. Memory Bridge
+The **Memory Bridge** connects Spring Boot's application layer (managing HTTP requests, chat sessions, and connection pools) with the off-heap Spector core memory engine.
+
+```mermaid
+graph TD
+    AppLayer[Spring Chat Session]:::synapse -->|1. Request Recall| Bridge[Memory Bridge]:::synapse
+    Bridge -->|2. Parallel Scan| CoreEngine[Spector Core Engine]:::core
+    CoreEngine -->|3. Quantized Vectors + Headers| Bridge
+    Bridge -->|4. Format Context| AppLayer
+    AppLayer -->|5. Commit Turn| Bridge
+    Bridge -->|6. WAL Write & Ingest| CoreEngine
+```
+
+It manages context priming (populating the LLM context window with recalled memories prior to execution) and handles asynchronous memory consolidation (consolidating episodic memories into permanent semantic nodes during reflection sleep cycles).
+
+---
+
+### 4. LLM Provider Registry
+The LLM Provider Registry acts as the routing and abstraction gateway for language models.
+
+```mermaid
+graph TD
+    Request[Agent LLM Request]:::synapse --> Registry[LLM Provider Registry]:::synapse
+    Registry --> Router{Model Router}:::synapse
+    Router -->|Ollama - Local| M1[Ollama Server]:::success
+    Router -->|OpenAI - Remote| M2[OpenAI Gateway]:::success
+    Router -->|Anthropic - Remote| M3[Anthropic Gateway]:::success
+
+    Registry -.->|Health Checks| Health{Status Monitor}:::synapse
+    Health -->|Ping / Check Latency| M1 & M2 & M3
+```
+
+It supports multi-provider registration (local Ollama instances, external OpenAI/Anthropic gateways), conducts background health monitoring, and automatically reroutes requests to failover providers if an endpoint experiences downtime.
+
+---
+
+### 5. Data Connectors
+The Connector Sync Engine schedules and executes background synchronization jobs via a plugin-based SPI.
+
+```mermaid
+graph TD
+    SyncEngine[Connector Sync Engine]:::synapse -->|Execute Job| SPI[Connector SPI]:::synapse
+    SPI -->|Pull| Slack[Slack Connector]:::success
+    SPI -->|Pull| GitHub[GitHub Connector]:::success
+    SPI -->|Pull| Notion[Notion Connector]:::success
+
+    Slack & GitHub & Notion -->|Raw Data| Parser[Ingestion Parser]:::synapse
+    Parser -->|Embed & Quantize| MB[Memory Bridge]:::synapse
+    MB -->|Store| Core[Spector Core]:::core
+```
+
+It fetches data from external workspace tools (Slack history, GitHub PRs/issues, Notion pages), processes and chunks the payloads, and ingests them directly into episodic and semantic memory tiers so they are instantly searchable.
+
+---
+
+### 6. Runtime Plugin System
+The Plugin SPI allows developers to extend Synapse capabilities at runtime without restarting the service. By loading external JAR plugins, developers can register custom tools, extend the LLM provider registry, or implement custom connector templates dynamically.
+
+---
+
+## Observability & Tracing
+
+Because agent loops are non-deterministic, understanding why an agent made a decision requires detailed tracing. Synapse exposes comprehensive tracing data at the session level:
+
+### State Tracing Elements
+When an agent executes, it populates three core structures in the state log:
+*   **`AgentThought`**: The internal reasoning path generated by the LLM prior to taking action.
+*   **`AgentAction`**: The tool selected for execution, including its input parameters.
+*   **`AgentObservation`**: The raw output returned by the tool, which is fed back into the reasoning loop.
+
+### Inspecting Traces
+1.  **Cortex UI Integration**: The Cortex Dashboard displays these steps in real-time as an interactive neural timeline, highlighting scoring weights, tool execution steps, and memory activation.
+2.  **API Log Access**: Developers can query the session history endpoint `/api/v1/chat/sessions/{id}/messages` to retrieve the full step-by-step trace of thoughts, actions, and observations.
+3.  **Spring Logging System**: Synapse outputs detailed execution spans via SLF4J, allowing external tracing tools (like OpenTelemetry or Jaeger) to monitor latency and routing across agent steps.
+
+---
+
+## Failure Recovery & Loop Prevention
+
+Synapse implements strict guardrails to guarantee the reliability and safety of autonomous agent loops:
+
+### 1. Loop and Iteration Limits
+To prevent an agent from entering infinite reasoning loops, the `AgenticChatGraph` enforces a hard limit on maximum iterations per turn (default: `10` iterations). If the agent fails to compile a final answer within this limit, the loop is terminated, and a graceful fallback message is returned.
+
+### 2. Tool Execution Fail-Safes
+*   **Sandboxing**: System and Shell execution tools (`shell_execute`) require explicit user authorization tokens or must be disabled via configuration.
+*   **Fallback Prompts**: If a tool fails (e.g., a network timeout or file access error), the exception is parsed, formatted into a structured `AgentObservation`, and returned to the LLM. The agent is trained to recognize the error and attempt a workaround or report the failure cleanly.
+*   **Write-Protection**: Synapse enforces read-only access on default connectors and file configurations to prevent unauthorized modifications by the agent.
+
+### 3. Provider Failover and Timeouts
+Synapse virtual threads manage LLM calls independently. If a provider endpoint goes offline or times out (configured via `SPECTOR_OLLAMA_TIMEOUT`), the registry intercepts the failure, reports it to the agent's runner, and switches to the designated fallback model automatically.
+
+---
+
+## Workflows vs. Autonomous Agents
+
+Developers must choose the correct execution pattern based on their task constraints:
+
+| Feature | Deterministic Workflows | Autonomous Agents |
+|:---|:---|:---|
+| **Control Flow** | Hardcoded in the graph topology | Dynamically decided by the LLM |
+| **Flexibility** | Low — follows strict steps | High — adapts to runtime inputs |
+| **Looping** | Cyclic transitions must be predefined | Natural loop cycle (reason → act) |
+| **Use Cases** | Ingestion pipelines, document parsing, fixed RAG | Coding assistants, customer support, open-ended research |
+| **Configuration** | Built using static Java/DSL chains | Defined via JSON `FlowSpec` or agent templates |
+
+---
+
+## 🔧 14 Built-in Agent Tools
 
 Agents can take action in the real world through tools:
 
@@ -116,182 +265,6 @@ Agents can take action in the real world through tools:
 | `current_time` | Utility | Get current date and time |
 
 Tools are categorized (`READ`, `WRITE`, `SYSTEM`) with write-protection for safety.
-
-### 🔀 LangGraph4j Cognitive Graphs
-
-Agent reasoning flows are defined as **directed graphs** using [LangGraph4j](https://github.com/bsc-lang/langgraph4j):
-
-```mermaid
-graph LR
-    START --> Retrieve
-    Retrieve --> Generate
-    Generate --> Evaluate
-    Evaluate -->|"needs more info"| Retrieve
-    Evaluate -->|"needs tools"| ToolExec["Tool Execution"]
-    ToolExec --> Generate
-    Evaluate -->|"good enough"| END
-```
-
-Built-in graph patterns include:
-
-- **Agentic Chat Graph** — Retrieve → Generate → Tool → Evaluate loop
-- **Cognitive RAG** — Memory-primed retrieval-augmented generation
-- **Coordinator Graph** — Multi-agent orchestration with planner, executor, evaluator
-- **Dynamic Graph Builder** — Construct graphs from JSON `FlowSpec` definitions at runtime
-
-### 🧩 Agent Templates
-
-6 pre-built agent templates for common use cases:
-
-| Template | Description |
-|:---------|:------------|
-| **Conversation Agent** | General-purpose conversational AI with memory |
-| **Research Agent** | Web research + memory synthesis |
-| **Code Generation** | Code writing with file system access |
-| **Content Creation** | Long-form content with research and iteration |
-| **Customer Support** | Knowledge-base backed support agent |
-| **Data Analysis** | Data querying and visualization |
-
-Templates define the agent's soul, tools, flow graph, and execution policies — all as JSON.
-
-### 🔌 Connector Framework
-
-Bring external data into cognitive memory through connectors:
-
-- **Slack** — channel history, messages
-- **Email** — inbox/sent messages
-- **GitHub** — issues, PRs, comments
-- **Google Drive** — documents, spreadsheets
-- **Notion** — pages, databases
-- **Custom** — build your own via the connector SPI
-
-### 🌐 LLM Provider Management
-
-Multi-provider LLM abstraction with health checking:
-
-- **Ollama** (local, default) — llama3.2, qwen, mistral, etc.
-- Provider registry with health checks and failover
-- Configurable per-agent model selection
-
-### 🔌 MCP Endpoint
-
-Model Context Protocol (MCP) compatible HTTP endpoint for tool discovery and invocation — allows external AI systems to discover and use Synapse's tools.
-
-### 🔌 Plugin SPI
-
-Runtime plugin system for extending Synapse:
-
-```java
-public interface SynapsePlugin {
-    String id();
-    void onLoad(PluginContext context);
-    void onUnload();
-    List<AgentTool> tools();
-}
-```
-
----
-
-## Architecture
-
-```mermaid
-graph TD
-    subgraph cortex["🧬 Cortex UI — Angular 22"]
-        chat_ui["Chat"]
-        memories_ui["Memories"]
-        agents_ui["Agents"]
-        connectors_ui["Connectors"]
-        settings_ui["Settings"]
-    end
-
-    cortex -->|"HTTP / WebSocket"| synapse
-
-    subgraph synapse["⚡ Spector Synapse — Spring Boot 4 + Armeria"]
-        direction TB
-        subgraph services["Application Layer"]
-            chat["Chat Service\n· Context priming\n· Summarizer\n· Reflector"]
-            agent["Agent Graph\n· LangGraph4j\n· Tool execution\n· Templates"]
-            provider["Provider Registry\n· Ollama bridge\n· Health checks\n· Failover"]
-            engine_gateway["Engine Gateways\n· Search Endpoint\n· Ingestion Endpoint\n· RAG Endpoint"]
-        end
-        subgraph integration["Integration Layer"]
-            bridge["Memory Bridge\n· recall → cognitive memory\n· remember → store\n· reinforce → strengthen"]
-            connector["Connector SPI\n· Templates\n· Sync engine\n· Scheduling"]
-        end
-        subgraph extension["Extension Layer"]
-            plugin["Plugin SPI\n· Load / Unload\n· Custom tools"]
-            mcp_ep["MCP Endpoint\n· Tool discovery\n· Tool invocation"]
-        end
-        services --> integration
-        integration --> extension
-    end
-
-    synapse -->|"Java API"| core
-
-    subgraph core["🧠 Spector Core"]
-        memory["memory<br/><i>(Cognitive Store + Search Facade)</i>"]
-        rag["rag"]
-        embed["embed"]
-        ingestion["ingestion"]
-        gpu["gpu"]
-    end
-
-    style cortex fill:#1a1a2e,stroke:#7c3aed,color:#e0e0e0
-    style synapse fill:#16213e,stroke:#0ea5e9,color:#e0e0e0
-    style core fill:#1a2e1a,stroke:#22c55e,color:#e0e0e0
-```
-
----
-
-## Cognitive Conversation Engines
-
-### Conversation Summarizer
-
-When conversations grow beyond a configurable length, the summarizer automatically:
-
-1. Extracts key topics, decisions, and action items
-2. Compresses the conversation into a summary memory
-3. Stores the summary in cognitive memory for future recall
-4. Replaces the full history with the summary in the LLM context
-
-This prevents context window overflow while preserving essential information.
-
-### Conversation Reflector
-
-After significant interactions, the reflector:
-
-1. Analyzes the conversation for insights, patterns, and relationships
-2. Extracts user preferences, emotional states, and behavioral patterns
-3. Creates reflection memories tagged for long-term retention
-4. Strengthens relevant existing memories via Hebbian reinforcement
-
-This is how agents develop genuine understanding of their users over time.
-
----
-
-## What's Coming
-
-### Near-Term (In Progress)
-
-- [ ] **Streaming responses** — real-time token streaming via Server-Sent Events
-- [ ] **Multi-agent coordination** — agents collaborating on complex tasks
-- [ ] **Conversation branching** — fork conversations for exploration
-- [ ] **Agent marketplace** — community-contributed agent templates
-- [ ] **Voice channel adapter** — speech-to-text + text-to-speech integration
-
-### Medium-Term (Planned)
-
-- [ ] **Emotional intelligence** — agents that detect and respond to user emotional states
-- [ ] **Proactive memory** — agents that surface relevant memories unprompted
-- [ ] **Scheduled actions** — agents that execute tasks on schedules
-- [ ] **Multi-modal tools** — image analysis, code execution, data visualization
-- [ ] **Fine-tuning pipeline** — continuous learning from conversation outcomes
-
-### Long-Term (Vision)
-
-- [ ] **Federated agents** — agents across organizations sharing knowledge safely
-- [ ] **Embodied agents** — integration with robotics and IoT
-- [ ] **Cognitive simulation** — replay and simulate cognitive states for debugging
 
 ---
 


### PR DESCRIPTION
### Summary of Changes

This Pull Request reorganizes the Spector OSS documentation in the core repository, cleans up leaked Java implementation details, substantially expands the synapse agentic documentation layer, and introduces theme-aware Mermaid styling.

### 1. Reorganized & Cleaned Up Cognitive Memory Docs
- **`docs/docs/memory/index.md`**: Reordered the flagship Cognitive Memory landing page (Vision & Philosophy → 4-Tier Functional Model → Biological Metaphors → Advantages & Benchmarks → Deep Dives). Removed Java-specific references like `Arena.ofShared()` and `FileChannel.map()` from high-level summaries.
- **`docs/docs/memory/cortex.md`**: Replaced technical details like `FileChannel` and `mmap` with functional/high-level descriptions.
- **`docs/docs/memory/architecture.md`**: Standardized Custom Tier descriptions.

### 2. Expanded Synapse & Agentic Layer Documentation
- **`docs/docs/synapse/index.md`**:
  - Removed `AgentSoul` class-level fields and UML class diagrams.
  - Documented the relationship between the **Agent Soul** (personality/governor) and the **User Salience Profile** (personalized retrieval filter) and how they complement each other.
  - Added functional descriptions and sequence/flow charts for submodules: **Agentic Chat Graph**, **Dynamic Agent Execution (FlowSpec compiler)**, **Memory Bridge**, **LLM Provider Registry**, **Data Connectors**, and the **Plugin System**.
  - Added new operational sections for **Observability & Tracing** (thought/action/observation inspection), **Failure Recovery & Loop Prevention**, and **Workflows vs. Autonomous Agents**.

### 3. Theme-Aware Mermaid Styling
- **`docs/docs/stylesheets/extra.css`**: Appended CSS class definitions matching Material theme variables for both `slate` (dark) and `default` (light) schemes.
- Mapped all modified Mermaid diagrams to these new classes (e.g., `:::working`, `:::episodic`, `:::synapse`, `:::cortex`), removing all hardcoded `style` attributes.

### Verification
- Verified by compiling with `mkdocs build`, which succeeded in 2.84s with zero warnings/errors on modified files.
- Verified local rendering by serving the site in the background.