### PR TITLE
deps(synapse): upgrade Spring Boot to 4.1.0 and align dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,15 +121,18 @@
         <jackson.version>3.1.4</jackson.version>
         <jackson2.version>2.22.1</jackson2.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.18</logback.version>
+        <logback.version>1.5.34</logback.version>
         <jmh.version>1.37</jmh.version>
         <mcp-sdk.version>2.0.0-M3</mcp-sdk.version>
         <commons-configuration2.version>2.15.0</commons-configuration2.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <micrometer.version>1.14.5</micrometer.version>
+        <micrometer.version>1.17.0</micrometer.version>
         <armeria.version>1.39.1</armeria.version>
         <langchain4j.version>1.17.1</langchain4j.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
+        <langgraph4j.version>1.8.20</langgraph4j.version>
 
         <!-- Test dependency versions -->
         <junit.version>5.11.4</junit.version>
@@ -345,6 +348,11 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
 

--- a/synapse/spector-spring/pom.xml
+++ b/synapse/spector-spring/pom.xml
@@ -19,12 +19,32 @@
         <spector.module.name>com.spectrayan.spector.spring</spector.module.name>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Spring AI BOM -->
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Spring AI Vector Store (VectorStore, SearchRequest, Filter) -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-vector-store</artifactId>
-            <version>2.0.0-M4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -37,7 +57,6 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-commons</artifactId>
-            <version>2.0.0-M4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -50,7 +69,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>7.0.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -107,7 +125,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>3.5.3</version>
             <optional>true</optional>
         </dependency>
 
@@ -115,7 +132,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
-            <version>3.5.3</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- ── Spring Boot Health (for custom HealthIndicators in Spring Boot 4) ── -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-health</artifactId>
             <optional>true</optional>
         </dependency>
 
@@ -136,7 +159,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.5.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorHealthIndicator.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorHealthIndicator.java
@@ -18,8 +18,8 @@ package com.spectrayan.spector.spring.autoconfigure;
 import com.spectrayan.spector.core.simd.SimdCapability;
 import com.spectrayan.spector.memory.SpectorMemory;
 
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.stereotype.Component;
 

--- a/synapse/spector-synapse/pom.xml
+++ b/synapse/spector-synapse/pom.xml
@@ -22,23 +22,8 @@
     <properties>
         <spector.module.name>com.spectrayan.spector.synapse</spector.module.name>
 
-        <!-- Spring Boot 4 (ADR-010: gradual adoption) -->
-        <spring-boot.version>4.0.2</spring-boot.version>
-
-        <!-- Override core's logback 1.5.18 pin — Spring Boot 4.0.2 requires 1.5.25 -->
-        <logback.version>1.5.25</logback.version>
-
         <!-- Armeria (bumped for Spring Boot 4 compatibility) -->
         <armeria.version>1.40.0</armeria.version>
-
-        <!-- LangGraph4j (agentic graph execution) -->
-        <langgraph4j.version>1.8.20</langgraph4j.version>
-
-        <!-- LangChain4j (LLM abstraction) -->
-        <langchain4j.version>1.17.1</langchain4j.version>
-
-        <!-- Spring AI (ChatMemory, Advisors, ToolCallback) -->
-        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <dependencyManagement>
@@ -275,7 +260,6 @@
         <dependency>
             <groupId>com.github.jsqlparser</groupId>
             <artifactId>jsqlparser</artifactId>
-            <version>4.9</version>
         </dependency>
 
         <!-- Spring-boot starter JDBC dependency-->


### PR DESCRIPTION
Consolidate Spring dependencies to use BOMs in spector-spring, upgrade Spring Boot to 4.1.0 in spector-synapse, align micrometer to 1.17.0, and resolve other version management drifts.

Closes #318