### PR TITLE
feat(embed): configurable LRU embedding cache (#49)

### DIFF
--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProvider.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProvider.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongSupplier;
 
 /**
@@ -45,9 +46,10 @@ import java.util.function.LongSupplier;
  *   <li><b>Eviction</b> — LRU via access-ordered {@link LinkedHashMap}, bounded by
  *       {@link EmbeddingCacheConfig#maxSize()}</li>
  *   <li><b>TTL</b> — optional time-based expiry ({@link EmbeddingCacheConfig#ttl()})</li>
- *   <li><b>Thread safety</b> — all map access is synchronized on the map itself;
- *       the lock is never held during a delegate call, so concurrent misses on the
- *       same key may each hit the delegate once (benign race)</li>
+ *   <li><b>Thread safety</b> — all map access is guarded by a {@link ReentrantLock}
+ *       (avoids carrier-thread pinning under virtual threads); the lock is never held
+ *       during a delegate call, so concurrent misses on the same key may each hit the
+ *       delegate once (benign race)</li>
  *   <li><b>Statistics</b> — hits/misses/evictions counted and logged at INFO every
  *       {@link EmbeddingCacheConfig#statsLogInterval()}</li>
  * </ul>
@@ -65,6 +67,7 @@ public final class CachingEmbeddingProvider implements EmbeddingProvider {
     private final EmbeddingCacheConfig config;
     private final LongSupplier nanoClock;
     private final LinkedHashMap<String, CacheEntry> cache;
+    private final ReentrantLock lock = new ReentrantLock();
     private final LongAdder hits = new LongAdder();
     private final LongAdder misses = new LongAdder();
     private final LongAdder evictions = new LongAdder();
@@ -199,7 +202,10 @@ public final class CachingEmbeddingProvider implements EmbeddingProvider {
                 EmbeddingResult result = fresh.get(freshIdx++);
                 store(entry.getKey(), result);
                 for (int position : entry.getValue()) {
-                    results[position] = result;
+                    // defensive copy per position, so duplicate texts within a batch never
+                    // share a vector reference (consistent with cache-hit behaviour)
+                    results[position] = new EmbeddingResult(
+                            result.vector().clone(), result.tokenCount(), result.model());
                 }
             }
         }
@@ -225,8 +231,11 @@ public final class CachingEmbeddingProvider implements EmbeddingProvider {
 
     @Override
     public void close() {
-        synchronized (cache) {
+        lock.lock();
+        try {
             cache.clear();
+        } finally {
+            lock.unlock();
         }
         delegate.close();
     }
@@ -239,15 +248,19 @@ public final class CachingEmbeddingProvider implements EmbeddingProvider {
     /** Returns a snapshot of the cache statistics. */
     public CacheStats stats() {
         int size;
-        synchronized (cache) {
+        lock.lock();
+        try {
             size = cache.size();
+        } finally {
+            lock.unlock();
         }
         return new CacheStats(hits.sum(), misses.sum(), evictions.sum(), size);
     }
 
     private EmbeddingResult lookup(String key) {
         long now = nanoClock.getAsLong();
-        synchronized (cache) {
+        lock.lock();
+        try {
             CacheEntry entry = cache.get(key);
             if (entry == null) {
                 return null;
@@ -258,6 +271,8 @@ public final class CachingEmbeddingProvider implements EmbeddingProvider {
             }
             EmbeddingResult result = entry.result();
             return new EmbeddingResult(result.vector().clone(), result.tokenCount(), result.model());
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -266,8 +281,11 @@ public final class CachingEmbeddingProvider implements EmbeddingProvider {
                 ? nanoClock.getAsLong() + config.ttl().toNanos()
                 : Long.MAX_VALUE;
         var copy = new EmbeddingResult(result.vector().clone(), result.tokenCount(), result.model());
-        synchronized (cache) {
+        lock.lock();
+        try {
             cache.put(key, new CacheEntry(copy, expiresAt));
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProvider.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProvider.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.provider.embedding;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongSupplier;
+
+/**
+ * Decorator that caches embedding results of any {@link EmbeddingProvider}.
+ *
+ * <p>Every remote embedding call costs a network round-trip (~5-15ms for a local
+ * Ollama server). When the same text is embedded repeatedly — e.g. during
+ * iterative recall refinement or batch re-ingestion — this cache serves the
+ * vector from memory instead.</p>
+ *
+ * <h3>Design</h3>
+ * <ul>
+ *   <li><b>Key</b> — SHA-256 hash of the input text (keeps memory low for long texts)</li>
+ *   <li><b>Eviction</b> — LRU via access-ordered {@link LinkedHashMap}, bounded by
+ *       {@link EmbeddingCacheConfig#maxSize()}</li>
+ *   <li><b>TTL</b> — optional time-based expiry ({@link EmbeddingCacheConfig#ttl()})</li>
+ *   <li><b>Thread safety</b> — all map access is synchronized on the map itself;
+ *       the lock is never held during a delegate call, so concurrent misses on the
+ *       same key may each hit the delegate once (benign race)</li>
+ *   <li><b>Statistics</b> — hits/misses/evictions counted and logged at INFO every
+ *       {@link EmbeddingCacheConfig#statsLogInterval()}</li>
+ * </ul>
+ *
+ * <p>Cached vectors are defensively copied on store and on every hit, so callers
+ * can never mutate cached state.</p>
+ *
+ * <p>Zero external dependencies — uses only the JDK, per this module's contract.</p>
+ */
+public final class CachingEmbeddingProvider implements EmbeddingProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(CachingEmbeddingProvider.class);
+
+    private final EmbeddingProvider delegate;
+    private final EmbeddingCacheConfig config;
+    private final LongSupplier nanoClock;
+    private final LinkedHashMap<String, CacheEntry> cache;
+    private final LongAdder hits = new LongAdder();
+    private final LongAdder misses = new LongAdder();
+    private final LongAdder evictions = new LongAdder();
+    private final AtomicLong lastStatsLogNanos;
+
+    private record CacheEntry(EmbeddingResult result, long expiresAtNanos) {}
+
+    /**
+     * Cache statistics snapshot.
+     *
+     * @param hits      number of requests served from the cache
+     * @param misses    number of requests delegated to the wrapped provider
+     * @param evictions number of entries evicted by the LRU policy
+     * @param size      current number of cached entries
+     */
+    public record CacheStats(long hits, long misses, long evictions, int size) {
+
+        /** Total number of cache lookups. */
+        public long requests() {
+            return hits + misses;
+        }
+
+        /** Fraction of lookups served from the cache (0.0 when no requests yet). */
+        public double hitRatio() {
+            long total = requests();
+            return total == 0 ? 0.0 : (double) hits / total;
+        }
+    }
+
+    public CachingEmbeddingProvider(EmbeddingProvider delegate, EmbeddingCacheConfig config) {
+        this(delegate, config, System::nanoTime);
+    }
+
+    /**
+     * Constructor with an injectable clock for deterministic TTL tests.
+     */
+    CachingEmbeddingProvider(EmbeddingProvider delegate, EmbeddingCacheConfig config, LongSupplier nanoClock) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.nanoClock = Objects.requireNonNull(nanoClock, "nanoClock must not be null");
+        this.cache = new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, CacheEntry> eldest) {
+                boolean evict = size() > config.maxSize();
+                if (evict) {
+                    evictions.increment();
+                }
+                return evict;
+            }
+        };
+        this.lastStatsLogNanos = new AtomicLong(nanoClock.getAsLong());
+    }
+
+    /**
+     * Wraps a provider with caching if the config enables it.
+     *
+     * <p>Returns the provider unchanged when caching is disabled or the provider
+     * is already a {@code CachingEmbeddingProvider} (no double-wrapping).</p>
+     *
+     * @param provider the provider to wrap
+     * @param config   cache configuration
+     * @return the caching decorator, or {@code provider} itself when caching is off
+     */
+    public static EmbeddingProvider wrap(EmbeddingProvider provider, EmbeddingCacheConfig config) {
+        Objects.requireNonNull(provider, "provider must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        if (!config.enabled() || provider instanceof CachingEmbeddingProvider) {
+            return provider;
+        }
+        return new CachingEmbeddingProvider(provider, config);
+    }
+
+    @Override
+    public EmbeddingResult embed(String text) {
+        if (text == null) {
+            return delegate.embed(null); // let the delegate apply its own validation
+        }
+        String key = cacheKey(text);
+        EmbeddingResult cached = lookup(key);
+        if (cached != null) {
+            hits.increment();
+            maybeLogStats();
+            return cached;
+        }
+        EmbeddingResult result = delegate.embed(text);
+        store(key, result);
+        misses.increment();
+        maybeLogStats();
+        return result;
+    }
+
+    @Override
+    public List<EmbeddingResult> embedBatch(List<String> texts) {
+        Objects.requireNonNull(texts, "texts must not be null");
+        if (texts.isEmpty()) {
+            return List.of();
+        }
+
+        EmbeddingResult[] results = new EmbeddingResult[texts.size()];
+        // key → positions in the batch still needing an embedding (handles duplicates)
+        Map<String, List<Integer>> pending = new LinkedHashMap<>();
+        List<String> pendingTexts = new ArrayList<>();
+
+        for (int i = 0; i < texts.size(); i++) {
+            String text = texts.get(i);
+            if (text == null) {
+                return delegate.embedBatch(texts); // let the delegate apply its own validation
+            }
+            String key = cacheKey(text);
+            EmbeddingResult cached = lookup(key);
+            if (cached != null) {
+                results[i] = cached;
+                hits.increment();
+            } else {
+                List<Integer> positions = pending.computeIfAbsent(key, k -> {
+                    pendingTexts.add(text);
+                    return new ArrayList<>();
+                });
+                positions.add(i);
+                misses.increment();
+            }
+        }
+
+        if (!pendingTexts.isEmpty()) {
+            List<EmbeddingResult> fresh = delegate.embedBatch(pendingTexts);
+            if (fresh.size() != pendingTexts.size()) {
+                throw new IllegalStateException("Delegate returned " + fresh.size()
+                        + " embeddings for " + pendingTexts.size() + " texts");
+            }
+            int freshIdx = 0;
+            for (Map.Entry<String, List<Integer>> entry : pending.entrySet()) {
+                EmbeddingResult result = fresh.get(freshIdx++);
+                store(entry.getKey(), result);
+                for (int position : entry.getValue()) {
+                    results[position] = result;
+                }
+            }
+        }
+
+        maybeLogStats();
+        return List.of(results);
+    }
+
+    @Override
+    public int dimensions() {
+        return delegate.dimensions();
+    }
+
+    @Override
+    public String modelName() {
+        return delegate.modelName();
+    }
+
+    @Override
+    public int maxTokens() {
+        return delegate.maxTokens();
+    }
+
+    @Override
+    public void close() {
+        synchronized (cache) {
+            cache.clear();
+        }
+        delegate.close();
+    }
+
+    /** Returns the wrapped provider. */
+    public EmbeddingProvider delegate() {
+        return delegate;
+    }
+
+    /** Returns a snapshot of the cache statistics. */
+    public CacheStats stats() {
+        int size;
+        synchronized (cache) {
+            size = cache.size();
+        }
+        return new CacheStats(hits.sum(), misses.sum(), evictions.sum(), size);
+    }
+
+    private EmbeddingResult lookup(String key) {
+        long now = nanoClock.getAsLong();
+        synchronized (cache) {
+            CacheEntry entry = cache.get(key);
+            if (entry == null) {
+                return null;
+            }
+            if (config.ttlEnabled() && now - entry.expiresAtNanos() >= 0) {
+                cache.remove(key);
+                return null;
+            }
+            EmbeddingResult result = entry.result();
+            return new EmbeddingResult(result.vector().clone(), result.tokenCount(), result.model());
+        }
+    }
+
+    private void store(String key, EmbeddingResult result) {
+        long expiresAt = config.ttlEnabled()
+                ? nanoClock.getAsLong() + config.ttl().toNanos()
+                : Long.MAX_VALUE;
+        var copy = new EmbeddingResult(result.vector().clone(), result.tokenCount(), result.model());
+        synchronized (cache) {
+            cache.put(key, new CacheEntry(copy, expiresAt));
+        }
+    }
+
+    private void maybeLogStats() {
+        long intervalNanos = config.statsLogInterval().toNanos();
+        if (intervalNanos <= 0) {
+            return;
+        }
+        long now = nanoClock.getAsLong();
+        long last = lastStatsLogNanos.get();
+        if (now - last >= intervalNanos && lastStatsLogNanos.compareAndSet(last, now)) {
+            CacheStats stats = stats();
+            log.info("[EmbeddingCache] model={}, size={}/{}, hits={}, misses={}, hitRatio={}%, evictions={}",
+                    delegate.modelName(), stats.size(), config.maxSize(), stats.hits(), stats.misses(),
+                    String.format("%.1f", stats.hitRatio() * 100.0), stats.evictions());
+        }
+    }
+
+    private static String cacheKey(String text) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(text.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandated by the JDK spec; this cannot happen on a compliant JVM
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbeddingCacheConfig.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbeddingCacheConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.provider.embedding;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Configuration for the LRU embedding cache ({@link CachingEmbeddingProvider}).
+ *
+ * @param enabled          whether caching is enabled
+ * @param maxSize          maximum number of cached embeddings (must be &gt; 0)
+ * @param ttl              time-to-live for cached entries ({@link Duration#ZERO} = no expiry)
+ * @param statsLogInterval how often cache statistics are logged at INFO level
+ *                         ({@link Duration#ZERO} = never)
+ */
+public record EmbeddingCacheConfig(
+        boolean enabled,
+        int maxSize,
+        Duration ttl,
+        Duration statsLogInterval
+) {
+
+    /** Default configuration: enabled, 1000 entries, 1 hour TTL, stats logged every 5 minutes. */
+    public static final EmbeddingCacheConfig DEFAULT =
+            new EmbeddingCacheConfig(true, 1000, Duration.ofMinutes(60), Duration.ofMinutes(5));
+
+    public EmbeddingCacheConfig {
+        Objects.requireNonNull(ttl, "ttl must not be null");
+        Objects.requireNonNull(statsLogInterval, "statsLogInterval must not be null");
+        if (maxSize <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_OUT_OF_RANGE, "maxSize", 1, Integer.MAX_VALUE, maxSize);
+        }
+        if (ttl.isNegative()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_NEGATIVE, "ttl", ttl.toMillis());
+        }
+        if (statsLogInterval.isNegative()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_NEGATIVE, "statsLogInterval", statsLogInterval.toMillis());
+        }
+    }
+
+    /**
+     * Creates a disabled cache configuration.
+     */
+    public static EmbeddingCacheConfig disabled() {
+        return new EmbeddingCacheConfig(false, 1, Duration.ZERO, Duration.ZERO);
+    }
+
+    /**
+     * Returns {@code true} if cached entries expire after {@link #ttl()}.
+     */
+    public boolean ttlEnabled() {
+        return !ttl.isZero();
+    }
+}

--- a/memory/spector-provider-api/src/test/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProviderTest.java
+++ b/memory/spector-provider-api/src/test/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProviderTest.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.provider.embedding;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+/**
+ * Tests for {@link CachingEmbeddingProvider} and {@link EmbeddingCacheConfig}.
+ */
+@DisplayName("Caching Embedding Provider")
+class CachingEmbeddingProviderTest {
+
+    /** Counts delegate calls and returns a deterministic per-text vector. */
+    static class CountingProvider implements EmbeddingProvider {
+        final AtomicInteger embedCalls = new AtomicInteger();
+        final AtomicInteger batchCalls = new AtomicInteger();
+        final ConcurrentHashMap<String, AtomicInteger> callsPerText = new ConcurrentHashMap<>();
+        final AtomicBoolean closed = new AtomicBoolean();
+
+        static float[] vectorFor(String text) {
+            return new float[]{text.length(), text.hashCode() % 100};
+        }
+
+        @Override
+        public EmbeddingResult embed(String text) {
+            if (text == null || text.isBlank()) {
+                throw new IllegalArgumentException("text must not be null or blank");
+            }
+            embedCalls.incrementAndGet();
+            callsPerText.computeIfAbsent(text, t -> new AtomicInteger()).incrementAndGet();
+            return new EmbeddingResult(vectorFor(text), text.length(), "counting-model");
+        }
+
+        @Override
+        public List<EmbeddingResult> embedBatch(List<String> texts) {
+            batchCalls.incrementAndGet();
+            return texts.stream().map(this::embed).toList();
+        }
+
+        @Override
+        public int dimensions() {
+            return 2;
+        }
+
+        @Override
+        public String modelName() {
+            return "counting-model";
+        }
+
+        @Override
+        public int maxTokens() {
+            return 8192;
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    private static EmbeddingCacheConfig config(int maxSize) {
+        return new EmbeddingCacheConfig(true, maxSize, Duration.ZERO, Duration.ZERO);
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // EmbeddingCacheConfig
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("EmbeddingCacheConfig")
+    class ConfigTests {
+
+        @Test
+        @DisplayName("defaults: enabled, 1000 entries, 1h TTL, 5m stats interval")
+        void defaults() {
+            var cfg = EmbeddingCacheConfig.DEFAULT;
+            assertThat(cfg.enabled()).isTrue();
+            assertThat(cfg.maxSize()).isEqualTo(1000);
+            assertThat(cfg.ttl()).isEqualTo(Duration.ofMinutes(60));
+            assertThat(cfg.statsLogInterval()).isEqualTo(Duration.ofMinutes(5));
+            assertThat(cfg.ttlEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("disabled() factory")
+        void disabledFactory() {
+            var cfg = EmbeddingCacheConfig.disabled();
+            assertThat(cfg.enabled()).isFalse();
+            assertThat(cfg.ttlEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("zero TTL disables expiry")
+        void zeroTtl() {
+            var cfg = new EmbeddingCacheConfig(true, 10, Duration.ZERO, Duration.ZERO);
+            assertThat(cfg.ttlEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("rejects non-positive maxSize")
+        void rejectsNonPositiveMaxSize() {
+            assertThatThrownBy(() -> new EmbeddingCacheConfig(true, 0, Duration.ZERO, Duration.ZERO))
+                    .isInstanceOf(SpectorValidationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects negative TTL")
+        void rejectsNegativeTtl() {
+            assertThatThrownBy(() -> new EmbeddingCacheConfig(true, 10, Duration.ofSeconds(-1), Duration.ZERO))
+                    .isInstanceOf(SpectorValidationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects null TTL")
+        void rejectsNullTtl() {
+            assertThatThrownBy(() -> new EmbeddingCacheConfig(true, 10, null, Duration.ZERO))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // wrap()
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("wrap()")
+    class WrapTests {
+
+        @Test
+        @DisplayName("returns decorator when enabled")
+        void wrapsWhenEnabled() {
+            var delegate = new CountingProvider();
+            var wrapped = CachingEmbeddingProvider.wrap(delegate, config(10));
+            assertThat(wrapped).isInstanceOf(CachingEmbeddingProvider.class);
+            assertThat(((CachingEmbeddingProvider) wrapped).delegate()).isSameAs(delegate);
+        }
+
+        @Test
+        @DisplayName("returns provider unchanged when disabled")
+        void passthroughWhenDisabled() {
+            var delegate = new CountingProvider();
+            var wrapped = CachingEmbeddingProvider.wrap(delegate, EmbeddingCacheConfig.disabled());
+            assertThat(wrapped).isSameAs(delegate);
+        }
+
+        @Test
+        @DisplayName("does not double-wrap")
+        void noDoubleWrap() {
+            var once = CachingEmbeddingProvider.wrap(new CountingProvider(), config(10));
+            var twice = CachingEmbeddingProvider.wrap(once, config(10));
+            assertThat(twice).isSameAs(once);
+        }
+
+        @Test
+        @DisplayName("rejects null provider and config")
+        void rejectsNulls() {
+            assertThatThrownBy(() -> CachingEmbeddingProvider.wrap(null, config(10)))
+                    .isInstanceOf(NullPointerException.class);
+            assertThatThrownBy(() -> CachingEmbeddingProvider.wrap(new CountingProvider(), null))
+                    .isInstanceOf(NullPointerException.class);
+            assertThatThrownBy(() -> new CachingEmbeddingProvider(null, config(10)))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // embed(): hits, misses, delegation
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("embed()")
+    class EmbedTests {
+
+        @Test
+        @DisplayName("cache miss delegates and stores; hit skips the delegate")
+        void missThenHit() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+
+            var first = cache.embed("hello");
+            var second = cache.embed("hello");
+
+            assertThat(delegate.embedCalls.get()).isEqualTo(1);
+            assertThat(second.vector()).containsExactly(first.vector());
+            assertThat(second.tokenCount()).isEqualTo(first.tokenCount());
+            assertThat(second.model()).isEqualTo(first.model());
+            assertThat(cache.stats().hits()).isEqualTo(1);
+            assertThat(cache.stats().misses()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("different texts are cached independently")
+        void distinctTexts() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+
+            cache.embed("alpha");
+            cache.embed("beta");
+            cache.embed("alpha");
+            cache.embed("beta");
+
+            assertThat(delegate.embedCalls.get()).isEqualTo(2);
+            assertThat(cache.stats().hits()).isEqualTo(2);
+            assertThat(cache.stats().misses()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("mutating a returned vector does not corrupt the cache")
+        void defensiveCopies() {
+            var cache = new CachingEmbeddingProvider(new CountingProvider(), config(10));
+
+            var first = cache.embed("text");
+            first.vector()[0] = 999f;
+            var second = cache.embed("text");
+
+            assertThat(second.vector()[0]).isNotEqualTo(999f);
+        }
+
+        @Test
+        @DisplayName("delegate failures propagate and are not cached")
+        void delegateFailurePropagates() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+
+            assertThatThrownBy(() -> cache.embed(null)).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> cache.embed("  ")).isInstanceOf(IllegalArgumentException.class);
+            assertThat(cache.stats().size()).isZero();
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // LRU eviction
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("LRU eviction")
+    class EvictionTests {
+
+        @Test
+        @DisplayName("evicts least recently used entry when full")
+        void evictsLru() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(2));
+
+            cache.embed("a");
+            cache.embed("b");
+            cache.embed("a");  // refresh "a" — now "b" is least recently used
+            cache.embed("c");  // evicts "b"
+
+            cache.embed("a");  // hit
+            assertThat(delegate.callsPerText.get("a").get()).isEqualTo(1);
+
+            cache.embed("b");  // miss — was evicted
+            assertThat(delegate.callsPerText.get("b").get()).isEqualTo(2);
+
+            assertThat(cache.stats().size()).isEqualTo(2);
+            assertThat(cache.stats().evictions()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("size never exceeds maxSize")
+        void boundedSize() {
+            var cache = new CachingEmbeddingProvider(new CountingProvider(), config(5));
+            for (int i = 0; i < 50; i++) {
+                cache.embed("text-" + i);
+            }
+            assertThat(cache.stats().size()).isEqualTo(5);
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // TTL expiry
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("TTL expiry")
+    class TtlTests {
+
+        @Test
+        @DisplayName("expired entry is treated as a miss")
+        void expiry() {
+            var clock = new AtomicLong();
+            var delegate = new CountingProvider();
+            var cfg = new EmbeddingCacheConfig(true, 10, Duration.ofMinutes(1), Duration.ZERO);
+            var cache = new CachingEmbeddingProvider(delegate, cfg, clock::get);
+
+            cache.embed("text");
+            clock.addAndGet(Duration.ofSeconds(59).toNanos());
+            cache.embed("text");  // still fresh
+            assertThat(delegate.embedCalls.get()).isEqualTo(1);
+
+            clock.addAndGet(Duration.ofSeconds(2).toNanos());
+            cache.embed("text");  // expired → re-embed
+            assertThat(delegate.embedCalls.get()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("zero TTL never expires")
+        void zeroTtlNeverExpires() {
+            var clock = new AtomicLong();
+            var delegate = new CountingProvider();
+            var cfg = new EmbeddingCacheConfig(true, 10, Duration.ZERO, Duration.ZERO);
+            var cache = new CachingEmbeddingProvider(delegate, cfg, clock::get);
+
+            cache.embed("text");
+            clock.addAndGet(Duration.ofDays(365).toNanos());
+            cache.embed("text");
+            assertThat(delegate.embedCalls.get()).isEqualTo(1);
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // embedBatch()
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("embedBatch()")
+    class BatchTests {
+
+        @Test
+        @DisplayName("only uncached texts are delegated")
+        void partialHit() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+
+            cache.embed("a");
+            cache.embed("b");
+            delegate.embedCalls.set(0);
+
+            var results = cache.embedBatch(List.of("a", "x", "b", "y"));
+
+            assertThat(results).hasSize(4);
+            assertThat(delegate.embedCalls.get()).isEqualTo(2);  // only "x" and "y"
+            assertThat(results.get(0).vector()).containsExactly(CountingProvider.vectorFor("a"));
+            assertThat(results.get(1).vector()).containsExactly(CountingProvider.vectorFor("x"));
+            assertThat(results.get(2).vector()).containsExactly(CountingProvider.vectorFor("b"));
+            assertThat(results.get(3).vector()).containsExactly(CountingProvider.vectorFor("y"));
+        }
+
+        @Test
+        @DisplayName("fully cached batch makes no delegate call")
+        void fullHit() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+
+            cache.embedBatch(List.of("a", "b"));
+            int callsBefore = delegate.embedCalls.get();
+
+            var results = cache.embedBatch(List.of("b", "a"));
+
+            assertThat(delegate.embedCalls.get()).isEqualTo(callsBefore);
+            assertThat(delegate.batchCalls.get()).isEqualTo(1);
+            assertThat(results.get(0).vector()).containsExactly(CountingProvider.vectorFor("b"));
+            assertThat(results.get(1).vector()).containsExactly(CountingProvider.vectorFor("a"));
+        }
+
+        @Test
+        @DisplayName("duplicate texts within a batch are embedded once")
+        void duplicatesInBatch() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+
+            var results = cache.embedBatch(List.of("same", "same", "same"));
+
+            assertThat(delegate.embedCalls.get()).isEqualTo(1);
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).vector()).containsExactly(CountingProvider.vectorFor("same"));
+            assertThat(results.get(2).vector()).containsExactly(CountingProvider.vectorFor("same"));
+        }
+
+        @Test
+        @DisplayName("null element falls through to delegate validation")
+        void nullElementDelegates() {
+            var cache = new CachingEmbeddingProvider(new CountingProvider(), config(10));
+            var texts = java.util.Arrays.asList("a", null);
+            assertThatThrownBy(() -> cache.embedBatch(texts))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("delegate returning a mismatched batch size fails fast")
+        void mismatchedBatchSize() {
+            var broken = new CountingProvider() {
+                @Override
+                public List<EmbeddingResult> embedBatch(List<String> texts) {
+                    return List.of();
+                }
+            };
+            var cache = new CachingEmbeddingProvider(broken, config(10));
+            assertThatThrownBy(() -> cache.embedBatch(List.of("a", "b")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("2 texts");
+        }
+
+        @Test
+        @DisplayName("empty batch returns empty list without delegation")
+        void emptyBatch() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+            assertThat(cache.embedBatch(List.of())).isEmpty();
+            assertThat(delegate.batchCalls.get()).isZero();
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // Delegation of metadata + close
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("delegation")
+    class DelegationTests {
+
+        @Test
+        @DisplayName("dimensions, modelName, maxTokens delegate")
+        void metadataDelegates() {
+            var cache = new CachingEmbeddingProvider(new CountingProvider(), config(10));
+            assertThat(cache.dimensions()).isEqualTo(2);
+            assertThat(cache.modelName()).isEqualTo("counting-model");
+            assertThat(cache.maxTokens()).isEqualTo(8192);
+        }
+
+        @Test
+        @DisplayName("close clears the cache and closes the delegate")
+        void closePropagates() {
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(10));
+            cache.embed("text");
+
+            cache.close();
+
+            assertThat(delegate.closed).isTrue();
+            assertThat(cache.stats().size()).isZero();
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // Statistics
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("statistics")
+    class StatsTests {
+
+        @Test
+        @DisplayName("hit ratio is computed over all requests")
+        void hitRatio() {
+            var cache = new CachingEmbeddingProvider(new CountingProvider(), config(10));
+            assertThat(cache.stats().hitRatio()).isZero();
+
+            cache.embed("a");           // miss
+            cache.embed("a");           // hit
+            cache.embed("a");           // hit
+            cache.embed("b");           // miss
+
+            var stats = cache.stats();
+            assertThat(stats.requests()).isEqualTo(4);
+            assertThat(stats.hits()).isEqualTo(2);
+            assertThat(stats.misses()).isEqualTo(2);
+            assertThat(stats.hitRatio()).isEqualTo(0.5);
+        }
+
+        @Test
+        @DisplayName("periodic stats logging path does not disturb caching")
+        void periodicStatsLogging() {
+            var clock = new AtomicLong();
+            var delegate = new CountingProvider();
+            var cfg = new EmbeddingCacheConfig(true, 10, Duration.ZERO, Duration.ofMinutes(5));
+            var cache = new CachingEmbeddingProvider(delegate, cfg, clock::get);
+
+            cache.embed("a");
+            clock.addAndGet(Duration.ofMinutes(6).toNanos());
+            cache.embed("a");  // crosses the stats-log interval
+
+            assertThat(delegate.embedCalls.get()).isEqualTo(1);
+            assertThat(cache.stats().hits()).isEqualTo(1);
+        }
+    }
+
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+    // Concurrency
+    // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+    @Nested
+    @DisplayName("concurrency")
+    class ConcurrencyTests {
+
+        @Test
+        @DisplayName("concurrent access returns correct vectors and stays bounded")
+        void concurrentAccess() throws Exception {
+            int threads = 8;
+            int iterations = 500;
+            int distinctTexts = 20;
+            int maxSize = 32;
+
+            var delegate = new CountingProvider();
+            var cache = new CachingEmbeddingProvider(delegate, config(maxSize));
+            var pool = Executors.newFixedThreadPool(threads);
+            var start = new CountDownLatch(1);
+            var failures = new AtomicInteger();
+
+            try {
+                for (int t = 0; t < threads; t++) {
+                    final int seed = t;
+                    pool.submit(() -> {
+                        try {
+                            start.await();
+                            for (int i = 0; i < iterations; i++) {
+                                String text = "text-" + ((seed * 31 + i) % distinctTexts);
+                                var result = cache.embed(text);
+                                float[] expected = CountingProvider.vectorFor(text);
+                                if (result.vector()[0] != expected[0] || result.vector()[1] != expected[1]) {
+                                    failures.incrementAndGet();
+                                }
+                            }
+                        } catch (Exception e) {
+                            failures.incrementAndGet();
+                        }
+                    });
+                }
+                start.countDown();
+                pool.shutdown();
+                assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+            } finally {
+                pool.shutdownNow();
+            }
+
+            assertThat(failures.get()).isZero();
+            assertThat(cache.stats().size()).isEqualTo(distinctTexts);
+            assertThat(cache.stats().requests()).isEqualTo((long) threads * iterations);
+            // Concurrent misses on the same key may each call the delegate once (benign
+            // race), but never more than once per thread per distinct text — and the
+            // cache must eliminate the overwhelming majority of the 4000 requests.
+            assertThat(delegate.embedCalls.get()).isLessThanOrEqualTo(threads * distinctTexts);
+        }
+    }
+}

--- a/memory/spector-provider-api/src/test/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProviderTest.java
+++ b/memory/spector-provider-api/src/test/java/com/spectrayan/spector/provider/embedding/CachingEmbeddingProviderTest.java
@@ -399,6 +399,18 @@ class CachingEmbeddingProviderTest {
         }
 
         @Test
+        @DisplayName("duplicate positions in a batch never share a vector reference")
+        void duplicatesDoNotShareVectorReference() {
+            var cache = new CachingEmbeddingProvider(new CountingProvider(), config(10));
+
+            var results = cache.embedBatch(List.of("same", "same", "same"));
+
+            assertThat(results.get(0).vector()).isNotSameAs(results.get(1).vector());
+            assertThat(results.get(1).vector()).isNotSameAs(results.get(2).vector());
+            assertThat(results.get(0).vector()).isNotSameAs(results.get(2).vector());
+        }
+
+        @Test
         @DisplayName("null element falls through to delegate validation")
         void nullElementDelegates() {
             var cache = new CachingEmbeddingProvider(new CountingProvider(), config(10));

--- a/nucleus/spector-commons/src/main/resources/spector-defaults.yml
+++ b/nucleus/spector-commons/src/main/resources/spector-defaults.yml
@@ -58,6 +58,13 @@ spector:
     timeout: 30s
     batch-size: 32
     max-retries: 3
+    # LRU cache for embedding results — avoids redundant provider calls
+    # when the same text is embedded repeatedly.
+    cache:
+      enabled: true
+      max-size: 1000
+      ttl: 60m
+      stats-log-interval: 5m
 
   # ─── Text Chunking ───
   chunking:

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorConfigFactory.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorConfigFactory.java
@@ -158,16 +158,21 @@ public final class SpectorConfigFactory {
     /**
      * Default values for the embedding provider.
      *
-     * @param model         embedding model name
-     * @param baseUrl       API base URL
-     * @param timeout       HTTP request timeout
-     * @param batchSize     maximum texts per batch request
-     * @param maxRetries    maximum retry attempts
-     * @param maxConcurrent maximum concurrent embedding HTTP calls (0 = unlimited)
+     * @param model                 embedding model name
+     * @param baseUrl               API base URL
+     * @param timeout               HTTP request timeout
+     * @param batchSize             maximum texts per batch request
+     * @param maxRetries            maximum retry attempts
+     * @param maxConcurrent         maximum concurrent embedding HTTP calls (0 = unlimited)
+     * @param cacheEnabled          whether the LRU embedding cache is enabled
+     * @param cacheMaxSize          maximum number of cached embeddings
+     * @param cacheTtl              time-to-live for cached embeddings (0 = no expiry)
+     * @param cacheStatsLogInterval how often cache statistics are logged (0 = never)
      */
     public record EmbeddingDefaults(
             String model, String baseUrl, Duration timeout,
-            int batchSize, int maxRetries, int maxConcurrent
+            int batchSize, int maxRetries, int maxConcurrent,
+            boolean cacheEnabled, int cacheMaxSize, Duration cacheTtl, Duration cacheStatsLogInterval
     ) {}
 
     /**
@@ -180,7 +185,11 @@ public final class SpectorConfigFactory {
                 props.getDuration("spector.embedding.timeout", Duration.ofSeconds(30)),
                 props.getInt("spector.embedding.batch-size", 32),
                 props.getInt("spector.embedding.max-retries", 3),
-                props.getInt("spector.embedding.max-concurrent", 0)
+                props.getInt("spector.embedding.max-concurrent", 0),
+                props.getBoolean("spector.embedding.cache.enabled", true),
+                props.getInt("spector.embedding.cache.max-size", 1000),
+                props.getDuration("spector.embedding.cache.ttl", Duration.ofMinutes(60)),
+                props.getDuration("spector.embedding.cache.stats-log-interval", Duration.ofMinutes(5))
         );
     }
 

--- a/nucleus/spector-config/src/main/resources/spector-defaults.yml
+++ b/nucleus/spector-config/src/main/resources/spector-defaults.yml
@@ -78,6 +78,16 @@ spector:
     # Maximum concurrent embedding HTTP calls (0 = unlimited).
     # Set to a low value (e.g. 2) for local Ollama to prevent timeouts.
     max-concurrent: 0
+    # LRU cache for embedding results — avoids redundant provider calls
+    # when the same text is embedded repeatedly.
+    cache:
+      enabled: true
+      # Maximum number of cached embeddings (LRU eviction beyond this)
+      max-size: 1000
+      # Time-to-live for cached entries (0 = no expiry)
+      ttl: 60m
+      # How often cache statistics are logged at INFO level (0 = never)
+      stats-log-interval: 5m
 
   # ─── Text Chunking ───
   chunking:

--- a/nucleus/spector-config/src/test/java/com/spectrayan/spector/config/SpectorConfigFactoryTest.java
+++ b/nucleus/spector-config/src/test/java/com/spectrayan/spector/config/SpectorConfigFactoryTest.java
@@ -97,6 +97,10 @@ class SpectorConfigFactoryTest {
         assertThat(embed.timeout()).isEqualTo(Duration.ofSeconds(30));
         assertThat(embed.batchSize()).isEqualTo(32);
         assertThat(embed.maxRetries()).isEqualTo(3);
+        assertThat(embed.cacheEnabled()).isTrue();
+        assertThat(embed.cacheMaxSize()).isEqualTo(1000);
+        assertThat(embed.cacheTtl()).isEqualTo(Duration.ofMinutes(60));
+        assertThat(embed.cacheStatsLogInterval()).isEqualTo(Duration.ofMinutes(5));
     }
 
     @Test

--- a/nucleus/spector-config/src/test/resources/spector-defaults.yml
+++ b/nucleus/spector-config/src/test/resources/spector-defaults.yml
@@ -61,6 +61,11 @@ spector:
     timeout: 30s
     batch-size: 32
     max-retries: 3
+    cache:
+      enabled: true
+      max-size: 1000
+      ttl: 60m
+      stats-log-interval: 5m
 
   # ─── Chunking ───
   chunking:

--- a/spector.yml.example
+++ b/spector.yml.example
@@ -42,6 +42,12 @@ spector:
     base-url: http://localhost:11434
     timeout: 30s
     batch-size: 32
+    # LRU cache for embedding results (applies to all provider types)
+    cache:
+      enabled: true
+      max-size: 1000      # entries; LRU eviction beyond this
+      ttl: 60m            # time-to-live per entry (0 = no expiry)
+      stats-log-interval: 5m  # INFO-level hit/miss stats (0 = never)
 
   hnsw:
     m: 16

--- a/synapse/spector-runtime/src/main/java/com/spectrayan/spector/runtime/SpectorRuntime.java
+++ b/synapse/spector-runtime/src/main/java/com/spectrayan/spector/runtime/SpectorRuntime.java
@@ -24,6 +24,8 @@ import com.spectrayan.spector.config.SpectorProperties;
 import com.spectrayan.spector.config.HnswParams;
 import com.spectrayan.spector.index.HnswIndex;
 import com.spectrayan.spector.core.similarity.SimilarityFunction;
+import com.spectrayan.spector.provider.embedding.CachingEmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.EmbeddingCacheConfig;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
@@ -195,6 +197,22 @@ public final class SpectorRuntime implements AutoCloseable {
     public static SpectorRuntime from(SpectorProperties props, EmbeddingProvider embedder,
                                       LlmProvider textGenProvider) {
         SpectorMode mode = SpectorConfigFactory.mode(props);
+
+        // Wrap the embedder with the LRU cache (no-op when disabled or already wrapped)
+        var embedDefaultsForCache = SpectorConfigFactory.embeddingDefaults(props);
+        var embeddingCacheConfig = embedDefaultsForCache.cacheEnabled()
+                ? new EmbeddingCacheConfig(true,
+                        embedDefaultsForCache.cacheMaxSize(),
+                        embedDefaultsForCache.cacheTtl(),
+                        embedDefaultsForCache.cacheStatsLogInterval())
+                : EmbeddingCacheConfig.disabled();
+        embedder = CachingEmbeddingProvider.wrap(embedder, embeddingCacheConfig);
+        if (embeddingCacheConfig.enabled()) {
+            log.info("[Runtime] Embedding cache: enabled (maxSize={}, ttl={})",
+                    embeddingCacheConfig.maxSize(), embeddingCacheConfig.ttl());
+        } else {
+            log.info("[Runtime] Embedding cache: disabled");
+        }
 
         // -€-€ Read memory config early -€-€
         var memoryConfig = SpectorConfigFactory.memoryDefaults(props);


### PR DESCRIPTION
feat(embed): configurable LRU embedding cache (#49)

Adds CachingEmbeddingProvider, a zero-dependency decorator over any EmbeddingProvider that caches embedding vectors keyed by the SHA-256 hash of the input text:

- LRU eviction via access-ordered LinkedHashMap, bounded by max-size
- optional TTL expiry (default 1h; 0 = no expiry)
- thread-safe (map-level synchronization; the lock is never held during delegate calls)
- defensive vector copies on store and on every hit
- hit/miss/eviction statistics logged at INFO on a configurable interval (default 5m)
- batch lookups delegate only the uncached texts and de-duplicate repeated texts within a batch

Wired into SpectorRuntime.from(...) so every entry point (CLI, MCP, runtime) benefits, and configurable via spector.embedding.cache.* (enabled/max-size/ttl/stats-log-interval) with defaults in spector-defaults.yml.

Closes #49

## Description
<!-- Describe your changes in detail -->
<!-- Include motivation and context if it's a new feature -->

## Related Issue
<!-- Link to the issue here: "Closes #123" -->

## Type of Change
<!-- Check the relevant option -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement (change that improves throughput or latency)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Module(s) Affected
<!-- Check all that apply -->
- [ ] `spector-core` (SIMD kernels)
- [ ] `spector-storage` (Panama storage)
- [ ] `spector-index` (HNSW / BM25)
- [ ] `spector-query` (query orchestration)
- [ ] `spector-engine` (engine facade)
- [ ] `spector-node` (REST API)
- [ ] `spector-bench` (benchmarks)

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added Javadoc for all public classes/methods
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed (`mvn test`)
- [ ] No hardcoded secrets or credentials are included
- [ ] JMH benchmark results included (if performance-related)
