### PR TITLE
Test/gemini e2e testing

### DIFF
--- a/memory/spector-providers/src/test/java/com/spectrayan/spector/provider/google/GoogleProviderFactoryTest.java
+++ b/memory/spector-providers/src/test/java/com/spectrayan/spector/provider/google/GoogleProviderFactoryTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.provider.google;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.provider.ProviderConfig;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+import com.spectrayan.spector.provider.langchain4j.LangChain4jEmbeddingAdapter;
+import com.spectrayan.spector.provider.langchain4j.LangChain4jGenerationAdapter;
+
+import dev.langchain4j.model.googleai.GoogleAiEmbeddingModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link GoogleProviderFactory}.
+ *
+ * <p>Tests cover metadata, factory construction of {@link LlmProvider} and
+ * {@link EmbeddingProvider} instances from {@link ProviderConfig}, and correct
+ * propagation of generation parameters (temperature, maxOutputTokens, topP)
+ * and custom headers to the underlying LangChain4j model builders.</p>
+ *
+ * <p>These tests exercise only builder/construction logic — no network calls
+ * are made, since {@code GoogleAiGeminiChatModel.builder().build()} does not
+ * validate connectivity or the API key at construction time.</p>
+ */
+class GoogleProviderFactoryTest {
+
+    private final GoogleProviderFactory factory = new GoogleProviderFactory();
+
+    // Test metadata
+    @Nested
+    class MetadataTests {
+
+        @Test
+        void nameIsGoogle() {
+            assertThat(factory.name()).isEqualTo("google");
+        }
+
+        @Test
+        void displayNameIsGoogleGemini() {
+            assertThat(factory.displayName()).isEqualTo("Google Gemini");
+        }
+
+        @Test
+        void supportsEmbeddingIsTrue() {
+            assertThat(factory.supportsEmbedding()).isTrue();
+        }
+
+        @Test
+        void supportsGenerationIsTrue() {
+            assertThat(factory.supportsGeneration()).isTrue();
+        }
+    }
+
+    // Testing generation
+    @Nested
+    class GenerationProviderTests {
+
+        // Test if the provider is google and the model is gemini-3.1-flash-lite
+        @Test 
+        void createsLlmProviderFromConfig() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of());
+
+            Optional<LlmProvider> provider = factory.createGenerationProvider(config);
+
+            assertThat(provider).isPresent();
+            assertThat(provider.get()).isInstanceOf(LangChain4jGenerationAdapter.class);
+            assertThat(provider.get().modelName()).isEqualTo("gemini-3.1-flash-lite");
+        }
+
+        // Test that the adaptor is an instance of Google Gemini
+        @Test
+        void wrapsGoogleAiGeminiChatModel() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of());
+
+            var adapter = (LangChain4jGenerationAdapter) factory.createGenerationProvider(config).orElseThrow();
+
+            assertThat(adapter.delegate()).isInstanceOf(GoogleAiGeminiChatModel.class);
+        }
+
+        // Test max temperature and output token values.
+        @Test
+        void appliesTemperatureMaxOutputTokensAndTopP() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of(
+                            "temperature", "0.7",
+                            "maxOutputTokens", "2048",
+                            "topP", "0.95"
+                    ));
+
+            var adapter = (LangChain4jGenerationAdapter) factory.createGenerationProvider(config).orElseThrow();
+            var params = adapter.delegate().defaultRequestParameters();
+
+            assertThat(params.temperature()).isEqualTo(0.7);
+            assertThat(params.maxOutputTokens()).isEqualTo(2048);
+            assertThat(params.topP()).isEqualTo(0.95);
+        }
+
+        // Test default value of temperature and tokens (null)
+        @Test
+        void omittedOptionalPropertiesLeaveDefaultsUnset() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of());
+
+            var adapter = (LangChain4jGenerationAdapter) factory.createGenerationProvider(config).orElseThrow();
+            var params = adapter.delegate().defaultRequestParameters();
+
+            assertThat(params.temperature()).isNull();
+            assertThat(params.maxOutputTokens()).isNull();
+            assertThat(params.topP()).isNull();
+        }
+
+        @Test
+        void appliesCustomHeaders() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of(
+                            "header.X-Custom-Trace", "abc123",
+                            "header.X-Tenant-Id", "tenant-42"
+                    ));
+
+            // Should not throw — custom header properties are consumed by
+            // LangChain4jHelper.resolveCustomHeaders and applied via
+            // builder.customHeaders(...) without affecting provider construction.
+            Optional<LlmProvider> provider = factory.createGenerationProvider(config);
+
+            assertThat(provider).isPresent();
+        }
+
+        // Test Default generation timeouts
+        @Test
+        void defaultTimeoutAppliedWhenNotConfigured() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of());
+
+            // Default generation timeout is 60s per GoogleProviderFactory javadoc.
+            // We only assert construction succeeds without a configured timeout;
+            // the concrete Duration is an internal builder detail.
+            Optional<LlmProvider> provider = factory.createGenerationProvider(config);
+
+            assertThat(provider).isPresent();
+        }
+
+        // Test custom timeout
+        @Test
+        void customTimeoutIsParsed() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "gemini-3.1-flash-lite", "test-api-key",
+                    "", 0, Map.of("timeout", "120"));
+
+            Optional<LlmProvider> provider = factory.createGenerationProvider(config);
+
+            assertThat(provider).isPresent();
+        }
+    }
+
+    // Embedding provider tests
+    @Nested
+    class EmbeddingProviderTests {
+
+        @Test
+        void createsEmbeddingProviderFromConfig() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "text-embedding-004", "test-api-key",
+                    "", 768, Map.of());
+
+            Optional<EmbeddingProvider> provider = factory.createEmbeddingProvider(config);
+
+            assertThat(provider).isPresent();
+            assertThat(provider.get()).isInstanceOf(LangChain4jEmbeddingAdapter.class);
+            assertThat(provider.get().modelName()).isEqualTo("text-embedding-004");
+        }
+
+        @Test
+        void wrapsGoogleAiEmbeddingModel() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "text-embedding-004", "test-api-key",
+                    "", 768, Map.of());
+
+            var adapter = (LangChain4jEmbeddingAdapter) factory.createEmbeddingProvider(config).orElseThrow();
+
+            assertThat(adapter.delegate()).isInstanceOf(GoogleAiEmbeddingModel.class);
+        }
+
+        // Test if configured dimensions are used
+        @Test
+        void usesConfiguredDimensions() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "text-embedding-004", "test-api-key",
+                    "", 1536, Map.of());
+
+            EmbeddingProvider provider = factory.createEmbeddingProvider(config).orElseThrow();
+
+            assertThat(provider.dimensions()).isEqualTo(1536);
+        }
+
+        // Test default dimensions
+        @Test
+        void defaultsToSevenSixtyEightDimensionsWhenUnspecified() {
+            ProviderConfig config = new ProviderConfig(
+                    "google", "google", "text-embedding-004", "test-api-key",
+                    "", 0, Map.of());
+
+            EmbeddingProvider provider = factory.createEmbeddingProvider(config).orElseThrow();
+
+            assertThat(provider.dimensions()).isEqualTo(768);
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/service/ChatService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/service/ChatService.java
@@ -35,6 +35,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 
 import com.spectrayan.spector.memory.id.TsidGenerator;
 
@@ -374,7 +375,30 @@ public class ChatService {
         if ("system".equalsIgnoreCase(role)) {
             return SystemMessage.from(String.valueOf(contentObj != null ? contentObj : ""));
         } else if ("assistant".equalsIgnoreCase(role) || "agent".equalsIgnoreCase(role)) {
-            return AiMessage.from(String.valueOf(contentObj != null ? contentObj : ""));
+            AiMessage.Builder builder = AiMessage.builder();
+            if (contentObj != null) {
+                builder.text(String.valueOf(contentObj));
+            }
+            if (msg.containsKey("thinking")) {
+                builder.thinking(String.valueOf(msg.get("thinking")));
+            }
+            if (msg.containsKey("attributes") && msg.get("attributes") instanceof Map<?, ?> attrs) {
+                builder.attributes((Map<String, Object>) attrs);
+            }
+            if (msg.containsKey("toolExecutionRequests") && msg.get("toolExecutionRequests") instanceof List<?> toolRequests) {
+                List<ToolExecutionRequest> requests = new java.util.ArrayList<>();
+                for (Object reqObj : toolRequests) {
+                    if (reqObj instanceof Map<?, ?> reqMap) {
+                        requests.add(ToolExecutionRequest.builder()
+                                .id(String.valueOf(reqMap.get("id")))
+                                .name(String.valueOf(reqMap.get("name")))
+                                .arguments(String.valueOf(reqMap.get("arguments")))
+                                .build());
+                    }
+                }
+                builder.toolExecutionRequests(requests);
+            }
+            return builder.build();
         } else {
             // USER or fallback
             if (contentObj instanceof List<?> list) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/AgenticChatGraph.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/AgenticChatGraph.java
@@ -106,8 +106,11 @@ public class AgenticChatGraph {
                     state -> agentNode(state, systemPrompt, toolSpecs, modelName);
             NodeAction<AgentState> toolAction = this::toolNode;
 
-            StateGraph<AgentState> graph = new StateGraph<>(channels,
-                    new LC4jStateSerializer<>(AgentState::new))
+            var stateSerializer = new LC4jStateSerializer<>(AgentState::new);
+            stateSerializer.mapper().register(dev.langchain4j.data.message.ImageContent.class,
+                    new com.spectrayan.spector.synapse.agent.graph.serializer.SafeImageContentSerializer());
+
+            StateGraph<AgentState> graph = new StateGraph<>(channels, stateSerializer)
                     .addNode(AGENT_NODE, AsyncNodeAction.node_async(agentAction))
                     .addNode(TOOLS_NODE, AsyncNodeAction.node_async(toolAction))
                     .addEdge(START, AGENT_NODE)

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/serializer/SafeImageContentSerializer.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/serializer/SafeImageContentSerializer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.graph.serializer;
+
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.image.Image;
+import org.bsc.langgraph4j.serializer.Serializer;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.net.URI;
+import java.util.Optional;
+
+public class SafeImageContentSerializer implements Serializer<ImageContent> {
+
+    @Override
+    public void write(ImageContent object, ObjectOutput out) throws IOException {
+        out.writeObject(object.detailLevel());
+        Image image = object.image();
+        String urlStr = (image.url() != null) ? image.url().toString() : null;
+        writeNullableUTF(urlStr, out);
+        String mimeType = (image.mimeType() != null) ? image.mimeType() : "image/png";
+        out.writeUTF(mimeType);
+        writeNullableUTF(image.base64Data(), out);
+    }
+
+    @Override
+    public ImageContent read(ObjectInput in) throws IOException, ClassNotFoundException {
+        ImageContent.DetailLevel detailLevel = (ImageContent.DetailLevel) in.readObject();
+        Optional<String> urlOpt = readNullableUTF(in);
+        String mimeType = in.readUTF();
+        Optional<String> base64Opt = readNullableUTF(in);
+        
+        Image.Builder builder = Image.builder();
+        urlOpt.map(URI::create).ifPresent(builder::url);
+        builder.mimeType(mimeType);
+        base64Opt.ifPresent(builder::base64Data);
+        
+        return ImageContent.from(builder.build(), detailLevel);
+    }
+
+    private void writeNullableUTF(String val, ObjectOutput out) throws IOException {
+        out.writeBoolean(val != null);
+        if (val != null) {
+            byte[] bytes = val.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            out.writeInt(bytes.length);
+            out.write(bytes);
+        }
+    }
+
+    private Optional<String> readNullableUTF(ObjectInput in) throws IOException {
+        if (in.readBoolean()) {
+            int length = in.readInt();
+            byte[] bytes = new byte[length];
+            in.readFully(bytes);
+            return Optional.of(new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
+        }
+        return Optional.empty();
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GoogleProviderConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GoogleProviderConfig.java
@@ -5,6 +5,9 @@ import com.spectrayan.spector.provider.ProviderRegistry;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.provider.google.GoogleProviderFactory;
+import com.spectrayan.spector.synapse.config.GoogleProviderConfig.EmbeddingProps;
+import com.spectrayan.spector.synapse.config.GoogleProviderConfig.GenerationProps;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -13,6 +16,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import jakarta.annotation.PostConstruct;
 
 import java.util.Map;
 
@@ -34,19 +39,32 @@ public class GoogleProviderConfig {
 
     private static final Logger log = LoggerFactory.getLogger(GoogleProviderConfig.class);
     private static final GoogleProviderFactory FACTORY = new GoogleProviderFactory();
+    private final Environment env;
+
+    public GoogleProviderConfig(Environment env) {
+        this.env = env;
+    }
+
+    @PostConstruct
+    void debugProviderType() {
+        log.info("[DEBUG] spector.provider.generation.type = '{}'", env.getProperty("spector.provider.generation.type"));
+        log.info("[DEBUG] GEMINI_API_KEY present = {}", System.getenv("GEMINI_API_KEY") != null);
+    }
 
     @Bean
     @ConditionalOnProperty(prefix = "spector.provider.generation", name = "type", havingValue = "google")
     @ConditionalOnMissingBean(LlmProvider.class)
     LlmProvider googleLlmProvider(ProviderRegistry registry, GenerationProps props) {
+        String apiKey = (props.apiKey != null && !props.apiKey.isBlank()) ? props.apiKey:System.getenv("GEMINI_API_KEY");
+
         ProviderConfig config = new ProviderConfig(
-                "google", "google", props.model, props.apiKey, "", 0, props.properties);
+                "google", "google", props.model, apiKey, "", 0, props.properties);
         LlmProvider llm = FACTORY.createGenerationProvider(config)
                 .orElseThrow(() -> new IllegalStateException("GoogleProviderFactory returned no generation provider"));
         registry.registerGeneration("google", llm);
         registry.activateGeneration("google");
         log.info("[GoogleProviderConfig] Registered + activated Gemini generation provider: model={}", props.model);
-        return llm;
+        return new com.spectrayan.spector.synapse.provider.DelegatingLlmProvider(registry);
     }
 
     @Bean

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GoogleProviderConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GoogleProviderConfig.java
@@ -1,0 +1,93 @@
+package com.spectrayan.spector.synapse.config;
+
+import com.spectrayan.spector.provider.ProviderConfig;
+import com.spectrayan.spector.provider.ProviderRegistry;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+import com.spectrayan.spector.provider.google.GoogleProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+/**
+ * Registers Google Gemini as an {@link LlmProvider} / {@link EmbeddingProvider}
+ * when {@code spector.provider.generation.type=google} (resp. {@code embedding.type=google}).
+ *
+ * <p>Mirrors {@link EmbeddingProviderConfig}'s Ollama wiring, but delegates
+ * construction to {@link GoogleProviderFactory} instead of hardcoding Ollama.
+ * The {@code @ConditionalOnMissingBean} guard on the default Ollama beans means
+ * this backs Ollama off automatically once these beans are present.</p>
+ */
+@Configuration
+@EnableConfigurationProperties({
+        GoogleProviderConfig.GenerationProps.class,
+        GoogleProviderConfig.EmbeddingProps.class
+})
+public class GoogleProviderConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(GoogleProviderConfig.class);
+    private static final GoogleProviderFactory FACTORY = new GoogleProviderFactory();
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spector.provider.generation", name = "type", havingValue = "google")
+    @ConditionalOnMissingBean(LlmProvider.class)
+    LlmProvider googleLlmProvider(ProviderRegistry registry, GenerationProps props) {
+        ProviderConfig config = new ProviderConfig(
+                "google", "google", props.model, props.apiKey, "", 0, props.properties);
+        LlmProvider llm = FACTORY.createGenerationProvider(config)
+                .orElseThrow(() -> new IllegalStateException("GoogleProviderFactory returned no generation provider"));
+        registry.registerGeneration("google", llm);
+        registry.activateGeneration("google");
+        log.info("[GoogleProviderConfig] Registered + activated Gemini generation provider: model={}", props.model);
+        return llm;
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "google")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    EmbeddingProvider googleEmbeddingProvider(ProviderRegistry registry, EmbeddingProps props) {
+        ProviderConfig config = new ProviderConfig(
+                "google", "google", props.model, props.apiKey, "", props.dimensions, Map.of());
+        EmbeddingProvider embedder = FACTORY.createEmbeddingProvider(config)
+                .orElseThrow(() -> new IllegalStateException("GoogleProviderFactory returned no embedding provider"));
+        registry.registerEmbedding("google", embedder);
+        registry.activateEmbedding("google");
+        log.info("[GoogleProviderConfig] Registered + activated Gemini embedding provider: model={}", props.model);
+        return embedder;
+    }
+
+    @ConfigurationProperties(prefix = "spector.provider.generation")
+    public static class GenerationProps {
+        private String model;
+        private String apiKey;
+        private Map<String, String> properties = Map.of();
+
+        public String getModel() { return model; }
+        public void setModel(String model) { this.model = model; }
+        public String getApiKey() { return apiKey; }
+        public void setApiKey(String apiKey) { this.apiKey = apiKey; }
+        public Map<String, String> getProperties() { return properties; }
+        public void setProperties(Map<String, String> properties) { this.properties = properties; }
+    }
+
+    @ConfigurationProperties(prefix = "spector.provider.embedding")
+    public static class EmbeddingProps {
+        private String model;
+        private String apiKey;
+        private int dimensions;
+
+        public String getModel() { return model; }
+        public void setModel(String model) { this.model = model; }
+        public String getApiKey() { return apiKey; }
+        public void setApiKey(String apiKey) { this.apiKey = apiKey; }
+        public int getDimensions() { return dimensions; }
+        public void setDimensions(int dimensions) { this.dimensions = dimensions; }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GoogleProviderConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GoogleProviderConfig.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
 package com.spectrayan.spector.synapse.config;
 
 import com.spectrayan.spector.provider.ProviderConfig;
@@ -55,15 +67,16 @@ public class GoogleProviderConfig {
     @ConditionalOnProperty(prefix = "spector.provider.generation", name = "type", havingValue = "google")
     @ConditionalOnMissingBean(LlmProvider.class)
     LlmProvider googleLlmProvider(ProviderRegistry registry, GenerationProps props) {
-        String apiKey = (props.apiKey != null && !props.apiKey.isBlank()) ? props.apiKey:System.getenv("GEMINI_API_KEY");
+        String apiKey = (props.apiKey != null && !props.apiKey.isBlank()) ? props.apiKey : System.getenv("GEMINI_API_KEY");
+        String model = (props.model != null && !props.model.isBlank()) ? props.model : "gemini-2.0-flash";
 
         ProviderConfig config = new ProviderConfig(
-                "google", "google", props.model, apiKey, "", 0, props.properties);
+                "google", "google", model, apiKey, "", 0, props.properties);
         LlmProvider llm = FACTORY.createGenerationProvider(config)
                 .orElseThrow(() -> new IllegalStateException("GoogleProviderFactory returned no generation provider"));
         registry.registerGeneration("google", llm);
         registry.activateGeneration("google");
-        log.info("[GoogleProviderConfig] Registered + activated Gemini generation provider: model={}", props.model);
+        log.info("[GoogleProviderConfig] Registered + activated Gemini generation provider: model={}", model);
         return new com.spectrayan.spector.synapse.provider.DelegatingLlmProvider(registry);
     }
 
@@ -71,13 +84,17 @@ public class GoogleProviderConfig {
     @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "google")
     @ConditionalOnMissingBean(EmbeddingProvider.class)
     EmbeddingProvider googleEmbeddingProvider(ProviderRegistry registry, EmbeddingProps props) {
+        String apiKey = (props.apiKey != null && !props.apiKey.isBlank()) ? props.apiKey : System.getenv("GEMINI_API_KEY");
+        String model = (props.model != null && !props.model.isBlank()) ? props.model : "text-embedding-004";
+        int dimensions = props.dimensions > 0 ? props.dimensions : 768;
+
         ProviderConfig config = new ProviderConfig(
-                "google", "google", props.model, props.apiKey, "", props.dimensions, Map.of());
+                "google", "google", model, apiKey, "", dimensions, Map.of());
         EmbeddingProvider embedder = FACTORY.createEmbeddingProvider(config)
                 .orElseThrow(() -> new IllegalStateException("GoogleProviderFactory returned no embedding provider"));
         registry.registerEmbedding("google", embedder);
         registry.activateEmbedding("google");
-        log.info("[GoogleProviderConfig] Registered + activated Gemini embedding provider: model={}", props.model);
+        log.info("[GoogleProviderConfig] Registered + activated Gemini embedding provider: model={}", model);
         return embedder;
     }
 


### PR DESCRIPTION
## Description
Hello @sbharatjoshi! I have completed the e2e testing for google gemini, and here are my findings:*
**1. Text generation - working fine**.
Msg - Hi! Response - Hello! How can I help you today? - single conversation
**2.  Memory recall**
Unable  to, with session id provided - 400 error - thought_signature missing
**3. Multimodal image input**
Not working, crashes with a **NullPointerException**.Stack trace - at java.base/java.util.Objects.requireNonNull(Objects.java:246)
        at org.bsc.langgraph4j.serializer.Serializer.writeUTF(Serializer.java:55)
This happens even before it reaches the LLM, and occurs for both - base64 and embedded URL images.
**4. Response Schema **
response, sessionID, isNewSession, model, status, 
latency, durationMS, primedMemories, trace - all are printed.
**5. Token count**
added input and output token count fields to the token count. Note: Input tokens >> Output

I have added unit tests for the google provider configuration, all tests have passed.

## Related Issue
Closes #309 

## Type of Change
<!-- Check the relevant option -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [Yes ] Performance improvement (change that improves throughput or latency)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Module(s) Affected
<!-- Check all that apply -->
- [ ] `spector-core` (SIMD kernels)
- [ ] `spector-storage` (Panama storage)
- [ ] `spector-index` (HNSW / BM25)
- [ ] `spector-query` (query orchestration)
- [ ] `spector-engine` (engine facade)
- [ ] `spector-node` (REST API)
- [ ] `spector-bench` (benchmarks)

## Checklist
- [Yes ] My code follows the code style of this project
- [ ] I have added Javadoc for all public classes/methods
- [Yes ] I have added tests to cover my changes
- [Yes ] All new and existing tests passed (`mvn test`)
- [No ] No hardcoded secrets or credentials are included
- [ ] JMH benchmark results included (if performance-related)
