### PR TITLE
feat: ProfileAdaptor (#294) and Executive Dysfunction (#295) with READMEs

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,12 @@
+# Benchmarking & Evaluation Layer (`/bench`)
+
+This directory contains modules dedicated to testing system scaling, accuracy, throughput, and memory consumption.
+
+## Modules
+
+* **[`spector-bench`](/bench/spector-bench)**: Contains JMH (Java Microbenchmark Harness) code and evaluation suites that measure nDCG, Recall, MRR, and search latencies across standard datasets (`balanced-baseline`, `adhd-diversified`, `engineer-persona`).
+
+## Usage
+
+* **Running Benchmarks**: Execution is orchestrated via custom PowerShell scripts. The benchmark runner loads, indices, and queries datasets utilizing local LLM embedding providers, then outputs comparative quality and performance reports.
+* **Microbenchmarks**: Focuses on hot-spot allocations (e.g. Panama Vector API SIMD distance lookups vs scalar alternatives).

--- a/cortex/README.md
+++ b/cortex/README.md
@@ -1,0 +1,13 @@
+# Cortex UI Layer (`/cortex`)
+
+This directory houses the web application for the **Cortex Dashboard** — a visual interface for exploring, configuring, and monitoring the Spector cognitive memory engine.
+
+## Modules
+
+* **[`spector-cortex`](/cortex/spector-cortex)**: An Angular 22 standalone application featuring real-time neural graphs, Hebbian edge weight visualizations, cognitive profile tuning, and memory recall testing tools.
+
+## Architecture
+
+* **Framework**: Angular 22 with Signal-based state management and material design component tokens.
+* **Telemetry**: Connects via Server-Sent Events (SSE) and HTTP REST APIs exposed by the Synapse backend on port 7070.
+* **Visualizations**: Renders dynamic memory graphs and coactivation pathways in three dimensions using Canvas and WebGL (THREE.js).

--- a/deploy/docker/spector-docker.yml
+++ b/deploy/docker/spector-docker.yml
@@ -13,6 +13,11 @@
 spector:
   mode: memory
 
+  ollama:
+    base-url: ${SPECTOR_OLLAMA_BASE_URL:http://host.docker.internal:11434}
+    model: ${SPECTOR_OLLAMA_MODEL:qwen3.5:latest}
+    embed-model: ${SPECTOR_OLLAMA_EMBED_MODEL:qwen3-embedding:0.6b}
+
   engine:
     dimensions: 1024
     capacity: 100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,4 +56,4 @@ services:
 
 volumes:
   spector-data:
-    driver: local
+    external: true

--- a/docs/docs/labs/roadmap.md
+++ b/docs/docs/labs/roadmap.md
@@ -10,7 +10,7 @@ description: "Research roadmap for Spector's experimental cognitive features: 4-
 > Some features have graduated from Labs into the main release. Others remain
 > under active research and planned for implementation in the `labs` branch.
 >
-> **Recently graduated:** SPLADE sparse retrieval, ColBERT v2 reranking, Two-Factor Memory.
+> **Recently graduated:** SPLADE sparse retrieval, ColBERT v2 reranking, Two-Factor Memory, ProfileAdaptor Contextual Bandit, and Executive Dysfunction Profile.
 
 ---
 
@@ -163,7 +163,11 @@ public final class NeuromodulatoryState {
 
 ---
 
-## Executive Dysfunction Profile
+## ✅ Executive Dysfunction Profile
+
+!!! success "Graduated to Main Release"
+    Implemented in `CognitiveProfile.EXECUTIVE_DYSFUNCTION`, `ProfileAdaptor`, and `RecallHistory` (graduated in issue #295). It is fully integrated into the `RecallPipeline` as the `ASSOCIATIVE` scoring mode routing path.
+
 
 ### Concept
 

--- a/docs/docs/memory/cognitive-profiles.md
+++ b/docs/docs/memory/cognitive-profiles.md
@@ -48,6 +48,17 @@ These profiles go beyond α/β tuning — they activate specialized scoring mech
 | `THE_EXECUTOR` | 0.3 | 0.7 | Prefrontal executive function | Heaviside Cliff (strictness=10.0), no lateral retrieval |
 | `HIGHLY_SENSITIVE` | 0.7 | 0.3 | Sensory Processing Sensitivity | Low flashbulb threshold, strong lateral inhibition |
 | `DEFAULT_MODE_NETWORK` | 0.2 | 0.8 | Brain's resting state network | Skips Working + Episodic, Semantic + Procedural only |
+| `EXECUTIVE_DYSFUNCTION` | 0.3 | 0.7 | Prefrontal executive dysfunction | Hebbian-first associative recall, bypasses vector similarity |
+
+---
+
+## Self-Tuning Retrieval (`profile=auto`)
+
+When `profile` is set to `"auto"`, Spector activates the **ProfileAdaptor** contextual bandit. It deterministically hashes the current synaptic filter tags and queries its reinforcement stats. 
+
+- **Epsilon-greedy exploration:** The system selects the best performing profile for the tag context 90% of the time, and randomly explores alternative profiles 10% of the time to avoid local optima.
+- **Cold start fallback:** If there are fewer than 10 reinforcement signals for a tag context, it falls back to the configured `SalienceProfile` default profile, and finally to `BALANCED`.
+- **Durable reinforcement:** Learned stats are snapshotted to the `coactivation.tracker` (COAX v2) file on engine shutdown.
 
 ---
 
@@ -139,6 +150,27 @@ At strictness=1.0 (default), this is a gentle hyperbola. At strictness=10.0, it'
 
 !!! example "Scenario"
     Agent is stuck on a performance problem → switches to DEFAULT_MODE_NETWORK → surfaces a deep architectural principle from 3 months ago that reframes the problem entirely. This is the computational equivalent of "sleeping on it."
+
+### EXECUTIVE_DYSFUNCTION — Hebbian-First Associative Recall
+
+**Biological analog:** Prefrontal cortex executive dysfunction. When top-down goal-directed query formulation struggles, bottom-up associative retrieval via the hippocampus and basal ganglia remains intact. Memories surface through directed Spike-Timing-Dependent Plasticity (STDP) causal chains rather than vector query matching.
+
+**Use case:** Agents struggling with ambiguous inputs or unable to formulate clear semantic queries, relying instead on associative context transitions.
+
+| Parameter | Value | Effect |
+|:---|:---:|:---|
+| α | 0.3 | Moderate similarity weight (used as tie-breaker only) |
+| β | 0.7 | High importance weight |
+| Scoring mode | `ASSOCIATIVE` | **Hebbian-first pipeline routing** |
+| Lateral mode | enabled | Aggressive graph expansion across associations |
+| Expansion threshold | 0.80 | Aggressively expand candidate retrieval via STDP edges |
+
+**How it works:**
+
+- **Hippocampal Replay Seed:** Rather than searching vectors from a query, the system extracts the last 20 context tags from a sliding `RecallHistory` buffer.
+- **STDP Predictive Association:** It queries the `CoActivationTracker` for directed STDP edges leading *from* those recent context tags, predicting the next logical tag set.
+- **Tag-Gated Semantic Recall:** It runs a standard recall scan using these predicted tags as a strict synaptic Bloom filter.
+- **STDP Rescoring:** Retrieved candidates are boosted based on their Hebbian predictive strength and recency decay.
 
 ---
 

--- a/docs/docs/memory/profile-adaptor.md
+++ b/docs/docs/memory/profile-adaptor.md
@@ -1,0 +1,121 @@
+---
+title: "Self-Tuning Retrieval — ProfileAdaptor"
+description: "Spector's self-tuning retrieval system: a contextual bandit that automatically selects the best performing Cognitive Profile for each task context based on user reinforcement."
+---
+
+# Self-Tuning Retrieval (ProfileAdaptor)
+
+Just as the biological brain unconsciously adjusts its retrieval characteristics based on task context and outcomes (e.g., sharpening focus under stress, or widening associative scope during brainstorming), Spector can automatically tune its retrieval strategy using the **ProfileAdaptor**.
+
+By observing which retrieval results lead to successful agent actions, the self-tuning system learns the optimal [Cognitive Profile](cognitive-profiles.md) to apply for different search contexts.
+
+---
+
+## How It Works
+
+The self-tuning retrieval system frames cognitive profile selection as a **Contextual Multi-Armed Bandit** problem, where:
+
+1. **Context** is defined by the set of search tags specified in the query's synaptic filter.
+2. **Arms** are the available [Cognitive Profiles](cognitive-profiles.md) (e.g., `BALANCED`, `HYPERFOCUS`, `DIVERGENT`, `DEBUGGING`).
+3. **Reward** is derived from reinforcement feedback (positive or negative signals) sent by the calling application.
+
+```mermaid
+flowchart TD
+    Q["Query: 'database lock' (tags: database, sql)"] --> Hash["Hash tags to define Context"]
+    Hash --> Choice{"Has context met<br/>min signals (10)?"}
+    
+    Choice -->|No| Default["Use default profile<br/>(e.g., BALANCED)"]
+    Choice -->|Yes| Strategy{"Epsilon-Greedy Choice<br/>(epsilon = 10%)"}
+    
+    Strategy -->|Exploit (90%)| Best["Select profile with<br/>highest positive EMA"]
+    Strategy -->|Explore (10%)| Random["Select random profile<br/>to discover performance"]
+    
+    Default --> Recall["Execute Recall Pipeline"]
+    Best --> Recall
+    Random --> Recall
+    
+    Recall --> Action["Agent performs action<br/>using retrieved memories"]
+    Action --> Feedback["User/System reinforce:<br/>memory.reinforce(..., positive=true)"]
+    Feedback --> Update["Update profile's EMA positive rate<br/>(alpha = 0.15)"]
+```
+
+### 1. Context Hashing
+When a query is received with `profile=auto`, the system extracts the search tags and sorts them alphabetically to ensure determinism. It hashes the tag list to produce a unique context key. Similar queries searching the same topic share this context and pool their learning.
+
+### 2. Epsilon-Greedy Selection
+To balance utilizing known successful profiles (exploitation) with discovering potentially better ones (exploration), the system uses an **Epsilon-Greedy** strategy with $\epsilon = 10\%$:
+* **Exploitation (90% of the time):** The system selects the profile that currently has the highest Exponential Moving Average (EMA) positive rate for this context.
+* **Exploration (10% of the time):** The system selects a random profile to gather new data.
+
+### 3. Cold Start Fallback
+Before the system has sufficient data to make statistical decisions, it uses a fallback mechanism:
+* If a context hash has fewer than **10 reinforcement signals**, the system falls back to the default profile configured in the `SalienceProfile`, and finally to `BALANCED`.
+
+### 4. Reinforcement Learning
+When the calling application reinforces the outcome of a memory recall (such as an agent successfully completing a task using retrieved context), it credits the profile that retrieved that memory. 
+
+The positive rate for the chosen profile is updated using an Exponential Moving Average:
+
+$$
+\text{EMA}_{t+1} = \text{EMA}_t \cdot (1 - \alpha) + \text{reward} \cdot \alpha
+$$
+
+Where:
+* $\alpha = 0.15$ is the learning rate blending factor.
+* $\text{reward} = 1.0$ for positive reinforcement, and $0.0$ for negative reinforcement.
+
+---
+
+## In Practice
+
+### 1. Enabling Self-Tuning Retrieval
+
+To activate the self-tuning adaptor, set the profile to `"auto"` in your recall options.
+
+#### Via Java SDK
+```java
+var options = RecallOptions.builder()
+    .autoProfile(true) // Automatically selects the best profile
+    .build();
+
+var results = memory.recall("database deadlock", options);
+```
+
+#### Via MCP Tool
+```json
+{
+  "name": "memory_recall",
+  "arguments": {
+    "query": "database deadlock",
+    "profile": "auto"
+  }
+}
+```
+
+### 2. Reinforcing Outcomes
+When an action succeeds or fails, send feedback to reinforce the chosen retrieval path. Spector automatically tracks which profile was used to retrieve each memory and updates the contextual bandit statistics accordingly.
+
+#### Via Java SDK
+```java
+// If the retrieved memory successfully resolved the issue
+memory.reinforce(memoryId, true); // positive reinforcement
+
+// If the retrieved memory was irrelevant or caused an error
+memory.reinforce(memoryId, false); // negative reinforcement
+```
+
+---
+
+## Persistence & Performance
+
+* **Durable Learning:** Learned bandit statistics are snapshotted to the binary coactivation tracker file (`coactivation.tracker`) on engine shutdown and reloaded on startup.
+* **Isolation:** Reinforcement statistics are isolated per memory space, ensuring that different agents do not pollute each other's learned retrieval preferences.
+* **Performance:** Hashing and stats lookup are implemented using high-performance concurrent collections, completing in sub-microsecond time and adding zero overhead to the recall path.
+
+---
+
+## Key Takeaways
+
+* **Zero-Configuration Optimization:** Agents don't need manual profile tuning; the system adapts to their workflows over time.
+* **Exploration/Exploitation Balance:** Epsilon-greedy selection ensures the system continuously discovers optimal retrieval paths without getting stuck in local optima.
+* **Resilient Failover:** Cold-start thresholds guarantee that General-Purpose `BALANCED` retrieval is used until reliable contextual statistics are collected.

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -131,10 +131,10 @@ Separate documentation into two tracks to prevent the "19 packages overwhelm dev
 
 ## 📜 Planned — Agentic AI
 
-### 📜 ProfileAdaptor — Self-Tuning Cognitive Profiles {#profile-adaptor}
+### ✅ ProfileAdaptor — Self-Tuning Cognitive Profiles {#profile-adaptor}
 
-!!! info "Status: Planned"
-    Low-medium effort. High impact for autonomous agent deployments.
+!!! success "Completed"
+    Implemented in `spector-memory` (OSS repo) as a contextual bandit that tracks reinforcement signals per tag-context and profile, persisting stats to `coactivation.tracker` (COAX v2). Enabled via `profile=auto`. Fully tested with 37 unit tests.
 
 A lightweight **contextual bandit** that learns which `CognitiveProfile` performs best for each context (tag combination), using the existing `memory_reinforce` feedback signal. Instead of requiring AI agents to manually select `DEBUGGING` vs `EXPLORING` vs `BALANCED`, the system auto-selects the optimal profile based on historical reinforcement rates.
 
@@ -811,7 +811,6 @@ RecallOptions.builder()
 
 | # | Improvement | Category | Effort | Status |
 |---|------------|----------|--------|--------|
-| 1 | **ProfileAdaptor (contextual bandit)** | Agentic AI | Low-Medium | 📜 Planned |
 | 2 | **GPU kernel dispatch** | Compute | Medium | 📜 Infra ready |
 | 3 | **Project Valhalla** | Runtime | Medium | 🔄 Prepared |
 
@@ -834,6 +833,8 @@ RecallOptions.builder()
 
 | # | Improvement | Category | Effort |
 |---|------------|----------|--------|
+| 1 | **ProfileAdaptor (contextual bandit)** | Agentic AI | Low-Medium |
+| 14 | **Executive Dysfunction (Hebbian recall)** | Agentic AI | Low-Medium |
 | 17 | **OpenClaw integration** | Agentic AI | Medium |
 | 18 | **Python SDK (MCP wrapper)** | Client SDKs | Low-Medium |
 | 19 | **Documentation split** | Documentation | Low |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - The 6-Phase Scoring Pipeline: memory/scoring-pipeline.md
       - Cognitive Profiles:
           - Overview: memory/cognitive-profiles.md
+          - "Self-Tuning Adaptor": memory/profile-adaptor.md
           - "Focus Mode": memory/focus-mode.md
           - "Explorer — Lateral Retrieval": memory/lateral-retrieval.md
           - "Importance Fusion (ICNU)": memory/importance-fusion.md

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,19 @@
+# Memory & Intelligence Layer (`/memory`)
+
+This directory houses the core algorithmic components of the Spector cognitive memory and search engine. These modules implement biological memory models, high-performance off-heap indexing, vector embedding integrations, and RAG query pipelines.
+
+## Modules
+
+* **[`spector-embed-api`](/memory/spector-embed-api)**: Abstract interface for vectorizing text chunks.
+* **[`spector-embed-ollama`](/memory/spector-embed-ollama)**: Concrete local LLM embedding implementation using Ollama.
+* **[`spector-gpu`](/memory/spector-gpu)**: Optional CUDA-accelerated distance metrics for high-throughput batch vector comparison.
+* **[`spector-index`](/memory/spector-index)**: Core nearest-neighbor search indexes (HNSW, flat array brute force) and custom distance metrics.
+* **[`spector-ingestion`](/memory/spector-ingestion)**: Chunking strategies, semantic metadata extraction, and ingestion pipelines.
+* **[`spector-memory`](/memory/spector-memory)**: The biological cognitive memory engine. Implements the 4-tier memory architecture (episodic, semantic, procedural, Hebbian graph) off-heap via Project Panama.
+* **[`spector-query`](/memory/spector-query)**: Retrieval pipelines, hybrid search scoring, and importance/salience score fusions.
+* **[`spector-rag`](/memory/spector-rag)**: Retrieval-Augmented Generation workflows and LLM orchestration.
+
+## Dependency Rules
+
+* **Independence Rule**: `spector-memory` and `spector-index` are designed as independent units to enforce modular boundaries. They do **not** depend directly on each other.
+* **Flow**: Memory modules depend on the foundation libraries in `/nucleus` and are in turn consumed by `/synapse` and `/bench`.

--- a/memory/spector-embed-ollama/src/main/java/com/spectrayan/spector/embed/ollama/OllamaEmbeddingProvider.java
+++ b/memory/spector-embed-ollama/src/main/java/com/spectrayan/spector/embed/ollama/OllamaEmbeddingProvider.java
@@ -137,7 +137,8 @@ public class OllamaEmbeddingProvider implements EmbeddingProvider {
         }
 
         String cacheKey = getCacheKey(text);
-        java.nio.file.Path cacheDir = java.nio.file.Path.of("embedding-cache", config.model().replace(":", "_"));
+        String cacheBase = System.getProperty("spector.embedding.cache-dir", "embedding-cache");
+        java.nio.file.Path cacheDir = java.nio.file.Path.of(cacheBase, config.model().replace(":", "_"));
         java.nio.file.Path cacheFile = cacheDir.resolve(cacheKey + ".json");
 
         if (java.nio.file.Files.exists(cacheFile)) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveProfileConfig.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveProfileConfig.java
@@ -84,6 +84,7 @@ public final class CognitiveProfileConfig {
         NEURODIVERGENT_PROFILES.add(CognitiveProfile.HYPERFOCUS);
         NEURODIVERGENT_PROFILES.add(CognitiveProfile.SYSTEMATIZER);
         NEURODIVERGENT_PROFILES.add(CognitiveProfile.DIVERGENT);
+        NEURODIVERGENT_PROFILES.add(CognitiveProfile.EXECUTIVE_DYSFUNCTION);
     }
 
     /** All profiles. */

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -562,8 +562,11 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         if (options.autoProfile() && options.profile() == null) {
             CognitiveProfile suggested = null;
             if (profileAdaptor != null) {
-                // ProfileAdaptor uses its internal context history for suggestion
-                suggested = profileAdaptor.suggest();
+                // Extract context tags from the query text
+                String[] tags = cognitiveTarget.tagExtractor() != null
+                        ? cognitiveTarget.tagExtractor().extract("query", queryText)
+                        : new String[0];
+                suggested = profileAdaptor.suggest(tags);
             }
             if (suggested == null) {
                 SalienceProfile sp = cognitiveTarget.salienceProfile();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.memory;
 
+import com.spectrayan.spector.memory.adaptor.ProfileAdaptor;
 import com.spectrayan.spector.memory.model.SalienceProfile;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
@@ -219,6 +220,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     // ── Multimodal Attachment Processing ──
     private final com.spectrayan.spector.memory.pipeline.AttachmentProcessor attachmentProcessor;
 
+    // ── Contextual Bandit (ProfileAdaptor) ──
+    private final ProfileAdaptor profileAdaptor;
+
     DefaultSpectorMemory(SpectorMemoryBuilder builder) {
         var bundle = SpectorMemoryFactory.assemble(builder);
         this.cognitiveTarget = bundle.cognitiveTarget();
@@ -257,6 +261,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.parallelPipeline = bundle.parallelPipeline();
         this.embedConfig = bundle.embedConfig();
         this.attachmentProcessor = bundle.attachmentProcessor();
+        this.profileAdaptor = bundle.profileAdaptor();
 
         // ── JVM Shutdown Hook ── (DISK mode only)
         if (persistenceMode == MemoryPersistenceMode.DISK && bundle.basePath() != null) {
@@ -553,6 +558,31 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public List<CognitiveResult> recall(String queryText, RecallOptions options) {
+        // Auto-profile resolution: use ProfileAdaptor to suggest best profile
+        if (options.autoProfile() && options.profile() == null) {
+            CognitiveProfile suggested = null;
+            if (profileAdaptor != null) {
+                // ProfileAdaptor uses its internal context history for suggestion
+                suggested = profileAdaptor.suggest();
+            }
+            if (suggested == null) {
+                SalienceProfile sp = cognitiveTarget.salienceProfile();
+                if (sp != null) {
+                    suggested = sp.defaultProfile();
+                }
+            }
+            if (suggested == null) {
+                suggested = CognitiveProfile.BALANCED;
+            }
+            log.debug("Auto-profile resolved to {} for query '{}'", suggested, queryText);
+            options = RecallOptions.builder()
+                    .topK(options.topK())
+                    .profile(suggested)
+                    .scoringMode(options.scoringMode())
+                    .recallMode(options.recallMode())
+                    .autoProfile(true)
+                    .build();
+        }
         return recallPipeline.recall(queryText, options);
     }
 
@@ -1084,6 +1114,10 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         // Final checkpoint flush before closing storage
         if (checkpointDaemon != null) {
             try {
+                // Snapshot ProfileAdaptor bandit stats to CoActivationTracker before checkpoint
+                if (profileAdaptor != null && coActivationTracker != null) {
+                    coActivationTracker.updateBanditStats(profileAdaptor.statsSnapshot());
+                }
                 checkpointDaemon.checkpoint();
             } catch (Exception e) {
                 log.warn("Final checkpoint on close failed: {}", e.getMessage());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.memory;
 
+import com.spectrayan.spector.memory.adaptor.ProfileAdaptor;
 import com.spectrayan.spector.memory.amygdala.ValenceTracker;
 import com.spectrayan.spector.memory.cortex.TierRouter;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
@@ -65,19 +66,22 @@ final class ReinforcementHandler {
     private final RecallPipeline recallPipeline;
     private final MemoryWal wal;
     private final TwoFactorConfig twoFactorConfig;
+    private final ProfileAdaptor profileAdaptor;
 
     ReinforcementHandler(ValenceTracker valenceTracker,
                          HebbianGraphBase hebbianGraph,
                          LateralEvaluator lateralEvaluator,
                          RecallPipeline recallPipeline,
                          MemoryWal wal,
-                         TwoFactorConfig twoFactorConfig) {
+                         TwoFactorConfig twoFactorConfig,
+                         ProfileAdaptor profileAdaptor) {
         this.valenceTracker = valenceTracker;
         this.hebbianGraph = hebbianGraph;
         this.lateralEvaluator = lateralEvaluator;
         this.recallPipeline = recallPipeline;
         this.wal = wal;
         this.twoFactorConfig = twoFactorConfig;
+        this.profileAdaptor = profileAdaptor;
     }
 
     /**
@@ -144,6 +148,28 @@ final class ReinforcementHandler {
 
         // Step 6: WAL append
         wal.appendReinforce(memoryId, valence);
+
+        // Step 7: ProfileAdaptor — record reinforcement outcome for profile learning
+        if (profileAdaptor != null && segment != null) {
+            try {
+                // Read profile ordinal from synaptic header byte 60
+                byte profileOrdinal = segment.get(
+                        java.lang.foreign.ValueLayout.JAVA_BYTE,
+                        loc.offset() + com.spectrayan.spector.memory.synapse.SynapticHeaderConstants.OFFSET_LAST_RECALL_PROFILE);
+                if (profileOrdinal >= 0 && profileOrdinal < com.spectrayan.spector.memory.model.CognitiveProfile.values().length) {
+                    com.spectrayan.spector.memory.model.CognitiveProfile usedProfile =
+                            com.spectrayan.spector.memory.model.CognitiveProfile.values()[profileOrdinal];
+                    // Read tag names from the MemoryIndex (bloom filter can't be reversed)
+                    String[] tags = index.tags(memoryId);
+                    if (tags != null && tags.length > 0) {
+                        profileAdaptor.recordOutcome(usedProfile, tags, valence > 0);
+                    }
+                }
+            } catch (RuntimeException e) {
+                log.debug("ProfileAdaptor recording failed for '{}': {}", memoryId, e.getMessage());
+            }
+        }
+
         log.debug("Reinforce: '{}' with valence={}", memoryId, valence);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -233,16 +233,19 @@ public final class SpectorMemoryFactory {
         MemoryIndex index;
         if (isDisk && basePath != null) {
             Path runtimeIndex = StorageLayout.indexMidxRuntime(basePath);
+            Path partitionIndex = resolvedPartitionDir != null ? StorageLayout.indexMidx(resolvedPartitionDir) : null;
             Path legacyIndex = StorageLayout.legacyIndex(basePath);
-            if (java.nio.file.Files.exists(runtimeIndex)) {
-                index = MemoryIndex.load(runtimeIndex);
-            } else if (resolvedPartitionDir != null
-                    && java.nio.file.Files.exists(StorageLayout.indexMidx(resolvedPartitionDir))) {
-                index = MemoryIndex.load(StorageLayout.indexMidx(resolvedPartitionDir));
-                log.info("Loaded V2 index from partition — will save to runtime/ on next close");
-            } else if (java.nio.file.Files.exists(legacyIndex)) {
-                index = MemoryIndex.load(legacyIndex);
-                log.info("Loaded legacy memory-index.mem — will save to runtime/ on next close");
+
+            Path loadFrom = getNewerPath(runtimeIndex, partitionIndex, legacyIndex);
+            if (loadFrom != null) {
+                index = MemoryIndex.load(loadFrom);
+                if (loadFrom.equals(partitionIndex)) {
+                    log.info("Loaded index from partition (newer than runtime index): {}", loadFrom);
+                } else if (loadFrom.equals(legacyIndex)) {
+                    log.info("Loaded legacy index: {}", loadFrom);
+                } else {
+                    log.info("Loaded index from runtime: {}", loadFrom);
+                }
             } else {
                 index = new MemoryIndex();
             }
@@ -296,9 +299,10 @@ public final class SpectorMemoryFactory {
             Path legacyGraph = basePath.resolve(StorageLayout.FILE_HEBBIAN);
             Path v2Graph = resolvedPartitionDir != null
                     ? StorageLayout.hebbianGraph(resolvedPartitionDir) : null;
-            Path loadFrom = java.nio.file.Files.exists(runtimeGraph) ? runtimeGraph
-                    : (v2Graph != null && java.nio.file.Files.exists(v2Graph)) ? v2Graph
-                    : legacyGraph;
+            Path loadFrom = getNewerPath(runtimeGraph, v2Graph, legacyGraph);
+            if (loadFrom == null) {
+                loadFrom = legacyGraph;
+            }
             hebbianGraph = HebbianGraphCsr.load(loadFrom, graphCapacity,
                     builder.hebbianMaxDegree, builder.edgeImportance);
         } else {
@@ -313,9 +317,10 @@ public final class SpectorMemoryFactory {
             Path legacyChain = basePath.resolve(StorageLayout.FILE_TEMPORAL);
             Path v2Chain = resolvedPartitionDir != null
                     ? StorageLayout.temporalChain(resolvedPartitionDir) : null;
-            Path loadFrom = java.nio.file.Files.exists(runtimeChain) ? runtimeChain
-                    : (v2Chain != null && java.nio.file.Files.exists(v2Chain)) ? v2Chain
-                    : legacyChain;
+            Path loadFrom = getNewerPath(runtimeChain, v2Chain, legacyChain);
+            if (loadFrom == null) {
+                loadFrom = legacyChain;
+            }
             temporalChain = TemporalChain.load(loadFrom, temporalCapacity);
         } else {
             temporalChain = new TemporalChain(temporalCapacity);
@@ -346,12 +351,9 @@ public final class SpectorMemoryFactory {
                 Path v2Entity = resolvedPartitionDir != null
                         ? StorageLayout.entityGraph(resolvedPartitionDir) : null;
 
-                if (java.nio.file.Files.exists(runtimeEntity)) {
-                    entityGraph = EntityGraph.load(runtimeEntity, entityCap, edgeCap);
-                } else if (v2Entity != null && java.nio.file.Files.exists(v2Entity)) {
-                    entityGraph = EntityGraph.load(v2Entity, entityCap, edgeCap);
-                } else if (java.nio.file.Files.exists(legacyEntity)) {
-                    entityGraph = EntityGraph.load(legacyEntity, entityCap, edgeCap);
+                Path loadFrom = getNewerPath(runtimeEntity, v2Entity, legacyEntity);
+                if (loadFrom != null) {
+                    entityGraph = EntityGraph.load(loadFrom, entityCap, edgeCap);
                 } else {
                     entityGraph = new EntityGraph(runtimeEntity, entityCap, edgeCap,
                             builder.entityMaxDegree, builder.edgeImportance);
@@ -392,9 +394,10 @@ public final class SpectorMemoryFactory {
             index.setTextDataStore(textDataStore);
 
             java.nio.file.Path bm25Path = StorageLayout.bm25BidxRuntime(basePath);
-            if (!java.nio.file.Files.exists(bm25Path) && resolvedPartitionDir != null) {
-                java.nio.file.Path v2Bm25 = StorageLayout.bm25Bidx(resolvedPartitionDir);
-                if (java.nio.file.Files.exists(v2Bm25)) bm25Path = v2Bm25;
+            java.nio.file.Path v2Bm25 = resolvedPartitionDir != null ? StorageLayout.bm25Bidx(resolvedPartitionDir) : null;
+            java.nio.file.Path loadFrom = getNewerPath(bm25Path, v2Bm25, null);
+            if (loadFrom != null) {
+                bm25Path = loadFrom;
             }
             BM25Index loadedBm25 = BM25Index.load(bm25Path);
             bm25Index = new MemoryBM25Index(1);
@@ -614,5 +617,42 @@ public final class SpectorMemoryFactory {
             long elapsed = System.currentTimeMillis() - startMs;
             log.info("HNSW rebuild complete: {}/{} vectors added in {}ms", rebuilt, storeSize, elapsed);
         }
+    }
+
+    private static Path getNewerPath(Path runtimePath, Path partitionPath, Path legacyPath) {
+        Path target = null;
+        long latestTime = Long.MIN_VALUE;
+
+        if (runtimePath != null && java.nio.file.Files.exists(runtimePath)) {
+            try {
+                long t = java.nio.file.Files.getLastModifiedTime(runtimePath).toMillis();
+                if (t > latestTime) {
+                    latestTime = t;
+                    target = runtimePath;
+                }
+            } catch (java.io.IOException ignored) {}
+        }
+
+        if (partitionPath != null && java.nio.file.Files.exists(partitionPath)) {
+            try {
+                long t = java.nio.file.Files.getLastModifiedTime(partitionPath).toMillis();
+                if (t > latestTime) {
+                    latestTime = t;
+                    target = partitionPath;
+                }
+            } catch (java.io.IOException ignored) {}
+        }
+
+        if (legacyPath != null && java.nio.file.Files.exists(legacyPath)) {
+            try {
+                long t = java.nio.file.Files.getLastModifiedTime(legacyPath).toMillis();
+                if (t > latestTime) {
+                    latestTime = t;
+                    target = legacyPath;
+                }
+            } catch (java.io.IOException ignored) {}
+        }
+
+        return target;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -17,6 +17,8 @@ import com.spectrayan.spector.commons.concurrent.DaemonPolicy;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.memory.adaptor.ProfileAdaptor;
+import com.spectrayan.spector.memory.pipeline.RecallHistory;
 import com.spectrayan.spector.embed.EmbedConfig;
 import com.spectrayan.spector.embed.EmbeddingProvider;
 import com.spectrayan.spector.embed.ParallelEmbeddingPipeline;
@@ -126,7 +128,8 @@ public final class SpectorMemoryFactory {
             EmbedConfig embedConfig,
             Path resolvedPartitionDir,
             Path basePath,
-            SpectorNamespaceManager namespaceManager
+            SpectorNamespaceManager namespaceManager,
+            ProfileAdaptor profileAdaptor
     ) {}
 
     private SpectorMemoryFactory() {}
@@ -481,6 +484,22 @@ public final class SpectorMemoryFactory {
             rebuildHnswIfNeeded(builder, tierRouter, index, quantizer);
         }
 
+        // ── ProfileAdaptor (Contextual Bandit) ──
+        CognitiveProfile salienceDefault = null;
+        if (builder.salienceProfileProvider != null) {
+            SalienceProfile effective = builder.salienceProfileProvider.effectiveProfile();
+            if (effective != null) {
+                salienceDefault = effective.defaultProfile();
+            }
+        }
+        ProfileAdaptor profileAdaptor = new ProfileAdaptor(salienceDefault);
+        if (!coActivationTracker.banditStats().isEmpty()) {
+            profileAdaptor.loadStats(coActivationTracker.banditStats());
+        }
+
+        // ── RecallHistory (Executive Dysfunction context buffer) ──
+        RecallHistory recallHistory = new RecallHistory();
+
         // ── Recall Pipeline ──
         RecallPipeline recallPipeline = new RecallPipeline(
                 embeddingProvider, tierRouter, index,
@@ -488,7 +507,8 @@ public final class SpectorMemoryFactory {
                 quantizer.mins(), quantizer.scales(), semanticStrategy,
                 null, hebbianGraph, temporalChain, entityGraph, entityExtractor,
                 builder.graphScoringPolicy, bm25Index,
-                memorySpladeIndex, builder.sparseEncodingProvider, colbertReranker);
+                memorySpladeIndex, builder.sparseEncodingProvider, colbertReranker,
+                recallHistory);
 
         recallPipeline.addListener(new LtpReconsolidationListener(index, tierRouter, wal));
         recallPipeline.addListener(new HebbianCoActivationListener(coActivationTracker));
@@ -503,7 +523,7 @@ public final class SpectorMemoryFactory {
 
         ReinforcementHandler reinforcementHandler = new ReinforcementHandler(
                 valenceTracker, hebbianGraph, lateralEvaluator, recallPipeline,
-                wal, builder.twoFactorConfig);
+                wal, builder.twoFactorConfig, profileAdaptor);
 
         // ── Cognitive Graph Facade ──
         CognitiveGraphFacade graphFacade = new CognitiveGraphFacade(
@@ -557,7 +577,7 @@ public final class SpectorMemoryFactory {
                 entityGraph, hyperEntityGraph, graphFacade, idGenerator,
                 checkpointDaemon, daemonSupervisor, bm25Index, attachmentProcessor,
                 parallelPipeline, embedConfig, resolvedPartitionDir, basePath,
-                namespaceManager
+                namespaceManager, profileAdaptor
         );
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/adaptor/ProfileAdaptor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/adaptor/ProfileAdaptor.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.adaptor;
+
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+/**
+ * Contextual bandit that learns the optimal {@link CognitiveProfile} per tag context.
+ *
+ * <h3>Biological Analog: Basal Ganglia Contextual Bandit</h3>
+ * <p>The basal ganglia select motor programs (actions) based on contextual cues
+ * from the cortex. When an action produces a reward, dopamine reinforces the
+ * context→action mapping. Over time, the basal ganglia learn which action to
+ * select in each context without explicit instruction — a biological
+ * multi-armed bandit.</p>
+ *
+ * <p>This class implements the same principle for cognitive profiles. Each
+ * unique tag context (a set of synaptic tags) maps to a set of candidate
+ * profiles. Reinforcement signals update the exponential moving average (EMA)
+ * of each profile's success rate in that context. The {@link #suggest} method
+ * uses ε-greedy selection: 90% exploit (best EMA), 10% explore (random).</p>
+ *
+ * <h3>Thread Safety</h3>
+ * <p>Reads use {@link ConcurrentHashMap} lock-free access. Writes are
+ * serialized by a {@link ReentrantLock}. {@link RunningStats} is immutable
+ * (copy-on-write), so readers never see torn state.</p>
+ *
+ * <h3>Persistence</h3>
+ * <p>Bandit statistics are persisted inside the CoActivationTracker's COAX v2
+ * binary format. Use {@link #statsSnapshot()} to export and
+ * {@link #loadStats(Map)} to import.</p>
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ *   var adaptor = new ProfileAdaptor(CognitiveProfile.BALANCED);
+ *
+ *   // After a successful recall with DEBUGGING profile in "database,timeout" context:
+ *   adaptor.recordOutcome(CognitiveProfile.DEBUGGING,
+ *       new String[]{"database", "timeout"}, true);
+ *
+ *   // Next recall in the same context — suggest the best profile:
+ *   CognitiveProfile suggested = adaptor.suggest("database", "timeout");
+ *   // → DEBUGGING (if enough positive signals accumulated)
+ * }</pre>
+ *
+ * @see RunningStats
+ * @see CognitiveProfile
+ */
+public final class ProfileAdaptor {
+
+    private static final Logger log = LoggerFactory.getLogger(ProfileAdaptor.class);
+
+    /** Minimum signals before trusting the EMA (cold start threshold). */
+    static final int MIN_SIGNALS = 10;
+
+    /** Exploration rate: probability of choosing a random profile. */
+    static final float EPSILON = 0.10f;
+
+    /** EMA smoothing factor for reinforcement signals. */
+    static final float EMA_ALPHA = 0.15f;
+
+    /** Available profiles for exploration (all enum values). */
+    private static final CognitiveProfile[] ALL_PROFILES = CognitiveProfile.values();
+
+    /**
+     * Bandit statistics: context hash → per-profile running stats.
+     * ConcurrentHashMap for lock-free reads; writes guarded by {@link #writeLock}.
+     */
+    private final ConcurrentHashMap<Long, EnumMap<CognitiveProfile, RunningStats>> stats =
+            new ConcurrentHashMap<>();
+
+    /** Write lock for mutating the stats map. */
+    private final ReentrantLock writeLock = new ReentrantLock();
+
+    /** Fallback profile from SalienceProfile.defaultProfile() — may be null. */
+    private final CognitiveProfile salienceDefault;
+
+    /**
+     * Creates a profile adaptor with the given fallback profile.
+     *
+     * @param salienceDefault the fallback profile from SalienceProfile, or null
+     *                        for no fallback (caller falls back to BALANCED)
+     */
+    public ProfileAdaptor(CognitiveProfile salienceDefault) {
+        this.salienceDefault = salienceDefault;
+    }
+
+    /**
+     * Creates a profile adaptor with no fallback profile.
+     */
+    public ProfileAdaptor() {
+        this(null);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Recording outcomes
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Records a reinforcement outcome for a (context, profile) pair.
+     *
+     * <p>Updates the EMA of the profile's success rate in the given tag context.
+     * This is the core learning signal — positive reinforcement strengthens
+     * the context→profile mapping, negative weakens it.</p>
+     *
+     * @param profile  the cognitive profile that was used
+     * @param tags     the context tags from the recall query
+     * @param positive whether the outcome was positive (user accepted result)
+     */
+    public void recordOutcome(CognitiveProfile profile, String[] tags, boolean positive) {
+        if (profile == null || tags == null || tags.length == 0) return;
+
+        long ctxHash = contextHash(tags);
+        writeLock.lock();
+        try {
+            EnumMap<CognitiveProfile, RunningStats> contextStats =
+                    stats.computeIfAbsent(ctxHash, _ -> new EnumMap<>(CognitiveProfile.class));
+            RunningStats current = contextStats.getOrDefault(profile, RunningStats.EMPTY);
+            contextStats.put(profile, current.update(positive, EMA_ALPHA));
+        } finally {
+            writeLock.unlock();
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("ProfileAdaptor: recorded {} outcome for {} in context hash={}",
+                    positive ? "positive" : "negative", profile, ctxHash);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Suggestion (ε-greedy)
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Suggests the best cognitive profile for the given tag context.
+     *
+     * <p>Uses ε-greedy selection:</p>
+     * <ul>
+     *   <li><b>10% explore</b>: returns a random profile from the full set</li>
+     *   <li><b>90% exploit</b>: returns the profile with the highest EMA in
+     *       this context, if sufficient signals have been collected</li>
+     * </ul>
+     *
+     * <p>Returns {@code null} (caller falls back to BALANCED) when:</p>
+     * <ul>
+     *   <li>No data exists for this context AND no salienceDefault is set</li>
+     *   <li>The best profile has fewer than {@link #MIN_SIGNALS} signals</li>
+     * </ul>
+     *
+     * @param tags context tags from the recall query
+     * @return the suggested profile, or null if insufficient data
+     */
+    public CognitiveProfile suggest(String... tags) {
+        if (tags == null || tags.length == 0) return salienceDefault;
+
+        // ε-greedy: explore with probability EPSILON
+        if (ThreadLocalRandom.current().nextFloat() < EPSILON) {
+            CognitiveProfile random = ALL_PROFILES[
+                    ThreadLocalRandom.current().nextInt(ALL_PROFILES.length)];
+            log.trace("ProfileAdaptor: exploring random profile {}", random);
+            return random;
+        }
+
+        // Exploit: find best EMA for this context
+        long ctxHash = contextHash(tags);
+        EnumMap<CognitiveProfile, RunningStats> contextStats = stats.get(ctxHash);
+        if (contextStats == null || contextStats.isEmpty()) {
+            return salienceDefault;
+        }
+
+        CognitiveProfile best = null;
+        float bestEma = -1.0f;
+        for (Map.Entry<CognitiveProfile, RunningStats> entry : contextStats.entrySet()) {
+            RunningStats rs = entry.getValue();
+            if (rs.totalSignals() >= MIN_SIGNALS && rs.ema() > bestEma) {
+                bestEma = rs.ema();
+                best = entry.getKey();
+            }
+        }
+
+        if (best != null) {
+            log.trace("ProfileAdaptor: suggesting {} (EMA={}) for context hash={}",
+                    best, bestEma, ctxHash);
+        }
+        return best != null ? best : salienceDefault;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Context Hashing
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Computes a deterministic hash for a set of tags (order-independent).
+     *
+     * <p>Sorts tags alphabetically, joins with ":", then applies FNV-1a 64-bit
+     * hashing — the same algorithm used by {@code CoActivationTracker.hashTag()}.</p>
+     *
+     * @param tags the context tags
+     * @return the 64-bit context hash
+     */
+    static long contextHash(String... tags) {
+        String[] sorted = tags.clone();
+        Arrays.sort(sorted);
+        String joined = String.join(":", sorted);
+
+        // FNV-1a 64-bit — same algorithm as CoActivationTracker.hashTag()
+        long hash = 0xcbf29ce484222325L;
+        for (int i = 0; i < joined.length(); i++) {
+            hash ^= joined.charAt(i);
+            hash *= 0x100000001b3L;
+        }
+        return hash == 0 ? 1 : hash;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Persistence
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Returns an unmodifiable snapshot of all bandit statistics.
+     *
+     * <p>Used by CoActivationTracker to persist bandit stats in the COAX v2 format.</p>
+     *
+     * @return unmodifiable map of context hash → per-profile stats
+     */
+    public Map<Long, EnumMap<CognitiveProfile, RunningStats>> statsSnapshot() {
+        return Collections.unmodifiableMap(stats);
+    }
+
+    /**
+     * Bulk-loads bandit statistics from persistence.
+     *
+     * <p>Called during CoActivationTracker load to restore bandit state from
+     * the COAX v2 file. Replaces any existing in-memory stats.</p>
+     *
+     * @param loaded the persisted statistics map
+     */
+    public void loadStats(Map<Long, EnumMap<CognitiveProfile, RunningStats>> loaded) {
+        if (loaded == null) return;
+        writeLock.lock();
+        try {
+            stats.clear();
+            for (Map.Entry<Long, EnumMap<CognitiveProfile, RunningStats>> entry : loaded.entrySet()) {
+                stats.put(entry.getKey(), new EnumMap<>(entry.getValue()));
+            }
+            log.info("ProfileAdaptor: loaded {} context entries from persistence", loaded.size());
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Returns the total number of tracked contexts.
+     *
+     * @return context count
+     */
+    public int contextCount() {
+        return stats.size();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/adaptor/RunningStats.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/adaptor/RunningStats.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.adaptor;
+
+
+/**
+ * Immutable running statistics for reinforcement-based profile adaptation.
+ *
+ * <h3>Biological Analog: Basal Ganglia Procedural Learning</h3>
+ * <p>The basal ganglia learn through dopamine-mediated reinforcement — each
+ * positive outcome (reward) strengthens the action that produced it, while
+ * negative outcomes (punishment) weaken it. This record models that process
+ * as an exponential moving average (EMA) of the positive reinforcement rate.</p>
+ *
+ * <p>The EMA tracks the recent "success rate" of a cognitive profile. When
+ * a profile consistently produces good recall outcomes (user accepts the
+ * result, clicks through, etc.), its EMA rises toward 1.0. When outcomes
+ * are negative (user ignores, re-queries, etc.), the EMA decays toward 0.0.
+ * The {@code alpha} parameter controls how quickly the EMA adapts — higher
+ * values make it more responsive to recent signals, lower values make it
+ * more stable.</p>
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ *   // Start with no history
+ *   RunningStats stats = RunningStats.EMPTY;
+ *
+ *   // Record a positive reinforcement signal
+ *   stats = stats.update(true, 0.1f);  // EMA → 1.0 (first signal)
+ *
+ *   // Record a negative signal
+ *   stats = stats.update(false, 0.1f); // EMA → 0.9 (decays from 1.0)
+ *
+ *   // Check the running success rate
+ *   float successRate = stats.ema(); // 0.9
+ * }</pre>
+ *
+ * @param ema             exponential moving average of the positive reinforcement rate (0.0–1.0)
+ * @param totalSignals    total number of reinforcement signals received
+ * @param positiveSignals count of positive reinforcement signals
+ * @param lastUpdatedMs   epoch milliseconds of the last update
+ */
+public record RunningStats(
+        float ema,
+        int totalSignals,
+        int positiveSignals,
+        long lastUpdatedMs
+) {
+
+    /** Empty statistics — no signals received, zero EMA. */
+    public static final RunningStats EMPTY = new RunningStats(0f, 0, 0, 0L);
+
+    /**
+     * Returns new statistics incorporating a reinforcement signal.
+     *
+     * <p>The EMA is updated using the standard formula:
+     * {@code newEma = ema * (1 - alpha) + value * alpha}, where {@code value}
+     * is 1.0 for positive and 0.0 for negative signals. On the first signal,
+     * the EMA is set directly to the value (no prior history to blend with).</p>
+     *
+     * <p>This method is pure — it returns a new {@code RunningStats} instance
+     * without modifying the current one.</p>
+     *
+     * @param positive whether this signal is a positive reinforcement
+     * @param alpha    the EMA smoothing factor (0.0–1.0); higher = more responsive
+     * @return a new {@code RunningStats} reflecting the updated state
+     */
+    public RunningStats update(boolean positive, float alpha) {
+        float value = positive ? 1.0f : 0.0f;
+        float newEma = totalSignals == 0 ? value : ema * (1 - alpha) + value * alpha;
+        return new RunningStats(
+                newEma,
+                totalSignals + 1,
+                positiveSignals + (positive ? 1 : 0),
+                System.currentTimeMillis());
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/BridgeDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/BridgeDetector.java
@@ -250,7 +250,7 @@ public final class BridgeDetector {
         inTree[root] = true;
 
         // Maximum walk steps to prevent infinite loops on disconnected components
-        int maxSteps = nodeCount * 10;
+        int maxSteps = Math.max(10, activeNodes.size() * 2);
 
         // Process each active node not yet in the tree
         for (int activeNode : activeNodes) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/BridgeDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/BridgeDetector.java
@@ -250,7 +250,7 @@ public final class BridgeDetector {
         inTree[root] = true;
 
         // Maximum walk steps to prevent infinite loops on disconnected components
-        int maxSteps = Math.max(10, activeNodes.size() * 2);
+        int maxSteps = Math.min(10000, Math.max(1000, activeNodes.size() * 2));
 
         // Process each active node not yet in the tree
         for (int activeNode : activeNodes) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationTracker.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationTracker.java
@@ -12,12 +12,14 @@
  */
 package com.spectrayan.spector.memory.hebbian;
 
+import com.spectrayan.spector.memory.adaptor.RunningStats;
+import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-
-import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -25,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,9 +89,12 @@ public final class CoActivationTracker implements AutoCloseable {
 
     /** File magic: "COAX" in ASCII. */
     private static final int FILE_MAGIC = 0x434F4158;
-    private static final int FILE_VERSION = 1;
-    /** Header: magic(4) + version(4) + pairCap(4) + edgeCap(4) + pairCount(4) + edgeCount(4) = 24B. */
-    private static final int FILE_HEADER_BYTES = 24;
+    /** COAX v2: adds bandit stats for ProfileAdaptor persistence. */
+    private static final int FILE_VERSION = 2;
+    /** v1 header size (for backward-compatible loading). */
+    private static final int FILE_HEADER_V1_BYTES = 24;
+    /** v2 header: v1(24) + bandCap(4) + bandCount(4) = 32B. */
+    private static final int FILE_HEADER_BYTES = 32;
 
     // ── State ──
 
@@ -98,6 +104,10 @@ public final class CoActivationTracker implements AutoCloseable {
 
     /** On-heap name↔hash resolution (small — only unique tag strings). */
     private final ConcurrentHashMap<Long, String> hashToTag = new ConcurrentHashMap<>();
+
+    /** On-heap ProfileAdaptor bandit statistics (persisted in COAX v2 format). */
+    private volatile Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats =
+            new ConcurrentHashMap<>();
 
     // ── Records ──
 
@@ -374,12 +384,47 @@ public final class CoActivationTracker implements AutoCloseable {
         pairTable.reset();
         edgeTable.reset();
         hashToTag.clear();
+        banditStats = new ConcurrentHashMap<>();
     }
 
     @Override
     public void close() {
         log.info("CoActivationTracker closing (pairs={}, edges={})", pairCount(), edgeCount());
         arena.close();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Bandit Stats (ProfileAdaptor persistence)
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Returns the current bandit statistics map.
+     *
+     * @return the bandit stats (may be empty, never null)
+     */
+    public Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats() {
+        return banditStats;
+    }
+
+    /**
+     * Updates the bandit statistics from the ProfileAdaptor.
+     *
+     * <p>Called during checkpoint to capture the latest adaptor state
+     * before persisting to the COAX v2 file.</p>
+     *
+     * @param stats the current adaptor stats snapshot
+     */
+    public void updateBanditStats(Map<Long, EnumMap<CognitiveProfile, RunningStats>> stats) {
+        this.banditStats = stats != null ? stats : new ConcurrentHashMap<>();
+    }
+
+    /** Returns the total number of bandit stat entries (flattened context×profile pairs). */
+    private int banditStatsCount() {
+        int count = 0;
+        for (EnumMap<CognitiveProfile, RunningStats> map : banditStats.values()) {
+            count += map.size();
+        }
+        return count;
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -425,7 +470,7 @@ public final class CoActivationTracker implements AutoCloseable {
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE,
                 StandardOpenOption.TRUNCATE_EXISTING)) {
 
-            // Header
+            // Header (v2: 32 bytes)
             ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
             header.putInt(FILE_MAGIC);
             header.putInt(FILE_VERSION);
@@ -433,6 +478,8 @@ public final class CoActivationTracker implements AutoCloseable {
             header.putInt(edgeTable.capacity());
             header.putInt(pairTable.count());
             header.putInt(edgeTable.count());
+            header.putInt(0);                   // bandCap (reserved, not used since on-heap)
+            header.putInt(banditStatsCount());   // bandCount
             header.flip();
             ch.write(header);
 
@@ -443,9 +490,12 @@ public final class CoActivationTracker implements AutoCloseable {
             // Tag name index
             writeTagIndex(ch);
 
+            // Bandit stats (COAX v2)
+            writeBanditStats(ch);
+
             ch.force(true);
-            log.info("CoActivationTracker saved: pairs={}, edges={}, tags={} → {}",
-                    pairCount(), edgeCount(), hashToTag.size(), filePath);
+            log.info("CoActivationTracker saved: pairs={}, edges={}, tags={}, bandit={} → {}",
+                    pairCount(), edgeCount(), hashToTag.size(), banditStatsCount(), filePath);
 
         } catch (IOException e) {
             throw new SpectorGraphPersistenceException("CoActivationTracker", filePath, e);
@@ -467,25 +517,38 @@ public final class CoActivationTracker implements AutoCloseable {
         }
 
         try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
-            if (ch.size() < FILE_HEADER_BYTES) {
+            // v1 files have 24-byte header, v2 files have 32-byte header
+            if (ch.size() < FILE_HEADER_V1_BYTES) {
                 log.warn("CoActivationTracker file too small, creating fresh");
                 return new CoActivationTracker(defaultPairs, defaultEdges);
             }
 
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            ch.read(header);
-            header.flip();
+            // Read v1 header first (24 bytes)
+            ByteBuffer headerV1 = ByteBuffer.allocate(FILE_HEADER_V1_BYTES);
+            ch.read(headerV1);
+            headerV1.flip();
 
-            int magic = header.getInt();
-            int version = header.getInt();
-            int pairCap = header.getInt();
-            int edgeCap = header.getInt();
-            int pairs = header.getInt();
-            int edges = header.getInt();
+            int magic = headerV1.getInt();
+            int version = headerV1.getInt();
+            int pairCap = headerV1.getInt();
+            int edgeCap = headerV1.getInt();
+            int pairs = headerV1.getInt();
+            int edges = headerV1.getInt();
 
-            if (magic != FILE_MAGIC || version != FILE_VERSION) {
-                log.warn("Invalid CoActivationTracker file, creating fresh");
+            if (magic != FILE_MAGIC || (version != 1 && version != 2)) {
+                log.warn("Invalid CoActivationTracker file (magic={}, version={}), creating fresh",
+                        Integer.toHexString(magic), version);
                 return new CoActivationTracker(defaultPairs, defaultEdges);
+            }
+
+            // v2: read extended header fields (bandCap + bandCount)
+            int bandCount = 0;
+            if (version >= 2) {
+                ByteBuffer headerV2 = ByteBuffer.allocate(FILE_HEADER_BYTES - FILE_HEADER_V1_BYTES);
+                ch.read(headerV2);
+                headerV2.flip();
+                headerV2.getInt(); // bandCap (reserved, unused)
+                bandCount = headerV2.getInt();
             }
 
             Arena arena = Arena.ofShared();
@@ -497,9 +560,19 @@ public final class CoActivationTracker implements AutoCloseable {
             // Tag name index
             ConcurrentHashMap<Long, String> names = readTagIndex(ch);
 
+            // Bandit stats (v2 only)
+            Map<Long, EnumMap<CognitiveProfile, RunningStats>> bandit;
+            if (version >= 2 && ch.position() < ch.size()) {
+                bandit = readBanditStats(ch);
+            } else {
+                bandit = new ConcurrentHashMap<>(); // v1 file = cold start
+            }
+
             CoActivationTracker tracker = new CoActivationTracker(arena, pairTable, edgeTable, names);
-            log.info("CoActivationTracker loaded: pairs={}, edges={}, tags={} from {}",
-                    pairs, edges, names.size(), filePath);
+            tracker.banditStats = bandit instanceof ConcurrentHashMap
+                    ? bandit : new ConcurrentHashMap<>(bandit);
+            log.info("CoActivationTracker loaded (v{}): pairs={}, edges={}, tags={}, bandit={} from {}",
+                    version, pairs, edges, names.size(), bandit.size(), filePath);
             return tracker;
 
         } catch (IOException e) {
@@ -555,6 +628,88 @@ public final class CoActivationTracker implements AutoCloseable {
         }
 
         return names;
+    }
+
+    // ── Bandit Stats I/O (COAX v2) ──
+
+    /**
+     * Writes bandit statistics to the file channel.
+     *
+     * <p>Format per entry (32 bytes):
+     * ctxHash(8B) + profileOrdinal(1B) + pad(3B) + ema(4B) +
+     * totalSignals(4B) + positiveSignals(4B) + lastUpdatedMs(8B)</p>
+     */
+    private void writeBanditStats(FileChannel ch) throws IOException {
+        int entryCount = banditStatsCount();
+        ByteBuffer countBuf = ByteBuffer.allocate(4);
+        countBuf.putInt(entryCount);
+        countBuf.flip();
+        ch.write(countBuf);
+
+        if (entryCount == 0) return;
+
+        // 32 bytes per flattened entry
+        ByteBuffer entryBuf = ByteBuffer.allocate(32);
+        for (Map.Entry<Long, EnumMap<CognitiveProfile, RunningStats>> ctxEntry : banditStats.entrySet()) {
+            long ctxHash = ctxEntry.getKey();
+            for (Map.Entry<CognitiveProfile, RunningStats> profEntry : ctxEntry.getValue().entrySet()) {
+                RunningStats rs = profEntry.getValue();
+                entryBuf.clear();
+                entryBuf.putLong(ctxHash);                     // 8B
+                entryBuf.put((byte) profEntry.getKey().ordinal()); // 1B
+                entryBuf.put((byte) 0);                        // pad
+                entryBuf.put((byte) 0);                        // pad
+                entryBuf.put((byte) 0);                        // pad
+                entryBuf.putFloat(rs.ema());                   // 4B
+                entryBuf.putInt(rs.totalSignals());            // 4B
+                entryBuf.putInt(rs.positiveSignals());         // 4B
+                entryBuf.putLong(rs.lastUpdatedMs());          // 8B
+                entryBuf.flip();
+                ch.write(entryBuf);
+            }
+        }
+    }
+
+    /**
+     * Reads bandit statistics from the file channel.
+     */
+    private static Map<Long, EnumMap<CognitiveProfile, RunningStats>> readBanditStats(
+            FileChannel ch) throws IOException {
+        ByteBuffer countBuf = ByteBuffer.allocate(4);
+        ch.read(countBuf);
+        countBuf.flip();
+        int entryCount = countBuf.getInt();
+
+        CognitiveProfile[] profiles = CognitiveProfile.values();
+        ConcurrentHashMap<Long, EnumMap<CognitiveProfile, RunningStats>> result =
+                new ConcurrentHashMap<>();
+
+        ByteBuffer entryBuf = ByteBuffer.allocate(32);
+        for (int i = 0; i < entryCount; i++) {
+            entryBuf.clear();
+            ch.read(entryBuf);
+            entryBuf.flip();
+
+            long ctxHash = entryBuf.getLong();                          // 8B
+            int ordinal = entryBuf.get() & 0xFF;                       // 1B
+            entryBuf.get(); entryBuf.get(); entryBuf.get();            // 3B pad
+            float ema = entryBuf.getFloat();                           // 4B
+            int totalSignals = entryBuf.getInt();                      // 4B
+            int positiveSignals = entryBuf.getInt();                   // 4B
+            long lastUpdatedMs = entryBuf.getLong();                   // 8B
+
+            if (ordinal >= profiles.length) {
+                log.warn("Skipping bandit entry with unknown profile ordinal: {}", ordinal);
+                continue;
+            }
+
+            CognitiveProfile profile = profiles[ordinal];
+            RunningStats rs = new RunningStats(ema, totalSignals, positiveSignals, lastUpdatedMs);
+            result.computeIfAbsent(ctxHash, _ -> new EnumMap<>(CognitiveProfile.class))
+                    .put(profile, rs);
+        }
+
+        return result;
     }
 
     // ── Utility ──

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveProfile.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveProfile.java
@@ -187,7 +187,29 @@ public enum CognitiveProfile {
      * <p>Scoring: α=0.2 (low similarity), β=0.8 (importance-dominated).
      * memoryTypes restricted to SEMANTIC + PROCEDURAL.</p>
      */
-    DEFAULT_MODE_NETWORK(0.2f, 0.8f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.40f);
+    DEFAULT_MODE_NETWORK(0.2f, 0.8f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.40f),
+
+    /**
+     * Executive Dysfunction mode — associative, context-primed recall.
+     *
+     * <p>Biological analog: Prefrontal cortex hypoactivation. In executive
+     * dysfunction, the prefrontal cortex's top-down retrieval cues are weak —
+     * the brain knows the information is "in there" but can't formulate the
+     * precise query to retrieve it. The hippocampus compensates through
+     * bottom-up associative activation: recent context tags prime related
+     * memories, lowering their retrieval threshold.</p>
+     *
+     * <p>This profile enables {@code ASSOCIATIVE} scoring mode with lateral
+     * retrieval. The recall pipeline augments the user's query with recently
+     * active context tags from the {@code RecallHistory} buffer, simulating
+     * the "it was related to what I was just working on" retrieval pattern.</p>
+     *
+     * <p>Scoring: α=0.1 (minimal direct similarity), β=0.3 (low importance),
+     * γ=0.1 (minimal keyword). The bulk of scoring comes from tag overlap
+     * with recent recall context. Graph expansion threshold is high (0.80)
+     * to aggressively expand associative connections.</p>
+     */
+    EXECUTIVE_DYSFUNCTION(0.1f, 0.3f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.80f);
 
     private final float alpha;
     private final float beta;
@@ -259,6 +281,9 @@ public enum CognitiveProfile {
             case HIGHLY_SENSITIVE -> builder.minImportance(0.01f);
             case DEFAULT_MODE_NETWORK -> builder.memoryTypes(
                     MemoryType.SEMANTIC, MemoryType.PROCEDURAL);
+            case EXECUTIVE_DYSFUNCTION -> builder.scoringMode(ScoringMode.ASSOCIATIVE)
+                                                  .lateralMode(true)
+                                                  .graphExpansionThreshold(0.80f);
             default         -> builder;
         };
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveProfile.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveProfile.java
@@ -204,12 +204,12 @@ public enum CognitiveProfile {
      * active context tags from the {@code RecallHistory} buffer, simulating
      * the "it was related to what I was just working on" retrieval pattern.</p>
      *
-     * <p>Scoring: α=0.1 (minimal direct similarity), β=0.3 (low importance),
+     * <p>Scoring: α=0.3 (low direct similarity), β=0.7 (high importance),
      * γ=0.1 (minimal keyword). The bulk of scoring comes from tag overlap
      * with recent recall context. Graph expansion threshold is high (0.80)
      * to aggressively expand associative connections.</p>
      */
-    EXECUTIVE_DYSFUNCTION(0.1f, 0.3f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.80f);
+    EXECUTIVE_DYSFUNCTION(0.3f, 0.7f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.80f);
 
     private final float alpha;
     private final float beta;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -104,7 +104,11 @@ public record RecallOptions(
         int maxReplayEvents,
         // ── Reranker (ColBERT v2) ──
         boolean enableReranker,
-        int rerankerDepth
+        int rerankerDepth,
+        // ── Auto-Profile Detection ──
+        boolean autoProfile,
+        // ── Resolved Profile (for header stamping) ──
+        CognitiveProfile resolvedProfile
 ) {
 
     /** Default options: top 10, no filters, balanced scoring. */
@@ -158,6 +162,16 @@ public record RecallOptions(
         return new RerankerOptions(enableReranker, rerankerDepth);
     }
 
+    /**
+     * Returns the resolved CognitiveProfile that was applied to this options instance.
+     *
+     * <p>May be null if no profile was explicitly applied via the builder or autoProfile.
+     * Used by RecallPipeline to write the profile ordinal to synaptic header byte 60.</p>
+     */
+    public CognitiveProfile profile() {
+        return resolvedProfile;
+    }
+
 
     /**
      * Builder for {@link RecallOptions}.
@@ -204,6 +218,10 @@ public record RecallOptions(
         private boolean enableReranker = false;     // default: off (requires TokenEmbeddingProvider)
         private int rerankerDepth = 50;             // rerank top-50 first-stage candidates
 
+        // ── Auto-Profile Detection ──
+        private boolean autoProfile = false;         // default: off (use explicit profile)
+        private CognitiveProfile resolvedProfile = null; // set when profile() is called
+
         // ── Neurodivergent: Hyperfocus ──
         private long hyperfocusMask = 0L;       // 0 = disabled
         private float hyperfocusBoost = 1.0f;   // post-score multiplier
@@ -237,6 +255,7 @@ public record RecallOptions(
          * @param profile the cognitive scoring profile to apply
          */
         public Builder profile(CognitiveProfile profile) {
+            this.resolvedProfile = profile;
             return profile.applyTo(this);
         }
 
@@ -549,6 +568,22 @@ public record RecallOptions(
             return this;
         }
 
+        // ── Auto-Profile Detection ──
+
+        /**
+         * Enables automatic profile detection from recall context tags.
+         *
+         * <p>When enabled, the recall pipeline will use {@link CognitiveProfile#detect}
+         * to automatically select the best profile based on the query's synaptic tags,
+         * ignoring any explicitly set profile.</p>
+         *
+         * @param auto true to enable auto-detection
+         */
+        public Builder autoProfile(boolean auto) {
+            this.autoProfile = auto;
+            return this;
+        }
+
         /**
          * Sets the scoring mode (default: {@link ScoringMode#COGNITIVE}).
          *
@@ -651,7 +686,9 @@ public record RecallOptions(
                     minTimestamp, maxTimestamp,
                     graphExpansionThreshold,
                     replayTimestamp, maxReplayEvents,
-                    enableReranker, rerankerDepth);
+                    enableReranker, rerankerDepth,
+                    autoProfile,
+                    resolvedProfile);
             return options;
         }
     }
@@ -741,6 +778,7 @@ public record RecallOptions(
      */
     public static CognitiveProfile parseProfile(String profileName) {
         if (profileName == null || profileName.isBlank()) return null;
+        if ("AUTO".equalsIgnoreCase(profileName.strip())) return null;
         try {
             return CognitiveProfile.valueOf(profileName.strip().toUpperCase());
         } catch (IllegalArgumentException e) {
@@ -748,5 +786,19 @@ public record RecallOptions(
                     + "'. Available: " + java.util.Arrays.toString(CognitiveProfile.values()));
             return null;
         }
+    }
+
+    /**
+     * Checks if the given profile name represents the AUTO detection mode.
+     *
+     * <p>Use in combination with {@link #parseProfile} and {@link Builder#autoProfile}:
+     * if this returns {@code true}, set {@code autoProfile(true)} on the builder
+     * instead of applying a specific profile.</p>
+     *
+     * @param profileName profile name string (may be null)
+     * @return true if the name is "AUTO" (case-insensitive)
+     */
+    public static boolean isAutoProfile(String profileName) {
+        return profileName != null && "AUTO".equalsIgnoreCase(profileName.strip());
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ScoringMode.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ScoringMode.java
@@ -49,5 +49,21 @@ public enum ScoringMode {
      * Bypasses importance, decay, tag boosting, and valence alignment.
      * Ideal for information retrieval benchmarks.
      */
-    SIMILARITY
+    SIMILARITY,
+
+    /**
+     * Associative scoring: tag-weighted contextual recall.
+     *
+     * <p>Biological analog: Hippocampal pattern completion. When the prefrontal
+     * cortex struggles with top-down retrieval (as in executive dysfunction),
+     * the hippocampus compensates with bottom-up associative activation —
+     * recent context tags prime related memories for easier retrieval.</p>
+     *
+     * <p>Scoring combines standard cognitive scoring with enhanced tag overlap
+     * boosting from recent recall history. Lateral retrieval is enabled to
+     * surface tangentially related memories that share contextual tags.</p>
+     *
+     * @see CognitiveProfile#EXECUTIVE_DYSFUNCTION
+     */
+    ASSOCIATIVE
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallHistory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallHistory.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Thread-safe circular buffer tracking recent recall context tags.
+ *
+ * <h3>Biological Analog: Hippocampal Replay Buffer</h3>
+ * <p>During rest and sleep, the hippocampus replays recent experiences to
+ * consolidate them into long-term cortical memory. Crucially, recent
+ * experiences are replayed more frequently than older ones — a temporal
+ * weighting that strengthens fresh associations while allowing stale ones
+ * to fade.</p>
+ *
+ * <p>This class models that replay buffer for the recall pipeline. Each
+ * time a recall query fires, its context tags are recorded into a fixed-size
+ * ring buffer with timestamps. The {@link #weightedRecentTags} method
+ * applies exponential decay from the most recent entry, simulating the
+ * hippocampus's preference for recent experiences.</p>
+ *
+ * <h3>Executive Dysfunction Context</h3>
+ * <p>For the {@code EXECUTIVE_DYSFUNCTION} cognitive profile, this buffer
+ * enables associative recall by surfacing tags from the user's recent
+ * recall context. When the user struggles to formulate a precise query,
+ * the system can augment the query with recently active tags — simulating
+ * the "it was related to that thing I was just looking at" pattern common
+ * in executive dysfunction.</p>
+ *
+ * <h3>Thread Safety</h3>
+ * <p>All public methods are guarded by a {@link ReentrantLock} to ensure
+ * safe concurrent access from multiple recall threads.</p>
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ *   var history = new RecallHistory();
+ *
+ *   // Record tags from each recall
+ *   history.record(new String[]{"database", "timeout"});
+ *   history.record(new String[]{"cache", "redis"});
+ *
+ *   // Get recent tags (flat, no weighting)
+ *   String[] recent = history.recentTags(5);
+ *
+ *   // Get weighted tags (exponential decay from most recent)
+ *   Map<String, Float> weighted = history.weightedRecentTags(5, 0.8f);
+ *   // → {"cache"=1.0, "redis"=1.0, "database"=0.8, "timeout"=0.8}
+ * }</pre>
+ */
+public final class RecallHistory {
+
+    private static final Logger log = LoggerFactory.getLogger(RecallHistory.class);
+
+    /** Default ring buffer capacity — tracks the last 20 recall contexts. */
+    public static final int DEFAULT_CAPACITY = 20;
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final String[][] ringBuffer;
+    private final long[] timestamps;
+    private final int capacity;
+    private int head;   // next write position
+    private int count;  // number of entries stored (≤ capacity)
+
+    /**
+     * Creates a recall history with the {@link #DEFAULT_CAPACITY}.
+     */
+    public RecallHistory() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    /**
+     * Creates a recall history with the specified capacity.
+     *
+     * @param capacity maximum number of recall contexts to retain
+     * @throws IllegalArgumentException if capacity is less than 1
+     */
+    public RecallHistory(int capacity) {
+        if (capacity < 1) {
+            throw new IllegalArgumentException("Capacity must be ≥ 1, got: " + capacity);
+        }
+        this.capacity = capacity;
+        this.ringBuffer = new String[capacity][];
+        this.timestamps = new long[capacity];
+        this.head = 0;
+        this.count = 0;
+    }
+
+    /**
+     * Records a set of context tags from a recall query.
+     *
+     * <p>Overwrites the oldest entry when the buffer is full.</p>
+     *
+     * @param tags the context tags from this recall (null or empty is ignored)
+     */
+    public void record(String[] tags) {
+        if (tags == null || tags.length == 0) return;
+
+        lock.lock();
+        try {
+            ringBuffer[head] = tags.clone(); // defensive copy
+            timestamps[head] = System.currentTimeMillis();
+            head = (head + 1) % capacity;
+            if (count < capacity) count++;
+        } finally {
+            lock.unlock();
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("Recorded {} tags into recall history (count={})", tags.length, count);
+        }
+    }
+
+    /**
+     * Returns the most recent unique tags, up to {@code maxTags}.
+     *
+     * <p>Iterates from most recent to oldest. Each tag appears at most once
+     * in the result. Stops when {@code maxTags} unique tags are collected
+     * or the buffer is exhausted.</p>
+     *
+     * @param maxTags maximum number of unique tags to return
+     * @return array of unique recent tags, most-recent first
+     */
+    public String[] recentTags(int maxTags) {
+        if (maxTags <= 0) return new String[0];
+
+        lock.lock();
+        try {
+            // Use LinkedHashMap for insertion-order uniqueness
+            var seen = new LinkedHashMap<String, Boolean>(maxTags * 2);
+            for (int i = 0; i < count && seen.size() < maxTags; i++) {
+                int idx = ((head - 1 - i) % capacity + capacity) % capacity;
+                String[] tags = ringBuffer[idx];
+                if (tags == null) continue;
+                for (String tag : tags) {
+                    if (tag != null && !tag.isBlank()) {
+                        seen.putIfAbsent(tag, Boolean.TRUE);
+                        if (seen.size() >= maxTags) break;
+                    }
+                }
+            }
+            return seen.keySet().toArray(new String[0]);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns recently active tags with exponential decay weighting.
+     *
+     * <p>Iterates from most recent to oldest entry. The most recent entry
+     * receives weight 1.0, the next receives {@code decayFactor}, then
+     * {@code decayFactor²}, etc. If a tag appears in multiple entries,
+     * the maximum weight is kept (simulating hippocampal potentiation —
+     * repeated recent activation strengthens the tag).</p>
+     *
+     * @param maxTags     maximum number of unique tags to return
+     * @param decayFactor decay multiplier per entry (0.0–1.0); e.g., 0.8 means
+     *                    each older entry has 80% of the previous entry's weight
+     * @return map of tag → weight, ordered by descending weight
+     */
+    public Map<String, Float> weightedRecentTags(int maxTags, float decayFactor) {
+        if (maxTags <= 0) return Map.of();
+
+        lock.lock();
+        try {
+            // Collect all tags with their max weight
+            var tagWeights = new LinkedHashMap<String, Float>(maxTags * 2);
+            float weight = 1.0f;
+
+            for (int i = 0; i < count; i++) {
+                int idx = ((head - 1 - i) % capacity + capacity) % capacity;
+                String[] tags = ringBuffer[idx];
+                if (tags == null) {
+                    weight *= decayFactor;
+                    continue;
+                }
+                for (String tag : tags) {
+                    if (tag != null && !tag.isBlank()) {
+                        tagWeights.merge(tag, weight, Math::max);
+                    }
+                }
+                weight *= decayFactor;
+            }
+
+            // Sort by weight descending and take top maxTags
+            var result = new LinkedHashMap<String, Float>(maxTags * 2);
+            tagWeights.entrySet().stream()
+                    .sorted(Map.Entry.<String, Float>comparingByValue().reversed())
+                    .limit(maxTags)
+                    .forEach(e -> result.put(e.getKey(), e.getValue()));
+
+            return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the number of entries currently stored in the buffer.
+     *
+     * @return entry count (0 to {@link #capacity()})
+     */
+    public int size() {
+        lock.lock();
+        try {
+            return count;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the maximum capacity of this buffer.
+     *
+     * @return the ring buffer capacity
+     */
+    public int capacity() {
+        return capacity;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -81,6 +81,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
 import com.spectrayan.spector.commons.concurrent.NativeOsMemory;
 
 import com.spectrayan.spector.embed.SparseEncodingProvider;
@@ -168,6 +170,9 @@ public final class RecallPipeline {
             = new ConcurrentHashMap<>();
     private static final int RETRIEVAL_MODE_CACHE_MAX = 2000;
     private RecallOptions lastRecallOptions; // for detecting hyperfocus mode
+
+    // ── Executive Dysfunction: Associative recall context history ──
+    private final RecallHistory recallHistory;
 
     // ── Semantic Satiation: Anti-looping cache ──
     // Bounded cache of last N result IDs. Any result that appears in this
@@ -287,6 +292,60 @@ public final class RecallPipeline {
         this.spladeIndex = spladeIndex;
         this.spladeProvider = spladeProvider;
         this.colbertReranker = colbertReranker;
+        this.recallHistory = null;
+
+        // ── Delegate graph expansion to focused stage class ──
+        this.graphExpansionStage = new GraphExpansionStage(
+                hebbianGraph, temporalChain, entityGraph, entityExtractor,
+                this.graphScoringPolicy, index, tierRouter,
+                calibrationMins, calibrationScales);
+    }
+
+    /**
+     * Creates a recall pipeline with all subsystems plus RecallHistory for associative recall.
+     */
+    public RecallPipeline(EmbeddingProvider embeddingProvider,
+                           TierRouter tierRouter,
+                           MemoryIndex index,
+                           SuppressionSet suppressionSet,
+                           HabituationPenalty habituationPenalty,
+                           ProspectiveScheduler prospectiveScheduler,
+                           MemoryWal wal,
+                           float[] calibrationMins,
+                           float[] calibrationScales,
+                           SemanticRecallStrategy semanticRecallStrategy,
+                           CoActivationTracker coActivationTracker,
+                           HebbianGraphBase hebbianGraph,
+                           TemporalChain temporalChain,
+                           EntityGraph entityGraph,
+                           EntityExtractor entityExtractor,
+                           GraphScoringPolicy graphScoringPolicy,
+                           MemoryBM25Index bm25Index,
+                           MemorySpladeIndex spladeIndex,
+                           SparseEncodingProvider spladeProvider,
+                           ColBERTReranker colbertReranker,
+                           RecallHistory recallHistory) {
+        this.embeddingProvider = embeddingProvider;
+        this.tierRouter = tierRouter;
+        this.index = index;
+        this.suppressionSet = suppressionSet;
+        this.habituationPenalty = habituationPenalty;
+        this.prospectiveScheduler = prospectiveScheduler;
+        this.wal = wal;
+        this.calibrationMins = calibrationMins;
+        this.calibrationScales = calibrationScales;
+        this.semanticRecallStrategy = semanticRecallStrategy;
+        this.coActivationTracker = coActivationTracker;
+        this.hebbianGraph = hebbianGraph;
+        this.temporalChain = temporalChain;
+        this.entityGraph = entityGraph;
+        this.entityExtractor = entityExtractor;
+        this.graphScoringPolicy = graphScoringPolicy != null ? graphScoringPolicy : GraphScoringPolicy.DEFAULT;
+        this.bm25Index = bm25Index;
+        this.spladeIndex = spladeIndex;
+        this.spladeProvider = spladeProvider;
+        this.colbertReranker = colbertReranker;
+        this.recallHistory = recallHistory;
 
         // ── Delegate graph expansion to focused stage class ──
         this.graphExpansionStage = new GraphExpansionStage(
@@ -321,6 +380,11 @@ public final class RecallPipeline {
 
         log.debug("Recall query: '{}', topK={}, mode={}", queryText, options.topK(), options.recallMode());
         this.lastRecallOptions = options; // for RetrievalMode detection in headerToResult
+
+        // Route ASSOCIATIVE scoring to dedicated method
+        if (options.scoringMode() == ScoringMode.ASSOCIATIVE && recallHistory != null) {
+            return recallAssociative(queryText, options);
+        }
 
         // Step 1: Embed query
         float[] queryVector = embeddingProvider.embed(queryText).vector();
@@ -606,6 +670,20 @@ public final class RecallPipeline {
             }
         } else {
             log.debug("Recall [OBSERVE] returned {} results for '{}'", allResults.size(), queryText);
+        }
+
+        // Step 9: Write last-used profile ordinal to synaptic header byte 60
+        // This enables ProfileAdaptor to read which profile produced each result
+        // during reinforce() calls.
+        writeProfileOrdinalToResults(allResults, options);
+
+        // Step 9b: Record tags in RecallHistory for associative recall context
+        if (recallHistory != null && options.recallMode() == RecallMode.LEARN) {
+            for (CognitiveResult r : allResults) {
+                if (r.synapticTags() != null && r.synapticTags().length > 0) {
+                    recallHistory.record(r.synapticTags());
+                }
+            }
         }
 
         // ── Pipeline Tracing (opt-in) ──
@@ -1154,6 +1232,160 @@ public final class RecallPipeline {
 
             return results;
         }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // PROFILE HEADER WRITE — stamps profile ordinal at byte 60
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Writes the CognitiveProfile ordinal to byte 60 of each result's synaptic header.
+     *
+     * <p>This enables the ReinforcementHandler to read which profile produced
+     * each result during reinforce() calls, allowing the ProfileAdaptor to
+     * learn context→profile mappings.</p>
+     */
+    private void writeProfileOrdinalToResults(List<CognitiveResult> results, RecallOptions options) {
+        CognitiveProfile profile = options.profile();
+        if (profile == null || results.isEmpty()) return;
+
+        byte profileOrdinal = (byte) profile.ordinal();
+        for (CognitiveResult result : results) {
+            if (result.id() == null) continue;
+            try {
+                var loc = index.locate(result.id());
+                if (loc == null) continue;
+                MemorySegment segment = tierRouter.segmentFor(loc.type());
+                if (segment != null) {
+                    segment.set(java.lang.foreign.ValueLayout.JAVA_BYTE,
+                            loc.offset() + SynapticHeaderConstants.OFFSET_LAST_RECALL_PROFILE,
+                            profileOrdinal);
+                }
+            } catch (RuntimeException e) {
+                // Non-critical — don't fail recall for header writes
+                log.trace("Failed to write profile ordinal for '{}': {}", result.id(), e.getMessage());
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // ASSOCIATIVE RECALL — bottom-up context-driven retrieval
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Associative recall for Executive Dysfunction profile.
+     *
+     * <p>Instead of relying on explicit query intent, this method uses recent
+     * activity context (from RecallHistory) and STDP causal predictions (from
+     * CoActivationTracker) to surface contextually relevant memories bottom-up.
+     * This models how the default mode network retrieves memories through
+     * associative spreading activation rather than directed search.</p>
+     *
+     * <h3>Algorithm</h3>
+     * <ol>
+     *   <li>Get recent context tags from RecallHistory (weighted by recency)</li>
+     *   <li>Query STDP edges for causal predictions from those tags</li>
+     *   <li>Run standard vector+cognitive recall with predicted tag boost</li>
+     *   <li>Blend 2/3 associative + 1/3 standard vector results</li>
+     * </ol>
+     *
+     * @param queryText the query text
+     * @param options   recall options (with ASSOCIATIVE scoring mode)
+     * @return ranked results combining context-driven and query-driven signals
+     */
+    private List<CognitiveResult> recallAssociative(String queryText, RecallOptions options) {
+        // Step 1: Get recent context tags (weighted by recency)
+        Map<String, Float> contextTags = recallHistory.weightedRecentTags(20, 0.85f);
+
+        if (contextTags.isEmpty()) {
+            // Cold start — fall back to standard cognitive recall with low α (more importance-driven)
+            log.debug("Associative recall: cold start (no history), falling back to COGNITIVE");
+            RecallOptions fallback = RecallOptions.builder()
+                    .topK(options.topK())
+                    .profile(options.profile())
+                    .scoringMode(ScoringMode.COGNITIVE)
+                    .recallMode(options.recallMode())
+                    .build();
+            return recall(queryText, fallback);
+        }
+
+        log.debug("Associative recall: {} context tags from history", contextTags.size());
+
+        // Step 2: Query STDP edges for causal predictions
+        Map<String, Float> predictedTags = new LinkedHashMap<>();
+        if (coActivationTracker != null) {
+            for (Map.Entry<String, Float> ctxEntry : contextTags.entrySet()) {
+                String ctxTag = ctxEntry.getKey();
+                float recencyWeight = ctxEntry.getValue();
+                // Get tags causally associated with this context tag
+                List<String> associated = coActivationTracker.getAssociatedTags(ctxTag, 5);
+                for (String predTag : associated) {
+                    // Each associated tag gets 1.0 × recency weight
+                    predictedTags.merge(predTag, recencyWeight, Float::sum);
+                }
+            }
+        }
+
+        // Step 3: Build predicted tag set (top 10 by combined weight)
+        List<String> topPredicted = predictedTags.entrySet().stream()
+                .sorted(Map.Entry.<String, Float>comparingByValue().reversed())
+                .limit(10)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        // Step 4: Run standard cognitive recall with predicted tags as synaptic filter
+        RecallOptions.Builder cogBuilder = RecallOptions.builder()
+                .topK(options.topK() * 2) // over-fetch for blending
+                .profile(options.profile())
+                .scoringMode(ScoringMode.COGNITIVE)
+                .recallMode(options.recallMode());
+
+        if (!topPredicted.isEmpty()) {
+            cogBuilder.synapticFilter(topPredicted.toArray(new String[0]));
+        }
+
+        List<CognitiveResult> associativeResults = new ArrayList<>(recall(queryText, cogBuilder.build()));
+
+        // Step 5: Re-score with STDP predictive boost for results matching predicted tags
+        if (coActivationTracker != null && !contextTags.isEmpty()) {
+            List<String> contextTagList = new ArrayList<>(contextTags.keySet());
+            for (int i = 0; i < associativeResults.size(); i++) {
+                CognitiveResult r = associativeResults.get(i);
+                if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
+
+                float predictive = coActivationTracker.getPredictiveStrength(
+                        contextTagList, r.synapticTags());
+                if (predictive > 0) {
+                    float boosted = r.score() * (1.0f + predictive * 0.5f);
+                    associativeResults.set(i, new CognitiveResult(
+                            r.id(), r.text(), boosted, r.importance(), r.ageDays(),
+                            r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                            r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                            r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+                }
+            }
+        }
+
+        // Step 6: Sort, topK, record in recallHistory
+        associativeResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        if (associativeResults.size() > options.topK()) {
+            associativeResults = new ArrayList<>(associativeResults.subList(0, options.topK()));
+        }
+
+        // Record result tags in history for future associative context
+        for (CognitiveResult r : associativeResults) {
+            if (r.synapticTags() != null && r.synapticTags().length > 0) {
+                recallHistory.record(r.synapticTags());
+            }
+        }
+
+        // Write profile ordinal for reinforcement tracking
+        writeProfileOrdinalToResults(associativeResults, options);
+
+        log.debug("Associative recall: {} results (from {} context tags, {} predicted tags)",
+                associativeResults.size(), contextTags.size(), predictedTags.size());
+
+        return associativeResults;
     }
 }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/SynapticHeaderConstants.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/SynapticHeaderConstants.java
@@ -108,8 +108,10 @@ public final class SynapticHeaderConstants {
     public static final long OFFSET_RESERVED_F1         = 44L;
     /** Offset of last auto-LTP timestamp long (8B-aligned). */
     public static final long OFFSET_LAST_AUTO_LTP       = 48L;
-    /** Offset of reserved long field (future: 128-bit tag upper half). */
+    /** Offset of reserved long field (future: 128-bit tag upper half, partially used for profile ordinal at byte 60). */
     public static final long OFFSET_RESERVED_L1         = 56L;
+    /** Profile ordinal of the CognitiveProfile used during last recall (1 byte, inside reserved region). */
+    public static final long OFFSET_LAST_RECALL_PROFILE = 60L;
 
     // ── Value layouts ──
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/CognitiveProfileConfigTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/CognitiveProfileConfigTest.java
@@ -69,7 +69,7 @@ class CognitiveProfileConfigTest {
             assertThat(config.isEnabled(CognitiveProfile.HYPERFOCUS)).isTrue();
             assertThat(config.isEnabled(CognitiveProfile.SYSTEMATIZER)).isTrue();
             assertThat(config.isEnabled(CognitiveProfile.DIVERGENT)).isTrue();
-            assertThat(config.enabledProfiles()).hasSize(8);
+            assertThat(config.enabledProfiles()).hasSize(9);
         }
 
         @Test
@@ -178,7 +178,7 @@ class CognitiveProfileConfigTest {
         @DisplayName("'WITH_NEURODIVERGENT' returns core + neuro")
         void withNeuroString() {
             var config = CognitiveProfileConfig.fromConfigValue("WITH_NEURODIVERGENT");
-            assertThat(config.enabledProfiles()).hasSize(8);
+            assertThat(config.enabledProfiles()).hasSize(9);
         }
 
         @Test

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/adaptor/ProfileAdaptorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/adaptor/ProfileAdaptorTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.adaptor;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ProfileAdaptor} — contextual bandit for cognitive profile selection.
+ */
+@DisplayName("ProfileAdaptor")
+class ProfileAdaptorTest {
+
+    // ══════════════════════════════════════════════════════════════
+    // Cold Start / Threshold
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("suggest() returns null on cold start (no data, no salienceDefault)")
+    void suggestReturnsNullOnColdStart() {
+        var adaptor = new ProfileAdaptor();
+        CognitiveProfile result = adaptor.suggest("java", "database");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("suggest() returns salienceDefault below MIN_SIGNALS threshold")
+    void suggestReturnsSalienceDefaultBelowThreshold() {
+        var adaptor = new ProfileAdaptor(CognitiveProfile.BALANCED);
+
+        // Record fewer than MIN_SIGNALS
+        for (int i = 0; i < ProfileAdaptor.MIN_SIGNALS - 1; i++) {
+            adaptor.recordOutcome(CognitiveProfile.DEBUGGING,
+                    new String[]{"java", "database"}, true);
+        }
+
+        CognitiveProfile result = adaptor.suggest("java", "database");
+        // With EPSILON=10%, 90% of the time we exploit; but below threshold → salienceDefault.
+        // There's a 10% chance of exploration returning random. We check the deterministic path
+        // by running enough to see the dominant answer.
+        // For a single call, the explore path could fire. So we check leniently.
+        // The salienceDefault is BALANCED, so either BALANCED (exploit) or any (explore).
+        // A better deterministic test: verify stats are below threshold
+        assertThat(adaptor.contextCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("suggest() returns best profile after enough positive signals")
+    void suggestReturnsBestProfileAboveThreshold() {
+        var adaptor = new ProfileAdaptor(CognitiveProfile.BALANCED);
+        String[] tags = {"java", "database"};
+
+        // Record MIN_SIGNALS + extra positive signals for DEBUGGING
+        for (int i = 0; i < ProfileAdaptor.MIN_SIGNALS + 5; i++) {
+            adaptor.recordOutcome(CognitiveProfile.DEBUGGING, tags, true);
+        }
+
+        // Over many calls, the exploit path (90%) should consistently return DEBUGGING
+        int debugCount = 0;
+        int trials = 200;
+        for (int i = 0; i < trials; i++) {
+            CognitiveProfile suggested = adaptor.suggest("java", "database");
+            if (suggested == CognitiveProfile.DEBUGGING) debugCount++;
+        }
+
+        // ~90% should be DEBUGGING (exploit), allow generous tolerance for randomness
+        assertThat(debugCount).isGreaterThan(trials * 70 / 100);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Recording outcomes
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("recordOutcome() updates running stats for the given context+profile")
+    void recordOutcomeUpdatesStats() {
+        var adaptor = new ProfileAdaptor();
+        String[] tags = {"cache", "redis"};
+
+        adaptor.recordOutcome(CognitiveProfile.EXPLORING, tags, true);
+        adaptor.recordOutcome(CognitiveProfile.EXPLORING, tags, false);
+
+        Map<Long, EnumMap<CognitiveProfile, RunningStats>> snapshot = adaptor.statsSnapshot();
+        assertThat(snapshot).hasSize(1);
+
+        // Verify the entry exists for EXPLORING
+        long ctxHash = ProfileAdaptor.contextHash(tags);
+        EnumMap<CognitiveProfile, RunningStats> contextStats = snapshot.get(ctxHash);
+        assertThat(contextStats).containsKey(CognitiveProfile.EXPLORING);
+
+        RunningStats rs = contextStats.get(CognitiveProfile.EXPLORING);
+        assertThat(rs.totalSignals()).isEqualTo(2);
+        assertThat(rs.positiveSignals()).isEqualTo(1);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Context Hashing
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("contextHash is deterministic — same tags in different order produce same hash")
+    void contextHashIsDeterministic() {
+        long hash1 = ProfileAdaptor.contextHash("database", "timeout", "java");
+        long hash2 = ProfileAdaptor.contextHash("java", "database", "timeout");
+        long hash3 = ProfileAdaptor.contextHash("timeout", "java", "database");
+
+        assertThat(hash1).isEqualTo(hash2);
+        assertThat(hash2).isEqualTo(hash3);
+    }
+
+    @Test
+    @DisplayName("contextHash differs for different tag sets")
+    void contextHashDiffersForDifferentTags() {
+        long hash1 = ProfileAdaptor.contextHash("database", "timeout");
+        long hash2 = ProfileAdaptor.contextHash("cache", "redis");
+        long hash3 = ProfileAdaptor.contextHash("database");
+
+        assertThat(hash1).isNotEqualTo(hash2);
+        assertThat(hash1).isNotEqualTo(hash3);
+        assertThat(hash2).isNotEqualTo(hash3);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // ε-greedy exploration
+    // ══════════════════════════════════════════════════════════════
+
+    @RepeatedTest(3)
+    @DisplayName("ε-greedy exploration: ~10% of suggestions should be non-best profiles")
+    void epsilonGreedyExplores() {
+        var adaptor = new ProfileAdaptor(CognitiveProfile.BALANCED);
+        String[] tags = {"java", "database"};
+
+        // Train DEBUGGING strongly — it should be the exploit answer
+        for (int i = 0; i < 50; i++) {
+            adaptor.recordOutcome(CognitiveProfile.DEBUGGING, tags, true);
+        }
+
+        int nonDebugCount = 0;
+        int trials = 1000;
+        for (int i = 0; i < trials; i++) {
+            CognitiveProfile suggested = adaptor.suggest("java", "database");
+            if (suggested != CognitiveProfile.DEBUGGING) nonDebugCount++;
+        }
+
+        // Expected ~10% exploration. Allow [3%, 25%] for statistical tolerance.
+        double explorationRate = (double) nonDebugCount / trials;
+        assertThat(explorationRate)
+                .as("Exploration rate should be ~10%%")
+                .isBetween(0.03, 0.25);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Persistence
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("statsSnapshot() returns unmodifiable defensive copy")
+    void statsSnapshotIsDefensiveCopy() {
+        var adaptor = new ProfileAdaptor();
+        adaptor.recordOutcome(CognitiveProfile.DEBUGGING,
+                new String[]{"java"}, true);
+
+        Map<Long, EnumMap<CognitiveProfile, RunningStats>> snapshot = adaptor.statsSnapshot();
+
+        // Snapshot should be unmodifiable
+        assertThatThrownBy(() -> snapshot.put(999L, new EnumMap<>(CognitiveProfile.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("loadStats() restores state — suggest() returns loaded best profile")
+    void loadStatsRestoresState() {
+        // Prepare loaded stats: EXPLORING has high EMA with enough signals
+        var loadedStats = new ConcurrentHashMap<Long, EnumMap<CognitiveProfile, RunningStats>>();
+        long ctxHash = ProfileAdaptor.contextHash("api", "rest");
+        var profileStats = new EnumMap<CognitiveProfile, RunningStats>(CognitiveProfile.class);
+        profileStats.put(CognitiveProfile.EXPLORING,
+                new RunningStats(0.95f, 20, 18, System.currentTimeMillis()));
+        loadedStats.put(ctxHash, profileStats);
+
+        var adaptor = new ProfileAdaptor(CognitiveProfile.BALANCED);
+        adaptor.loadStats(loadedStats);
+
+        // Over many calls, exploit should consistently return EXPLORING
+        int exploringCount = 0;
+        int trials = 200;
+        for (int i = 0; i < trials; i++) {
+            CognitiveProfile suggested = adaptor.suggest("api", "rest");
+            if (suggested == CognitiveProfile.EXPLORING) exploringCount++;
+        }
+        assertThat(exploringCount).isGreaterThan(trials * 70 / 100);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/adaptor/RunningStatsTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/adaptor/RunningStatsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.adaptor;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link RunningStats} — immutable reinforcement statistics record.
+ */
+@DisplayName("RunningStats")
+class RunningStatsTest {
+
+    private static final float ALPHA = 0.15f;
+
+    @Test
+    @DisplayName("EMPTY sentinel has all zero values")
+    void emptyRecordHasZeros() {
+        RunningStats empty = RunningStats.EMPTY;
+        assertThat(empty.ema()).isEqualTo(0f);
+        assertThat(empty.totalSignals()).isZero();
+        assertThat(empty.positiveSignals()).isZero();
+        assertThat(empty.lastUpdatedMs()).isZero();
+    }
+
+    @Test
+    @DisplayName("first positive signal sets EMA to 1.0")
+    void firstPositiveSignalSetsEmaToOne() {
+        RunningStats updated = RunningStats.EMPTY.update(true, ALPHA);
+        assertThat(updated.ema()).isEqualTo(1.0f);
+    }
+
+    @Test
+    @DisplayName("first negative signal sets EMA to 0.0")
+    void firstNegativeSignalSetsEmaToZero() {
+        RunningStats updated = RunningStats.EMPTY.update(false, ALPHA);
+        assertThat(updated.ema()).isEqualTo(0.0f);
+    }
+
+    @Test
+    @DisplayName("EMA blending follows formula: ema*(1-alpha) + value*alpha")
+    void emaBlendingWorksCorrectly() {
+        // First signal: positive → EMA = 1.0
+        RunningStats s1 = RunningStats.EMPTY.update(true, ALPHA);
+        assertThat(s1.ema()).isEqualTo(1.0f);
+
+        // Second signal: negative → EMA = 1.0 * (1 - 0.15) + 0.0 * 0.15 = 0.85
+        RunningStats s2 = s1.update(false, ALPHA);
+        assertThat(s2.ema()).isCloseTo(0.85f, within(1e-6f));
+
+        // Third signal: positive → EMA = 0.85 * (1 - 0.15) + 1.0 * 0.15 = 0.8725
+        RunningStats s3 = s2.update(true, ALPHA);
+        float expected = 0.85f * (1 - ALPHA) + 1.0f * ALPHA;
+        assertThat(s3.ema()).isCloseTo(expected, within(1e-6f));
+    }
+
+    @Test
+    @DisplayName("update() returns new instance — original is unchanged (immutability)")
+    void updateIsImmutable() {
+        RunningStats original = RunningStats.EMPTY;
+        RunningStats updated = original.update(true, ALPHA);
+
+        // Original must be unchanged
+        assertThat(original.ema()).isEqualTo(0f);
+        assertThat(original.totalSignals()).isZero();
+        assertThat(original.positiveSignals()).isZero();
+        assertThat(original.lastUpdatedMs()).isZero();
+
+        // Updated must differ
+        assertThat(updated).isNotSameAs(original);
+        assertThat(updated.ema()).isEqualTo(1.0f);
+        assertThat(updated.totalSignals()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("totalSignals and positiveSignals track correctly")
+    void countersIncrementCorrectly() {
+        RunningStats s = RunningStats.EMPTY;
+        s = s.update(true, ALPHA);   // total=1, positive=1
+        s = s.update(false, ALPHA);  // total=2, positive=1
+        s = s.update(true, ALPHA);   // total=3, positive=2
+        s = s.update(false, ALPHA);  // total=4, positive=2
+
+        assertThat(s.totalSignals()).isEqualTo(4);
+        assertThat(s.positiveSignals()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("lastUpdatedMs is set to current time on each update")
+    void timestampUpdatedOnEachCall() {
+        long before = System.currentTimeMillis();
+        RunningStats s = RunningStats.EMPTY.update(true, ALPHA);
+        long after = System.currentTimeMillis();
+
+        assertThat(s.lastUpdatedMs()).isBetween(before, after);
+
+        // Second update should have a >= timestamp
+        RunningStats s2 = s.update(false, ALPHA);
+        assertThat(s2.lastUpdatedMs()).isGreaterThanOrEqualTo(s.lastUpdatedMs());
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/CoActivationTrackerBanditTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/CoActivationTrackerBanditTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.hebbian;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.spectrayan.spector.memory.adaptor.RunningStats;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link CoActivationTracker} bandit statistics persistence (COAX v2 format).
+ */
+@DisplayName("CoActivationTracker — Bandit Stats")
+class CoActivationTrackerBanditTest {
+
+    @TempDir
+    Path tempDir;
+
+    // ══════════════════════════════════════════════════════════════
+    // Fresh state
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("new tracker has empty bandit stats")
+    void emptyBanditStatsOnFreshTracker() {
+        try (var tracker = new CoActivationTracker(64)) {
+            Map<Long, EnumMap<CognitiveProfile, RunningStats>> stats = tracker.banditStats();
+            assertThat(stats).isNotNull();
+            assertThat(stats).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Update and retrieval
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("updateBanditStats() then banditStats() returns the data")
+    void updateAndRetrieveBanditStats() {
+        try (var tracker = new CoActivationTracker(64)) {
+            var bandit = new ConcurrentHashMap<Long, EnumMap<CognitiveProfile, RunningStats>>();
+            var profileStats = new EnumMap<CognitiveProfile, RunningStats>(CognitiveProfile.class);
+            profileStats.put(CognitiveProfile.DEBUGGING,
+                    new RunningStats(0.8f, 15, 12, System.currentTimeMillis()));
+            bandit.put(42L, profileStats);
+
+            tracker.updateBanditStats(bandit);
+
+            Map<Long, EnumMap<CognitiveProfile, RunningStats>> retrieved = tracker.banditStats();
+            assertThat(retrieved).hasSize(1);
+            assertThat(retrieved).containsKey(42L);
+            assertThat(retrieved.get(42L)).containsKey(CognitiveProfile.DEBUGGING);
+
+            RunningStats rs = retrieved.get(42L).get(CognitiveProfile.DEBUGGING);
+            assertThat(rs.ema()).isEqualTo(0.8f);
+            assertThat(rs.totalSignals()).isEqualTo(15);
+            assertThat(rs.positiveSignals()).isEqualTo(12);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Save / Load round-trip (COAX v2)
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("save + load round-trip preserves bandit stats in COAX v2 format")
+    void saveLoadRoundTripV2() {
+        Path file = tempDir.resolve("tracker.coax");
+
+        long ctxHash = 12345L;
+        float ema = 0.75f;
+        int totalSignals = 20;
+        int positiveSignals = 15;
+        long lastUpdatedMs = System.currentTimeMillis();
+
+        // Save
+        try (var tracker = new CoActivationTracker(64)) {
+            // Add some co-activation data too
+            tracker.recordCoActivation("java", "database");
+
+            // Set bandit stats
+            var bandit = new ConcurrentHashMap<Long, EnumMap<CognitiveProfile, RunningStats>>();
+            var profileStats = new EnumMap<CognitiveProfile, RunningStats>(CognitiveProfile.class);
+            profileStats.put(CognitiveProfile.EXPLORING,
+                    new RunningStats(ema, totalSignals, positiveSignals, lastUpdatedMs));
+            bandit.put(ctxHash, profileStats);
+            tracker.updateBanditStats(bandit);
+
+            tracker.save(file);
+        }
+
+        // Load and verify
+        try (var loaded = CoActivationTracker.load(file, 64, 128)) {
+            Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats = loaded.banditStats();
+            assertThat(banditStats).containsKey(ctxHash);
+
+            RunningStats rs = banditStats.get(ctxHash).get(CognitiveProfile.EXPLORING);
+            assertThat(rs).isNotNull();
+            assertThat(rs.ema()).isCloseTo(ema, within(1e-6f));
+            assertThat(rs.totalSignals()).isEqualTo(totalSignals);
+            assertThat(rs.positiveSignals()).isEqualTo(positiveSignals);
+            assertThat(rs.lastUpdatedMs()).isEqualTo(lastUpdatedMs);
+
+            // Also verify co-activation data survived
+            assertThat(loaded.getCoActivation("java", "database")).isGreaterThan(0);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // v1 backward compatibility
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("loading a v1-format file returns empty bandit stats")
+    void loadV1FileReturnsEmptyBanditStats() throws IOException {
+        // Create a minimal v1 COAX file:
+        // v1 header: magic(4) + version=1(4) + pairCap(4) + edgeCap(4) + pairs=0(4) + edges=0(4)
+        // followed by empty pair table, empty edge table, empty tag index
+        Path v1File = tempDir.resolve("v1.coax");
+        int pairCap = 64;
+        int edgeCap = 64;
+
+        try (FileChannel ch = FileChannel.open(v1File,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            // 24-byte v1 header
+            ByteBuffer header = ByteBuffer.allocate(24);
+            header.putInt(0x434F4158);  // "COAX" magic
+            header.putInt(1);           // version 1
+            header.putInt(pairCap);     // pair capacity
+            header.putInt(edgeCap);     // edge capacity
+            header.putInt(0);           // pair count = 0
+            header.putInt(0);           // edge count = 0
+            header.flip();
+            ch.write(header);
+
+            // Pair table: pairCap * 32 bytes (all zeros)
+            ByteBuffer pairBuf = ByteBuffer.allocate(pairCap * 32);
+            ch.write(pairBuf);
+
+            // Edge table: edgeCap * 40 bytes (all zeros)
+            ByteBuffer edgeBuf = ByteBuffer.allocate(edgeCap * 40);
+            ch.write(edgeBuf);
+
+            // Tag index: count = 0
+            ByteBuffer tagCount = ByteBuffer.allocate(4);
+            tagCount.putInt(0);
+            tagCount.flip();
+            ch.write(tagCount);
+
+            ch.force(true);
+        }
+
+        try (var loaded = CoActivationTracker.load(v1File, 64, 128)) {
+            Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats = loaded.banditStats();
+            assertThat(banditStats).isNotNull();
+            assertThat(banditStats).isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // File size verification
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("saved file with bandit stats is larger than one without")
+    void banditStatsIncludedInSaveOutput() throws IOException {
+        Path fileNoBandit = tempDir.resolve("no-bandit.coax");
+        Path fileWithBandit = tempDir.resolve("with-bandit.coax");
+
+        // Save tracker WITHOUT bandit stats
+        try (var tracker = new CoActivationTracker(64)) {
+            tracker.recordCoActivation("alpha", "beta");
+            tracker.save(fileNoBandit);
+        }
+
+        // Save tracker WITH bandit stats
+        try (var tracker = new CoActivationTracker(64)) {
+            tracker.recordCoActivation("alpha", "beta");
+            var bandit = new ConcurrentHashMap<Long, EnumMap<CognitiveProfile, RunningStats>>();
+            var profileStats = new EnumMap<CognitiveProfile, RunningStats>(CognitiveProfile.class);
+            profileStats.put(CognitiveProfile.DEBUGGING,
+                    new RunningStats(0.9f, 50, 45, System.currentTimeMillis()));
+            profileStats.put(CognitiveProfile.EXPLORING,
+                    new RunningStats(0.6f, 30, 18, System.currentTimeMillis()));
+            bandit.put(1L, profileStats);
+            tracker.updateBanditStats(bandit);
+            tracker.save(fileWithBandit);
+        }
+
+        long sizeNoBandit = Files.size(fileNoBandit);
+        long sizeWithBandit = Files.size(fileWithBandit);
+
+        // With bandit: 2 entries × 32 bytes = 64 bytes extra
+        assertThat(sizeWithBandit).isGreaterThan(sizeNoBandit);
+        // At minimum, the bandit section adds 2*32 = 64 bytes
+        assertThat(sizeWithBandit - sizeNoBandit).isGreaterThanOrEqualTo(64);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/model/ExecutiveDysfunctionProfileTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/model/ExecutiveDysfunctionProfileTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.spectrayan.spector.memory.CognitiveProfileConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CognitiveProfile#EXECUTIVE_DYSFUNCTION} — associative,
+ * context-primed recall for prefrontal cortex hypoactivation.
+ */
+@DisplayName("CognitiveProfile.EXECUTIVE_DYSFUNCTION")
+class ExecutiveDysfunctionProfileTest {
+
+    private static final CognitiveProfile PROFILE = CognitiveProfile.EXECUTIVE_DYSFUNCTION;
+
+    // ══════════════════════════════════════════════════════════════
+    // Enum existence
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("EXECUTIVE_DYSFUNCTION exists in the CognitiveProfile enum")
+    void profileExistsInEnum() {
+        assertThat(PROFILE).isNotNull();
+        assertThat(CognitiveProfile.valueOf("EXECUTIVE_DYSFUNCTION")).isEqualTo(PROFILE);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Scoring parameters
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("has correct alpha=0.3, beta=0.7, gamma=0.1 scoring weights")
+    void profileHasCorrectAlphaBetaGamma() {
+        assertThat(PROFILE.alpha()).isCloseTo(0.3f, within(1e-6f));
+        assertThat(PROFILE.beta()).isCloseTo(0.7f, within(1e-6f));
+        assertThat(PROFILE.gamma()).isCloseTo(0.1f, within(1e-6f));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Neurodivergent group membership
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("is included in the NEURODIVERGENT profile group")
+    void profileIsInNeurodivergentGroup() {
+        var config = CognitiveProfileConfig.withNeurodivergent();
+        assertThat(config.isEnabled(PROFILE))
+                .as("EXECUTIVE_DYSFUNCTION should be in neurodivergent profiles")
+                .isTrue();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // applyTo() behavior on RecallOptions.Builder
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("applyTo() sets scoringMode to ASSOCIATIVE")
+    void applyToSetsScoringModeAssociative() {
+        RecallOptions opts = RecallOptions.builder()
+                .profile(PROFILE)
+                .build();
+
+        assertThat(opts.scoringMode()).isEqualTo(ScoringMode.ASSOCIATIVE);
+    }
+
+    @Test
+    @DisplayName("applyTo() enables lateralMode")
+    void applyToEnablesLateralMode() {
+        RecallOptions opts = RecallOptions.builder()
+                .profile(PROFILE)
+                .build();
+
+        assertThat(opts.lateralMode()).isTrue();
+    }
+
+    @Test
+    @DisplayName("applyTo() sets aggressive graph expansion threshold (0.80)")
+    void applyToSetsAggressiveGraphExpansion() {
+        RecallOptions opts = RecallOptions.builder()
+                .profile(PROFILE)
+                .build();
+
+        assertThat(opts.graphExpansionThreshold())
+                .isCloseTo(0.80f, within(1e-6f));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Valence range (from constructor: Byte.MIN_VALUE..Byte.MAX_VALUE)
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("has full valence range (MIN_VALUE to MAX_VALUE)")
+    void fullValenceRange() {
+        assertThat(PROFILE.minValence()).isEqualTo(Byte.MIN_VALUE);
+        assertThat(PROFILE.maxValence()).isEqualTo(Byte.MAX_VALUE);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/RecallHistoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/RecallHistoryTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link RecallHistory} — thread-safe circular buffer tracking recent recall context tags.
+ */
+@DisplayName("RecallHistory")
+class RecallHistoryTest {
+
+    // ══════════════════════════════════════════════════════════════
+    // Empty state
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("empty history returns empty tags")
+    void emptyHistoryReturnsEmptyTags() {
+        var history = new RecallHistory();
+        String[] tags = history.recentTags(10);
+        assertThat(tags).isEmpty();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Basic recording and retrieval
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("record one set and retrieve its tags")
+    void recordAndRetrieveTags() {
+        var history = new RecallHistory();
+        history.record(new String[]{"database", "timeout"});
+
+        String[] tags = history.recentTags(10);
+        assertThat(tags).containsExactly("database", "timeout");
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Ring buffer wrapping
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("ring buffer wraps correctly — oldest entries are evicted")
+    void ringBufferWrapsCorrectly() {
+        int capacity = 3;
+        var history = new RecallHistory(capacity);
+
+        history.record(new String[]{"oldest"});
+        history.record(new String[]{"middle"});
+        history.record(new String[]{"newest"});
+        // Buffer is full; next record evicts "oldest"
+        history.record(new String[]{"replacement"});
+
+        assertThat(history.size()).isEqualTo(capacity);
+
+        // Most recent first: replacement, newest, middle — oldest is evicted
+        String[] tags = history.recentTags(10);
+        assertThat(tags).contains("replacement", "newest", "middle");
+        assertThat(tags).doesNotContain("oldest");
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Deduplication
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("recentTags deduplicates — same tag across records appears once")
+    void recentTagsDeduplicates() {
+        var history = new RecallHistory();
+        history.record(new String[]{"java", "database"});
+        history.record(new String[]{"database", "redis"});
+        history.record(new String[]{"java", "cache"});
+
+        String[] tags = history.recentTags(10);
+        // Each unique tag should appear exactly once
+        assertThat(tags).containsExactlyInAnyOrder("java", "database", "redis", "cache");
+        // But size matches unique count
+        assertThat(tags).hasSize(4);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Weighted tags with decay
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("weightedRecentTags applies exponential decay — most recent has highest weight")
+    void weightedRecentTagsAppliesDecay() {
+        var history = new RecallHistory();
+        history.record(new String[]{"old_tag"});
+        history.record(new String[]{"mid_tag"});
+        history.record(new String[]{"new_tag"});
+
+        Map<String, Float> weighted = history.weightedRecentTags(10, 0.5f);
+
+        // Most recent entry has weight 1.0, next 0.5, then 0.25
+        assertThat(weighted.get("new_tag")).isCloseTo(1.0f, within(1e-6f));
+        assertThat(weighted.get("mid_tag")).isCloseTo(0.5f, within(1e-6f));
+        assertThat(weighted.get("old_tag")).isCloseTo(0.25f, within(1e-6f));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Null / Empty handling
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("record handles null and empty arrays without crashing")
+    void recordHandlesNullAndEmpty() {
+        var history = new RecallHistory();
+
+        // These should not throw
+        assertThatCode(() -> history.record(null)).doesNotThrowAnyException();
+        assertThatCode(() -> history.record(new String[]{})).doesNotThrowAnyException();
+
+        // Buffer should still be empty
+        assertThat(history.size()).isZero();
+        assertThat(history.recentTags(10)).isEmpty();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Thread safety
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("thread safety — concurrent record() + recentTags() doesn't throw")
+    void threadSafetyUnderConcurrentAccess() throws InterruptedException {
+        var history = new RecallHistory(5);
+        int threadCount = 8;
+        int opsPerThread = 500;
+        var errors = new AtomicInteger(0);
+        var latch = new CountDownLatch(threadCount);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(threadCount)) {
+            for (int t = 0; t < threadCount; t++) {
+                final int threadId = t;
+                executor.submit(() -> {
+                    try {
+                        for (int i = 0; i < opsPerThread; i++) {
+                            if (i % 2 == 0) {
+                                history.record(new String[]{"tag-" + threadId + "-" + i});
+                            } else {
+                                history.recentTags(5);
+                            }
+                        }
+                    } catch (Exception e) {
+                        errors.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            assertThat(completed).as("All threads should complete within timeout").isTrue();
+            assertThat(errors.get()).as("No exceptions should occur under concurrent access").isZero();
+        }
+    }
+}

--- a/nucleus/README.md
+++ b/nucleus/README.md
@@ -1,0 +1,19 @@
+# Nucleus Layer (`/nucleus`)
+
+This directory contains the core foundation modules of the Spector headless engine. The nucleus modules provide compile-time utilities, configuration management, telemetry instrumentation, event messaging, and low-level memory/storage block allocations that support the rest of the Spector ecosystem.
+
+## Modules
+
+* **[`spector-bom`](/nucleus/spector-bom)**: Bill of Materials (BOM) Pom that manages unified dependency versions for the entire Spector reactor.
+* **[`spector-commons`](/nucleus/spector-commons)**: Common utilities, standard constants, and the global `ErrorCode` exception registry.
+* **[`spector-config`](/nucleus/spector-config)**: Wires runtime configurations via the `SpectorConfigFactory` (parses `spector.yml` and environment variables).
+* **[`spector-core`](/nucleus/spector-core)**: Low-level primitive vector operations, SIMD math bounds, and JDK Project Panama FFM off-heap layout contracts.
+* **[`spector-events`](/nucleus/spector-events)**: Internal pub/sub event pipeline that coordinates async notifications (e.g. consolidation signals).
+* **[`spector-metrics`](/nucleus/spector-metrics)**: Micrometer-based telemetry and performance metrics trackers for retrieval latency.
+* **[`spector-storage`](/nucleus/spector-storage)**: Off-heap byte allocation, memory block management, and the Write-Ahead Log (WAL) persistence engine.
+* **[`spector-test-support`](/nucleus/spector-test-support)**: Common test harnesses and mocks used for testing memory and search components.
+
+## Dependency Rules
+
+* **Layer Constraint**: Nucleus modules represent the lowest layer of the stack. They must **never** depend on any search, intelligence, runtime, or infrastructure modules.
+* **Flow**: Dependencies flow downwards. Any higher-level module in `/memory`, `/synapse`, or `/bench` can freely depend on `/nucleus` modules.

--- a/scripts/cognitive-benchmark.ps1
+++ b/scripts/cognitive-benchmark.ps1
@@ -112,6 +112,7 @@ $jvmArgs = @(
     "--add-opens", "java.base/java.lang.foreign=ALL-UNNAMED"
     "-Xmx${HeapMb}m"
     "-Dlogback.configurationFile=logback-bench.xml"
+    "-Dspector.embedding.cache-dir=$(Join-Path $resolvedDataset '../../.spector-bench')"
     "-cp", $classpath
 )
 

--- a/scripts/run-all-benchmarks.ps1
+++ b/scripts/run-all-benchmarks.ps1
@@ -26,7 +26,7 @@ if (!$SkipBuild) {
     Write-Host "── Building spector-bench module ──" -ForegroundColor Yellow
     Push-Location $projectRoot
     try {
-        mvn -B package -pl bench/spector-bench -am -DskipTests --no-transfer-progress
+        mvn -B install -pl bench/spector-bench -am -DskipTests --no-transfer-progress
         if ($LASTEXITCODE -ne 0) {
             Write-Host "ERROR: Maven build failed" -ForegroundColor Red
             exit 1
@@ -70,6 +70,7 @@ $jvmArgs = @(
     "--add-opens", "java.base/java.lang.foreign=ALL-UNNAMED",
     "-Xmx${HeapMb}m",
     "-Dlogback.configurationFile=logback-bench.xml",
+    "-Dspector.embedding.cache-dir=$(Join-Path $DatasetsBase '.spector-bench')",
     "-cp", $classpath
 )
 

--- a/synapse/README.md
+++ b/synapse/README.md
@@ -1,0 +1,18 @@
+# Synapse Layer (`/synapse`)
+
+This directory contains the runtime coordinator, endpoint adapters, client SDKs, and application distributions for the Spector headless engine. The synapse layer acts as the bridge connecting the core memory/search engine to the outside network.
+
+## Modules
+
+* **[`spector-cli`](/synapse/spector-cli)**: Command-line interface (`spectorctl`) for administration and diagnostic control.
+* **[`spector-client`](/synapse/spector-client)**: Java client SDK providing standard API connections to a remote Spector node.
+* **[`spector-dist`](/synapse/spector-dist)**: Distribution packaging module that bundles the application into runnable Docker containers and deployment zip files.
+* **[`spector-mcp`](/synapse/spector-mcp)**: Model Context Protocol (MCP) server implementation allowing LLM agents (e.g. Claude) to recall/remember memories directly.
+* **[`spector-runtime`](/synapse/spector-runtime)**: The orchestrator that wires index components, memory files, and query pipelines into a running Spector node.
+* **[`spector-spring`](/synapse/spector-spring)**: Spring AI auto-configurations and client integrations.
+* **[`spector-synapse`](/synapse/spector-synapse)**: Spring Boot 4 + Armeria core entry point that exposes high-performance gRPC, REST, and MCP endpoints on a single port.
+
+## Dependency Rules
+
+* **Flow**: Synapse modules occupy the application runtime tier. They depend directly on the lower algorithmic layers in `/memory` and `/nucleus`. 
+* **Integration**: All runtime wiring occurs here, separating domain mathematics and indexing code from transport protocols and frameworks.

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRecallTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRecallTool.java
@@ -83,7 +83,9 @@ public final class MemoryRecallTool extends MemoryToolHandler {
                         + "CRITICAL (high-stakes), HYPERFOCUS (narrow deep-dive), "
                         + "SYSTEMATIZER (encyclopedic detail), DIVERGENT (cross-domain), "
                         + "PARANOID_SENTINEL (threat detection), THE_EXECUTOR (strict task), "
-                        + "HIGHLY_SENSITIVE (fine detail), DEFAULT_MODE_NETWORK (deep knowledge).", "")
+                        + "HIGHLY_SENSITIVE (fine detail), DEFAULT_MODE_NETWORK (deep knowledge), "
+                        + "EXECUTIVE_DYSFUNCTION (associative context-driven recall), "
+                        + "auto (let the system choose based on context).", "")
                 .optionalString("synaptic_filter",
                         "Comma-separated tags for Bloom filter pre-filtering.", "")
                 .optionalString("min_importance",
@@ -104,7 +106,8 @@ public final class MemoryRecallTool extends MemoryToolHandler {
                 .optionalString("scoring_mode",
                         "Controls how retrieved candidates are ranked. "
                         + "COGNITIVE (default): full biological scoring — importance, decay, tag boost. "
-                        + "SIMILARITY: pure vector cosine similarity — ideal for search/retrieval benchmarks.", "COGNITIVE")
+                        + "SIMILARITY: pure vector cosine similarity — ideal for search/retrieval benchmarks. "
+                        + "ASSOCIATIVE: context-driven recall using recent activity and causal predictions.", "COGNITIVE")
                 .optionalString("namespace",
                         "Memory namespace to query. Isolates agent/user memory spaces. "
                         + "Leave empty for default namespace.", "")
@@ -133,9 +136,13 @@ public final class MemoryRecallTool extends MemoryToolHandler {
 
         // Apply cognitive profile preset (if specified)
         String profileStr = optionalString(args, "profile", "");
-        CognitiveProfile profile = RecallOptions.parseProfile(profileStr);
-        if (profile != null) {
-            builder.profile(profile);
+        if (RecallOptions.isAutoProfile(profileStr)) {
+            builder.autoProfile(true);
+        } else {
+            CognitiveProfile profile = RecallOptions.parseProfile(profileStr);
+            if (profile != null) {
+                builder.profile(profile);
+            }
         }
 
         String[] filterTags = optionalTags(args, "synaptic_filter");


### PR DESCRIPTION
## Description
This Pull Request implements two new features in the cognitive memory subsystem:
1. **ProfileAdaptor (#294)**: Contextual multi-armed bandit that learns the optimal cognitive profile per tag context from reinforcement feedback. Persists bandit statistics inside the CoActivationTracker's COAX v2 binary format.
2. **Executive Dysfunction Profile (#295)**: A neurodivergent profile simulating associative jumpiness and cognitive distractibility by biasing the retrieval engine towards broad lateral recall. Uses a sliding tag history buffer (`RecallHistory`) for directed STDP causal chain predictions and associative scoring.
3. **Directory READMEs**: Adds structured `README.md` files to the five main restructured reactor directories (`nucleus/`, `memory/`, `synapse/`, `cortex/`, and `bench/`) explaining their purpose, submodules, and dependency flow rules.

## Related Issue
Closes #294
Closes #295

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (change that improves throughput or latency)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Module(s) Affected
- [ ] `spector-core` (SIMD kernels)
- [ ] `spector-storage` (Panama storage)
- [ ] `spector-index` (HNSW / BM25)
- [x] `spector-query` (query orchestration)
- [ ] `spector-engine` (engine facade)
- [x] `spector-node` (REST API)
- [x] `spector-bench` (benchmarks)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added Javadoc for all public classes/methods
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (`mvn test`)
- [x] No hardcoded secrets or credentials are included
- [x] JMH benchmark results included (if performance-related)