### PR TITLE
feat(memory): add memory consolidation engine

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -2,14 +2,15 @@
 
 ## Why a CLA?
 
-This Contributor License Agreement ("Agreement") ensures that contributions to Spector are properly licensed and that the project can continue to be distributed under the Apache License 2.0 (for core modules) and the Business Source License 1.1 (for synapse modules, which convert to Apache License 2.0 after the Change Date).
+This Contributor License Agreement ("Agreement") ensures that contributions to Spector are properly licensed and that the project can continue to be distributed under the Apache License 2.0 (for core modules) and the Business Source License 1.1 (for the spector-memory, spector-synapse, and spector-cortex modules, which convert to Apache License 2.0 after their respective Change Dates).
 
 ## Agreement
 
 By signing this CLA, you confirm that:
 
 1. **You are the author** of the contribution, or you have the right to submit it.
-2. **You grant a license** to the Spector project (spectrayan/spector) to use, modify, and distribute your contribution under the project's licenses: the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) or the [Business Source License 1.1](https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE), as applicable.
+2. **You grant a license** to the Spector project (spectrayan/spector) to use, modify, and distribute your contribution under the project's licenses: the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) or the Business Source License 1.1 (for spector-memory, spector-synapse, or spector-cortex), as applicable.
+
 3. **You understand** that your contribution is public and that a record of the contribution (including your name and the contribution itself) is maintained indefinitely.
 4. **You are not expected** to provide support for your contribution, although you are welcome to do so.
 5. **Your contribution** does not include any third-party code that is incompatible with the project's licenses.

--- a/NOTICE
+++ b/NOTICE
@@ -10,18 +10,21 @@ LICENSE STRUCTURE
 
 This repository utilizes a split licensing model:
 
-  1. The "spector-memory" module (located under the spector-memory/ directory)
-     is licensed under the Business Source License 1.1 (BSL 1.1). Under the
-     terms of the BSL 1.1, you are granted non-production use rights, with
-     an Additional Use Grant permitting production use except for offering
-     the module as a managed service or embedding it in a competing AI
-     cognitive memory product. On the Change Date (May 27, 2030), this module
-     automatically transitions to the Apache License 2.0.
-     Please see spector-memory/LICENSE for details.
+  1. The "spector-memory" (located under memory/spector-memory/), "spector-cortex"
+     (located under cortex/spector-cortex/), and "spector-synapse" (located under
+     synapse/spector-synapse/) modules are licensed under the Business Source License
+     1.1 (BSL 1.1). Under the terms of the BSL 1.1, you are granted non-production
+     use rights, with an Additional Use Grant permitting production use except for
+     offering the modules as a managed service, or embedding or integrating them
+     in a competing AI cognitive memory product or service. On the Change Date
+     (May 27, 2030 for spector-memory; July 6, 2030 for spector-cortex and
+     spector-synapse), these modules automatically transition to the Apache License 2.0.
+     Please see the LICENSE files in their respective module directories for details.
 
   2. All other directories, modules, and core infrastructure in this repository
      are licensed under the Apache License 2.0.
      Please see the root LICENSE file for details.
+
 
 ================================================================================
 ATTRIBUTION NOTICE

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -168,15 +168,13 @@ Each workflow matches a specific slash command or task trigger. Use them sequent
 
 ## 6. Spector Enterprise
 
-The **Cortex dashboard** and full-stack product features have been extracted to a separate repository: [spector-enterprise](https://github.com/spectrayan/spector-enterprise).
+The full-stack enterprise product features have been extracted to a separate repository: [spector-enterprise](https://github.com/spectrayan/spector-enterprise).
 
-**This repository (spector)** is the **core embeddable engine** — headless, no UI, no management APIs. Think of it as "Elasticsearch without Kibana."
+**This repository (spector)** is the **core engine** — which includes the **Cortex dashboard** (Angular 22 neural visualization and chat UI) located in `cortex/spector-cortex/` as a core OSS module.
 
 **spector-enterprise** adds:
-*   Data connectors (Apache Camel) — template-driven ingestion from REST, file, Kafka, S3, etc.
-*   LLM provider orchestration — OpenAI, Anthropic, Google via ServiceLoader
-*   Management APIs — versioned REST endpoints for configuration and monitoring
-*   Cortex Dashboard — Angular 22 neural visualization (migrated from `spector-cortex/`)
-*   Single-port architecture — everything on port 7070 via Armeria
+*   Enterprise data connectors (Apache Camel) — template-driven ingestion from Kafka, S3, Salesforce, Confluence, etc.
+*   Multi-tenant namespace manager & access control
+*   Corporate management APIs for clustering, monitoring, and scaling
 
 Enterprise **depends on** `spector-synapse` and always starts the core engine.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ All numbers measured on Intel Core Ultra 9 285K, Java 25, AVX2 256-bit.
 | **Add cognitive memory** | [Memory Overview](https://spectrayan.github.io/spector/memory/) · [Getting Started](https://spectrayan.github.io/spector/memory/getting-started/) · [Use Cases](https://spectrayan.github.io/spector/memory/use-cases/) |
 | **Use the Java SDK** | [Java SDK Guide](https://spectrayan.github.io/spector/sdk-usage/java-client/) · [Spring AI Integration](https://spectrayan.github.io/spector/sdk-usage/spring-ai/) |
 | **Deploy to production** | [Docker Deployment](deploy/docker/) · [Performance Tuning](https://spectrayan.github.io/spector/operations/performance-tuning/) |
-| **Extend with Enterprise** | [Spector Enterprise](https://github.com/spectrayan/spector-enterprise) — LLM providers, Cortex dashboard, data connectors |
+| **Extend with Enterprise** | [Spector Enterprise](https://github.com/spectrayan/spector-enterprise) — enterprise connectors, access control, management APIs |
 
 > 📖 **[Full Documentation →](https://spectrayan.github.io/spector/)**
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,10 @@ We welcome contributions of all kinds — code, docs, tests, benchmarks, and ide
 This repository uses a **split licensing model**:
 
 - **`spector-memory`** — [Business Source License 1.1](memory/spector-memory/LICENSE) (transitions to Apache 2.0 on May 27, 2030)
+- **`spector-cortex`** — [Business Source License 1.1](cortex/spector-cortex/LICENSE) (transitions to Apache 2.0 on July 6, 2030)
+- **`spector-synapse`** — [Business Source License 1.1](synapse/spector-synapse/LICENSE) (transitions to Apache 2.0 on July 6, 2030)
 - **All other modules** — [Apache License 2.0](LICENSE)
+
 
 For branding and trademark guidelines, see the [NOTICE](NOTICE) file.
 

--- a/docs/docs/memory/synapse.md
+++ b/docs/docs/memory/synapse.md
@@ -56,14 +56,25 @@ The sole header layout, aligned to a full **CPU cache line** (64 bytes) for opti
 The `flags` byte at offset 1 encodes per-record state:
 
 ```
- Bit   Name          Description
- ───   ────          ───────────
-  0    tombstone     Record is logically deleted (pruned by Deep Sleep)
-  1-2  memory_type   2-bit type: 0=WORKING, 1=EPISODIC, 2=SEMANTIC, 3=PROCEDURAL
-  3    consolidated  Has been reflected into Semantic tier
-  4    pinned        Exempt from decay and pruning (flashbulb memories)
-  5    resolved      Zeigarnik Effect — resolved tasks return to normal decay
-  6-7  reserved      Future use
+ Bit   Name            Description
+ ───   ────            ───────────
+  0    tombstone       Record is logically deleted (pruned by Deep Sleep)
+  1-2  memory_type     2-bit type: 0=WORKING, 1=EPISODIC, 2=SEMANTIC, 3=PROCEDURAL
+  3    consolidated    Has been reflected into Semantic tier
+  4    pinned          Exempt from decay and pruning (flashbulb memories)
+  5    resolved        Zeigarnik Effect — resolved tasks return to normal decay
+  6-7  source_modality 2-bit modality: 0=TEXT, 1=IMAGE, 2=AUDIO, 3=VIDEO
+```
+
+### Consolidation Flags (Offset 34)
+
+The byte at offset 34 (previously alignment padding) encodes consolidation and maintenance states:
+
+```
+ Bit   Name            Description
+ ───   ────            ───────────
+  0    contradicted    Memory has a conflicting near-duplicate in the tier
+  1-7  reserved        Future use
 ```
 
 ### Zeigarnik Effect (Bit 5)

--- a/docs/docs/modules/index.md
+++ b/docs/docs/modules/index.md
@@ -209,6 +209,6 @@ graph TD
 |:---|:---|
 | [spector-events](spector-events.md) | Telemetry — decoupled event bus (`TelemetryBus`, `TelemetryScope`, 12 event types) |
 | [spector-metrics](spector-metrics.md) | Metrics — Micrometer + TelemetryBus instrumentation |
-| [spector-cortex](spector-cortex.md) | ⚠️ **Moved to [spector-enterprise](https://github.com/spectrayan/spector-enterprise)** — Angular 22 neural dashboard |
+| [spector-cortex](spector-cortex.md) | Angular 22 neural dashboard & chat UI |
 | [spector-bench](spector-bench.md) | Benchmarks — JMH performance testing |
 | [spector-dist](spector-dist.md) | Distribution — single fat JAR packaging |

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -56,9 +56,11 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphCsr;
 import com.spectrayan.spector.memory.hippocampus.CircadianPolicy;
 import com.spectrayan.spector.memory.hippocampus.ReflectDaemon;
+import com.spectrayan.spector.memory.consolidation.ConsolidationService;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
+
 import com.spectrayan.spector.memory.interference.SemanticDeduplicator;
 import com.spectrayan.spector.memory.metamemory.MemoryInsight;
 import com.spectrayan.spector.memory.metamemory.MemoryIntrospector;
@@ -167,6 +169,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     private final ImportanceEstimator importanceEstimator;
     private final ReflectionOrchestrator reflectionOrchestrator;
     private final ReinforcementHandler reinforcementHandler;
+    private final ConsolidationService consolidationService;
+
 
     // -€-€ Biological Subsystems -€-€
     private final ValenceTracker valenceTracker;
@@ -235,6 +239,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.importanceEstimator = bundle.importanceEstimator();
         this.reflectionOrchestrator = bundle.reflectionOrchestrator();
         this.reinforcementHandler = bundle.reinforcementHandler();
+        this.consolidationService = new ConsolidationService(builder.LlmProvider, this.embeddingProvider);
+
         this.valenceTracker = bundle.valenceTracker();
         this.coActivationTracker = bundle.coActivationTracker();
         this.suppressionSet = bundle.suppressionSet();
@@ -639,6 +645,20 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         return reflectionOrchestrator.reflect(partitionManager.tierRouter(), index);
     }
 
+    @Override
+    public void consolidate() {
+        consolidationService.consolidate(
+                partitionManager.tierRouter(),
+                index,
+                quantizer,
+                entityGraph,
+                cognitiveTarget,
+                wal,
+                this::inspect
+        );
+    }
+
+
     // ==============================================================
     // EXTENDED API  --  reinforce / suppress / introspect
     // ==============================================================
@@ -794,6 +814,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
         // Read extended fields that aren't in the base CognitiveHeader
         int spectorRecallCount = layout.readSpectorRecallCount(segment, loc.offset());
+        byte consolidationFlags = layout.readConsolidationFlags(segment, loc.offset());
 
         // Metadata and suppression state
         var metadata = java.util.Map.<String, String>of();
@@ -804,7 +825,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 header.timestampMs(), header.synapticTags(), header.exactNorm(),
                 header.importance(), header.agentRecallCount(), spectorRecallCount,
                 header.centroidId(), header.valence(), header.arousal(),
-                header.storageStrength(), header.flags(),
+                header.storageStrength(), header.flags(), consolidationFlags,
                 quantizedVec, loc.partitionIndex(), loc.offset(),
                 metadata, suppressed);
     }
@@ -834,6 +855,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 var header = layout.readHeader(segment, loc.offset());
                 if (!SynapticHeaderConstants.isTombstoned(header.flags())) {
                     int spectorRecallCount = layout.readSpectorRecallCount(segment, loc.offset());
+                    byte consolidationFlags = layout.readConsolidationFlags(segment, loc.offset());
                     String[] memTags = index.tags(memId);
                     results.add(new CognitiveRecord(
                             memId, index.text(memId), loc.type(),
@@ -841,7 +863,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                             header.timestampMs(), header.synapticTags(), header.exactNorm(),
                             header.importance(), header.agentRecallCount(), spectorRecallCount,
                             header.centroidId(), header.valence(), header.arousal(),
-                            header.storageStrength(), header.flags(),
+                            header.storageStrength(), header.flags(), consolidationFlags,
                             null, // no vector for browse (use inspect for full detail)
                             loc.partitionIndex(), loc.offset(),
                             java.util.Map.of(), suppressionSet.isSuppressed(memId)));

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -234,6 +234,10 @@ public interface SpectorMemory extends AutoCloseable {
     /** Triggers a synchronous reflection (sleep consolidation) cycle. */
     ReflectReport reflect();
 
+    /** Triggers a manual memory consolidation process. */
+    void consolidate();
+
+
     // ══════════════════════════════════════════════════════════════
     // IMPORTANCE ESTIMATION — pre-ingestion computation
     // ══════════════════════════════════════════════════════════════

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.consolidation;
+
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.TierRouter;
+import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.model.CognitiveRecord;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Orchestrator service for background memory consolidation.
+ */
+public final class ConsolidationService {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsolidationService.class);
+
+    private final DuplicateDetector duplicateDetector;
+    private final ContradictionDetector contradictionDetector;
+    private final MemoryMerger memoryMerger;
+
+    public ConsolidationService(LlmProvider textGenerator, EmbeddingProvider embeddingProvider) {
+        this.duplicateDetector = new DuplicateDetector();
+        this.contradictionDetector = new ContradictionDetector(textGenerator);
+        this.memoryMerger = new MemoryMerger(textGenerator, embeddingProvider);
+    }
+
+    /**
+     * Executes the consolidation cycle across the semantic store.
+     */
+    public void consolidate(TierRouter tierRouter, MemoryIndex index, ScalarQuantizer quantizer,
+                            EntityGraph entityGraph, CognitiveIngestionTarget ingestionTarget,
+                            MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
+        AbstractTierStore semanticStore = (AbstractTierStore) tierRouter.semantic();
+        if (semanticStore == null || semanticStore.visibleCount() < 2) {
+            log.debug("Consolidation: semantic store too small to run consolidation (visibleCount={})",
+                    semanticStore == null ? 0 : semanticStore.visibleCount());
+            return;
+        }
+
+        log.info("Consolidation: scanning semantic memory for duplicates... ({} visible)", semanticStore.visibleCount());
+        List<DuplicateDetector.DuplicatePair> duplicatePairs = duplicateDetector.findDuplicates(semanticStore, index, quantizer);
+        if (duplicatePairs.isEmpty()) {
+            log.info("Consolidation: no duplicate pairs found.");
+            return;
+        }
+
+        log.info("Consolidation: found {} duplicate pairs. Evaluating contradictions & merging...", duplicatePairs.size());
+
+        // Map memory slot indices to entity IDs
+        Map<Integer, List<Integer>> memToEntities = new HashMap<>();
+        if (entityGraph != null) {
+            int ecnt = entityGraph.entityCount();
+            for (int e = 0; e < ecnt; e++) {
+                int refCount = entityGraph.memoryRefCount(e);
+                for (int r = 0; r < refCount; r++) {
+                    int memIdx = entityGraph.memoryRefAt(e, r);
+                    if (memIdx >= 0) {
+                        memToEntities.computeIfAbsent(memIdx, k -> new ArrayList<>(2)).add(e);
+                    }
+                }
+            }
+        }
+
+        Set<String> processedIds = new HashSet<>();
+
+        for (DuplicateDetector.DuplicatePair pair : duplicatePairs) {
+            if (processedIds.contains(pair.idA()) || processedIds.contains(pair.idB())) {
+                continue; // already handled in a previous merge/contradiction in this cycle
+            }
+
+            CognitiveRecord recordA = inspectFunction.apply(pair.idA());
+            CognitiveRecord recordB = inspectFunction.apply(pair.idB());
+
+            if (recordA == null || recordB == null || recordA.isTombstoned() || recordB.isTombstoned()) {
+                continue;
+            }
+
+            // 1. Check if contradictory
+            boolean isContradictory = contradictionDetector.areContradictory(recordA.text(), recordB.text());
+
+            if (isContradictory) {
+                log.info("Consolidation: Detected contradiction between memory '{}' and '{}'", pair.idA(), pair.idB());
+
+                // Set FLAG_CONTRADICTED in headers off-heap
+                MemorySegment segment = semanticStore.segment();
+                CognitiveRecordLayout layout = semanticStore.layout();
+
+                long offsetA = recordA.byteOffset();
+                long offsetB = recordB.byteOffset();
+
+                layout.markContradicted(segment, offsetA);
+                layout.markContradicted(segment, offsetB);
+
+                // Add CONTRADICTS relation in EntityGraph
+                if (entityGraph != null) {
+                    int slotA = (int) ((offsetA - (semanticStore.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L)) / layout.stride());
+                    int slotB = (int) ((offsetB - (semanticStore.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L)) / layout.stride());
+
+                    List<Integer> entitiesA = memToEntities.get(slotA);
+                    List<Integer> entitiesB = memToEntities.get(slotB);
+
+                    if (entitiesA != null && entitiesB != null) {
+                        for (int eA : entitiesA) {
+                            for (int eB : entitiesB) {
+                                if (eA != eB) {
+                                    entityGraph.addRelation(eA, eB, "CONTRADICTS");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                processedIds.add(pair.idA());
+                processedIds.add(pair.idB());
+
+            } else {
+                log.info("Consolidation: Merging duplicate memories '{}' and '{}'", pair.idA(), pair.idB());
+
+                // 2. Merge non-contradictory records
+                MemoryMerger.MergedMemory merged = memoryMerger.merge(recordA, recordB, quantizer);
+
+                // Generate new time-sorted ID for merged result
+                String newId = "cns-" + new com.spectrayan.spector.memory.id.TsidGenerator().generate();
+
+
+                // Tombstone old records in off-heap, WAL, and index
+                tombstoneRecord(recordA, semanticStore, index, wal);
+                tombstoneRecord(recordB, semanticStore, index, wal);
+
+                // Ingest new merged record
+                byte semanticFlags = SynapticHeaderConstants.withMemoryType(
+                        SynapticHeaderConstants.FLAG_CONSOLIDATED,
+                        MemoryType.SEMANTIC.ordinal());
+
+                CognitiveHeader header = new CognitiveHeader(
+                        merged.timestampMs(),
+                        merged.synapticTags(),
+                        1.0f, // norm will be calculated inside ingest
+                        merged.importance(),
+                        recordA.agentRecallCount() + recordB.agentRecallCount(),
+                        (short) 0,
+                        merged.valence(),
+                        semanticFlags,
+                        merged.arousal(),
+                        merged.storageStrength()
+                );
+
+                String[] tags = mergeTags(recordA.tags(), recordB.tags());
+
+                ingestionTarget.ingestCognitiveWithHeader(
+                        newId,
+                        merged.text(),
+                        merged.vector(),
+                        MemoryType.SEMANTIC,
+                        tags,
+                        MemorySource.REFLECTED,
+                        header
+                );
+
+                processedIds.add(pair.idA());
+                processedIds.add(pair.idB());
+            }
+        }
+    }
+
+    private void tombstoneRecord(CognitiveRecord record, AbstractTierStore store, MemoryIndex index, MemoryWal wal) {
+        MemorySegment segment = store.segment();
+        CognitiveRecordLayout layout = store.layout();
+        layout.tombstone(segment, record.byteOffset());
+
+        if (wal != null) {
+            wal.appendForget(record.id());
+        }
+        index.remove(record.id());
+        log.debug("Consolidation: Tombstoned and de-indexed memory '{}'", record.id());
+    }
+
+    private String[] mergeTags(String[] tagsA, String[] tagsB) {
+        Set<String> merged = new HashSet<>();
+        if (tagsA != null) {
+            for (String t : tagsA) merged.add(t.trim().toLowerCase());
+        }
+        if (tagsB != null) {
+            for (String t : tagsB) merged.add(t.trim().toLowerCase());
+        }
+        return merged.toArray(new String[0]);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ContradictionDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ContradictionDetector.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.consolidation;
+
+import com.spectrayan.spector.provider.generation.GenerationOptions;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Detector that checks if two semantically similar memories contradict each other.
+ */
+public final class ContradictionDetector {
+
+    private static final Logger log = LoggerFactory.getLogger(ContradictionDetector.class);
+
+    private final LlmProvider textGenerator;
+
+    public ContradictionDetector(LlmProvider textGenerator) {
+        this.textGenerator = textGenerator;
+    }
+
+    /**
+     * Determines whether two memory texts contradict each other.
+     *
+     * @param textA first memory text
+     * @param textB second memory text
+     * @return true if the statements assert opposing facts or mutually exclusive preferences
+     */
+    public boolean areContradictory(String textA, String textB) {
+        if (textGenerator == null) {
+            // Standalone mode: cannot verify contradictions via LLM, default to false (safe merge fallback)
+            return false;
+        }
+
+        try {
+            String prompt = String.format(
+                    "Analyze these two statements and determine if they contradict each other " +
+                    "(i.e., they assert opposing facts or mutually exclusive preferences). " +
+                    "Reply with exactly 'YES' if they contradict, or 'NO' if they are complementary or non-contradictory.\n\n" +
+                    "Statement 1: \"%s\"\n" +
+                    "Statement 2: \"%s\"\n\n" +
+                    "Contradicts:", textA, textB);
+
+            String response = textGenerator.generate(prompt, GenerationOptions.CONCISE);
+            if (response != null) {
+                String cleaned = response.trim().toUpperCase();
+                if (cleaned.contains("YES")) {
+                    log.debug("ContradictionDetector: contradiction detected between: [\"{}\"] and [\"{}\"]", textA, textB);
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("ContradictionDetector: LLM call failed, assuming no contradiction: {}", e.getMessage());
+        }
+
+        return false;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.consolidation;
+
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.core.similarity.SimilarityFunction;
+import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Detector for finding near-duplicate memory records within a specific memory store tier.
+ */
+public final class DuplicateDetector {
+
+    private static final Logger log = LoggerFactory.getLogger(DuplicateDetector.class);
+
+    private final float distanceThreshold; // L2 distance threshold (< 0.05 is near-duplicate)
+
+    public DuplicateDetector(float distanceThreshold) {
+        this.distanceThreshold = distanceThreshold;
+    }
+
+    public DuplicateDetector() {
+        this(0.05f); // default L2 threshold (~0.95+ cosine similarity)
+    }
+
+    public record DuplicatePair(int indexA, int indexB, String idA, String idB, float distance) {}
+
+    /**
+     * Scans the given store for duplicate pairs.
+     */
+    public List<DuplicatePair> findDuplicates(AbstractTierStore store, MemoryIndex index, ScalarQuantizer quantizer) {
+        List<DuplicatePair> pairs = new ArrayList<>();
+        int recordCount = store.visibleCount();
+        if (recordCount < 2) {
+            return pairs;
+        }
+
+        MemorySegment segment = store.segment();
+        CognitiveRecordLayout layout = store.layout();
+        long baseOffset = store.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L;
+        int stride = layout.stride();
+        int vecBytes = layout.quantizedVecBytes();
+        float[] mins = quantizer.mins();
+        float[] scales = quantizer.scales();
+
+        byte[] quantizedBuf = new byte[vecBytes];
+        float[] decodedVector = new float[quantizer.dimensions()];
+
+        for (int i = 0; i < recordCount; i++) {
+            long offsetI = baseOffset + (long) i * stride;
+            byte flagsI = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS, offsetI + SynapticHeaderConstants.OFFSET_FLAGS);
+
+            // Skip tombstoned records
+            if (SynapticHeaderConstants.isTombstoned(flagsI)) {
+                continue;
+            }
+
+            // Resolve ID of record A
+            String idA = index.findIdByOffset(store.type(), offsetI);
+            if (idA == null) {
+                continue;
+            }
+
+            // Read and dequantize vector A
+            long vecOffsetI = layout.vectorOffset(offsetI);
+            MemorySegment.copy(segment, java.lang.foreign.ValueLayout.JAVA_BYTE, vecOffsetI,
+                    MemorySegment.ofArray(quantizedBuf), java.lang.foreign.ValueLayout.JAVA_BYTE, 0, vecBytes);
+            quantizer.decode(quantizedBuf, 0, decodedVector, 0);
+
+            // Compare against subsequent records
+            for (int j = i + 1; j < recordCount; j++) {
+                long offsetJ = baseOffset + (long) j * stride;
+                byte flagsJ = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS, offsetJ + SynapticHeaderConstants.OFFSET_FLAGS);
+
+                if (SynapticHeaderConstants.isTombstoned(flagsJ)) {
+                    continue;
+                }
+
+                String idB = index.findIdByOffset(store.type(), offsetJ);
+
+                if (idB == null) {
+                    continue;
+                }
+
+                // Compute calibrated L2 distance via SimilarityFunction
+                float dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
+                        decodedVector, segment, layout.vectorOffset(offsetJ),
+                        mins, scales, vecBytes);
+
+                if (dist <= distanceThreshold) {
+                    log.debug("DuplicateDetector: found near-duplicate pair [{}, {}] with L2={}", idA, idB, dist);
+                    pairs.add(new DuplicatePair(i, j, idA, idB, dist));
+                }
+            }
+        }
+
+        return pairs;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/MemoryMerger.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/MemoryMerger.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.consolidation;
+
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.memory.model.CognitiveRecord;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.generation.GenerationOptions;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles merging of complementary duplicate memories.
+ */
+public final class MemoryMerger {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryMerger.class);
+
+    private final LlmProvider textGenerator;
+    private final EmbeddingProvider embeddingProvider;
+
+    public MemoryMerger(LlmProvider textGenerator, EmbeddingProvider embeddingProvider) {
+        this.textGenerator = textGenerator;
+        this.embeddingProvider = embeddingProvider;
+    }
+
+    public record MergedMemory(
+            String text,
+            float[] vector,
+            float importance,
+            long timestampMs,
+            long synapticTags,
+            byte valence,
+            byte arousal,
+            float storageStrength
+    ) {}
+
+    /**
+     * Merges two cognitive records into a single consolidated representation.
+     */
+    public MergedMemory merge(CognitiveRecord recordA, CognitiveRecord recordB, ScalarQuantizer quantizer) {
+        // 1. Text merge
+        String mergedText = null;
+        if (textGenerator != null) {
+            try {
+                String prompt = String.format(
+                        "Merge these two duplicate/related statements into a single, cohesive, concise factual statement.\n\n" +
+                        "Statement 1: \"%s\"\n" +
+                        "Statement 2: \"%s\"\n\n" +
+                        "Merged statement:", recordA.text(), recordB.text());
+
+                String response = textGenerator.generate(prompt, GenerationOptions.CONCISE);
+                if (response != null && !response.isBlank()) {
+                    mergedText = response.trim();
+                }
+            } catch (Exception e) {
+                log.warn("MemoryMerger: LLM synthesis failed, falling back to selection: {}", e.getMessage());
+            }
+        }
+
+        boolean usedLlm = (mergedText != null);
+        if (!usedLlm) {
+            // Fallback: pick the higher importance, or the more recent one if equal
+            if (recordA.importance() > recordB.importance()) {
+                mergedText = recordA.text();
+            } else if (recordB.importance() > recordA.importance()) {
+                mergedText = recordB.text();
+            } else {
+                mergedText = recordA.timestampMs() >= recordB.timestampMs() ? recordA.text() : recordB.text();
+            }
+        }
+
+        // 2. Vector computation
+        float[] mergedVector = null;
+        if (usedLlm && embeddingProvider != null) {
+            try {
+                mergedVector = embeddingProvider.embed(mergedText).vector();
+            } catch (Exception e) {
+                log.warn("MemoryMerger: Failed to embed merged text, falling back to source vector: {}", e.getMessage());
+            }
+        }
+
+        if (mergedVector == null) {
+            // Reconstruct/use the vector of the selected record
+            byte[] quantizedSource = mergedText.equals(recordB.text()) ? recordB.quantizedVector() : recordA.quantizedVector();
+            if (quantizedSource == null) {
+                quantizedSource = recordA.quantizedVector() != null ? recordA.quantizedVector() : recordB.quantizedVector();
+            }
+            if (quantizedSource != null) {
+                mergedVector = quantizer.decode(quantizedSource);
+            }
+        }
+
+        // 3. Metadata merge
+        float importance = Math.max(recordA.importance(), recordB.importance());
+        long timestampMs = Math.max(recordA.timestampMs(), recordB.timestampMs());
+        long synapticTags = recordA.synapticTags() | recordB.synapticTags();
+        byte valence = (byte) ((recordA.valence() + recordB.valence()) / 2);
+        byte arousal = (byte) ((Byte.toUnsignedInt(recordA.arousal()) + Byte.toUnsignedInt(recordB.arousal())) / 2);
+        float storageStrength = Math.max(recordA.storageStrength(), recordB.storageStrength());
+
+        return new MergedMemory(mergedText, mergedVector, importance, timestampMs, synapticTags, valence, arousal, storageStrength);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -146,6 +146,12 @@ public final class SemanticRecallStrategy {
             // Phase 1: Tombstone check (always applied)
             if (SynapticHeaderConstants.isTombstoned(header.flags())) continue;
 
+            if (!options.includeContradictions()) {
+                byte cFlags = layout.readConsolidationFlags(headerSlab, headerOffset);
+                if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
+            }
+
+
             // Phase 1b: Temporal gating (absolute timestamp bounds)
             long timestamp = header.timestampMs();
             if (minTimestamp != null && timestamp < minTimestamp) continue;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveRecord.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveRecord.java
@@ -90,6 +90,7 @@ public record CognitiveRecord(
         byte arousal,
         float storageStrength,
         byte flags,
+        byte consolidationFlags,
 
         // ── Vector ──
         byte[] quantizedVector,
@@ -106,6 +107,11 @@ public record CognitiveRecord(
     // ══════════════════════════════════════════════════════════════
     // FLAG INTROSPECTION HELPERS
     // ══════════════════════════════════════════════════════════════
+
+    /** Returns true if this memory has a conflicting near-duplicate in the tier. */
+    public boolean isContradicted() {
+        return SynapticHeaderConstants.isContradicted(consolidationFlags);
+    }
 
     /** Returns true if this memory has been logically deleted. */
     public boolean isTombstoned() {
@@ -192,6 +198,7 @@ public record CognitiveRecord(
         node.put("consolidated", isConsolidated());
         node.put("pinned", isPinned());
         node.put("resolved", isResolved());
+        node.put("contradicted", isContradicted());
         node.put("sourceModality", sourceModality().name());
         node.put("multimodal", isMultimodal());
         node.put("partitionIndex", partitionIndex);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -107,6 +107,8 @@ public record RecallOptions(
         int rerankerDepth,
         // -€-€ Auto-Profile Detection -€-€
         boolean autoProfile,
+        // -€-€ Consolidation & Contradictions -€-€
+        boolean includeContradictions,
         // -€-€ Resolved Profile (for header stamping) -€-€
         CognitiveProfile resolvedProfile
 ) {
@@ -220,6 +222,7 @@ public record RecallOptions(
 
         // -€-€ Auto-Profile Detection -€-€
         private boolean autoProfile = false;         // default: off (use explicit profile)
+        private boolean includeContradictions = false; // default: off (exclude contradicted records)
         private CognitiveProfile resolvedProfile = null; // set when profile() is called
 
         // -€-€ Neurodivergent: Hyperfocus -€-€
@@ -585,6 +588,15 @@ public record RecallOptions(
         }
 
         /**
+         * Expose contradicted memories (default: false).
+         * Set to true to include memories marked as contradicted in the consolidation cycle.
+         */
+        public Builder includeContradictions(boolean include) {
+            this.includeContradictions = include;
+            return this;
+        }
+
+        /**
          * Sets the scoring mode (default: {@link ScoringMode#COGNITIVE}).
          *
          * <p>Use {@link ScoringMode#SIMILARITY} for pure vector retrieval
@@ -688,6 +700,7 @@ public record RecallOptions(
                     replayTimestamp, maxReplayEvents,
                     enableReranker, rerankerDepth,
                     autoProfile,
+                    includeContradictions,
                     resolvedProfile);
             return options;
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -999,8 +999,21 @@ public final class RecallPipeline {
                         existing.sourceModality(), existing.metadata()));
             } else {
                 // BM25-only result  --  create from index metadata
+                if (!options.includeContradictions()) {
+                    MemoryIndex.MemoryLocation loc = index.locate(id);
+                    if (loc != null) {
+                        MemorySegment segment = tierRouter.segmentFor(loc.type());
+                        if (segment != null) {
+                            CognitiveRecordLayout layout = tierRouter.layoutFor(loc.type());
+                            byte cFlags = layout.readConsolidationFlags(segment, loc.offset());
+                            if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
+                        }
+                    }
+                }
+
                 String text = index.text(id);
                 if (text == null || text.isEmpty()) continue;
+
 
                 MemorySource source = index.source(id);
                 String[] tags = index.tags(id);
@@ -1192,6 +1205,11 @@ public final class RecallPipeline {
 
             byte flags = header.flags();
             if (SynapticHeaderConstants.isTombstoned(flags)) continue;
+
+            if (!options.includeContradictions()) {
+                byte cFlags = layout.readConsolidationFlags(headerSlab, offset);
+                if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
+            }
 
             // Phase 2: Synaptic tag gating (was missing for semantic tier)
             if (queryTagMask != 0) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveRecordLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveRecordLayout.java
@@ -228,6 +228,16 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
         headerLayout.markUnresolved(segment, offset);
     }
 
+    /** Reads the consolidation flags byte (offset 34). */
+    public byte readConsolidationFlags(MemorySegment segment, long offset) {
+        return headerLayout.readConsolidationFlags(segment, offset);
+    }
+
+    /** Sets the contradicted flag (bit 0 of consolidation flags byte). */
+    public void markContradicted(MemorySegment segment, long offset) {
+        headerLayout.markContradicted(segment, offset);
+    }
+
     /** Updates the importance field. */
     public void writeImportance(MemorySegment segment, long offset, float importance) {
         headerLayout.writeImportance(segment, offset, importance);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
@@ -275,6 +275,13 @@ public final class CognitiveScorer {
             if (isTombstoned(flags))
                 continue;
 
+            // ── Phase 1c: Contradiction Gating ──
+            if (!options.includeContradictions()) {
+                byte cFlags = segment.get(LAYOUT_CONSOLIDATION_FLAGS, offset + OFFSET_CONSOLIDATION_FLAGS);
+                if (isContradicted(cFlags))
+                    continue;
+            }
+
             // ── Phase 1b: Temporal gating (absolute timestamp bounds) ──
             long timestamp = segment.get(LAYOUT_TIMESTAMP, offset + OFFSET_TIMESTAMP);
             if (minTimestamp != null && timestamp < minTimestamp)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/HeaderLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/HeaderLayout.java
@@ -144,6 +144,15 @@ public sealed interface HeaderLayout
      */
     void markUnresolved(MemorySegment seg, long off);
 
+    /** Reads the consolidation flags byte (offset 34). */
+    byte readConsolidationFlags(MemorySegment seg, long off);
+
+    /** Writes the consolidation flags byte (offset 34). */
+    void writeConsolidationFlags(MemorySegment seg, long off, byte consolidationFlags);
+
+    /** Sets the contradicted flag (bit 0 of consolidation flags byte). Atomic/CAS. */
+    void markContradicted(MemorySegment seg, long off);
+
     /**
      * Atomically increments the recall count (LTP reinforcement).
      *

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/HeaderLayout64.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/HeaderLayout64.java
@@ -143,7 +143,8 @@ public record HeaderLayout64() implements HeaderLayout {
         seg.set(LAYOUT_SYNAPTIC_TAGS, off + OFFSET_SYNAPTIC_TAGS,  header.synapticTags());
         // Extended fields
         seg.set(LAYOUT_CENTROID_ID,   off + OFFSET_CENTROID_ID,    header.centroidId());
-        seg.set(ValueLayout.JAVA_SHORT, off + 34L, (short) 0);    // _pad0
+        seg.set(LAYOUT_CONSOLIDATION_FLAGS, off + OFFSET_CONSOLIDATION_FLAGS, (byte) 0);
+        seg.set(ValueLayout.JAVA_BYTE, off + 35L, (byte) 0); // remaining alignment padding byte
         seg.set(LAYOUT_STORAGE_STRENGTH, off + OFFSET_STORAGE_STRENGTH, header.storageStrength());
         // Zero auto-LTP and reserved fields (ensure clean state)
         seg.set(LAYOUT_SPECTOR_RECALL_COUNT, off + OFFSET_SPECTOR_RECALL_COUNT, 0);
@@ -189,6 +190,19 @@ public record HeaderLayout64() implements HeaderLayout {
     @Override public void markUnresolved(MemorySegment seg, long off) {
         byte flags = readFlags(seg, off);
         seg.set(LAYOUT_FLAGS, off + OFFSET_FLAGS, (byte) (flags & ~FLAG_RESOLVED));
+    }
+
+    @Override public byte readConsolidationFlags(MemorySegment seg, long off) {
+        return seg.get(LAYOUT_CONSOLIDATION_FLAGS, off + OFFSET_CONSOLIDATION_FLAGS);
+    }
+
+    @Override public void writeConsolidationFlags(MemorySegment seg, long off, byte consolidationFlags) {
+        seg.set(LAYOUT_CONSOLIDATION_FLAGS, off + OFFSET_CONSOLIDATION_FLAGS, consolidationFlags);
+    }
+
+    @Override public void markContradicted(MemorySegment seg, long off) {
+        byte cFlags = readConsolidationFlags(seg, off);
+        writeConsolidationFlags(seg, off, (byte) (cFlags | FLAG_CONTRADICTED));
     }
 
     @Override public int incrementAgentRecallCount(MemorySegment seg, long off) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/SynapticHeaderConstants.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/SynapticHeaderConstants.java
@@ -100,6 +100,8 @@ public final class SynapticHeaderConstants {
     /** Offset of centroid_id short (IVF routing). */
     public static final long OFFSET_CENTROID_ID         = 32L;
     // 34-35: alignment padding
+    /** Offset of consolidation flags byte (repurposed from _pad0). */
+    public static final long OFFSET_CONSOLIDATION_FLAGS = 34L;
     /** Offset of storage_strength float (Two-Factor scoring). */
     public static final long OFFSET_STORAGE_STRENGTH    = 36L;
     /** Offset of spector-internal recall count int (auto-LTP). */
@@ -125,6 +127,7 @@ public final class SynapticHeaderConstants {
     public static final ValueLayout.OfFloat LAYOUT_EXACT_NORM         = ValueLayout.JAVA_FLOAT;
     public static final ValueLayout.OfLong  LAYOUT_SYNAPTIC_TAGS      = ValueLayout.JAVA_LONG;
     public static final ValueLayout.OfShort LAYOUT_CENTROID_ID        = ValueLayout.JAVA_SHORT;
+    public static final ValueLayout.OfByte  LAYOUT_CONSOLIDATION_FLAGS = ValueLayout.JAVA_BYTE;
     public static final ValueLayout.OfFloat LAYOUT_STORAGE_STRENGTH   = ValueLayout.JAVA_FLOAT;
     public static final ValueLayout.OfInt   LAYOUT_SPECTOR_RECALL_COUNT = ValueLayout.JAVA_INT;
     public static final ValueLayout.OfLong  LAYOUT_LAST_AUTO_LTP      = ValueLayout.JAVA_LONG;
@@ -156,6 +159,11 @@ public final class SynapticHeaderConstants {
     public static final byte FLAG_MODALITY_MASK  = (byte) 0xC0;
     /** Number of bits to shift to read/write source modality from flags. */
     public static final int  FLAG_MODALITY_SHIFT = 6;
+
+    // ── Consolidation Flags bitmasks (offset 34) ──
+
+    /** Bit 0: Memory has a conflicting near-duplicate in the tier. */
+    public static final byte FLAG_CONTRADICTED = 0x01;
 
     // ── Convenience methods ──
 
@@ -223,5 +231,12 @@ public final class SynapticHeaderConstants {
     public static byte withSourceModality(byte flags, int modalityOrdinal) {
         return (byte) ((flags & ~FLAG_MODALITY_MASK)
                 | ((modalityOrdinal << FLAG_MODALITY_SHIFT) & (FLAG_MODALITY_MASK & 0xFF)));
+    }
+
+    /**
+     * Checks if the contradicted flag is set in the given consolidation flags byte.
+     */
+    public static boolean isContradicted(byte consolidationFlags) {
+        return (consolidationFlags & FLAG_CONTRADICTED) != 0;
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/ConsolidationIntegrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/ConsolidationIntegrationTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveRecord;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.EmbeddingResult;
+import com.spectrayan.spector.provider.generation.GenerationOptions;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+import com.spectrayan.spector.provider.model.LlmRequest;
+import com.spectrayan.spector.provider.model.LlmResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for memory consolidation.
+ */
+class ConsolidationIntegrationTest {
+
+    private static final int DIMENSIONS = 32;
+    private SpectorMemory memory;
+    private TestEmbeddingProvider embeddingProvider;
+    private MockLlmProvider llmProvider;
+
+    @BeforeEach
+    void setUp() {
+        embeddingProvider = new TestEmbeddingProvider(DIMENSIONS);
+        llmProvider = new MockLlmProvider();
+
+        memory = DefaultSpectorMemory.builder()
+                .dimensions(DIMENSIONS)
+                .embeddingProvider(embeddingProvider)
+                .LlmProvider(llmProvider)
+                .persistenceMode(MemoryPersistenceMode.IN_MEMORY)
+                .workingCapacity(20)
+                .episodicPartitionCapacity(100)
+                .semanticCapacity(100)
+                .proceduralCapacity(100)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        memory.close();
+    }
+
+    @Test
+    void testMergeNonContradictoryDuplicates() throws Exception {
+        // Create duplicate vectors
+        float[] vector = new float[DIMENSIONS];
+        vector[0] = 1.0f; // simple unit vector
+
+        String textA = "User prefers light theme.";
+        String textB = "User likes light theme UI.";
+
+        embeddingProvider.register(textA, vector);
+        embeddingProvider.register(textB, vector);
+
+        // Store them in the SEMANTIC tier
+        memory.remember("dup-a", textA, MemoryType.SEMANTIC, MemorySource.OBSERVED, "ui").get(5, TimeUnit.SECONDS);
+        memory.remember("dup-b", textB, MemoryType.SEMANTIC, MemorySource.OBSERVED, "theme").get(5, TimeUnit.SECONDS);
+
+        assertThat(memory.memoryCount(MemoryType.SEMANTIC)).isEqualTo(2);
+
+        // Run consolidation
+        memory.consolidate();
+
+        // The original memories should be tombstoned/removed from the index
+        assertThat(memory.inspect("dup-a")).isNull();
+        assertThat(memory.inspect("dup-b")).isNull();
+
+        // A new consolidated memory should be created
+        List<CognitiveResult> results = memory.recall("light theme", RecallOptions.builder().topK(10).build());
+        assertThat(results).isNotEmpty();
+
+        CognitiveResult merged = results.get(0);
+        assertThat(merged.id()).startsWith("cns-");
+        assertThat(merged.text()).contains("light theme");
+    }
+
+    @Test
+    void testContradictoryDuplicatesFlagged() throws Exception {
+        // Create duplicate vectors
+        float[] vector = new float[DIMENSIONS];
+        vector[5] = 1.0f;
+
+        String textA = "The capital of France is Paris.";
+        String textB = "The capital of France is Lyon.";
+
+        embeddingProvider.register(textA, vector);
+        embeddingProvider.register(textB, vector);
+
+        // Setup LLM mock to return YES for contradiction check
+        llmProvider.registerResponse(" Paris", "YES");
+        llmProvider.registerResponse(" Lyon", "YES");
+
+        // Store in SEMANTIC tier
+        memory.remember("fact-a", textA, MemoryType.SEMANTIC, MemorySource.OBSERVED, "geography").get(5, TimeUnit.SECONDS);
+        memory.remember("fact-b", textB, MemoryType.SEMANTIC, MemorySource.OBSERVED, "geography").get(5, TimeUnit.SECONDS);
+
+        // Run consolidation
+        memory.consolidate();
+
+        // Verify that the original memories still exist, but they are flagged as contradicted
+        CognitiveRecord recordA = memory.inspect("fact-a");
+        CognitiveRecord recordB = memory.inspect("fact-b");
+
+        assertThat(recordA).isNotNull();
+        assertThat(recordB).isNotNull();
+        assertThat(recordA.isContradicted()).isTrue();
+        assertThat(recordB.isContradicted()).isTrue();
+
+        // Standard recall should filter/gate them out
+        List<CognitiveResult> standardRecall = memory.recall("capital of France", RecallOptions.builder().includeContradictions(false).build());
+        assertThat(standardRecall).noneMatch(r -> "fact-a".equals(r.id()) || "fact-b".equals(r.id()));
+
+        // Recall with includeContradictions(true) should return them
+        List<CognitiveResult> recallWithContradictions = memory.recall("capital of France", RecallOptions.builder().includeContradictions(true).build());
+        assertThat(recallWithContradictions).anyMatch(r -> "fact-a".equals(r.id()));
+        assertThat(recallWithContradictions).anyMatch(r -> "fact-b".equals(r.id()));
+    }
+
+    static class TestEmbeddingProvider implements EmbeddingProvider {
+        private final int dims;
+        private final Map<String, float[]> presetVectors = new HashMap<>();
+
+        TestEmbeddingProvider(int dims) {
+            this.dims = dims;
+        }
+
+        void register(String text, float[] vec) {
+            presetVectors.put(text, vec);
+        }
+
+        @Override
+        public EmbeddingResult embed(String text) {
+            float[] vec = presetVectors.get(text);
+            if (vec == null) {
+                Random rng = new Random(text.hashCode());
+                vec = new float[dims];
+                for (int i = 0; i < dims; i++) {
+                    vec[i] = (rng.nextFloat() - 0.5f) * 2.0f;
+                }
+                float norm = 0f;
+                for (float v : vec) norm += v * v;
+                norm = (float) Math.sqrt(norm);
+                if (norm > 0) {
+                    for (int i = 0; i < dims; i++) vec[i] /= norm;
+                }
+            }
+            return new EmbeddingResult(vec, text.split("\\s+").length, "test");
+        }
+
+        @Override public int dimensions() { return dims; }
+        @Override public String modelName() { return "test"; }
+    }
+
+    static class MockLlmProvider implements LlmProvider {
+        private final Map<String, String> responses = new HashMap<>();
+
+        void registerResponse(String keyword, String reply) {
+            responses.put(keyword, reply);
+        }
+
+        @Override
+        public LlmResponse generate(LlmRequest request, GenerationOptions options) {
+            String prompt = request.messages().isEmpty() ? "" : request.messages().get(0).text();
+            if (prompt.contains("Merge these")) {
+                return new LlmResponse("User prefers light theme UI.", 10, 10, "mock-llm");
+            }
+            String foundReply = "NO";
+            for (Map.Entry<String, String> entry : responses.entrySet()) {
+                if (prompt.contains(entry.getKey())) {
+                    foundReply = entry.getValue();
+                    break;
+                }
+            }
+            return new LlmResponse(foundReply, 10, 10, "mock-llm");
+        }
+
+
+
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        public String modelName() {
+            return "mock-llm";
+        }
+    }
+
+}

--- a/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -278,6 +278,12 @@ public class MeteredSpectorMemory implements SpectorMemory {
         return report;
     }
 
+    @Override
+    public void consolidate() {
+        delegate.consolidate();
+    }
+
+
     /** Captures a memory snapshot for telemetry. */
     private MemorySnapshotTelemetry captureMemorySnapshot(String phase, String cycleId) {
         return new MemorySnapshotTelemetry(

--- a/nucleus/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
+++ b/nucleus/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
@@ -154,7 +154,9 @@ class MeteredSpectorMemoryTest {
         @Override public List<CognitiveResult> recall(String queryText) { return null; }
         @Override public void forget(String id) {}
         @Override public ReflectReport reflect() { return null; }
+        @Override public void consolidate() {}
         @Override public void reinforce(String memoryId, byte valence) {}
+
         @Override public void suppress(String memoryId, String reason) {}
         @Override public void suppress(String memoryId) {}
         @Override public void unsuppress(String memoryId) {}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/SynapseApplication.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/SynapseApplication.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import com.spectrayan.spector.synapse.config.FeatureFlags;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
@@ -42,7 +43,9 @@ import com.spectrayan.spector.synapse.config.SynapseProperties;
  */
 @SpringBootApplication
 @EnableConfigurationProperties({SynapseProperties.class, FeatureFlags.class})
+@EnableScheduling
 public class SynapseApplication {
+
 
     private static final Logger log = LoggerFactory.getLogger(SynapseApplication.class);
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java
@@ -78,7 +78,12 @@ public record SynapseProperties(
             if (dimensions < 0) dimensions = 0;
             if (consolidation == null) consolidation = new ConsolidationProperties(21600000L); // 6 hours
         }
+
+        public MemoryProperties(int maxMemories, int dimensions) {
+            this(maxMemories, dimensions, new ConsolidationProperties(21600000L));
+        }
     }
+
 
     /**
      * Consolidation settings.

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java
@@ -45,7 +45,8 @@ public record SynapseProperties(
         if (apiKey == null || apiKey.isBlank()) apiKey = "spector-dev-key";
         if (dataDir == null || dataDir.isBlank()) dataDir = "./spector-data";
         if (ollama == null) ollama = new OllamaProperties(null, null, null);
-        if (memory == null) memory = new MemoryProperties(0, 0);
+        if (memory == null) memory = new MemoryProperties(0, 0, null);
+
         if (cors == null) cors = new CorsProperties(null);
     }
 
@@ -69,13 +70,27 @@ public record SynapseProperties(
      *
      * @param maxMemories   maximum number of memories (0 = unlimited)
      * @param dimensions    embedding vector dimensions (0 = auto-detect from provider)
+     * @param consolidation consolidation settings
      */
-    public record MemoryProperties(int maxMemories, int dimensions) {
+    public record MemoryProperties(int maxMemories, int dimensions, ConsolidationProperties consolidation) {
         public MemoryProperties {
             if (maxMemories < 0) maxMemories = 0;
             if (dimensions < 0) dimensions = 0;
+            if (consolidation == null) consolidation = new ConsolidationProperties(21600000L); // 6 hours
         }
     }
+
+    /**
+     * Consolidation settings.
+     *
+     * @param interval consolidation run interval in milliseconds (default: 21600000 ms = 6 hours)
+     */
+    public record ConsolidationProperties(long interval) {
+        public ConsolidationProperties {
+            if (interval <= 0) interval = 21600000L;
+        }
+    }
+
 
     /**
      * CORS settings for the Cortex UI.

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/ConsolidationScheduler.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/ConsolidationScheduler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled task that triggers background memory consolidation periodically.
+ */
+@Component
+public class ConsolidationScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsolidationScheduler.class);
+
+    private final MemoryService memoryService;
+
+    public ConsolidationScheduler(MemoryService memoryService) {
+        this.memoryService = memoryService;
+    }
+
+    /**
+     * Periodically triggers memory consolidation.
+     * Uses fixedDelayString configured via {@code spector.memory.consolidation.interval}
+     * with a fallback default of 6 hours (21600000 ms).
+     */
+    @Scheduled(fixedDelayString = "${spector.memory.consolidation.interval:21600000}", initialDelay = 60000)
+    public void scheduleConsolidation() {
+        log.info("ConsolidationScheduler: Starting periodic background consolidation task...");
+        try {
+            memoryService.consolidate();
+        } catch (Exception e) {
+            log.error("ConsolidationScheduler: periodic memory consolidation failed", e);
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
@@ -114,6 +114,21 @@ public class MemoryAccessObject {
     }
 
     /**
+     * Triggers manual memory consolidation.
+     */
+    public void consolidate() {
+        if (!isAvailable()) return;
+        try {
+            memory.consolidate();
+            log.info("[MemoryAccessObject] Triggered memory consolidation");
+        } catch (Exception e) {
+            log.error("[MemoryAccessObject] Consolidation failed: {}", e.getMessage(), e);
+            throw new IllegalStateException("Memory consolidation failed: " + e.getMessage(), e);
+        }
+    }
+
+
+    /**
      * Reinforce a memory via emotional valence feedback.
      */
     public void reinforce(String id, int valence) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
@@ -138,6 +138,18 @@ public class MemoryController {
         return ResponseEntity.accepted().body(memoryService.remember(request));
     }
 
+    /**
+     * Trigger manual memory consolidation.
+     *
+     * <p>{@code POST /api/v1/memory/consolidate}</p>
+     */
+    @PostMapping("/consolidate")
+    public ResponseEntity<Void> consolidate() {
+        memoryService.consolidate();
+        return ResponseEntity.ok().build();
+    }
+
+
     // ══════════════════════════════════════════════════════════════
     // RECALL / SEARCH
     // ══════════════════════════════════════════════════════════════

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -151,6 +151,29 @@ public class MemoryService {
         return AcceptedResponse.forRemember(taskId, effectiveId);
     }
 
+    /**
+     * Manually triggers memory consolidation in the background.
+     */
+    public void consolidate() {
+        if (!mao.isAvailable()) {
+            log.warn("[MemoryService] Consolidate called but engine is not available");
+            return;
+        }
+        virtualThreadExecutor.submit(() -> {
+            try {
+                log.info("[MemoryService] Starting manual memory consolidation...");
+                eventPublisher.broadcast("consolidation.start", Map.of("status", "in_progress"));
+                mao.consolidate();
+                eventPublisher.broadcast("consolidation.done", Map.of("status", "success"));
+                log.info("[MemoryService] Manual memory consolidation complete.");
+            } catch (Exception e) {
+                log.error("[MemoryService] Manual memory consolidation failed", e);
+                eventPublisher.broadcast("consolidation.error", Map.of("status", "error", "message", e.getMessage()));
+            }
+        });
+    }
+
+
     // ══════════════════════════════════════════════════════════════
     // RECALL / SEARCH
     // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Description
This PR implements the background Memory Consolidation Engine for Spector. It scans semantic memory partitions for near-duplicates using Panama SIMD-accelerated L2 vector distance computations, detects whether they are contradictory using `LlmProvider`, merges complementary non-contradictory records into a single consolidated memory (re-indexing and tombstoning the originals), and flags contradictory records off-heap using the BSL `FLAG_CONTRADICTED` flag.

## Related Issue
Closes #209

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Module(s) Affected
- [x] `spector-index` (HNSW / BM25)
- [x] `spector-core` (SIMD kernels)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added Javadoc for all public classes/methods
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (`mvn test`)
- [x] No hardcoded secrets or credentials are included