### PR TITLE
fix(cortex,synapse): rename health route and fix connection leak

### DIFF
--- a/cortex/spector-cortex/src/app/app.routes.ts
+++ b/cortex/spector-cortex/src/app/app.routes.ts
@@ -50,7 +50,7 @@ export const routes: Routes = [
         title: 'Settings — Spector Cortex'
       },
       {
-        path: 'health',
+        path: 'memory-health',
         loadComponent: () => import('./features/health/health.component').then(m => m.HealthComponent),
         title: 'Health — Spector Cortex'
       },

--- a/cortex/spector-cortex/src/app/features/shell/shell.component.ts
+++ b/cortex/spector-cortex/src/app/features/shell/shell.component.ts
@@ -52,7 +52,7 @@ export class ShellComponent {
     { icon: 'hub', label: 'Graph', route: '/graph' },
     { icon: 'search', label: 'Query', route: '/query' },
     { icon: 'auto_stories', label: 'Memories', route: '/memories' },
-    { icon: 'donut_large', label: 'Health', route: '/health' },
+    { icon: 'donut_large', label: 'Health', route: '/memory-health' },
   ];
 
   /** Filtered nav items based on user role and feature flags. */

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/WebConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/WebConfig.java
@@ -53,7 +53,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addViewController("/memories/{id}").setViewName("forward:/index.html");
         registry.addViewController("/graph").setViewName("forward:/index.html");
         registry.addViewController("/settings").setViewName("forward:/index.html");
-        registry.addViewController("/health").setViewName("forward:/index.html");
+        registry.addViewController("/memory-health").setViewName("forward:/index.html");
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -639,13 +639,14 @@ public class MemoryService {
                 Map<String, Long> growthOverTime = new java.util.TreeMap<>();
                 if (jdbc != null) {
                     try {
-                        growthOverTime = jdbc.sql("SELECT CAST(snapshot_time AS DATE) as s_date, MAX(total_count) as max_count " +
+                        var entries = jdbc.sql("SELECT CAST(snapshot_time AS DATE) as s_date, MAX(total_count) as max_count " +
                                         "FROM memory_analytics_snapshot " +
                                         "WHERE snapshot_time >= :since " +
                                         "GROUP BY s_date ORDER BY s_date")
                                 .param("since", Timestamp.from(Instant.now().minus(java.time.Duration.ofDays(30))))
                                 .query((rs, rowNum) -> Map.entry(rs.getDate("s_date").toString(), rs.getLong("max_count")))
-                                .stream()
+                                .list();
+                        growthOverTime = entries.stream()
                                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v2, java.util.TreeMap::new));
                     } catch (Exception e) {
                         log.warn("Failed to load historical growth from database: {}", e.getMessage());


### PR DESCRIPTION
This PR addresses local uncommitted fixes that were left behind during standardizing MCP tools in the synapse/cortex components:

1. **Route Renaming (`health` -> `memory-health`)**: Renames the `/health` frontend Angular route and the associated backend Armeria/Spring SPA forward view controller config to `/memory-health` to prevent route collision with Actuator health endpoint.
2. **Database Resource Leak Fix**: Modifies H2 query resolution in `MemoryService.java` to fetch growth data list first `.list().stream()`, which automatically handles closing connection/statement resource wrappers, rather than streaming directly over the query specification.