### PR TITLE
feat(memory): Spector Memory Kernel Design Implementation (Phases 1-3)

### DIFF
--- a/docs/docs/cli-reference/spector-inspect.md
+++ b/docs/docs/cli-reference/spector-inspect.md
@@ -1,0 +1,62 @@
+---
+title: "spector-inspect — Diagnostics CLI"
+description: "Diagnostics and inspection CLI utility for reading and analyzing off-heap Spector Memory Kernel (SMK) binary files and headers."
+---
+
+# 🔍 spector-inspect — Diagnostics CLI
+
+`spector-inspect` is a command-line utility designed for offline diagnostics, introspection, and binary header validation of Spector Memory Kernel (SMK) files. It maps and inspects off-heap segments directly without booting the full JVM memory engine.
+
+---
+
+## Installation & Running
+
+The utility is packaged as part of the `spector-inspect` module:
+
+```bash
+java -jar target/spector-inspect-0.1.0-alpha.jar header <file-path>
+```
+
+---
+
+## Commands
+
+### `header`
+
+Parses the versioned 64-byte binary header of a memory shape file (e.g., `.mem`, `.dat`) and prints human-readable diagnostics.
+
+#### Usage
+```bash
+spector-inspect header <file-path>
+```
+
+#### Example Output
+```text
+==================================================
+Spector Memory Kernel Header: episodic-20260527.mem
+==================================================
+Magic:            0x534D4B4D (SMKM)
+Schema Version:   1
+Memory Shape:     PARTITIONED_RECORD
+Flags:            0x00000000
+Capacity:         10000
+Count:            5042
+Record Stride:    832 bytes
+Layout ID:        0x434F474E ("COGN")
+Created At:       Wed May 27 10:00:00 UTC 2026 (1777284000000)
+Last Flush:       Wed May 27 10:30:00 UTC 2026 (1777285800000)
+==================================================
+```
+
+#### Field Details
+
+*   **Magic:** The SMK file identifier signature (`0x534D4B4D` which translates to ASCII string `"SMKM"`).
+*   **Schema Version:** Stamped layout version used for compatibility checks.
+*   **Memory Shape:** The SMK structural shape of this file (e.g., `RECORD`, `PARTITIONED_RECORD`, `APPEND`, `REGISTRY`, `GRAPH`, `CHAIN`).
+*   **Flags:** Shape-specific bitwise flag markers.
+*   **Capacity:** Bounded limit of records/slots allocated for this segment.
+*   **Count:** Number of active, non-tombstoned entries currently materialized.
+*   **Record Stride:** Byte stride of each record in the segment (header + payload size).
+*   **Layout ID:** The 4-character ASCII layout signature code (e.g., `"COGN"` for cognitive records, `"ENTT"` for entities, `"HEBB"` for Hebbian weights).
+*   **Created At:** Time the memory region segment was initialized.
+*   **Last Flush:** Monotonic timestamp of the last durable checkpoint flush.

--- a/docs/docs/memory/panama-design.md
+++ b/docs/docs/memory/panama-design.md
@@ -54,60 +54,96 @@ graph LR
 
 ---
 
-## Three Storage Modes
+## Spector Memory Kernel Shapes
+
+Spector Memory achieves structural flexibility by mapping all high-level cognitive subsystems to a unified storage hierarchy managed by the Spector Memory Kernel (`Memory<Layout>`). Every off-heap segment maps to one of five core **Memory Shapes** implemented using Java Project Panama's Foreign Function & Memory API:
 
 ```mermaid
 flowchart TD
-    subgraph "Volatile (In-Memory)"
-        WM["Working Memory<br/><i>circular buffer</i>"]
-        PM["Procedural Memory<br/><i>learned procedures</i>"]
+    subgraph "Spector Memory Kernel (Memory shapes)"
+        RM["RecordMemory<br/><i>Contiguous slots</i>"]
+        AM["AppendMemory<br/><i>Cursor log</i>"]
+        GM["GraphMemory<br/><i>CSR & Adjacency slabs</i>"]
+        CM["ChainMemory<br/><i>Causal linking</i>"]
+        YM["RegistryMemory<br/><i>String mapping</i>"]
     end
 
-    subgraph "Persistent (mmap)"
-        EM["Episodic Memory<br/><i>time-partitioned files</i>"]
+    subgraph "Subsystem Backing"
+        RM_C["Cortex Tiers &<br/>CoActivationTracker"]
+        AM_C["TextDataStore &<br/>MemoryWal"]
+        GM_C["EntityGraph &<br/>HebbianGraph"]
+        CM_C["TemporalChain"]
+        YM_C["TypeRegistry"]
     end
 
-    subgraph "Compact (Header-Only)"
-        SM["Semantic Memory<br/><i>metadata slab, no vectors</i>"]
-    end
+    RM -.-> RM_C
+    AM -.-> AM_C
+    GM -.-> GM_C
+    CM -.-> CM_C
+    YM -.-> YM_C
 
-    style WM fill:#e74c3c,color:white
-    style PM fill:#e74c3c,color:white
-    style EM fill:#0984e3,color:white
-    style SM fill:#00b894,color:white
+    style RM fill:#e74c3c,color:white
+    style AM fill:#0984e3,color:white
+    style GM fill:#00b894,color:white
+    style CM fill:#f39c12,color:white
+    style YM fill:#8e44ad,color:white
 ```
 
-### 1. Arena-Allocated (Working, Procedural)
+### 1. `RecordMemory<L>` & `PartitionedRecordMemory<L>`
+Stores fixed-size structures as cache-aligned contiguous byte slots. Subsystems (Working, Semantic, and Procedural tiers, and `CoActivationTracker`) read/write directly at slot offsets within a mapped `MemorySegment`.
+*   **Volatile Arena Allocation:** Working and Procedural stores use volatile, in-memory shared arenas for transient operations.
+*   **Memory-Mapped File Allocation (`PartitionedRecordMemory`):** Episodic memory uses memory-mapped files partitioned by time (e.g., `episodic-20260527.mem`), mapped dynamically to share physical memory pages as needed.
 
-Volatile, in-memory segments for transient data.
+### 2. `AppendMemory<L>`
+Provides append-only sequential streams with cursor position tracking.
+*   Backs the Write-Ahead Log (`MemoryWal`) and the text document store (`TextDataStore`).
+*   Optimized for high-throughput appends with minimal write lock contention.
 
-**Characteristics**:
+### 3. `RegistryMemory`
+Maintains bidirectional mappings between string symbols and compact integer identifiers.
+*   Backs `TypeRegistry`, allowing open-schema entity and relation types to be registered dynamically without string overhead on the off-heap hot paths.
 
-- Fast allocation (~1µs)
-- Lost on JVM shutdown
-- No file I/O overhead
-- Fixed capacity
+### 4. `GraphMemory`
+Manages sparse node-relationship matrices using compact Compressed Sparse Row (CSR) and slab-allocated adjacency lists.
+*   Backs `EntityGraph` and `HebbianGraph`, offering high-performance off-heap graph traversals and associative weights adjustment.
 
-### 2. mmap-Backed (Episodic)
+### 5. `ChainMemory`
+Tracks ordered sequences of temporal events linking sessions together.
+*   Backs the `TemporalChain` list structure to reconstruct causal reasoning pathways ("what happened next?").
 
-Persistent, memory-mapped files for durable storage. The OS handles paging data between RAM and disk.
+---
 
-**Characteristics**:
+## Namespace Management & Multi-Tenant Isolation
 
-- Persists across JVM restarts
-- OS handles paging to/from disk
-- Lazy loading — only mapped pages are in physical RAM
-- Atomic flush for durability
+To manage resource boundaries for multiple concurrent AI agents/conversations, Spector uses the `NamespaceRegistry` and `SpectorNamespaceManager`:
 
-### 3. Header-Only Slab (Semantic)
+```mermaid
+sequenceDiagram
+    participant Agent as AI Agent Thread
+    participant Mgr as SpectorNamespaceManager
+    participant Reg as NamespaceRegistry
+    participant FS as File System (Disk)
 
-Compact metadata-only storage (no vectors).
+    Agent->>Mgr: getOrOpen("tenant-A")
+    Mgr->>Reg: active namespaces check
+    alt is loaded in memory
+        Reg-->>Agent: SpectorMemory instance
+    else evicted / closed
+        Reg->>Reg: check capacity (LRU limit)
+        alt capacity exceeded
+            Reg->>Reg: evict eldest inactive namespace
+            Reg->>FS: flush checkpoints & close arenas
+        end
+        Reg->>FS: mmap namespace files (Panama segments)
+        FS-->>Reg: warming complete (WAL recovery)
+        Reg-->>Agent: SpectorMemory instance
+    end
+```
 
-**Characteristics**:
-
-- Minimal memory footprint (64B per record vs. ~832B for full records)
-- Fast metadata scans (tag match, importance, valence, arousal)
-- No vector data — re-embed at query time if needed
+### LRU Eviction & Resource Protection
+*   **Active Capacity Limits:** Defines the maximum number of concurrent active namespaces mapped in RAM.
+*   **Lease Gating:** Threads call `.acquireLease()` when executing queries. Lease-locked namespaces are guaranteed **never** to be evicted mid-query, even if capacity is exceeded.
+*   **Warming Cache Replay:** When a namespace is reopened, the kernel maps segments and processes the local WAL events via the `WalRecoveryDispatcher` to restore exact state before query dispatch.
 
 ---
 

--- a/docs/docs/memory/sync.md
+++ b/docs/docs/memory/sync.md
@@ -32,7 +32,7 @@ flowchart LR
 | Capability | Description |
 |---|---|
 | **Crash recovery** | Replay the log → full state reconstruction |
-| **Event types** | REMEMBER, FORGET, REINFORCE, REFLECT, TAG_MERGE, RECALL_HIT |
+| **Event types** | REMEMBER, FORGET, REINFORCE, REFLECT, TAG_MERGE, RECALL_HIT, RECORD_WRITE, ADJ_ADD_EDGE, ADJ_DEL_EDGE, REGISTRY_INTERN, APPEND, SNAPSHOT_MARK, GRAPH_ADD_NODE, GRAPH_LINK_MEMORY, CHAIN_LINK |
 | **Chunked files** | Auto-roll at 8 MB boundaries |
 | **Dual CRC-32** | Independent header + payload checksums |
 | **Compression** | Optional DEFLATE for large payloads |

--- a/docs/docs/memory/wal-design.md
+++ b/docs/docs/memory/wal-design.md
@@ -93,6 +93,15 @@ Every memory mutation produces a WAL event with the following fields:
 | `REFLECT` | Sleep consolidation cycle | Consolidation metadata |
 | `TAG_MERGE` | Synaptic tag update | Updated tag bitfield |
 | `RECALL_HIT` | `memory.recall(query)` | Recall count increment |
+| `RECORD_WRITE` | Memory block update in `RecordMemory` | Target slot bytes (updated header + vector data) |
+| `ADJ_ADD_EDGE` | Relation edge addition in `GraphMemory` (EntityGraph/HebbianGraph) | Endpoint node IDs, weight deltas, and relation label string |
+| `ADJ_DEL_EDGE` | Relation edge deletion in `GraphMemory` | Endpoint node IDs |
+| `REGISTRY_INTERN` | String-to-int interning in `RegistryMemory` | Interned ID and UTF-8 string name |
+| `APPEND` | Byte block append to `AppendMemory` | Raw appended segment bytes |
+| `SNAPSHOT_MARK` | Checkpoint snapshot boundary trigger | High-water mark sequence and state metadata |
+| `GRAPH_ADD_NODE` | Entity node insertion in `EntityGraph` | Entity name and type label |
+| `GRAPH_LINK_MEMORY` | Association between entity and record in `EntityGraph` | Entity ID and target memory record index |
+| `CHAIN_LINK` | Sequence link creation in `TemporalChain` | Source index, target index, and session ID |
 
 ---
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -122,7 +122,9 @@ nav:
       - Java SDK: sdk-usage/java-client.md
       - Python SDK: sdk-usage/python-sdk.md
       - Spring AI Integration: sdk-usage/spring-ai.md
-      - CLI Reference: cli-reference/spectorctl.md
+      - CLI Reference:
+          - spectorctl: cli-reference/spectorctl.md
+          - spector-inspect: cli-reference/spector-inspect.md
       - REST API: api-reference/rest-endpoints.md
       - Configuration: configuration/parameters.md
 

--- a/memory/spector-inspect/pom.xml
+++ b/memory/spector-inspect/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Spectrayan
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.spectrayan</groupId>
+        <artifactId>spector</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spector-inspect</artifactId>
+    <name>Spector Inspect CLI</name>
+    <description>CommandLine inspector tool for checking, verifying and compacting Spector Memory Kernel files.</description>
+
+    <properties>
+        <spector.module.name>com.spectrayan.spector.inspect</spector.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.spectrayan</groupId>
+            <artifactId>spector-memory</artifactId>
+        </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/memory/spector-inspect/src/main/java/com/spectrayan/spector/inspect/SpectorInspectCli.java
+++ b/memory/spector-inspect/src/main/java/com/spectrayan/spector/inspect/SpectorInspectCli.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.inspect;
+
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Date;
+
+/**
+ * Empty skeleton/CLI implementation for spector-inspect module in Phase 1.
+ * Supports the "header" subcommand to parse and output MemoryHeader details.
+ */
+public class SpectorInspectCli {
+
+    public static void main(String[] args) {
+        if (args.length < 2 || !args[0].equalsIgnoreCase("header")) {
+            System.err.println("Usage: spector-inspect header <file-path>");
+            System.exit(1);
+        }
+
+        String filePathStr = args[1];
+        Path path = Paths.get(filePathStr);
+
+        if (!Files.exists(path)) {
+            System.err.println("Error: File does not exist: " + path.toAbsolutePath());
+            System.exit(1);
+        }
+
+        try {
+            long size = Files.size(path);
+            if (size < MemoryHeader.HEADER_BYTES) {
+                System.err.println("Error: File is too small to contain a valid Spector Memory Kernel header (size: " + size + " bytes).");
+                System.exit(1);
+            }
+        } catch (IOException e) {
+            System.err.println("Error reading file size: " + e.getMessage());
+            System.exit(1);
+        }
+
+        try (Arena arena = Arena.ofShared();
+             FileChannel fc = FileChannel.open(path, StandardOpenOption.READ)) {
+            
+            MemorySegment segment = fc.map(FileChannel.MapMode.READ_ONLY, 0, MemoryHeader.HEADER_BYTES, arena);
+            
+            if (!MemoryHeader.isValid(segment, 0)) {
+                System.err.println("Error: Invalid or corrupted Spector Memory Kernel header.");
+                System.exit(1);
+            }
+
+            int schemaVersion = MemoryHeader.readSchemaVersion(segment, 0);
+            MemoryShape shape = MemoryHeader.readShape(segment, 0);
+            long capacity = MemoryHeader.readCapacity(segment, 0);
+            long count = MemoryHeader.readCount(segment, 0);
+            int recordStride = MemoryHeader.readRecordStride(segment, 0);
+            int layoutId = MemoryHeader.readLayoutId(segment, 0);
+            long createdAt = MemoryHeader.readCreatedAt(segment, 0);
+            long lastFlush = MemoryHeader.readLastFlush(segment, 0);
+            int flags = MemoryHeader.readFlags(segment, 0);
+
+            // Convert layoutId back to 4-character string
+            String layoutIdStr = String.format("%c%c%c%c",
+                    (char) (layoutId & 0xFF),
+                    (char) ((layoutId >> 8) & 0xFF),
+                    (char) ((layoutId >> 16) & 0xFF),
+                    (char) ((layoutId >> 24) & 0xFF));
+
+            System.out.println("==================================================");
+            System.out.println("Spector Memory Kernel Header: " + path.getFileName());
+            System.out.println("==================================================");
+            System.out.printf("Magic:            0x%08X (SMKM)\n", MemoryHeader.MAGIC);
+            System.out.printf("Schema Version:   %d\n", schemaVersion);
+            System.out.printf("Memory Shape:     %s\n", shape);
+            System.out.printf("Flags:            0x%08X\n", flags);
+            System.out.printf("Capacity:         %d\n", capacity);
+            System.out.printf("Count:            %d\n", count);
+            System.out.printf("Record Stride:    %d bytes\n", recordStride);
+            System.out.printf("Layout ID:        0x%08X (\"%s\")\n", layoutId, layoutIdStr);
+            System.out.printf("Created At:       %s (%d)\n", new Date(createdAt), createdAt);
+            System.out.printf("Last Flush At:    %s (%d)\n", new Date(lastFlush), lastFlush);
+            System.out.println("==================================================");
+
+        } catch (IOException e) {
+            System.err.println("IO Error reading header: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/memory/spector-inspect/src/test/java/com/spectrayan/spector/inspect/SpectorInspectCliTest.java
+++ b/memory/spector-inspect/src/test/java/com/spectrayan/spector/inspect/SpectorInspectCliTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.inspect;
+
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpectorInspectCliTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    @Test
+    void testHeaderSubcommandPrintsCorrectMetadata() throws Exception {
+        Path file = tempDir.resolve("test_memory.bin");
+
+        // Write a mock standard header
+        try (Arena arena = Arena.ofShared();
+             FileChannel fc = FileChannel.open(file,
+                     StandardOpenOption.CREATE,
+                     StandardOpenOption.WRITE,
+                     StandardOpenOption.READ)) {
+
+            fc.position(MemoryHeader.HEADER_BYTES - 1);
+            fc.write(java.nio.ByteBuffer.wrap(new byte[]{0}));
+
+            MemorySegment segment = fc.map(FileChannel.MapMode.READ_WRITE, 0, MemoryHeader.HEADER_BYTES, arena);
+            MemoryHeader.write(segment, 0, 5, MemoryShape.RECORD, 1, 1000L, 500L, 32, 0x54585444, 1717171717000L, 1818181818000L);
+        }
+
+        SpectorInspectCli.main(new String[]{"header", file.toAbsolutePath().toString()});
+
+        String output = outContent.toString();
+        assertThat(output)
+                .contains("Schema Version:   5")
+                .contains("Memory Shape:     RECORD")
+                .contains("Capacity:         1000")
+                .contains("Count:            500")
+                .contains("Record Stride:    32 bytes")
+                .contains("Layout ID:        0x54585444")
+                .contains("DTXT");
+    }
+}

--- a/memory/spector-memory/README.md
+++ b/memory/spector-memory/README.md
@@ -37,6 +37,12 @@ spector-memory/
 │     ├── RecallPipeline.java           (parallel tier scanning + scoring)
 │     └── HebbianCoActivationListener   (Observer pattern post-recall)
 │
+├── kernel/                         ← "Memory Kernel" — Memory<Layout> & Shapes
+│     ├── Memory.java                   (Base interface)
+│     ├── MemoryHeader.java             (On-disk header structures)
+│     ├── layout/                       (Layout types for records, entities, graphs)
+│     └── shape/                        (RecordMemory, AppendMemory, GraphMemory, etc.)
+│
 ├── cortex/                         ← "Cerebral Cortex" — 4 tier stores
 │     ├── TierStore.java                (Strategy interface)
 │     ├── TierRouter.java               (Registry + polymorphic dispatch)
@@ -106,6 +112,7 @@ spector-memory/
 
 | Brain Region | Package | Java Classes | Function |
 |---|---|---|---|
+| 💾 Sub-cortical Core | `kernel/` | `Memory`, `MemoryHeader`, `MemoryShape` | Core Panama storage abstractions (RecordMemory, AppendMemory, etc.) |
 | 🧠 Cerebral Cortex | `cortex/` | `TierRouter`, `TierStore`, 4 stores | 4-tier memory storage (Working → Episodic → Semantic → Procedural) |
 | 🔗 Synapses | `synapse/` | `CognitiveScorer`, `SynapticTagEncoder`, `CognitiveRecordLayout` | 64-byte header, 6-phase scoring, Bloom filter gating |
 | ⚡ Dopamine System | `dopamine/` | `SurpriseDetector`, `FlashbulbPolicy` | Surprise detection, auto-importance, flashbulb pinning |
@@ -118,6 +125,20 @@ spector-memory/
 | 🚫 Inhibition | `inhibition/` | `SuppressionSet` | Explicit memory suppression (user redaction) |
 | 🔮 Prospective Memory | `prospective/` | `ProspectiveScheduler`, `Reminder` | Future-oriented intent reminders |
 | 🪞 Metamemory | `metamemory/` | `MemoryIntrospector` | Self-reflective memory health analytics |
+
+---
+
+## Spector Memory Kernel (SMK)
+
+Spector Memory uses a unified **Memory Kernel** abstraction (`Memory<Layout>`) that standardizes all persistent and volatile storage structures using Project Panama's Foreign Function & Memory API. Rather than implementing individual binary layouts from scratch, every subsystem maps to a standardized kernel **Shape**:
+
+*   **`RecordMemory` / `PartitionedRecordMemory`**: Fixed-size contiguous slots used by the cognitive tiers (`Working`, `Semantic`, and `Procedural` stores) and `CoActivationTracker`.
+*   **`AppendMemory`**: Append-only log arrays with cursor offsets, backing `TextDataStore` and the Write-Ahead Log.
+*   **`RegistryMemory`**: Open-schema string-to-int mapping used for metadata serialization (`TypeRegistry`).
+*   **`GraphMemory`**: CSR (Compressed Sparse Row) and slab-allocated structures backing the `EntityGraph` and `HebbianGraph`.
+*   **`ChainMemory`**: Causal sequence structures backing the `TemporalChain`.
+
+All memory operations are journaled to the WAL at the kernel shape level, enabling complete state reconstruction on startup via `WalRecoveryDispatcher`.
 
 ---
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -198,6 +198,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     // -€-€ Multi-Tenant Namespace -€-€
     private final SpectorNamespaceManager namespaceManager;
+    private final String namespaceId;
+    private final java.util.concurrent.atomic.AtomicInteger activeLeases = new java.util.concurrent.atomic.AtomicInteger(0);
 
     // -€-€ ID Generation -€-€
     private final MemoryIdGenerator idGenerator;
@@ -263,6 +265,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.circadianPolicy = builder.circadianPolicy;
         this.profileConfig = builder.profileConfig;
         this.namespaceManager = bundle.namespaceManager();
+        this.namespaceId = builder.namespaceId;
         this.idGenerator = bundle.idGenerator();
         this.checkpointDaemon = bundle.checkpointDaemon();
         this.daemonSupervisor = bundle.daemonSupervisor();
@@ -325,6 +328,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                                               com.spectrayan.spector.memory.neurodivergent.IngestionHints hints,
                                               String... tags) {
         return CompletableFuture.runAsync(() -> {
+            acquireLease();
             try {
                 if (shouldChunk(text)) {
                     rememberChunked(id, text, type, source, hints, null, tags);
@@ -343,6 +347,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             } catch (RuntimeException e) {
                 log.error("Failed to remember '{}': {}", id, e.getMessage(), e);
                 throw new SpectorServerException(ErrorCode.INGESTION_PIPELINE_FAILED, e, id);
+            } finally {
+                releaseLease();
             }
         }, ConcurrentTasks.virtualExecutor());
     }
@@ -387,6 +393,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                                               IngestionContext context,
                                               String... tags) {
         return CompletableFuture.runAsync(() -> {
+            acquireLease();
             try {
                 if (shouldChunk(text)) {
                     rememberChunked(id, text, type, source, null, context, tags);
@@ -411,6 +418,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             } catch (RuntimeException e) {
                 log.error("Failed to remember '{}': {}", id, e.getMessage(), e);
                 throw new SpectorServerException(ErrorCode.INGESTION_PIPELINE_FAILED, e, id);
+            } finally {
+                releaseLease();
             }
         }, ConcurrentTasks.virtualExecutor());
     }
@@ -630,35 +639,40 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public List<CognitiveResult> recall(String queryText, RecallOptions options) {
-        // Auto-profile resolution: use ProfileAdaptor to suggest best profile
-        if (options.autoProfile() && options.profile() == null) {
-            CognitiveProfile suggested = null;
-            if (profileAdaptor != null) {
-                // Extract context tags from the query text
-                String[] tags = cognitiveTarget.tagExtractor() != null
-                        ? cognitiveTarget.tagExtractor().extract("query", queryText)
-                        : new String[0];
-                suggested = profileAdaptor.suggest(tags);
-            }
-            if (suggested == null) {
-                SalienceProfile sp = cognitiveTarget.salienceProfile();
-                if (sp != null) {
-                    suggested = sp.defaultProfile();
+        acquireLease();
+        try {
+            // Auto-profile resolution: use ProfileAdaptor to suggest best profile
+            if (options.autoProfile() && options.profile() == null) {
+                CognitiveProfile suggested = null;
+                if (profileAdaptor != null) {
+                    // Extract context tags from the query text
+                    String[] tags = cognitiveTarget.tagExtractor() != null
+                            ? cognitiveTarget.tagExtractor().extract("query", queryText)
+                            : new String[0];
+                    suggested = profileAdaptor.suggest(tags);
                 }
+                if (suggested == null) {
+                    SalienceProfile sp = cognitiveTarget.salienceProfile();
+                    if (sp != null) {
+                        suggested = sp.defaultProfile();
+                    }
+                }
+                if (suggested == null) {
+                    suggested = CognitiveProfile.BALANCED;
+                }
+                log.debug("Auto-profile resolved to {} for query '{}'", suggested, queryText);
+                options = RecallOptions.builder()
+                        .topK(options.topK())
+                        .profile(suggested)
+                        .scoringMode(options.scoringMode())
+                        .recallMode(options.recallMode())
+                        .autoProfile(true)
+                        .build();
             }
-            if (suggested == null) {
-                suggested = CognitiveProfile.BALANCED;
-            }
-            log.debug("Auto-profile resolved to {} for query '{}'", suggested, queryText);
-            options = RecallOptions.builder()
-                    .topK(options.topK())
-                    .profile(suggested)
-                    .scoringMode(options.scoringMode())
-                    .recallMode(options.recallMode())
-                    .autoProfile(true)
-                    .build();
+            return recallPipeline.recall(queryText, options);
+        } finally {
+            releaseLease();
         }
-        return recallPipeline.recall(queryText, options);
     }
 
     @Override
@@ -674,38 +688,53 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public void forget(String id) {
-        if (id == null) { throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "id"); }
-        MemoryLocation loc = index.locate(id);
-        if (loc == null) {
-            log.warn("Forget: memory '{}' not found in index", id);
-            return;
+        acquireLease();
+        try {
+            if (id == null) { throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "id"); }
+            MemoryLocation loc = index.locate(id);
+            if (loc == null) {
+                log.warn("Forget: memory '{}' not found in index", id);
+                return;
+            }
+            MemorySegment segment = partitionManager.tierRouter().segmentFor(loc.type());
+            if (segment != null) {
+                CognitiveRecordLayout layout = partitionManager.tierRouter().layoutFor(loc.type());
+                layout.tombstone(segment, loc.offset());
+            }
+            wal.appendForget(id);
+            index.remove(id);
+            log.debug("Forget: '{}' tombstoned", id);
+        } finally {
+            releaseLease();
         }
-        MemorySegment segment = partitionManager.tierRouter().segmentFor(loc.type());
-        if (segment != null) {
-            CognitiveRecordLayout layout = partitionManager.tierRouter().layoutFor(loc.type());
-            layout.tombstone(segment, loc.offset());
-        }
-        wal.appendForget(id);
-        index.remove(id);
-        log.debug("Forget: '{}' tombstoned", id);
     }
 
     @Override
     public ReflectReport reflect() {
-        return reflectionOrchestrator.reflect(partitionManager.tierRouter(), index);
+        acquireLease();
+        try {
+            return reflectionOrchestrator.reflect(partitionManager.tierRouter(), index);
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
     public void consolidate() {
-        consolidationService.consolidate(
-                partitionManager.tierRouter(),
-                index,
-                quantizer,
-                entityGraph,
-                cognitiveTarget,
-                wal,
-                this::inspect
-        );
+        acquireLease();
+        try {
+            consolidationService.consolidate(
+                    partitionManager.tierRouter(),
+                    index,
+                    quantizer,
+                    entityGraph,
+                    cognitiveTarget,
+                    wal,
+                    this::inspect
+            );
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
@@ -724,27 +753,42 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public void reinforce(String memoryId, byte valence) {
-        reinforcementHandler.reinforce(memoryId, valence,
-                partitionManager.tierRouter(), index);
+        acquireLease();
+        try {
+            reinforcementHandler.reinforce(memoryId, valence,
+                    partitionManager.tierRouter(), index);
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
     public void reinforce(String memoryId, byte valence,
                            com.spectrayan.spector.memory.neurodivergent.IngestionHints updatedHints) {
-        reinforcementHandler.reinforceWithHints(memoryId, valence, updatedHints,
-                partitionManager.tierRouter(), index);
+        acquireLease();
+        try {
+            reinforcementHandler.reinforceWithHints(memoryId, valence, updatedHints,
+                    partitionManager.tierRouter(), index);
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
     public void suppress(String memoryId, String reason) {
-        suppressionSet.suppress(memoryId, reason);
-        MemoryLocation loc = index.locate(memoryId);
-        if (loc != null) {
-            suppressionSet.registerOffset(loc.type().ordinal(), loc.offset());
-        }
-        if (recallPipeline.wasLateral(memoryId)) {
-            lateralEvaluator.recordLateralSuppression();
-            log.debug("Lateral suppression: '{}' (reason={})", memoryId, reason);
+        acquireLease();
+        try {
+            suppressionSet.suppress(memoryId, reason);
+            MemoryLocation loc = index.locate(memoryId);
+            if (loc != null) {
+                suppressionSet.registerOffset(loc.type().ordinal(), loc.offset());
+            }
+            if (recallPipeline.wasLateral(memoryId)) {
+                lateralEvaluator.recordLateralSuppression();
+                log.debug("Lateral suppression: '{}' (reason={})", memoryId, reason);
+            }
+        } finally {
+            releaseLease();
         }
     }
 
@@ -752,91 +796,118 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     public void suppress(String memoryId) { suppress(memoryId, null); }
 
     @Override
-    public void unsuppress(String memoryId) { suppressionSet.unsuppress(memoryId); }
+    public void unsuppress(String memoryId) {
+        acquireLease();
+        try {
+            suppressionSet.unsuppress(memoryId);
+        } finally {
+            releaseLease();
+        }
+    }
 
     @Override
     public void markResolved(String memoryId) {
-        var loc = index.locate(memoryId);
-        if (loc == null) return;
-        partitionManager.tierRouter().layoutFor(loc.type())
-                .markResolved(partitionManager.tierRouter().segmentFor(loc.type()), loc.offset());
-        log.debug("Zeigarnik: marked '{}' as RESOLVED", memoryId);
+        acquireLease();
+        try {
+            var loc = index.locate(memoryId);
+            if (loc == null) return;
+            partitionManager.tierRouter().layoutFor(loc.type())
+                    .markResolved(partitionManager.tierRouter().segmentFor(loc.type()), loc.offset());
+            log.debug("Zeigarnik: marked '{}' as RESOLVED", memoryId);
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
     public void markUnresolved(String memoryId) {
-        var loc = index.locate(memoryId);
-        if (loc == null) return;
-        partitionManager.tierRouter().layoutFor(loc.type())
-                .markUnresolved(partitionManager.tierRouter().segmentFor(loc.type()), loc.offset());
-        log.debug("Zeigarnik: marked '{}' as UNRESOLVED", memoryId);
+        acquireLease();
+        try {
+            var loc = index.locate(memoryId);
+            if (loc == null) return;
+            partitionManager.tierRouter().layoutFor(loc.type())
+                    .markUnresolved(partitionManager.tierRouter().segmentFor(loc.type()), loc.offset());
+            log.debug("Zeigarnik: marked '{}' as UNRESOLVED", memoryId);
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
     public MemoryInsight introspect(String topic) {
-        List<CognitiveResult> results = recall(topic, RecallOptions.builder().topK(20).build());
-        return introspector.analyze(topic, results);
+        acquireLease();
+        try {
+            List<CognitiveResult> results = recall(topic, RecallOptions.builder().topK(20).build());
+            return introspector.analyze(topic, results);
+        } finally {
+            releaseLease();
+        }
     }
 
     @Override
     public WhyNotExplanation whyNot(String memoryId, String queryText, RecallOptions options) {
-        var loc = index.locate(memoryId);
-        if (loc == null) {
-            return new WhyNotExplanation(memoryId, queryText, false, false,
-                    null, 0f, WhyNotExplanation.Reason.NOT_FOUND,
-                    "Memory '" + memoryId + "' does not exist in the index.");
-        }
+        acquireLease();
+        try {
+            var loc = index.locate(memoryId);
+            if (loc == null) {
+                return new WhyNotExplanation(memoryId, queryText, false, false,
+                        null, 0f, WhyNotExplanation.Reason.NOT_FOUND,
+                        "Memory '" + memoryId + "' does not exist in the index.");
+            }
 
-        var layout = partitionManager.tierRouter().layoutFor(loc.type());
-        var segment = partitionManager.tierRouter().segmentFor(loc.type());
-        if (layout != null && segment != null) {
-            byte flags = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS,
-                    loc.offset() + SynapticHeaderConstants.OFFSET_FLAGS);
-            if (SynapticHeaderConstants.isTombstoned(flags)) {
+            var layout = partitionManager.tierRouter().layoutFor(loc.type());
+            var segment = partitionManager.tierRouter().segmentFor(loc.type());
+            if (layout != null && segment != null) {
+                byte flags = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS,
+                        loc.offset() + SynapticHeaderConstants.OFFSET_FLAGS);
+                if (SynapticHeaderConstants.isTombstoned(flags)) {
+                    return new WhyNotExplanation(memoryId, queryText, true, false,
+                            null, 0f, WhyNotExplanation.Reason.TOMBSTONED,
+                            "Memory '" + memoryId + "' has been deleted (tombstone flag set).");
+                }
+            }
+
+            if (suppressionSet.isSuppressed(memoryId)) {
+                return new WhyNotExplanation(memoryId, queryText, true, true,
+                        null, 0f, WhyNotExplanation.Reason.SUPPRESSED,
+                        "Memory '" + memoryId + "' is in the suppression set. "
+                        + "Use unsuppress(\"" + memoryId + "\") to allow recall.");
+            }
+
+            int originalTopK = options != null ? options.topK() : 5;
+            RecallOptions observeOptions = RecallOptions.builder()
+                    .recallMode(RecallMode.OBSERVE)
+                    .topK(Math.max(originalTopK, 20))
+                    .build();
+
+            List<CognitiveResult> results = recall(queryText, observeOptions);
+
+            CognitiveResult found = null;
+            for (CognitiveResult r : results) {
+                if (memoryId.equals(r.id())) {
+                    found = r;
+                    break;
+                }
+            }
+
+            if (found != null) {
                 return new WhyNotExplanation(memoryId, queryText, true, false,
-                        null, 0f, WhyNotExplanation.Reason.TOMBSTONED,
-                        "Memory '" + memoryId + "' has been deleted (tombstone flag set).");
+                        found.breakdown(), 0f, WhyNotExplanation.Reason.OUTRANKED,
+                        "Memory '" + memoryId + "' WAS found in extended recall "
+                        + "(score=" + String.format("%.4f", found.score()) + "). "
+                        + "It may have been outside your original topK cutoff.");
             }
-        }
 
-        if (suppressionSet.isSuppressed(memoryId)) {
-            return new WhyNotExplanation(memoryId, queryText, true, true,
-                    null, 0f, WhyNotExplanation.Reason.SUPPRESSED,
-                    "Memory '" + memoryId + "' is in the suppression set. "
-                    + "Use unsuppress(\"" + memoryId + "\") to allow recall.");
-        }
-
-        int originalTopK = options != null ? options.topK() : 5;
-        RecallOptions observeOptions = RecallOptions.builder()
-                .recallMode(RecallMode.OBSERVE)
-                .topK(Math.max(originalTopK, 20))
-                .build();
-
-        List<CognitiveResult> results = recall(queryText, observeOptions);
-
-        CognitiveResult found = null;
-        for (CognitiveResult r : results) {
-            if (memoryId.equals(r.id())) {
-                found = r;
-                break;
-            }
-        }
-
-        if (found != null) {
+            float cutoffScore = results.isEmpty() ? 0f : results.get(results.size() - 1).score();
             return new WhyNotExplanation(memoryId, queryText, true, false,
-                    found.breakdown(), 0f, WhyNotExplanation.Reason.OUTRANKED,
-                    "Memory '" + memoryId + "' WAS found in extended recall "
-                    + "(score=" + String.format("%.4f", found.score()) + "). "
-                    + "It may have been outside your original topK cutoff.");
+                    null, cutoffScore, WhyNotExplanation.Reason.FILTERED,
+                    "Memory '" + memoryId + "' was eliminated by pre-filters "
+                    + "(tag gate, valence range, importance floor, or time decay). "
+                    + "TopK cutoff score: " + String.format("%.4f", cutoffScore) + ". "
+                    + (cutoffScore > 0 ? "Check if tags/valence/importance match your query options." : ""));
+        } finally {
+            releaseLease();
         }
-
-        float cutoffScore = results.isEmpty() ? 0f : results.get(results.size() - 1).score();
-        return new WhyNotExplanation(memoryId, queryText, true, false,
-                null, cutoffScore, WhyNotExplanation.Reason.FILTERED,
-                "Memory '" + memoryId + "' was eliminated by pre-filters "
-                + "(tag gate, valence range, importance floor, or time decay). "
-                + "TopK cutoff score: " + String.format("%.4f", cutoffScore) + ". "
-                + (cutoffScore > 0 ? "Check if tags/valence/importance match your query options." : ""));
     }
 
     // ==============================================================
@@ -1144,6 +1215,23 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     /** Returns the namespace manager (null if IN_MEMORY mode). */
     public SpectorNamespaceManager namespaceManager() { return namespaceManager; }
+
+    @Override
+    public String namespaceId() {
+        return namespaceId;
+    }
+
+    public void acquireLease() {
+        activeLeases.incrementAndGet();
+    }
+
+    public void releaseLease() {
+        activeLeases.decrementAndGet();
+    }
+
+    public boolean hasActiveLeases() {
+        return activeLeases.get() > 0;
+    }
 
     // ==============================================================
     // VACUUM / COMPACTION

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -97,6 +97,7 @@ import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.namespace.SpectorNamespaceManager;
 import com.spectrayan.spector.memory.namespace.NamespaceQuotas;
 import com.spectrayan.spector.memory.temporal.TemporalChain;
+import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.commons.TextChunker;
 
 import org.slf4j.Logger;
@@ -185,6 +186,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     // -€-€ 3-Layer Cognitive Graph -€-€
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChain temporalChain;
+    private final TemporalKnowledgeGraph temporalKnowledgeGraph;
     private final EntityGraph entityGraph;
     private final HyperEntityGraph hyperEntityGraph;
     private final CognitiveGraphFacade graphFacade;
@@ -256,6 +258,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.wal = bundle.wal();
         this.hebbianGraph = bundle.hebbianGraph();
         this.temporalChain = bundle.temporalChain();
+        this.temporalKnowledgeGraph = bundle.temporalKnowledgeGraph();
         this.entityGraph = bundle.entityGraph();
         this.hyperEntityGraph = bundle.hyperEntityGraph();
         this.graphFacade = bundle.graphFacade();
@@ -1181,6 +1184,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     @SuppressWarnings("deprecation")
     @Override public HyperEntityGraph hyperEntityGraph() { return graphFacade.hyperEntityGraph(); }
     @Override public com.spectrayan.spector.index.VectorIndex semanticIndex() { return semanticIndex; }
+    @Override public TemporalKnowledgeGraph temporalKnowledgeGraph() { return temporalKnowledgeGraph; }
 
     // -€-€ listAll implementations -€-€
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -79,6 +79,9 @@ public interface SpectorMemory extends AutoCloseable {
     /** Returns the cognitive ingestion target for use with the unified IngestionPipeline. */
     CognitiveIngestionTarget target();
 
+    /** Returns the namespace ID of this memory. */
+    default String namespaceId() { return "default"; }
+
     // ══════════════════════════════════════════════════════════════
     // CORE API — remember / recall / forget / reflect
     // ══════════════════════════════════════════════════════════════

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
@@ -30,6 +30,7 @@ import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.sync.CompactionResult;
 import com.spectrayan.spector.memory.temporal.TemporalChain;
+import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 
 import java.time.Duration;
 import java.util.List;
@@ -99,6 +100,9 @@ public interface SpectorMemoryAdmin {
     // ══════════════════════════════════════════════════════════════
     // GRAPH SUBSYSTEM
     // ══════════════════════════════════════════════════════════════
+
+    /** Returns the Temporal Knowledge Graph. */
+    TemporalKnowledgeGraph temporalKnowledgeGraph();
 
     /** Returns the cognitive graph facade for high-level graph queries. */
     CognitiveGraphFacade graph();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -68,6 +68,8 @@ public final class SpectorMemoryBuilder {
     EmbeddingProvider embeddingProvider;
     Path persistencePath;
     MemoryPersistenceMode persistenceMode = MemoryPersistenceMode.DISK;
+    int maxActiveNamespaces = Integer.getInteger("spector.memory.max-namespaces", 100);
+    String namespaceId = "default";
     boolean persistWorkingMemory = false;
     CircadianPolicy circadianPolicy = CircadianPolicy.DEFAULT;
     int workingCapacity = 100;
@@ -382,6 +384,17 @@ public final class SpectorMemoryBuilder {
         this.salienceProfileProvider = provider;
         return this;
     }
+
+    public SpectorMemoryBuilder maxActiveNamespaces(int maxActiveNamespaces) {
+        this.maxActiveNamespaces = maxActiveNamespaces;
+        return this;
+    }
+
+    public SpectorMemoryBuilder namespaceId(String namespaceId) {
+        this.namespaceId = namespaceId;
+        return this;
+    }
+
 
     // ==============================================================
     // BUILD

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -76,6 +76,13 @@ import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.namespace.SpectorNamespaceManager;
 import com.spectrayan.spector.memory.temporal.TemporalChain;
 import com.spectrayan.spector.memory.pipeline.AttachmentProcessor;
+import com.spectrayan.spector.memory.sync.WalRecoveryDispatcher;
+import com.spectrayan.spector.memory.sync.WalEvent;
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import java.nio.file.Files;
+import java.util.List;
+import java.nio.ByteBuffer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -477,6 +484,9 @@ public final class SpectorMemoryFactory {
                     index, hebbianGraph, temporalChain, cognitiveTarget);
         }
 
+        // -€-€ WAL Recovery -€-€
+        performWalRecovery(wal, tierRouter, index, hebbianGraph, temporalChain, entityGraph, coActivationTracker, cognitiveTarget, basePath);
+
         // -€-€ Semantic Recall Strategy + HNSW Rebuild -€-€
         SemanticRecallStrategy semanticStrategy = null;
         if (builder.semanticIndex != null && tierRouter.semantic() != null) {
@@ -680,6 +690,157 @@ public final class SpectorMemoryFactory {
                 log.warn("Could not set strict file permissions on temporary directory: {}", tempDir);
             }
             return tempDir;
+        }
+    }
+
+    private static void performWalRecovery(
+            MemoryWal wal,
+            TierRouter tierRouter,
+            MemoryIndex index,
+            HebbianGraphBase hebbianGraph,
+            TemporalChain temporalChain,
+            EntityGraph entityGraph,
+            CoActivationTracker coActivationTracker,
+            CognitiveIngestionTarget cognitiveTarget,
+            Path basePath) {
+        
+        if (wal == null || !wal.isPersistent()) {
+            return;
+        }
+        
+        long checkpointHwm = 0;
+        if (basePath != null) {
+            Path metaPath = StorageLayout.checkpointMeta(basePath);
+            if (Files.exists(metaPath)) {
+                checkpointHwm = CheckpointDaemon.readCheckpointHwm(metaPath);
+                log.info("WAL recovery: loaded checkpoint HWM {}", checkpointHwm);
+            }
+        }
+        
+        List<WalEvent> events = wal.replay(checkpointHwm);
+        if (events.isEmpty()) {
+            log.info("WAL recovery: no events to replay after HWM {}", checkpointHwm);
+            return;
+        }
+        
+        log.info("WAL recovery: replaying {} events after HWM {}", events.size(), checkpointHwm);
+        
+        // 1. Gather all shape-specific Memory instances
+        java.util.Map<MemoryId, Memory<?>> memories = new java.util.HashMap<>();
+        
+        if (tierRouter != null) {
+            if (tierRouter.working() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
+                Memory<?> backing = s.backing();
+                memories.put(backing.id(), backing);
+            }
+            if (tierRouter.semantic() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
+                Memory<?> backing = s.backing();
+                memories.put(backing.id(), backing);
+            }
+            if (tierRouter.procedural() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
+                Memory<?> backing = s.backing();
+                memories.put(backing.id(), backing);
+            }
+            if (tierRouter.episodic() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
+                Memory<?> backing = s.backing();
+                memories.put(backing.id(), backing);
+            }
+        }
+        
+        if (entityGraph != null) {
+            memories.put(entityGraph.id(), entityGraph);
+        }
+        if (hebbianGraph instanceof HebbianGraphCsr hg) {
+            memories.put(hg.id(), hg);
+        }
+        if (temporalChain != null) {
+            memories.put(MemoryId.of("temporal", "chain"), temporalChain);
+        }
+
+        // Add textDataStore backing memory if available
+        MemoryId textId = MemoryId.of("cortex", "text");
+        if (index.textDataStore() != null) {
+            memories.put(textId, index.textDataStore().backing());
+        }
+
+        long countBeforeRecovery = 0;
+        Memory<?> textMem = memories.get(textId);
+        if (textMem instanceof com.spectrayan.spector.memory.kernel.shape.AppendMemory<?> am) {
+            countBeforeRecovery = am.appendCursor();
+        }
+        
+        // 2. Dispatch shape mutations directly to target memory segments
+        WalRecoveryDispatcher.recover(wal, memories);
+        
+        // 3. Rebuild MemoryIndex on-heap maps from high-level REMEMBER/FORGET/REINFORCE events
+        long lastRecordOffset = -1;
+        MemoryType lastRecordType = null;
+        long lastTextOffset = -1;
+        int lastTextLength = -1;
+        long currentTextCursor = countBeforeRecovery;
+        
+        for (WalEvent event : events) {
+            if (event.sequence() <= checkpointHwm) {
+                continue;
+            }
+            
+            try {
+                switch (event.type()) {
+                    case RECORD_WRITE -> {
+                        ByteBuffer buf = java.nio.ByteBuffer.wrap(event.payload());
+                        long recordId = buf.getLong();
+                        MemoryId targetId = MemoryId.parse(event.memoryId());
+                        Memory<?> target = memories.get(targetId);
+                        if (target instanceof com.spectrayan.spector.memory.kernel.shape.RecordMemory<?> rm) {
+                            lastRecordOffset = rm.recordOffset(recordId);
+                            String pathName = targetId.memoryName();
+                            if ("working".equals(pathName)) lastRecordType = MemoryType.WORKING;
+                            else if ("semantic".equals(pathName)) lastRecordType = MemoryType.SEMANTIC;
+                            else if ("procedural".equals(pathName)) lastRecordType = MemoryType.PROCEDURAL;
+                            else if ("episodic".equals(pathName)) lastRecordType = MemoryType.EPISODIC;
+                        }
+                    }
+                    case APPEND -> {
+                        MemoryId targetId = MemoryId.parse(event.memoryId());
+                        if ("cortex".equals(targetId.namespace()) && "text".equals(targetId.memoryName())) {
+                            lastTextOffset = currentTextCursor;
+                            lastTextLength = event.payload().length;
+                            currentTextCursor += 4 + lastTextLength;
+                        }
+                    }
+                    case REMEMBER -> {
+                        if (lastRecordOffset != -1 && lastRecordType != null) {
+                            // CognitiveRecordLayout has dynamic stride
+                            int stride = 164; // default
+                            MemoryId targetId = MemoryId.of("tier", lastRecordType.name().toLowerCase());
+                            Memory<?> target = memories.get(targetId);
+                            if (target != null) {
+                                stride = target.layout().recordStride();
+                            }
+                            int storeIndex = (int) (lastRecordOffset / stride);
+                            com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation loc =
+                                    new com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation(
+                                            lastRecordType, lastRecordOffset, -1, lastTextOffset, lastTextLength);
+                            
+                            String text = "";
+                            if (index.textDataStore() != null && lastTextOffset != -1) {
+                                try {
+                                    text = index.textDataStore().readTextDirect(lastTextOffset, lastTextLength);
+                                } catch (Exception ignored) {}
+                            }
+                            
+                            index.register(event.memoryId(), loc, text, MemorySource.OBSERVED, new String[0]);
+                        }
+                    }
+                    case FORGET -> {
+                        index.remove(event.memoryId());
+                    }
+                    default -> {}
+                }
+            } catch (Exception e) {
+                log.warn("WAL recovery index sync failed for event seq={}, type={}: {}", 
+                        event.sequence(), event.type(), e.getMessage());
+            }
         }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -46,6 +46,7 @@ import com.spectrayan.spector.memory.graph.CognitiveGraphFacade;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
 import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.TypeRegistry;
 import com.spectrayan.spector.memory.graph.HyperEntityGraph;
 import com.spectrayan.spector.memory.graph.LlmEntityExtractor;
 import com.spectrayan.spector.memory.graph.NoOpEntityExtractor;
@@ -75,6 +76,7 @@ import com.spectrayan.spector.memory.sync.CheckpointDaemon;
 import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.namespace.SpectorNamespaceManager;
 import com.spectrayan.spector.memory.temporal.TemporalChain;
+import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.memory.pipeline.AttachmentProcessor;
 import com.spectrayan.spector.memory.sync.WalRecoveryDispatcher;
 import com.spectrayan.spector.memory.sync.WalEvent;
@@ -123,6 +125,7 @@ public final class SpectorMemoryFactory {
             MemoryWal wal,
             HebbianGraphBase hebbianGraph,
             TemporalChain temporalChain,
+            TemporalKnowledgeGraph temporalKnowledgeGraph,
             EntityGraph entityGraph,
             HyperEntityGraph hyperEntityGraph,
             CognitiveGraphFacade graphFacade,
@@ -388,6 +391,16 @@ public final class SpectorMemoryFactory {
             hyperEntityGraph = null;
         }
 
+        TemporalKnowledgeGraph temporalKnowledgeGraph;
+        TypeRegistry predRegistry = (entityGraph != null) ? entityGraph.relationTypeRegistry() : new TypeRegistry("relation-type");
+        if (isDisk && basePath != null) {
+            Path runtimeTkg = StorageLayout.temporalFactsRuntime(basePath);
+            long initialSize = 16L * 1024 * 1024; // 16MB
+            temporalKnowledgeGraph = new TemporalKnowledgeGraph(runtimeTkg, initialSize, predRegistry);
+        } else {
+            temporalKnowledgeGraph = new TemporalKnowledgeGraph(predRegistry);
+        }
+
         // -€-€ BM25 Text Search -€-€
         MemoryBM25Index bm25Index;
         TextDataStore textDataStore;
@@ -485,7 +498,7 @@ public final class SpectorMemoryFactory {
         }
 
         // -€-€ WAL Recovery -€-€
-        performWalRecovery(wal, tierRouter, index, hebbianGraph, temporalChain, entityGraph, coActivationTracker, cognitiveTarget, basePath);
+        performWalRecovery(wal, tierRouter, index, hebbianGraph, temporalChain, temporalKnowledgeGraph, entityGraph, coActivationTracker, cognitiveTarget, basePath);
 
         // -€-€ Semantic Recall Strategy + HNSW Rebuild -€-€
         SemanticRecallStrategy semanticStrategy = null;
@@ -584,6 +597,7 @@ public final class SpectorMemoryFactory {
                 reinforcementHandler, valenceTracker, coActivationTracker,
                 suppressionSet, habituationPenalty, prospectiveScheduler,
                 introspector, lateralEvaluator, wal, hebbianGraph, temporalChain,
+                temporalKnowledgeGraph,
                 entityGraph, hyperEntityGraph, graphFacade, idGenerator,
                 checkpointDaemon, daemonSupervisor, bm25Index, attachmentProcessor,
                 parallelPipeline, embedConfig, resolvedPartitionDir, basePath,
@@ -699,6 +713,7 @@ public final class SpectorMemoryFactory {
             MemoryIndex index,
             HebbianGraphBase hebbianGraph,
             TemporalChain temporalChain,
+            TemporalKnowledgeGraph temporalKnowledgeGraph,
             EntityGraph entityGraph,
             CoActivationTracker coActivationTracker,
             CognitiveIngestionTarget cognitiveTarget,
@@ -755,6 +770,9 @@ public final class SpectorMemoryFactory {
         }
         if (temporalChain != null) {
             memories.put(MemoryId.of("temporal", "chain"), temporalChain);
+        }
+        if (temporalKnowledgeGraph != null) {
+            memories.put(temporalKnowledgeGraph.id(), temporalKnowledgeGraph.backing());
         }
 
         // Add textDataStore backing memory if available

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -744,20 +744,20 @@ public final class SpectorMemoryFactory {
         java.util.Map<MemoryId, Memory<?>> memories = new java.util.HashMap<>();
         
         if (tierRouter != null) {
-            if (tierRouter.working() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
-                Memory<?> backing = s.backing();
+            if (tierRouter.working() != null) {
+                Memory<?> backing = tierRouter.working().backing();
                 memories.put(backing.id(), backing);
             }
-            if (tierRouter.semantic() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
-                Memory<?> backing = s.backing();
+            if (tierRouter.semantic() != null) {
+                Memory<?> backing = tierRouter.semantic().backing();
                 memories.put(backing.id(), backing);
             }
-            if (tierRouter.procedural() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
-                Memory<?> backing = s.backing();
+            if (tierRouter.procedural() != null) {
+                Memory<?> backing = tierRouter.procedural().backing();
                 memories.put(backing.id(), backing);
             }
-            if (tierRouter.episodic() instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore s) {
-                Memory<?> backing = s.backing();
+            if (tierRouter.episodic() != null) {
+                Memory<?> backing = tierRouter.episodic().backing();
                 memories.put(backing.id(), backing);
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/StorageLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/StorageLayout.java
@@ -154,6 +154,9 @@ public final class StorageLayout {
     /** Global temporal sequence links. Stored in runtime/ (V3). */
     public static final String FILE_TEMPORAL = "temporal.chain";
 
+    /** Temporal Knowledge Graph facts (bitemporal append-only log). Stored in runtime/ (V3). */
+    public static final String FILE_TEMPORAL_FACTS = "temporal-facts.tfacts";
+
     /** Global entity knowledge graph. Stored in runtime/ (V3). */
     public static final String FILE_ENTITY = "entity.graph";
 
@@ -477,6 +480,11 @@ public final class StorageLayout {
     /** Resolves the temporal.chain file path (in runtime/). */
     public static Path temporalChainRuntime(Path basePath) {
         return runtimeDir(basePath).resolve(FILE_TEMPORAL);
+    }
+
+    /** Resolves the temporal-facts.tfacts file path (in runtime/). */
+    public static Path temporalFactsRuntime(Path basePath) {
+        return runtimeDir(basePath).resolve(FILE_TEMPORAL_FACTS);
     }
 
     /** Resolves the entity.graph file path (in runtime/). */

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
@@ -19,6 +19,7 @@ import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryLayout;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayoutAdapter;
+import com.spectrayan.spector.memory.kernel.shape.AbstractRecordMemory;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorStorageException;
 
@@ -129,6 +130,9 @@ public abstract class AbstractTierStore implements TierStore {
     protected final MemorySegment segment;
     protected int count = 0;
 
+    /** Kernel backing — owns arena, segment, and file channel lifecycle. */
+    private final TierRecordBacking backing;
+
     /**
      * The number of records visible to concurrent readers.
      * Published with release semantics after each complete record write.
@@ -140,8 +144,6 @@ public abstract class AbstractTierStore implements TierStore {
     /** True if this store is backed by a file (persistent). */
     protected final boolean persistent;
 
-    /** File channel for persistent stores (null for volatile). */
-    private FileChannel fileChannel;
 
     /** File path for persistent stores (null for volatile). */
     private final Path filePath;
@@ -157,11 +159,16 @@ public abstract class AbstractTierStore implements TierStore {
         this.layout = new CognitiveRecordLayout(quantizedVecBytes);
         this.layoutAdapter = new CognitiveRecordLayoutAdapter(this.layout);
         this.capacity = capacity;
-        this.arena = Arena.ofShared();
-        this.segment = arena.allocate(segmentBytes, SynapticHeaderConstants.HEADER_BYTES);
         this.persistent = false;
         this.filePath = null;
-        // MemoryId is set lazily after type() is available (abstract method)
+        // Kernel backing owns the arena and segment
+        Arena backingArena = Arena.ofShared();
+        MemorySegment backingSegment = backingArena.allocate(segmentBytes, SynapticHeaderConstants.HEADER_BYTES);
+        this.backing = new TierRecordBacking(
+                MemoryId.of("tier", "pending"), layoutAdapter, capacity,
+                backingArena, backingSegment, 0, false, null, null);
+        this.arena = backingArena;
+        this.segment = backingSegment;
         this.memoryId = null;
     }
 
@@ -183,8 +190,7 @@ public abstract class AbstractTierStore implements TierStore {
         this.capacity = capacity;
         this.persistent = true;
         this.filePath = filePath;
-        this.arena = Arena.ofShared();
-        // MemoryId is set lazily after type() is available (abstract method)
+        Arena backingArena = Arena.ofShared();
         this.memoryId = null;
 
         try {
@@ -197,20 +203,27 @@ public abstract class AbstractTierStore implements TierStore {
             long totalBytes = METADATA_HEADER_BYTES + segmentBytes;
             boolean isNew = !Files.exists(filePath) || Files.size(filePath) < METADATA_HEADER_BYTES;
 
-            fileChannel = FileChannel.open(filePath,
+            FileChannel fc = FileChannel.open(filePath,
                     StandardOpenOption.CREATE,
                     StandardOpenOption.READ,
                     StandardOpenOption.WRITE);
 
             if (isNew) {
                 // Extend file to full size
-                fileChannel.position(totalBytes - 1);
-                fileChannel.write(ByteBuffer.wrap(new byte[]{0}));
+                fc.position(totalBytes - 1);
+                fc.write(ByteBuffer.wrap(new byte[]{0}));
             }
 
             // Map the entire file
-            long mapSize = Math.max(totalBytes, fileChannel.size());
-            this.segment = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, mapSize, arena);
+            long mapSize = Math.max(totalBytes, fc.size());
+            MemorySegment mapped = fc.map(FileChannel.MapMode.READ_WRITE, 0, mapSize, backingArena);
+
+            // Kernel backing owns arena, segment, and file channel
+            this.backing = new TierRecordBacking(
+                    MemoryId.of("tier", "pending"), layoutAdapter, capacity,
+                    backingArena, mapped, 0, true, filePath, fc);
+            this.arena = backingArena;
+            this.segment = mapped;
 
             if (isNew) {
                 // Write fresh metadata header
@@ -444,14 +457,32 @@ public abstract class AbstractTierStore implements TierStore {
                 log.debug("Error forcing segment: {}", e.getMessage());
             }
         }
-        arena.close();
-        if (fileChannel != null) {
-            try {
-                fileChannel.close();
-            } catch (IOException e) {
-                log.debug("Error closing file channel: {}", e.getMessage());
-            }
+        // Delegate lifecycle to kernel backing (closes arena + file channel)
+        backing.close();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // KERNEL BACKING
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Concrete kernel {@link AbstractRecordMemory} backing for tier stores.
+     *
+     * <p>This class exists solely to provide a concrete instantiation of
+     * the kernel's {@code AbstractRecordMemory} hierarchy. It receives
+     * ownership of the arena, segment, and file channel from the enclosing
+     * tier store and handles close/flush lifecycle.</p>
+     *
+     * <p>The tier store delegates arena/segment ownership to this backing.
+     * Tier-specific logic (SWMR, cognitive headers, tombstones) remains
+     * in {@code AbstractTierStore}.</p>
+     */
+    static final class TierRecordBacking extends AbstractRecordMemory<CognitiveRecordLayoutAdapter> {
+
+        TierRecordBacking(MemoryId id, CognitiveRecordLayoutAdapter layout, int capacity,
+                          Arena arena, MemorySegment segment, int count,
+                          boolean persistent, Path filePath, FileChannel fileChannel) {
+            super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
         }
     }
 }
-

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
@@ -423,6 +423,13 @@ public abstract class AbstractTierStore implements TierStore {
     }
 
     /**
+     * Returns the underlying kernel Memory backing for this tier store.
+     */
+    public TierRecordBacking backing() {
+        return this.backing;
+    }
+
+    /**
      * Returns the kernel-compatible layout adapter for this store.
      *
      * <p>Bridges the existing {@link CognitiveRecordLayout} to the kernel's

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
@@ -15,6 +15,10 @@ package com.spectrayan.spector.memory.cortex;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayoutAdapter;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorStorageException;
 
@@ -77,6 +81,14 @@ import java.nio.file.StandardOpenOption;
 public abstract class AbstractTierStore implements TierStore {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractTierStore.class);
+
+    // ── Kernel Integration ──
+    // MemoryId provides stable identity for WAL targeting, metrics, and logs.
+    // Lazily initialized because type() is abstract and not available in the constructor.
+    // CognitiveRecordLayoutAdapter bridges the tier store's CognitiveRecordLayout
+    // to the kernel's MemoryLayout interface.
+    private volatile MemoryId memoryId;
+    private final CognitiveRecordLayoutAdapter layoutAdapter;
 
     /** Metadata header magic: "TIER" in ASCII. */
     static final int TIER_MAGIC = 0x54494552;
@@ -143,11 +155,14 @@ public abstract class AbstractTierStore implements TierStore {
      */
     protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes) {
         this.layout = new CognitiveRecordLayout(quantizedVecBytes);
+        this.layoutAdapter = new CognitiveRecordLayoutAdapter(this.layout);
         this.capacity = capacity;
         this.arena = Arena.ofShared();
         this.segment = arena.allocate(segmentBytes, SynapticHeaderConstants.HEADER_BYTES);
         this.persistent = false;
         this.filePath = null;
+        // MemoryId is set lazily after type() is available (abstract method)
+        this.memoryId = null;
     }
 
     /**
@@ -164,10 +179,13 @@ public abstract class AbstractTierStore implements TierStore {
      */
     protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes, Path filePath) {
         this.layout = new CognitiveRecordLayout(quantizedVecBytes);
+        this.layoutAdapter = new CognitiveRecordLayoutAdapter(this.layout);
         this.capacity = capacity;
         this.persistent = true;
         this.filePath = filePath;
         this.arena = Arena.ofShared();
+        // MemoryId is set lazily after type() is available (abstract method)
+        this.memoryId = null;
 
         try {
             // Ensure parent directories exist
@@ -363,6 +381,56 @@ public abstract class AbstractTierStore implements TierStore {
         if (count == 0) return 0.0f;
         return (float) tombstoneCount() / count;
     }
+
+    // ══════════════════════════════════════════════════════════════
+    // KERNEL INTEGRATION
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Returns the stable kernel identity for this store.
+     *
+     * <p>Lazily initialized because {@link #type()} is abstract and not
+     * available during {@code AbstractTierStore} construction. Thread-safe
+     * via double-checked locking on a volatile field.</p>
+     *
+     * @return the kernel-compatible memory identifier
+     */
+    public MemoryId memoryId() {
+        MemoryId id = this.memoryId;
+        if (id == null) {
+            synchronized (this) {
+                id = this.memoryId;
+                if (id == null) {
+                    id = MemoryId.of("tier", type().name().toLowerCase());
+                    this.memoryId = id;
+                }
+            }
+        }
+        return id;
+    }
+
+    /**
+     * Returns the kernel-compatible layout adapter for this store.
+     *
+     * <p>Bridges the existing {@link CognitiveRecordLayout} to the kernel's
+     * {@link MemoryLayout} interface, enabling kernel consumers to read
+     * stride, layoutId, and schema version from tier stores.</p>
+     *
+     * @return the cognitive record layout adapter
+     */
+    public CognitiveRecordLayoutAdapter kernelLayout() {
+        return layoutAdapter;
+    }
+
+    /**
+     * Returns the kernel shape classification for this store.
+     *
+     * @return {@link MemoryShape#RECORD} for all tier stores
+     */
+    public MemoryShape kernelShape() {
+        return MemoryShape.RECORD;
+    }
+
 
     @Override
     public void close() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TextDataStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TextDataStore.java
@@ -15,6 +15,10 @@ package com.spectrayan.spector.memory.cortex;
 import com.spectrayan.spector.memory.DataEncryptor;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.StorageLayout;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.layout.TextBlobLayout;
+import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,77 +38,29 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Binary reader/writer for {@code text.dat} files within partition directories.
- *
- * <h3>Purpose</h3>
- * <p>Stores the raw text content for all memory tiers in a single partition.
- * On startup, the file is memory-mapped for zero-copy off-heap reads to populate
- * both {@link com.spectrayan.spector.memory.index.MemoryIndex} texts and
- * per-partition BM25/SPLADE indexes.</p>
- *
- * <h3>Binary Format (V2 — mmap-backed)</h3>
- * <pre>
- *   Header (16 bytes):
- *     [4B magic: 0x54585444 "TXTD"]
- *     [4B version: 2]
- *     [4B entry_count]
- *     [4B reserved]
- *
- *   For each entry:
- *     [1B tier_ordinal]              — 0=WORKING, 1=EPISODIC, 2=SEMANTIC, 3=PROCEDURAL
- *     [4B id_len] [N id_bytes]       — Memory ID (UTF-8)
- *     [4B text_len] [N text_bytes]   — Raw text content (UTF-8)
- * </pre>
- *
- * <h3>Off-Heap Architecture</h3>
- * <p>{@link #readAll()} memory-maps the entire file via {@link FileChannel#map}
- * into a {@link MemorySegment}. Strings are decoded directly from the mapped
- * segment — no intermediate {@code byte[]} copies. The mapped segment remains
- * open for downstream zero-copy text access until {@link #close()} is called.</p>
- *
- * <h3>Performance</h3>
- * <p>Sequential SSD read at 3GB/s → 10K entries (~5MB of text) loads in ~1.7ms.
- * mmap avoids heap allocation pressure, reducing GC pauses during startup by ~40%
- * compared to the V1 ByteBuffer approach.</p>
- *
- * <h3>Thread Safety</h3>
- * <p>Read operations on the mapped segment are thread-safe (read-only, shared Arena).
- * Write operations (append) are not thread-safe — callers must synchronize externally
- * (typically writes happen from a single ingestion thread per partition).</p>
- *
- * @see StorageLayout#FILE_TEXT
- * @see StorageLayout#TEXT_DAT_MAGIC
+ * Binary reader/writer for {@code text.dat} files within partition directories,
+ * delegating storage to {@link DefaultAppendMemory} with standard kernel layout.
  */
 public final class TextDataStore implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(TextDataStore.class);
 
-    /** Header size: magic(4) + version(4) + count(4) + reserved(4). */
-    private static final int HEADER_BYTES = 16;
+    private static final int LEGACY_HEADER_BYTES = 16;
 
-    /**
-     * Big-endian int layout matching ByteBuffer's default byte order.
-     * Required because {@link ValueLayout#JAVA_INT_UNALIGNED} uses native order
-     * (little-endian on x86), but we write via {@link ByteBuffer} which defaults
-     * to big-endian.
-     */
     private static final ValueLayout.OfInt BE_INT =
             ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN);
 
     private final Path file;
     private final DataEncryptor encryptor;
     private int entryCount;
+    private DefaultAppendMemory<TextBlobLayout> appendMemory;
 
-    /** Off-heap mapped segment for zero-copy reads (null until readAll() or refreshed after write). */
-    private volatile MemorySegment mappedSegment;
-
-    /** Arena managing the mapped segment lifecycle. */
-    private Arena mapArena;
-
-    /** Populated during readAll() — maps memoryId → text byte position for backfill. */
-    private final java.util.Map<String, TextPosition> textPositionMap = new java.util.LinkedHashMap<>();
+    private final Map<String, TextPosition> textPositionMap = new LinkedHashMap<>();
+    private final Map<Long, TextPosition> hashToPosition = new java.util.HashMap<>();
+    private final AtomicInteger decryptFailCount = new AtomicInteger();
 
     /**
      * Creates a TextDataStore for the given file path (no encryption).
@@ -117,9 +73,6 @@ public final class TextDataStore implements AutoCloseable {
 
     /**
      * Creates a TextDataStore with encryption support.
-     *
-     * <p>When a non-NOOP encryptor is provided, text is decrypted on read
-     * (both {@link #readAll()} and {@link #readTextDirect}).</p>
      *
      * @param file      path to the text.dat file
      * @param encryptor data encryptor for text-at-rest (null → NOOP)
@@ -168,87 +121,196 @@ public final class TextDataStore implements AutoCloseable {
      */
     public record TextPosition(long textOffset, int textLength) {}
 
+    private synchronized void initAppendMemory(long requiredSize) {
+        if (appendMemory != null) {
+            appendMemory.close();
+            appendMemory = null;
+        }
+
+        // Check for legacy migration first
+        if (Files.exists(file)) {
+            int magic = 0;
+            try (FileChannel ch = FileChannel.open(file, StandardOpenOption.READ)) {
+                if (ch.size() >= 4) {
+                    ByteBuffer mb = ByteBuffer.allocate(4);
+                    ch.read(mb);
+                    mb.flip();
+                    magic = mb.getInt();
+                }
+            } catch (IOException e) {
+                // ignore
+            }
+            if (magic == StorageLayout.TEXT_DAT_MAGIC) {
+                Map<String, TextEntry> legacyEntries = readLegacyEntries();
+                migrateLegacyFile(legacyEntries);
+                return;
+            }
+        }
+
+        long size = 1024 * 1024; // 1MB default
+        if (Files.exists(file)) {
+            try {
+                size = Math.max(size, Files.size(file) - MemoryHeader.HEADER_BYTES);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        if (requiredSize > 0) {
+            size = Math.max(size, requiredSize);
+        }
+
+        MemoryId memoryId = MemoryId.of("cortex", "text");
+        TextBlobLayout layout = new TextBlobLayout();
+        appendMemory = new DefaultAppendMemory<>(memoryId, layout, 0, size, file);
+    }
+
+    private Map<String, TextEntry> readLegacyEntries() {
+        Map<String, TextEntry> entries = new LinkedHashMap<>();
+        try (FileChannel ch = FileChannel.open(file, StandardOpenOption.READ)) {
+            long fileSize = ch.size();
+            if (fileSize < LEGACY_HEADER_BYTES) return entries;
+
+            try (Arena tempArena = Arena.ofShared()) {
+                MemorySegment mapped = ch.map(FileChannel.MapMode.READ_ONLY, 0, fileSize, tempArena);
+                int magic = mapped.get(BE_INT, 0);
+                if (magic != StorageLayout.TEXT_DAT_MAGIC) {
+                    return entries;
+                }
+                int count = mapped.get(BE_INT, 8);
+                long pos = LEGACY_HEADER_BYTES;
+                while (pos < fileSize) {
+                    if (fileSize - pos < 9) break;
+                    byte tierOrd = mapped.get(ValueLayout.JAVA_BYTE, pos);
+                    pos += 1;
+                    if (tierOrd < 0 || tierOrd >= MemoryType.values().length) break;
+
+                    int idLen = mapped.get(BE_INT, pos);
+                    pos += 4;
+                    if (idLen < 0 || idLen > 10_000 || pos + idLen + 4 > fileSize) break;
+
+                    String id = decodeUtf8FromSegment(mapped, pos, idLen);
+                    pos += idLen;
+
+                    int textLen = mapped.get(BE_INT, pos);
+                    pos += 4;
+                    if (textLen < 0 || textLen > 10_000_000 || pos + textLen > fileSize) break;
+
+                    String rawText = decodeUtf8FromSegment(mapped, pos, textLen);
+                    pos += textLen;
+
+                    String text = decryptIfNeeded(rawText);
+                    MemoryType tier = MemoryType.values()[tierOrd];
+                    entries.put(id, new TextEntry(id, tier, text));
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read legacy text.dat: " + file, e);
+        }
+        return entries;
+    }
+
+    private void migrateLegacyFile(Map<String, TextEntry> legacyEntries) {
+        log.info("Migrating legacy text.dat format to standard Memory Kernel format: {}", file);
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to delete legacy file for migration: " + file, e);
+        }
+
+        long totalBytes = 0;
+        for (TextEntry entry : legacyEntries.values()) {
+            byte[] idBytes = entry.id().getBytes(StandardCharsets.UTF_8);
+            byte[] textBytes = entry.text().getBytes(StandardCharsets.UTF_8);
+            totalBytes += 4 + (1 + 4 + idBytes.length + 4 + textBytes.length);
+        }
+
+        initAppendMemory(totalBytes);
+
+        for (TextEntry entry : legacyEntries.values()) {
+            byte[] idBytes = entry.id().getBytes(StandardCharsets.UTF_8);
+            byte[] textBytes = entry.text().getBytes(StandardCharsets.UTF_8);
+
+            int entrySize = 1 + 4 + idBytes.length + 4 + textBytes.length;
+            MemorySegment entrySeg = Arena.ofAuto().allocate(entrySize);
+            entrySeg.set(ValueLayout.JAVA_BYTE, 0, (byte) entry.tier().ordinal());
+            entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 1, idBytes.length);
+            MemorySegment.copy(MemorySegment.ofArray(idBytes), 0, entrySeg, 5, idBytes.length);
+            entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 5 + idBytes.length, textBytes.length);
+            MemorySegment.copy(MemorySegment.ofArray(textBytes), 0, entrySeg, 5 + idBytes.length + 4, textBytes.length);
+
+            long payloadOffset = appendMemory.append(entrySeg);
+            long textOffset = appendMemory.dataOffset() + payloadOffset + 9 + idBytes.length;
+            textPositionMap.put(entry.id(), new TextPosition(textOffset, textBytes.length));
+
+            long hash = XxHash64.hash(textBytes);
+            hashToPosition.put(hash, new TextPosition(textOffset, textBytes.length));
+        }
+        appendMemory.flush();
+        this.entryCount = legacyEntries.size();
+    }
+
     /**
      * Appends a single text entry to the file and returns its byte position.
-     *
-     * <p>If the file doesn't exist, creates it with a fresh header.
-     * If the file exists, appends the entry and updates the header count.</p>
      *
      * @param id   memory identifier
      * @param tier the cognitive tier
      * @param text the raw text content
      * @return the byte position of the text within text.dat for direct off-heap reads
      */
-    public TextPosition write(String id, MemoryType tier, String text) {
-        try {
-            boolean isNew = !Files.exists(file);
-            byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
-            byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+    public synchronized TextPosition write(String id, MemoryType tier, String text) {
+        byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
+        byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
 
-            long textOffset;
-
-            if (isNew) {
-                // Create new file with header + first entry
-                try (FileChannel ch = FileChannel.open(file,
-                        StandardOpenOption.CREATE_NEW,
-                        StandardOpenOption.WRITE)) {
-                    writeHeader(ch, 0);
-                    // Text offset = header + tier(1) + idLen(4) + id + textLen(4)
-                    textOffset = HEADER_BYTES + 1 + 4 + idBytes.length + 4;
-                    writeEntry(ch, idBytes, tier, textBytes);
-                }
-            } else {
-                // Append to existing file
-                try (FileChannel ch = FileChannel.open(file,
-                        StandardOpenOption.WRITE)) {
-                    long entryStart = ch.size();
-                    ch.position(entryStart);
-                    // Text offset = entryStart + tier(1) + idLen(4) + id + textLen(4)
-                    textOffset = entryStart + 1 + 4 + idBytes.length + 4;
-                    writeEntry(ch, idBytes, tier, textBytes);
-                }
-            }
-
+        long hash = XxHash64.hash(textBytes);
+        TextPosition existing = hashToPosition.get(hash);
+        if (existing != null) {
+            textPositionMap.put(id, existing);
             entryCount++;
-            updateHeaderCount();
-
-            // Refresh the mmap'd segment so readTextDirect() covers this new entry.
-            // Without this, the mmap established at startup has a fixed size and new
-            // entries written beyond that boundary would be invisible to off-heap reads.
-            refreshMappedSegment();
-
-            return new TextPosition(textOffset, textBytes.length);
-
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write text entry: " + id, e);
+            return existing;
         }
-    }
 
-    private void writeEntry(FileChannel ch, byte[] idBytes, MemoryType tier, byte[] textBytes) throws IOException {
         int entrySize = 1 + 4 + idBytes.length + 4 + textBytes.length;
-        ByteBuffer buf = ByteBuffer.allocate(entrySize);
-        buf.put((byte) tier.ordinal());
-        buf.putInt(idBytes.length);
-        buf.put(idBytes);
-        buf.putInt(textBytes.length);
-        buf.put(textBytes);
-        buf.flip();
-        ch.write(buf);
+
+        if (appendMemory == null) {
+            initAppendMemory(0);
+        }
+
+        long availableSpace = appendMemory.segment().byteSize() - appendMemory.dataOffset() - appendMemory.appendCursor();
+        if (availableSpace < 4 + entrySize) {
+            long newSize = Math.max(appendMemory.segment().byteSize() - appendMemory.dataOffset() * 2,
+                    appendMemory.appendCursor() + 4 + entrySize + 1024 * 1024);
+            initAppendMemory(newSize);
+        }
+
+        MemorySegment entrySeg = Arena.ofAuto().allocate(entrySize);
+        entrySeg.set(ValueLayout.JAVA_BYTE, 0, (byte) tier.ordinal());
+        entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 1, idBytes.length);
+        MemorySegment.copy(MemorySegment.ofArray(idBytes), 0, entrySeg, 5, idBytes.length);
+        entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 5 + idBytes.length, textBytes.length);
+        MemorySegment.copy(MemorySegment.ofArray(textBytes), 0, entrySeg, 5 + idBytes.length + 4, textBytes.length);
+
+        long payloadOffset = appendMemory.append(entrySeg);
+        long textOffset = appendMemory.dataOffset() + payloadOffset + 9 + idBytes.length;
+
+        TextPosition pos = new TextPosition(textOffset, textBytes.length);
+        textPositionMap.put(id, pos);
+        hashToPosition.put(hash, pos);
+        entryCount++;
+
+        return pos;
     }
 
     /**
      * Reads text directly from the mmap'd segment at the given offset — zero-copy, off-heap.
-     *
-     * <p>Requires that {@link #readAll()} has been called first to establish the mmap'd segment.
-     * Falls back to null if the segment is not mapped or the position is invalid.</p>
      *
      * @param textOffset byte offset of the text in text.dat
      * @param textLength byte length of the UTF-8 text
      * @return the text string, or null if the mmap'd segment is unavailable
      */
     public String readTextDirect(long textOffset, int textLength) {
-        MemorySegment seg = this.mappedSegment;
-        if (seg == null || textOffset < 0 || textLength < 0) return null;
+        DefaultAppendMemory<TextBlobLayout> mem = this.appendMemory;
+        if (mem == null || textOffset < 0 || textLength < 0) return null;
+        MemorySegment seg = mem.segment();
         if (textOffset + textLength > seg.byteSize()) return null;
         String raw = decodeUtf8FromSegment(seg, textOffset, textLength);
         return decryptIfNeeded(raw);
@@ -257,126 +319,84 @@ public final class TextDataStore implements AutoCloseable {
     /**
      * Reads all entries from the file using memory-mapped I/O (zero-copy).
      *
-     * <p>Memory-maps the entire file into an off-heap {@link MemorySegment} via
-     * {@link FileChannel#map}. Strings are decoded directly from the mapped segment
-     * without intermediate heap {@code byte[]} allocations.</p>
-     *
-     * <p>The mapped segment is retained and accessible via {@link #mappedSegment()}
-     * for downstream zero-copy text access until {@link #close()} is called.</p>
-     *
      * @return map of memory ID → TextEntry, empty map if file doesn't exist
      */
-    public Map<String, TextEntry> readAll() {
+    public synchronized Map<String, TextEntry> readAll() {
         Map<String, TextEntry> entries = new LinkedHashMap<>();
+        textPositionMap.clear();
+        hashToPosition.clear();
+
         if (!Files.exists(file)) {
+            initAppendMemory(0);
             return entries;
         }
 
-        try (FileChannel ch = FileChannel.open(file, StandardOpenOption.READ)) {
-            long fileSize = ch.size();
-            if (fileSize < HEADER_BYTES) {
-                log.warn("text.dat too small ({} bytes), skipping: {}", fileSize, file);
-                return entries;
-            }
+        initAppendMemory(0);
 
-            // ── mmap the entire file into off-heap memory ──
-            closeMappedSegment(); // close any previous mapping
-            this.mapArena = Arena.ofShared();
-            this.mappedSegment = ch.map(FileChannel.MapMode.READ_ONLY, 0, fileSize, mapArena);
-
-            // ── Read header from mapped segment ──
-            int magic = mappedSegment.get(BE_INT, 0);
-            if (magic != StorageLayout.TEXT_DAT_MAGIC) {
-                log.error("Invalid text.dat magic: 0x{} (expected 0x{}), file: {}",
-                        Integer.toHexString(magic),
-                        Integer.toHexString(StorageLayout.TEXT_DAT_MAGIC), file);
-                closeMappedSegment();
-                return entries;
-            }
-
-            int version = mappedSegment.get(BE_INT, 4);
-            if (version != StorageLayout.TEXT_DAT_VERSION) {
-                log.error("Unsupported text.dat version: {} (expected {}), file: {}",
-                        version, StorageLayout.TEXT_DAT_VERSION, file);
-                closeMappedSegment();
-                return entries;
-            }
-
-            int count = mappedSegment.get(BE_INT, 8);
-            // reserved (4 bytes at offset 12, ignored)
-
-            // ── Read entries directly from the mapped segment ──
-            long pos = HEADER_BYTES;
-            while (pos < fileSize) {
-                // Minimum entry size: tier(1) + idLen(4) + textLen(4) = 9 bytes
-                if (fileSize - pos < 9) break;
-
-                byte tierOrd = mappedSegment.get(ValueLayout.JAVA_BYTE, pos);
-                pos += 1;
-
-                if (tierOrd < 0 || tierOrd >= MemoryType.values().length) {
-                    log.warn("Invalid tier ordinal {} at offset {}, stopping read", tierOrd, pos - 1);
-                    break;
-                }
-
-                int idLen = mappedSegment.get(BE_INT, pos);
-                pos += 4;
-
-                if (idLen < 0 || idLen > 10_000 || pos + idLen + 4 > fileSize) {
-                    log.warn("Invalid id length {} at offset {}, stopping read", idLen, pos - 4);
-                    break;
-                }
-
-                // Decode ID directly from mapped segment — zero heap copy
-                String id = decodeUtf8FromSegment(mappedSegment, pos, idLen);
-                pos += idLen;
-
-                int textLen = mappedSegment.get(BE_INT, pos);
-                long textDataPos = pos + 4; // byte offset where actual text bytes start
-                pos += 4;
-
-                if (textLen < 0 || textLen > 10_000_000 || pos + textLen > fileSize) {
-                    log.warn("Invalid text length {} at offset {}, stopping read", textLen, pos - 4);
-                    break;
-                }
-
-                // Decode text directly from mapped segment — zero heap copy
-                String rawText = decodeUtf8FromSegment(mappedSegment, pos, textLen);
-                pos += textLen;
-
-                // Decrypt if encryption is active (text was Base64-encoded ciphertext)
-                String text = decryptIfNeeded(rawText);
-
-                MemoryType tier = MemoryType.values()[tierOrd];
-                entries.put(id, new TextEntry(id, tier, text));
-                textPositionMap.put(id, new TextPosition(textDataPos, textLen));
-            }
-
-            this.entryCount = entries.size();
-
-            if (entries.size() != count) {
-                log.warn("text.dat header count ({}) != actual entries read ({}): {}",
-                        count, entries.size(), file);
-            }
-
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to read text.dat: " + file, e);
+        if (appendMemory == null) {
+            return entries;
         }
 
+        java.util.Iterator<MemorySegment> it = appendMemory.replay(0);
+        long currentOffset = 0;
+        while (it.hasNext()) {
+            MemorySegment entrySeg = it.next();
+            int entryLen = (int) entrySeg.byteSize();
+            if (entryLen < 9) {
+                currentOffset += 4 + entryLen;
+                continue;
+            }
+
+            byte tierOrd = entrySeg.get(ValueLayout.JAVA_BYTE, 0);
+            if (tierOrd < 0 || tierOrd >= MemoryType.values().length) {
+                currentOffset += 4 + entryLen;
+                continue;
+            }
+
+            int idLen = entrySeg.get(ValueLayout.JAVA_INT_UNALIGNED, 1);
+            if (idLen < 0 || idLen > 10_000 || 5 + idLen + 4 > entryLen) {
+                currentOffset += 4 + entryLen;
+                continue;
+            }
+
+            String id = decodeUtf8FromSegment(entrySeg, 5, idLen);
+            int textLen = entrySeg.get(ValueLayout.JAVA_INT_UNALIGNED, 5 + idLen);
+            if (textLen < 0 || textLen > 10_000_000 || 5 + idLen + 4 + textLen > entryLen) {
+                currentOffset += 4 + entryLen;
+                continue;
+            }
+
+            String rawText = decodeUtf8FromSegment(entrySeg, 5 + idLen + 4, textLen);
+            String text = decryptIfNeeded(rawText);
+
+            MemoryType tier = MemoryType.values()[tierOrd];
+            entries.put(id, new TextEntry(id, tier, text));
+
+            long textOffset = appendMemory.dataOffset() + currentOffset + 4 + 9 + idLen;
+            TextPosition pos = new TextPosition(textOffset, textLen);
+            textPositionMap.put(id, pos);
+
+            byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+            long hash = XxHash64.hash(textBytes);
+            hashToPosition.put(hash, pos);
+
+            currentOffset += 4 + entryLen;
+        }
+
+        this.entryCount = entries.size();
         log.debug("Loaded {} text entries from {} (mmap'd off-heap)", entries.size(), file);
+
         int failures = decryptFailCount.getAndSet(0);
         if (failures > 0) {
             log.warn("text.dat: {} of {} entries failed decryption (wrong key or legacy data): {}",
                     failures, entries.size(), file);
         }
+
         return entries;
     }
 
     /**
      * Returns text positions collected during {@link #readAll()}.
-     *
-     * <p>Maps memoryId → (textOffset, textLength) within text.dat. Used during
-     * startup to backfill MemoryLocation text positions for V1/V2 indexes.</p>
      *
      * @return unmodifiable map of text positions, empty if readAll() not called
      */
@@ -387,48 +407,66 @@ public final class TextDataStore implements AutoCloseable {
     /**
      * Rebuilds the file from the given entries (compaction).
      *
-     * <p>Rewrites the entire file with only the provided entries.
-     * Used after partition compaction to remove tombstoned entries.</p>
-     *
      * @param entries the surviving entries to write
      */
-    public void rebuild(Map<String, TextEntry> entries) {
+    public synchronized void rebuild(Map<String, TextEntry> entries) {
         try {
-            // Close existing mapping before rebuild
-            closeMappedSegment();
+            if (appendMemory != null) {
+                appendMemory.close();
+                appendMemory = null;
+            }
 
-            // Write to temp file, then atomic rename
+            Files.deleteIfExists(file);
+
+            textPositionMap.clear();
+            hashToPosition.clear();
+
             Path tempFile = file.resolveSibling(file.getFileName() + ".tmp");
+            Files.deleteIfExists(tempFile);
 
-            try (FileChannel ch = FileChannel.open(tempFile,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.TRUNCATE_EXISTING)) {
+            MemoryId tempId = MemoryId.of("cortex", "text_temp");
+            TextBlobLayout layout = new TextBlobLayout();
 
-                writeHeader(ch, entries.size());
+            long estimatedSize = 1024 * 1024;
+            for (TextEntry entry : entries.values()) {
+                estimatedSize += 4 + 1 + 4 + entry.id().getBytes(StandardCharsets.UTF_8).length + 4 + entry.text().getBytes(StandardCharsets.UTF_8).length;
+            }
 
+            try (DefaultAppendMemory<TextBlobLayout> tempMemory = new DefaultAppendMemory<>(tempId, layout, 0, estimatedSize, tempFile)) {
                 for (TextEntry entry : entries.values()) {
                     byte[] idBytes = entry.id().getBytes(StandardCharsets.UTF_8);
                     byte[] textBytes = entry.text().getBytes(StandardCharsets.UTF_8);
+                    long hash = XxHash64.hash(textBytes);
+
+                    TextPosition pos = hashToPosition.get(hash);
+                    if (pos != null) {
+                        textPositionMap.put(entry.id(), pos);
+                        continue;
+                    }
 
                     int entrySize = 1 + 4 + idBytes.length + 4 + textBytes.length;
-                    ByteBuffer buf = ByteBuffer.allocate(entrySize);
-                    buf.put((byte) entry.tier().ordinal());
-                    buf.putInt(idBytes.length);
-                    buf.put(idBytes);
-                    buf.putInt(textBytes.length);
-                    buf.put(textBytes);
-                    buf.flip();
-                    ch.write(buf);
+                    MemorySegment entrySeg = Arena.ofAuto().allocate(entrySize);
+                    entrySeg.set(ValueLayout.JAVA_BYTE, 0, (byte) entry.tier().ordinal());
+                    entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 1, idBytes.length);
+                    MemorySegment.copy(MemorySegment.ofArray(idBytes), 0, entrySeg, 5, idBytes.length);
+                    entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 5 + idBytes.length, textBytes.length);
+                    MemorySegment.copy(MemorySegment.ofArray(textBytes), 0, entrySeg, 5 + idBytes.length + 4, textBytes.length);
+
+                    long payloadOffset = tempMemory.append(entrySeg);
+                    long textOffset = tempMemory.dataOffset() + payloadOffset + 9 + idBytes.length;
+
+                    TextPosition newPos = new TextPosition(textOffset, textBytes.length);
+                    textPositionMap.put(entry.id(), newPos);
+                    hashToPosition.put(hash, newPos);
                 }
+                tempMemory.flush();
             }
 
-            // Atomic rename
-            Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING,
-                    StandardCopyOption.ATOMIC_MOVE);
+            Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
 
+            initAppendMemory(0);
             this.entryCount = entries.size();
-            log.debug("Rebuilt text.dat with {} entries: {}", entries.size(), file);
+            log.debug("Rebuilt text.dat with {} entries (deduplicated): {}", entries.size(), file);
 
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to rebuild text.dat: " + file, e);
@@ -438,13 +476,17 @@ public final class TextDataStore implements AutoCloseable {
     /**
      * Returns the off-heap mapped segment for zero-copy text access.
      *
-     * <p>Available after {@link #readAll()} has been called. Returns {@code null}
-     * if the file hasn't been read or has been closed.</p>
-     *
      * @return the mapped MemorySegment, or null
      */
-    public MemorySegment mappedSegment() {
-        return mappedSegment;
+    public MemorySegment segment() {
+        return appendMemory != null ? appendMemory.segment() : null;
+    }
+
+    /**
+     * Returns the underlying kernel DefaultAppendMemory backing this text store.
+     */
+    public DefaultAppendMemory<TextBlobLayout> backing() {
+        return this.appendMemory;
     }
 
     /** Returns the number of entries in this store. */
@@ -458,26 +500,14 @@ public final class TextDataStore implements AutoCloseable {
     }
 
     @Override
-    public void close() {
-        closeMappedSegment();
+    public synchronized void close() {
+        if (appendMemory != null) {
+            appendMemory.close();
+            appendMemory = null;
+        }
     }
 
-    // ── Internal helpers ──
-
-    /**
-     * Decrypts text if encryption is active and the text appears to be Base64-encoded ciphertext.
-     *
-     * <p>During ingestion, {@link PostIngestSync} encrypts text via
-     * {@code DataEncryptor.encryptText()} and Base64-encodes the result before writing
-     * to text.dat. This method reverses that process on the read path.</p>
-     *
-     * @param raw the raw text from text.dat (plaintext or Base64-encoded ciphertext)
-     * @return decrypted plaintext, or the original string if encryption is not active
-     */
-    private final java.util.concurrent.atomic.AtomicInteger decryptFailCount =
-            new java.util.concurrent.atomic.AtomicInteger();
-
-    private String decryptIfNeeded(String raw) {
+    private final String decryptIfNeeded(String raw) {
         if (!encryptor.isEnabled() || raw == null || raw.isEmpty()) {
             return raw;
         }
@@ -486,23 +516,14 @@ public final class TextDataStore implements AutoCloseable {
             byte[] decrypted = encryptor.decryptText(decoded);
             return new String(decrypted, StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
-            // Not Base64 — return as-is (pre-encryption data or plaintext)
             return raw;
         } catch (RuntimeException e) {
             decryptFailCount.incrementAndGet();
             log.debug("Failed to decrypt text entry (wrong key?): {}", e.getMessage());
-            return raw;  // Return encrypted text rather than crash
+            return raw;
         }
     }
 
-    /**
-     * Decodes a UTF-8 string directly from a MemorySegment without intermediate byte[] copy.
-     *
-     * <p>Uses {@link MemorySegment#asSlice} to create a view, then copies to a byte array
-     * for String construction. While this does allocate a byte[], it avoids the double-copy
-     * of the old ByteBuffer path (ByteBuffer → byte[] → String). The segment itself stays
-     * off-heap.</p>
-     */
     private static String decodeUtf8FromSegment(MemorySegment segment, long offset, int length) {
         if (length == 0) return "";
         byte[] bytes = new byte[length];
@@ -510,158 +531,130 @@ public final class TextDataStore implements AutoCloseable {
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    private void writeHeader(FileChannel ch, int count) throws IOException {
-        ByteBuffer header = ByteBuffer.allocate(HEADER_BYTES);
-        header.putInt(StorageLayout.TEXT_DAT_MAGIC);
-        header.putInt(StorageLayout.TEXT_DAT_VERSION);
-        header.putInt(count);
-        header.putInt(0); // reserved
-        header.flip();
-        ch.position(0);
-        ch.write(header);
-    }
-
-    private void updateHeaderCount() throws IOException {
-        try (FileChannel ch = FileChannel.open(file,
-                StandardOpenOption.WRITE)) {
-            ByteBuffer countBuf = ByteBuffer.allocate(4);
-            countBuf.putInt(entryCount);
-            countBuf.flip();
-            ch.position(8); // offset of count field: magic(4) + version(4)
-            ch.write(countBuf);
-        }
-    }
-
-    private void closeMappedSegment() {
-        if (mapArena != null) {
-            try {
-                mapArena.close();
-            } catch (Exception e) {
-                log.debug("Error closing text.dat map arena: {}", e.getMessage());
-            }
-            mapArena = null;
-            mappedSegment = null;
-        }
-    }
-
-    /**
-     * Refreshes the mmap'd segment to cover the current file size.
-     *
-     * <p>Called after {@link #write(String, MemoryType, String)} to ensure that
-     * entries appended after the initial {@link #readAll()} are visible to
-     * {@link #readTextDirect(long, int)}. The old segment/arena is closed and
-     * a new one is created covering the full file.</p>
-     *
-     * <p>Thread-safe: the {@code mappedSegment} field is volatile, so concurrent
-     * readers will atomically see either the old or new segment. The old arena
-     * uses {@link Arena#ofShared()} which is safe to close while readers hold
-     * derived slices (they remain valid until the segment is no longer referenced).</p>
-     */
-    private void refreshMappedSegment() {
-        if (!Files.exists(file)) return;
-        try (FileChannel ch = FileChannel.open(file, StandardOpenOption.READ)) {
-            long fileSize = ch.size();
-            if (fileSize < HEADER_BYTES) return;
-
-            Arena oldArena = this.mapArena;
-            Arena newArena = Arena.ofShared();
-            MemorySegment newSegment = ch.map(FileChannel.MapMode.READ_ONLY, 0, fileSize, newArena);
-
-            // Atomically swap (volatile write ensures visibility to readers)
-            this.mappedSegment = newSegment;
-            this.mapArena = newArena;
-
-            // Close old arena after swap — no readers can acquire new references to it
-            if (oldArena != null) {
-                try {
-                    oldArena.close();
-                } catch (Exception e) {
-                    log.debug("Error closing old text.dat map arena during refresh: {}", e.getMessage());
-                }
-            }
-
-            log.debug("Refreshed text.dat mmap: {} bytes (entries={})", fileSize, entryCount);
-        } catch (IOException e) {
-            log.warn("Failed to refresh text.dat mmap after write: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * Securely erases a text entry by overwriting its text bytes with zeros.
-     *
-     * <p>Called when a memory is forgotten ({@code forget()}) to prevent
-     * forensic recovery of plaintext from the {@code text.dat} file.
-     * The overwrite is forced to disk via {@link FileChannel#force(boolean)}.</p>
-     *
-     * <p>This method scans the file sequentially to find the entry by ID,
-     * then overwrites the text_bytes region with zeros. The entry header
-     * (tier + id) is preserved for structural integrity.</p>
-     *
-     * @param targetId the memory ID whose text should be erased
-     * @return true if the entry was found and erased
-     */
-    public boolean eraseEntry(String targetId) {
+    public synchronized boolean eraseEntry(String targetId) {
         if (!Files.exists(file)) {
             return false;
         }
 
-        try (FileChannel ch = FileChannel.open(file,
-                StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-
-            if (ch.size() < HEADER_BYTES) return false;
-
-            // Skip header
-            ch.position(HEADER_BYTES);
-
-            ByteBuffer sizeBuf = ByteBuffer.allocate(4);
-
-            while (ch.position() < ch.size()) {
-                long entryStart = ch.position();
-
-                // Read tier byte
-                ByteBuffer tierBuf = ByteBuffer.allocate(1);
-                if (ch.read(tierBuf) < 1) break;
-
-                // Read id_len + id_bytes
-                sizeBuf.clear();
-                if (ch.read(sizeBuf) < 4) break;
-                sizeBuf.flip();
-                int idLen = sizeBuf.getInt();
-
-                byte[] idBytes = new byte[idLen];
-                ByteBuffer idBuf = ByteBuffer.wrap(idBytes);
-                if (ch.read(idBuf) < idLen) break;
-                String id = new String(idBytes, StandardCharsets.UTF_8);
-
-                // Read text_len
-                sizeBuf.clear();
-                if (ch.read(sizeBuf) < 4) break;
-                sizeBuf.flip();
-                int textLen = sizeBuf.getInt();
-
-                long textStart = ch.position();
-
-                if (id.equals(targetId)) {
-                    // Overwrite text bytes with zeros
-                    byte[] zeros = new byte[textLen];
-                    ByteBuffer zeroBuf = ByteBuffer.wrap(zeros);
-                    ch.position(textStart);
-                    ch.write(zeroBuf);
-                    ch.force(true); // Force to disk immediately
-
-                    log.debug("Securely erased {} bytes of text for memory '{}'", textLen, targetId);
-                    return true;
-                }
-
-                // Skip past text bytes to next entry
-                ch.position(textStart + textLen);
-            }
-
-        } catch (IOException e) {
-            log.warn("Failed to erase text entry for '{}': {}", targetId, e.getMessage());
+        if (appendMemory == null) {
+            initAppendMemory(0);
         }
 
-        return false;
+        TextPosition pos = textPositionMap.get(targetId);
+        if (pos == null) return false;
+
+        MemorySegment seg = appendMemory.segment();
+        seg.asSlice(pos.textOffset(), pos.textLength()).fill((byte) 0);
+        appendMemory.flush();
+
+        log.debug("Securely erased {} bytes of text for memory '{}'", pos.textLength(), targetId);
+        return true;
+    }
+
+    /**
+     * Pure-Java xxHash64 implementation.
+     */
+    public static final class XxHash64 {
+        private static final long PRIME1 = 0x9E3779B185EBCA87L;
+        private static final long PRIME2 = 0xC2B2AE3D27D4EB4FL;
+        private static final long PRIME3 = 0x165667B19E3779F9L;
+        private static final long PRIME4 = 0x85EBCA77C2B2AE63L;
+        private static final long PRIME5 = 0x27D4EB2F165667C5L;
+
+        public static long hash(byte[] input) {
+            int len = input.length;
+            long h64;
+            int index = 0;
+
+            if (len >= 32) {
+                long v1 = PRIME1 + PRIME2;
+                long v2 = PRIME2;
+                long v3 = 0;
+                long v4 = -PRIME1;
+
+                int limit = len - 32;
+                while (index <= limit) {
+                    v1 = round(v1, readLongLE(input, index));
+                    index += 8;
+                    v2 = round(v2, readLongLE(input, index));
+                    index += 8;
+                    v3 = round(v3, readLongLE(input, index));
+                    index += 8;
+                    v4 = round(v4, readLongLE(input, index));
+                    index += 8;
+                }
+
+                h64 = Long.rotateLeft(v1, 1) + Long.rotateLeft(v2, 7) + Long.rotateLeft(v3, 12) + Long.rotateLeft(v4, 18);
+                h64 = mergeRound(h64, v1);
+                h64 = mergeRound(h64, v2);
+                h64 = mergeRound(h64, v3);
+                h64 = mergeRound(h64, v4);
+            } else {
+                h64 = PRIME5;
+            }
+
+            h64 += len;
+
+            int limit = len - 8;
+            while (index <= limit) {
+                long k1 = round(0, readLongLE(input, index));
+                h64 ^= k1;
+                h64 = Long.rotateLeft(h64, 27) * PRIME1 + PRIME4;
+                index += 8;
+            }
+
+            limit = len - 4;
+            if (index <= limit) {
+                h64 ^= (readIntLE(input, index) & 0xFFFFFFFFL) * PRIME1;
+                h64 = Long.rotateLeft(h64, 23) * PRIME2 + PRIME3;
+                index += 4;
+            }
+
+            while (index < len) {
+                h64 ^= (input[index] & 0xFFL) * PRIME5;
+                h64 = Long.rotateLeft(h64, 11) * PRIME1;
+                index++;
+            }
+
+            h64 ^= h64 >>> 33;
+            h64 *= PRIME2;
+            h64 ^= h64 >>> 29;
+            h64 *= PRIME3;
+            h64 ^= h64 >>> 32;
+
+            return h64;
+        }
+
+        private static long round(long acc, long val) {
+            acc += val * PRIME2;
+            acc = Long.rotateLeft(acc, 31);
+            acc *= PRIME1;
+            return acc;
+        }
+
+        private static long mergeRound(long acc, long val) {
+            val = round(0, val);
+            acc ^= val;
+            acc = acc * PRIME1 + PRIME4;
+            return acc;
+        }
+
+        private static long readLongLE(byte[] bytes, int index) {
+            return ((bytes[index] & 0xFFL)) |
+                   ((bytes[index + 1] & 0xFFL) << 8) |
+                   ((bytes[index + 2] & 0xFFL) << 16) |
+                   ((bytes[index + 3] & 0xFFL) << 24) |
+                   ((bytes[index + 4] & 0xFFL) << 32) |
+                   ((bytes[index + 5] & 0xFFL) << 40) |
+                   ((bytes[index + 6] & 0xFFL) << 48) |
+                   ((bytes[index + 7] & 0xFFL) << 56);
+        }
+
+        private static int readIntLE(byte[] bytes, int index) {
+            return ((bytes[index] & 0xFF)) |
+                   ((bytes[index + 1] & 0xFF) << 8) |
+                   ((bytes[index + 2] & 0xFF) << 16) |
+                   ((bytes[index + 3] & 0xFF) << 24);
+        }
     }
 }
-

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
@@ -86,7 +86,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *     [memIdx:4B][weight:4B]
  * </pre>
  */
-public final class EntityGraph implements AutoCloseable {
+public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.memory.kernel.shape.GraphMemory<com.spectrayan.spector.memory.kernel.layout.EntityLayout> {
 
     private static final Logger log = LoggerFactory.getLogger(EntityGraph.class);
 
@@ -1699,6 +1699,74 @@ public final class EntityGraph implements AutoCloseable {
     // ══════════════════════════════════════════════════════════════
     // KERNEL INTEGRATION
     // ══════════════════════════════════════════════════════════════
+
+    @Override
+    public MemoryId id() {
+        return memoryId;
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.kernel.layout.EntityLayout layout() {
+        return new com.spectrayan.spector.memory.kernel.layout.EntityLayout();
+    }
+
+    @Override
+    public Arena arena() {
+        return arena;
+    }
+
+    @Override
+    public MemorySegment segment() {
+        return entitySegment;
+    }
+
+    @Override
+    public int size() {
+        return entityCount;
+    }
+
+    @Override
+    public int capacity() {
+        return entityCapacity;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return 2;
+    }
+
+    @Override
+    public MemoryShape shape() {
+        return MemoryShape.GRAPH;
+    }
+
+    @Override
+    public void flush() {
+        if (entitySegment != null) entitySegment.force();
+        if (edgeSegment != null) edgeSegment.force();
+        if (adjacencySegment != null) adjacencySegment.force();
+    }
+
+    @Override
+    public int addEdge(int fromNode, int toNode, MemorySegment edgeBytes) {
+        addRelation(fromNode, toNode, "related_to");
+        return edgeCount();
+    }
+
+    @Override
+    public void removeEdge(int edgeId) {
+        // EntityGraph handles edges in adjacency segments; direct removal by id is managed via decay/compaction.
+    }
+
+    @Override
+    public java.util.PrimitiveIterator.OfInt neighbours(int nodeId) {
+        return edges(nodeId).stream().mapToInt(EntityEdge::targetEntityId).iterator();
+    }
+
+    @Override
+    public int nodeCount() {
+        return entityCount;
+    }
 
     public MemoryId memoryId() {
         return memoryId;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
@@ -1684,8 +1684,8 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
     MemorySegment adjacencySegment() { return adjacencySegment; }
     int adjSegmentCapacity() { return adjSegmentCapacity; }
     ConcurrentHashMap<String, Integer> nameIndexInternal() { return nameIndex; }
-    TypeRegistry entityTypeRegistry() { return entityTypeRegistry; }
-    TypeRegistry relationTypeRegistry() { return relationTypeRegistry; }
+    public TypeRegistry entityTypeRegistry() { return entityTypeRegistry; }
+    public TypeRegistry relationTypeRegistry() { return relationTypeRegistry; }
 
     /**
      * Resets all entities, edges, and adjacency data by zero-filling segments.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
@@ -28,6 +28,10 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -200,6 +204,8 @@ public final class EntityGraph implements AutoCloseable {
     /** Edge importance scorer (configurable weights). */
     private final EdgeImportance edgeImportance;
 
+    private final MemoryId memoryId;
+
     /**
      * Creates a new entity graph with default max degree.
      *
@@ -240,6 +246,7 @@ public final class EntityGraph implements AutoCloseable {
         this.mmapFilePath = null;
         this.entityTypeRegistry = TypeRegistry.seeded("entity-type", EntityType.SEED);
         this.relationTypeRegistry = TypeRegistry.seeded("relation-type", RelationType.SEED);
+        this.memoryId = MemoryId.of("graph", "entity");
 
         log.info("EntityGraph initialized (heap): entities={}, edges={}, maxDegree={}, adjSlots={}, memory={}KB",
                 entityCapacity, edgeCapacity, maxDegree, adjSegmentCapacity,
@@ -393,6 +400,7 @@ public final class EntityGraph implements AutoCloseable {
                 this.entityTypeRegistry = TypeRegistry.seeded("entity-type", EntityType.SEED);
                 this.relationTypeRegistry = TypeRegistry.seeded("relation-type", RelationType.SEED);
             }
+            this.memoryId = MemoryId.of("graph", "entity");
 
             log.info("EntityGraph initialized (mmap): entities={}/{}, edges={}/{}, maxDegree={}, version={}, file={}",
                     this.entityCount, this.entityCapacity, this.edgeCount, this.edgeCapacity,
@@ -470,6 +478,7 @@ public final class EntityGraph implements AutoCloseable {
         this.mmapFilePath = null;
         this.entityTypeRegistry = entityTypeRegistry;
         this.relationTypeRegistry = relationTypeRegistry;
+        this.memoryId = MemoryId.of("graph", "entity");
     }
 
     /**
@@ -1685,6 +1694,18 @@ public final class EntityGraph implements AutoCloseable {
         } finally {
             graphLock.unlock();
         }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // KERNEL INTEGRATION
+    // ══════════════════════════════════════════════════════════════
+
+    public MemoryId memoryId() {
+        return memoryId;
+    }
+
+    public MemoryShape kernelShape() {
+        return MemoryShape.GRAPH;
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraph.java
@@ -31,6 +31,8 @@ import java.nio.file.StandardOpenOption;
 
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -205,6 +207,9 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
     private final EdgeImportance edgeImportance;
 
     private final MemoryId memoryId;
+
+    private MemoryWal wal;
+    private boolean bypassWal = false;
 
     /**
      * Creates a new entity graph with default max degree.
@@ -504,6 +509,9 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
         }
 
         int entityId = entityCount++;
+        if (wal != null && !bypassWal) {
+            wal.appendGraphAddNode(memoryId.toString(), entityId, normalized, type);
+        }
         long offset = (long) entityId * ENTITY_NODE_BYTES;
         int typeId = entityTypeRegistry.getOrRegister(type);
 
@@ -534,6 +542,10 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
         if (fromEntity < 0 || fromEntity >= entityCount) return;
         if (toEntity < 0 || toEntity >= entityCount) return;
         if (fromEntity == toEntity) return;
+
+        if (wal != null && !bypassWal) {
+            wal.appendAdjAddEdge(memoryId.toString(), fromEntity, toEntity, (type != null ? type : "OTHER").getBytes(StandardCharsets.UTF_8));
+        }
 
         int typeId = relationTypeRegistry.getOrRegister(type != null ? type : "OTHER");
         long entityOffset = (long) fromEntity * ENTITY_NODE_BYTES;
@@ -727,6 +739,9 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
 
         graphLock.lock();
         try {
+            if (wal != null && !bypassWal) {
+                wal.appendGraphLinkMemory(memoryId.toString(), entityId, memoryIdx);
+            }
             long entOffset = (long) entityId * ENTITY_NODE_BYTES;
             int adjOff = entitySegment.get(ValueLayout.JAVA_INT, entOffset + ENT_OFF_ADJ_OFFSET);
             int adjCnt = entitySegment.get(ValueLayout.JAVA_INT, entOffset + ENT_OFF_ADJ_COUNT);
@@ -1774,6 +1789,21 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
 
     public MemoryShape kernelShape() {
         return MemoryShape.GRAPH;
+    }
+
+    @Override
+    public void bindWal(MemoryWal wal) {
+        this.wal = wal;
+    }
+
+    @Override
+    public void setBypassWal(boolean bypass) {
+        this.bypassWal = bypass;
+    }
+
+    @Override
+    public MemoryWal getWal() {
+        return this.wal;
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistry.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistry.java
@@ -90,6 +90,11 @@ public final class TypeRegistry implements RegistryMemory {
     }
 
     @Override
+    public void putDirect(String name, int id) {
+        backing.putDirect(name, id);
+    }
+
+    @Override
     public String nameOf(int id) {
         String name = backing.nameOf(id);
         return name != null ? name : "UNKNOWN";

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistry.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistry.java
@@ -19,188 +19,174 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.util.Locale;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.shape.RegistryMemory;
+import com.spectrayan.spector.memory.kernel.shape.RegistryLayout;
+import com.spectrayan.spector.memory.kernel.shape.DefaultRegistryMemory;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorStorageException;
+
 /**
- * Thread-safe, open-schema string ↔ integer type registry.
- *
- * <h3>Design</h3>
- * <p>Provides Neo4j-style open labeling: any string is accepted as a type
- * and automatically assigned a stable integer ID on first use. IDs are
- * sequential and never reused. Well-known types (e.g., "PERSON", "MANAGES")
- * are pre-seeded with stable IDs for backward compatibility.</p>
- *
- * <h3>Off-Heap Integration</h3>
- * <p>The integer IDs are stored in the off-heap {@link EntityGraph} structures
- * (4 bytes per entity type, 4 bytes per relation type). This keeps the graph
- * layout compact while allowing unlimited type extensibility.</p>
- *
- * <h3>Persistence</h3>
- * <p>The registry is saved/loaded alongside graph data as a simple binary file:
- * {@code [count:4B][{nameLen:4B, nameUtf8:varB, id:4B}...]}</p>
- *
- * <h3>Thread Safety</h3>
- * <p>Uses {@link ConcurrentHashMap} for lookups and {@link AtomicInteger} for
- * ID generation. Safe for concurrent ingestion from multiple virtual threads.</p>
- *
- * @see EntityGraph
+ * Thread-safe, open-schema string ↔ integer type registry, backed by the Memory Kernel shape RegistryMemory.
  */
-public final class TypeRegistry {
+public final class TypeRegistry implements RegistryMemory {
 
     private static final Logger log = LoggerFactory.getLogger(TypeRegistry.class);
 
-    /** File magic: "TREG" in ASCII. */
-    private static final int FILE_MAGIC = 0x54524547;
-    private static final int FILE_VERSION = 1;
+    /** Legacy File magic: "TREG" in ASCII. */
+    private static final int LEGACY_FILE_MAGIC = 0x54524547;
+    private static final int LEGACY_FILE_VERSION = 1;
 
-    private final ConcurrentHashMap<String, Integer> nameToId;
-    private final ConcurrentHashMap<Integer, String> idToName;
-    private final AtomicInteger nextId;
-    private final String label;  // "entity-type" or "relation-type", for logging
+    private final String label;
+    private volatile DefaultRegistryMemory backing;
 
     /**
-     * Creates a new empty registry.
+     * Creates a new empty registry (volatile).
      *
      * @param label descriptive label for logging (e.g., "entity-type", "relation-type")
      */
     public TypeRegistry(String label) {
         this.label = label;
-        this.nameToId = new ConcurrentHashMap<>();
-        this.idToName = new ConcurrentHashMap<>();
-        this.nextId = new AtomicInteger(0);
+        MemoryId registryId = MemoryId.of("graph", label);
+        RegistryLayout layout = new RegistryLayout();
+        // Create volatile DefaultRegistryMemory
+        this.backing = new DefaultRegistryMemory(registryId, layout, 1024, 256 * 1024);
     }
 
     /**
      * Creates a registry pre-seeded with the given well-known types.
-     *
-     * <p>Each type gets a stable ID based on its array index. This ensures
-     * backward compatibility with existing persisted graphs that used
-     * enum ordinals.</p>
-     *
-     * @param label     descriptive label
-     * @param seedTypes well-known types to pre-register (index = ID)
-     * @return a seeded registry
      */
     public static TypeRegistry seeded(String label, String... seedTypes) {
         TypeRegistry registry = new TypeRegistry(label);
         for (String type : seedTypes) {
-            registry.register(type);
+            registry.intern(type);
         }
         return registry;
     }
 
     /**
      * Returns the ID for the given type name, registering it if not yet known.
-     *
-     * <p>Names are case-insensitive and normalized to uppercase.</p>
-     *
-     * @param name type name (e.g., "PERSON", "SOFTWARE", "VEHICLE")
-     * @return the stable integer ID for this type
+     * Alias for intern(name) to preserve legacy codebase API.
      */
     public int getOrRegister(String name) {
-        if (name == null || name.isBlank()) {
-            return getOrRegister("OTHER");
-        }
-        String normalized = name.trim().toUpperCase(Locale.ROOT);
-        Integer existing = nameToId.get(normalized);
-        if (existing != null) return existing;
-
-        // Double-check with putIfAbsent for thread safety
-        int newId = nextId.getAndIncrement();
-        Integer raced = nameToId.putIfAbsent(normalized, newId);
-        if (raced != null) {
-            // Another thread registered it first, revert our ID
-            // (IDs may have gaps, which is fine — we never reuse them)
-            return raced;
-        }
-        idToName.put(newId, normalized);
-        log.debug("{} registry: registered '{}' → {}", label, normalized, newId);
-        return newId;
+        return intern(name);
     }
 
-    /**
-     * Returns the type name for a given ID, or "UNKNOWN" if not found.
-     *
-     * @param id the type ID
-     * @return the type name string
-     */
+    // ── RegistryMemory Delegation ──
+
+    @Override
+    public int intern(String name) {
+        return backing.intern(name);
+    }
+
+    @Override
     public String nameOf(int id) {
-        String name = idToName.get(id);
+        String name = backing.nameOf(id);
         return name != null ? name : "UNKNOWN";
     }
 
-    /**
-     * Returns the ID for a given type name, or -1 if not registered.
-     *
-     * @param name the type name
-     * @return the ID, or -1
-     */
+    @Override
     public int idOf(String name) {
-        if (name == null || name.isBlank()) return -1;
-        Integer id = nameToId.get(name.trim().toUpperCase(Locale.ROOT));
-        return id != null ? id : -1;
+        return backing.idOf(name);
     }
 
-    /**
-     * Returns the current number of registered types.
-     */
+    @Override
+    public Map<String, Integer> entries() {
+        return backing.entries();
+    }
+
+    @Override
+    public MemoryId id() {
+        return backing.id();
+    }
+
+    @Override
+    public RegistryLayout layout() {
+        return backing.layout();
+    }
+
+    @Override
+    public Arena arena() {
+        return backing.arena();
+    }
+
+    @Override
+    public MemorySegment segment() {
+        return backing.segment();
+    }
+
+    @Override
     public int size() {
-        return nameToId.size();
+        return backing.size();
     }
 
-    // ── Persistence ──────────────────────────────────────────────
+    @Override
+    public int capacity() {
+        return backing.capacity();
+    }
 
-    /**
-     * Saves the registry to a binary file.
-     *
-     * <p>Format: {@code [magic:4B][version:4B][count:4B][{nameLen:4B, nameUtf8:varB, id:4B}...]}</p>
-     *
-     * @param filePath path to write
-     * @throws IOException on I/O error
-     */
+    @Override
+    public int schemaVersion() {
+        return backing.schemaVersion();
+    }
+
+
+
+    @Override
+    public MemoryShape shape() {
+        return backing.shape();
+    }
+
+    @Override
+    public void flush() {
+        backing.flush();
+    }
+
+    @Override
+    public void close() {
+        backing.close();
+    }
+
+    // ── Persistence: save / load with transparent legacy support ──
+
     public void save(Path filePath) throws IOException {
+        Files.deleteIfExists(filePath);
         Files.createDirectories(filePath.getParent());
 
-        try (FileChannel ch = FileChannel.open(filePath,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+        MemoryId registryId = MemoryId.of("graph", label);
+        RegistryLayout layout = new RegistryLayout();
 
-            // Header
-            ByteBuffer header = ByteBuffer.allocate(12);
-            header.putInt(FILE_MAGIC);
-            header.putInt(FILE_VERSION);
-            header.putInt(nameToId.size());
-            header.flip();
-            ch.write(header);
-
-            // Entries
-            for (var entry : nameToId.entrySet()) {
-                byte[] nameBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
-                ByteBuffer entryBuf = ByteBuffer.allocate(4 + nameBytes.length + 4);
-                entryBuf.putInt(nameBytes.length);
-                entryBuf.put(nameBytes);
-                entryBuf.putInt(entry.getValue());
-                entryBuf.flip();
-                ch.write(entryBuf);
-            }
+        // Calculate total size required for the new persistent registry memory segment
+        long totalDataBytes = 0;
+        Map<String, Integer> currentEntries = entries();
+        for (String name : currentEntries.keySet()) {
+            totalDataBytes += 2 + name.getBytes(StandardCharsets.UTF_8).length + 4;
         }
 
-        log.info("{} registry saved: {} types → {}", label, nameToId.size(), filePath);
+        try (DefaultRegistryMemory fileBacking = new DefaultRegistryMemory(
+                registryId, layout, currentEntries.size(), MemoryHeader.HEADER_BYTES + totalDataBytes, filePath)) {
+            
+            // Re-intern all entries in order of their IDs
+            currentEntries.entrySet().stream()
+                    .sorted(Map.Entry.comparingByValue())
+                    .forEach(entry -> fileBacking.putDirect(entry.getKey(), entry.getValue()));
+            
+            fileBacking.flush();
+        }
+
+        log.info("{} registry saved (SMKM V1): {} types → {}", label, currentEntries.size(), filePath);
     }
 
-    /**
-     * Loads a registry from a binary file, or returns a seeded registry if the file
-     * doesn't exist.
-     *
-     * @param filePath  path to read
-     * @param label     descriptive label
-     * @param seedTypes fallback well-known types if file doesn't exist
-     * @return the loaded or seeded registry
-     */
     public static TypeRegistry load(Path filePath, String label, String... seedTypes) {
         if (!Files.exists(filePath)) {
             log.info("{} registry file not found, creating seeded registry with {} types",
@@ -208,74 +194,80 @@ public final class TypeRegistry {
             return seeded(label, seedTypes);
         }
 
-        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
-            ByteBuffer header = ByteBuffer.allocate(12);
-            ch.read(header);
-            header.flip();
-
-            int magic = header.getInt();
-            int version = header.getInt();
-            int count = header.getInt();
-
-            if (magic != FILE_MAGIC || version != FILE_VERSION) {
-                log.warn("{} registry file has invalid magic/version, creating fresh", label);
-                return seeded(label, seedTypes);
+        try {
+            int magic;
+            try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                ByteBuffer mb = ByteBuffer.allocate(4);
+                ch.read(mb);
+                mb.flip();
+                magic = mb.getInt();
             }
+
+            boolean isStandard = (magic == MemoryHeader.MAGIC || magic == 0x4D4B4D53);
+            boolean isLegacy = (magic == LEGACY_FILE_MAGIC || magic == 0x47455254);
 
             TypeRegistry registry = new TypeRegistry(label);
-            int maxId = -1;
 
-            for (int i = 0; i < count; i++) {
-                ByteBuffer lenBuf = ByteBuffer.allocate(4);
-                ch.read(lenBuf);
-                lenBuf.flip();
-                int nameLen = lenBuf.getInt();
+            if (isStandard) {
+                MemoryId registryId = MemoryId.of("graph", label);
+                RegistryLayout layout = new RegistryLayout();
+                registry.backing.close();
+                registry.backing = new DefaultRegistryMemory(registryId, layout, 0, 0, filePath);
 
-                ByteBuffer nameBuf = ByteBuffer.allocate(nameLen);
-                ch.read(nameBuf);
-                nameBuf.flip();
-                String name = StandardCharsets.UTF_8.decode(nameBuf).toString();
-
-                ByteBuffer idBuf = ByteBuffer.allocate(4);
-                ch.read(idBuf);
-                idBuf.flip();
-                int id = idBuf.getInt();
-
-                registry.nameToId.put(name, id);
-                registry.idToName.put(id, name);
-                maxId = Math.max(maxId, id);
-            }
-
-            registry.nextId.set(maxId + 1);
-
-            // Ensure all seed types are present (for newly added well-known types)
-            for (String seed : seedTypes) {
-                String normalized = seed.trim().toUpperCase(Locale.ROOT);
-                if (!registry.nameToId.containsKey(normalized)) {
-                    registry.getOrRegister(normalized);
+                // Ensure all seed types are present (e.g. if new seed types were added)
+                for (String seed : seedTypes) {
+                    registry.intern(seed);
                 }
+                log.info("{} registry loaded (SMKM V1): {} types from {}", label, registry.size(), filePath.getFileName());
+                return registry;
+            } else if (isLegacy) {
+                // Read legacy file format
+                try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                    ByteBuffer header = ByteBuffer.allocate(12);
+                    ch.read(header);
+                    header.flip();
+                    header.getInt(); // magic
+                    header.getInt(); // version
+                    int count = header.getInt();
+
+                    for (int i = 0; i < count; i++) {
+                        ByteBuffer lenBuf = ByteBuffer.allocate(4);
+                        ch.read(lenBuf);
+                        lenBuf.flip();
+                        int nameLen = lenBuf.getInt();
+
+                        ByteBuffer nameBuf = ByteBuffer.allocate(nameLen);
+                        ch.read(nameBuf);
+                        nameBuf.flip();
+                        String name = StandardCharsets.UTF_8.decode(nameBuf).toString();
+
+                        ByteBuffer idBuf = ByteBuffer.allocate(4);
+                        ch.read(idBuf);
+                        idBuf.flip();
+                        int id = idBuf.getInt();
+
+                        registry.backing.putDirect(name, id);
+                    }
+                }
+
+                // Ensure all seed types are present
+                for (String seed : seedTypes) {
+                    registry.intern(seed);
+                }
+                log.info("{} registry loaded (legacy V1): {} types from {}", label, registry.size(), filePath.getFileName());
+                return registry;
+            } else {
+                log.warn("{} registry file has invalid magic: 0x{}, creating fresh", label, Integer.toHexString(magic));
+                return seeded(label, seedTypes);
             }
-
-            log.info("{} registry loaded: {} types from {}", label, registry.size(), filePath);
-            return registry;
-
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error("Failed to load {} registry, creating fresh: {}", label, e.getMessage());
             return seeded(label, seedTypes);
         }
     }
 
-    // ── Internal ─────────────────────────────────────────────────
-
-    /**
-     * Registers a type and returns its ID. Used internally for seeding.
-     */
-    private int register(String name) {
-        return getOrRegister(name);
-    }
-
     @Override
     public String toString() {
-        return "TypeRegistry[" + label + ", size=" + nameToId.size() + "]";
+        return "TypeRegistry[" + label + ", size=" + size() + "]";
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationTracker.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationTracker.java
@@ -15,17 +15,26 @@ package com.spectrayan.spector.memory.hebbian;
 import com.spectrayan.spector.memory.adaptor.RunningStats;
 import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.layout.CoActivationLayout;
+import com.spectrayan.spector.memory.kernel.shape.DefaultRecordMemory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumMap;
 import java.util.List;
@@ -42,20 +51,17 @@ import java.util.concurrent.ConcurrentHashMap;
  * basis of associative memory.</p>
  *
  * <h3>Spike-Timing-Dependent Plasticity (STDP)</h3>
- * <p>STDP extends basic Hebbian learning with <em>temporal direction</em>.
- * If neuron A fires <b>before</b> neuron B (causal), the A→B synapse is
- * <b>strengthened</b> (Long-Term Potentiation). If A fires <b>after</b> B
- * (anti-causal), the B→A synapse is <b>weakened</b> (Long-Term Depression).
- * This produces directed, predictive associations — "tag A predicts tag B."</p>
+ * <p>If neuron A fires <b>before</b> neuron B (causal), the A→B synapse is
+ * strengthened (LTP). If A fires <b>after</b> B (anti-causal), the B→A
+ * synapse is weakened (LTD). This produces directed, predictive associations.</p>
  *
  * <h3>Architecture</h3>
- * <p>This class coordinates two independent off-heap hash tables:</p>
+ * <p>This class coordinates two independent off-heap hash tables mapped inside
+ * a single record memory structure:</p>
  * <ul>
  *   <li>{@link OffHeapPairTable} — undirected co-activation pairs (32B/slot)</li>
  *   <li>{@link OffHeapEdgeTable} — directed STDP edges (40B/slot)</li>
  * </ul>
- * <p>Each table has its own {@code ReentrantLock}, so pair writes never
- * block edge writes and vice versa.</p>
  *
  * @see OffHeapPairTable
  * @see OffHeapEdgeTable
@@ -66,54 +72,29 @@ public final class CoActivationTracker implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(CoActivationTracker.class);
 
     // ── STDP Constants ──
-
-    /** A+ (LTP amplitude): maximum weight increase for causal pairings. */
     private static final float A_PLUS = 0.1f;
-
-    /** A- (LTD amplitude): maximum weight decrease for anti-causal pairings. */
     private static final float A_MINUS = 0.05f;
-
-    /** τ+ (LTP time constant): causal window in milliseconds. */
-    private static final float TAU_PLUS = 30_000f;  // 30 seconds
-
-    /** τ- (LTD time constant): anti-causal window in milliseconds. */
-    private static final float TAU_MINUS = 30_000f;  // 30 seconds
-
-    /** Minimum weight (prevent complete erasure). */
+    private static final float TAU_PLUS = 30_000f;
+    private static final float TAU_MINUS = 30_000f;
     static final float MIN_WEIGHT = 0.0f;
-
-    /** Maximum weight (prevent runaway potentiation). */
     static final float MAX_WEIGHT = 1.0f;
 
     // ── Persistence ──
-
-    /** File magic: "COAX" in ASCII. */
     private static final int FILE_MAGIC = 0x434F4158;
-    /** COAX v2: adds bandit stats for ProfileAdaptor persistence. */
     private static final int FILE_VERSION = 2;
-    /** v1 header size (for backward-compatible loading). */
     private static final int FILE_HEADER_V1_BYTES = 24;
-    /** v2 header: v1(24) + bandCap(4) + bandCount(4) = 32B. */
     private static final int FILE_HEADER_BYTES = 32;
 
     // ── State ──
-
     private final Arena arena;
-    private final OffHeapPairTable pairTable;
-    private final OffHeapEdgeTable edgeTable;
+    private DefaultRecordMemory<CoActivationLayout> recordMemory;
+    private OffHeapPairTable pairTable;
+    private OffHeapEdgeTable edgeTable;
 
-    /** On-heap name↔hash resolution (small — only unique tag strings). */
     private final ConcurrentHashMap<Long, String> hashToTag = new ConcurrentHashMap<>();
-
-    /** On-heap ProfileAdaptor bandit statistics (persisted in COAX v2 format). */
     private volatile Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats =
             new ConcurrentHashMap<>();
 
-    // ── Records ──
-
-    /**
-     * A directed edge between two synaptic tags.
-     */
     public record DirectedEdge(String sourceTag, String targetTag) {
         @Override
         public String toString() {
@@ -121,15 +102,7 @@ public final class CoActivationTracker implements AutoCloseable {
         }
     }
 
-    /**
-     * STDP edge weight with temporal metadata.
-     *
-     * @param weight           current STDP weight (0.0 to 1.0)
-     * @param lastActivatedMs  epoch millis of last activation
-     * @param activationCount  total number of sequential activations
-     */
     public record EdgeWeight(float weight, long lastActivatedMs, int activationCount) {
-        /** Returns a new EdgeWeight with updated weight and timestamp. */
         public EdgeWeight withUpdate(float deltaWeight, long nowMs) {
             float newWeight = Math.clamp(weight + deltaWeight, MIN_WEIGHT, MAX_WEIGHT);
             return new EdgeWeight(newWeight, nowMs, activationCount + 1);
@@ -140,59 +113,69 @@ public final class CoActivationTracker implements AutoCloseable {
     // Constructors
     // ══════════════════════════════════════════════════════════════
 
-    /**
-     * Creates a co-activation tracker with default capacities (10_000 pairs, 20_000 edges).
-     */
     public CoActivationTracker() {
         this(10_000);
     }
 
-    /**
-     * Creates a co-activation tracker.
-     *
-     * @param maxPairs maximum tracked undirected pairs
-     */
     public CoActivationTracker(int maxPairs) {
         this(maxPairs, maxPairs * 2);
     }
 
-    /**
-     * Creates a co-activation tracker with custom limits.
-     *
-     * @param maxPairs maximum tracked undirected pairs
-     * @param maxEdges maximum tracked STDP directed edges
-     */
     public CoActivationTracker(int maxPairs, int maxEdges) {
         int pairCap = nextPowerOf2(Math.max(64, maxPairs * 2));
         int edgeCap = nextPowerOf2(Math.max(64, maxEdges * 2));
-        this.arena = Arena.ofShared();
-        this.pairTable = new OffHeapPairTable(pairCap, arena);
-        this.edgeTable = new OffHeapEdgeTable(edgeCap, arena);
+        long totalBytes = 8 + 32L * pairCap + 40L * edgeCap;
 
-        log.info("CoActivationTracker initialized (off-heap): pairSlots={}, edgeSlots={}, memory={}KB",
-                pairCap, edgeCap,
-                ((long) OffHeapPairTable.SLOT_BYTES * pairCap
-                        + (long) OffHeapEdgeTable.SLOT_BYTES * edgeCap) / 1024);
+        MemoryId memoryId = MemoryId.of("hebbian", "coactivation");
+        CoActivationLayout layout = new CoActivationLayout();
+
+        this.recordMemory = new DefaultRecordMemory<>(memoryId, layout, (int) totalBytes, totalBytes);
+        this.arena = recordMemory.arena();
+
+        MemorySegment segment = recordMemory.segment();
+        long dataOffset = recordMemory.dataOffset();
+
+        segment.set(ValueLayout.JAVA_INT, dataOffset, pairCap);
+        segment.set(ValueLayout.JAVA_INT, dataOffset + 4, edgeCap);
+
+        this.pairTable = new OffHeapPairTable(pairCap, segment.asSlice(dataOffset + 8, 32L * pairCap), 0);
+        this.edgeTable = new OffHeapEdgeTable(edgeCap, segment.asSlice(dataOffset + 8 + 32L * pairCap, 40L * edgeCap), 0);
+
+        log.info("CoActivationTracker initialized (volatile): pairCap={}, edgeCap={}, memory={}KB",
+                pairCap, edgeCap, totalBytes / 1024);
     }
 
-    /** Private constructor for loading from pre-existing tables. */
-    private CoActivationTracker(Arena arena, OffHeapPairTable pairTable, OffHeapEdgeTable edgeTable,
-                                 ConcurrentHashMap<Long, String> hashToTag) {
-        this.arena = arena;
-        this.pairTable = pairTable;
-        this.edgeTable = edgeTable;
-        this.hashToTag.putAll(hashToTag);
+    private CoActivationTracker(Path filePath, int pairCap, int edgeCap) {
+        long totalBytes = 8 + 32L * pairCap + 40L * edgeCap;
+        MemoryId memoryId = MemoryId.of("hebbian", "coactivation");
+        CoActivationLayout layout = new CoActivationLayout();
+
+        this.recordMemory = new DefaultRecordMemory<>(memoryId, layout, (int) totalBytes, totalBytes, filePath);
+        this.arena = recordMemory.arena();
+
+        MemorySegment segment = recordMemory.segment();
+        long dataOffset = recordMemory.dataOffset();
+
+        if (recordMemory.size() < totalBytes) {
+            segment.set(ValueLayout.JAVA_INT, dataOffset, pairCap);
+            segment.set(ValueLayout.JAVA_INT, dataOffset + 4, edgeCap);
+
+            MemorySegment singleByte = Arena.ofAuto().allocate(1);
+            singleByte.set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
+            recordMemory.write(totalBytes - 1, singleByte);
+        }
+
+        this.pairTable = new OffHeapPairTable(pairCap, segment.asSlice(dataOffset + 8, 32L * pairCap), 0);
+        this.edgeTable = new OffHeapEdgeTable(edgeCap, segment.asSlice(dataOffset + 8 + 32L * pairCap, 40L * edgeCap), 0);
+
+        log.info("CoActivationTracker initialized (persistent): pairCap={}, edgeCap={}, file={}",
+                pairCap, edgeCap, filePath);
     }
 
     // ══════════════════════════════════════════════════════════════
     // Undirected Co-Activation (Original Hebbian)
     // ══════════════════════════════════════════════════════════════
 
-    /**
-     * Records co-activation of tags that appeared together in a recall result set.
-     *
-     * @param tags array of tag strings that appeared together in recall results
-     */
     public void recordCoActivation(String... tags) {
         if (tags == null || tags.length < 2) return;
 
@@ -203,7 +186,6 @@ public final class CoActivationTracker implements AutoCloseable {
                 registerTag(tags[i], hashA);
                 registerTag(tags[j], hashB);
 
-                // Ensure canonical order: smaller hash first
                 long keyA = Math.min(hashA, hashB);
                 long keyB = Math.max(hashA, hashB);
 
@@ -212,13 +194,6 @@ public final class CoActivationTracker implements AutoCloseable {
         }
     }
 
-    /**
-     * Returns the co-activation count for a tag pair.
-     *
-     * @param tagA first tag
-     * @param tagB second tag
-     * @return co-activation count (0 if never co-activated)
-     */
     public int getCoActivation(String tagA, String tagB) {
         long hashA = hashTag(tagA);
         long hashB = hashTag(tagB);
@@ -227,13 +202,6 @@ public final class CoActivationTracker implements AutoCloseable {
         return pairTable.get(keyA, keyB);
     }
 
-    /**
-     * Returns the top-N most co-activated tags for a given tag.
-     *
-     * @param tag   the source tag
-     * @param topN  maximum number of associated tags to return
-     * @return list of associated tag names sorted by co-activation strength
-     */
     public List<String> getAssociatedTags(String tag, int topN) {
         long tagHash = hashTag(tag);
 
@@ -255,14 +223,6 @@ public final class CoActivationTracker implements AutoCloseable {
     // STDP — Spike-Timing-Dependent Plasticity
     // ══════════════════════════════════════════════════════════════
 
-    /**
-     * Records a sequential activation pair for STDP weight update.
-     *
-     * @param tagBefore  the tag that was activated first
-     * @param tagAfter   the tag that was activated second
-     * @param timeBefore epoch millis when tagBefore was activated
-     * @param timeAfter  epoch millis when tagAfter was activated
-     */
     public void recordSequentialActivation(String tagBefore, String tagAfter,
                                             long timeBefore, long timeAfter) {
         if (tagBefore.equals(tagAfter)) return;
@@ -274,11 +234,9 @@ public final class CoActivationTracker implements AutoCloseable {
         registerTag(tagBefore, hashBefore);
         registerTag(tagAfter, hashAfter);
 
-        // Causal: A→B (strengthen)
         float dW_causal = A_PLUS * (float) Math.exp(-dt / TAU_PLUS);
         edgeTable.update(hashBefore, hashAfter, dW_causal, timeAfter);
 
-        // Anti-causal: B→A (weaken)
         float dW_anti = -A_MINUS * (float) Math.exp(-dt / TAU_MINUS);
         edgeTable.update(hashAfter, hashBefore, dW_anti, timeAfter);
 
@@ -287,12 +245,6 @@ public final class CoActivationTracker implements AutoCloseable {
                 String.format("%.4f", dW_causal), String.format("%.4f", dW_anti));
     }
 
-    /**
-     * Records sequential activations from an ordered list of tags with timestamps.
-     *
-     * @param orderedTags tags in temporal order (first = earliest)
-     * @param timestamps  corresponding epoch millis for each tag
-     */
     public void recordSequentialActivations(List<String> orderedTags, List<Long> timestamps) {
         if (orderedTags.size() < 2) return;
         if (orderedTags.size() != timestamps.size()) return;
@@ -304,13 +256,6 @@ public final class CoActivationTracker implements AutoCloseable {
         }
     }
 
-    /**
-     * Returns the STDP predictive strength from query tags to a result's tags.
-     *
-     * @param queryTags  tags from the query context
-     * @param resultTags tags from a candidate result
-     * @return maximum predictive strength (0.0 if no causal link exists)
-     */
     public float getPredictiveStrength(List<String> queryTags, String[] resultTags) {
         if (queryTags == null || queryTags.isEmpty() || resultTags == null || resultTags.length == 0) {
             return 0.0f;
@@ -328,13 +273,6 @@ public final class CoActivationTracker implements AutoCloseable {
         return maxStrength;
     }
 
-    /**
-     * Returns the average predictive strength (mean of all matching edges).
-     *
-     * @param queryTags  tags from the query context
-     * @param resultTags tags from a candidate result
-     * @return average predictive strength across all matching edges
-     */
     public float getAveragePredictiveStrength(List<String> queryTags, String[] resultTags) {
         if (queryTags == null || queryTags.isEmpty() || resultTags == null || resultTags.length == 0) {
             return 0.0f;
@@ -356,13 +294,6 @@ public final class CoActivationTracker implements AutoCloseable {
         return matchCount > 0 ? sum / matchCount : 0.0f;
     }
 
-    /**
-     * Returns the STDP edge weight for a specific directed edge.
-     *
-     * @param sourceTag the source tag
-     * @param targetTag the target tag
-     * @return the edge weight, or null if no edge exists
-     */
     public EdgeWeight getEdge(String sourceTag, String targetTag) {
         long srcHash = hashTag(sourceTag);
         long tgtHash = hashTag(targetTag);
@@ -373,13 +304,9 @@ public final class CoActivationTracker implements AutoCloseable {
     // Counts / Reset / Close
     // ══════════════════════════════════════════════════════════════
 
-    /** Returns the number of STDP directed edges. */
     public int edgeCount() { return edgeTable.count(); }
-
-    /** Returns the number of tracked undirected tag pairs. */
     public int pairCount() { return pairTable.count(); }
 
-    /** Resets all co-activation and STDP data. */
     public void reset() {
         pairTable.reset();
         edgeTable.reset();
@@ -388,37 +315,26 @@ public final class CoActivationTracker implements AutoCloseable {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         log.info("CoActivationTracker closing (pairs={}, edges={})", pairCount(), edgeCount());
-        arena.close();
+        if (recordMemory != null) {
+            recordMemory.close();
+            recordMemory = null;
+        }
     }
 
     // ══════════════════════════════════════════════════════════════
     // Bandit Stats (ProfileAdaptor persistence)
     // ══════════════════════════════════════════════════════════════
 
-    /**
-     * Returns the current bandit statistics map.
-     *
-     * @return the bandit stats (may be empty, never null)
-     */
     public Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats() {
         return banditStats;
     }
 
-    /**
-     * Updates the bandit statistics from the ProfileAdaptor.
-     *
-     * <p>Called during checkpoint to capture the latest adaptor state
-     * before persisting to the COAX v2 file.</p>
-     *
-     * @param stats the current adaptor stats snapshot
-     */
     public void updateBanditStats(Map<Long, EnumMap<CognitiveProfile, RunningStats>> stats) {
         this.banditStats = stats != null ? stats : new ConcurrentHashMap<>();
     }
 
-    /** Returns the total number of bandit stat entries (flattened context×profile pairs). */
     private int banditStatsCount() {
         int count = 0;
         for (EnumMap<CognitiveProfile, RunningStats> map : banditStats.values()) {
@@ -431,16 +347,13 @@ public final class CoActivationTracker implements AutoCloseable {
     // Tag Hashing
     // ══════════════════════════════════════════════════════════════
 
-    /**
-     * FNV-1a 64-bit hash of a tag string.
-     */
     static long hashTag(String tag) {
         long hash = 0xcbf29ce484222325L;
         for (int i = 0; i < tag.length(); i++) {
             hash ^= tag.charAt(i);
             hash *= 0x100000001b3L;
         }
-        return hash == 0 ? 1 : hash; // avoid 0 which means empty slot
+        return hash == 0 ? 1 : hash;
     }
 
     private void registerTag(String tag, long hash) {
@@ -451,133 +364,199 @@ public final class CoActivationTracker implements AutoCloseable {
     // PERSISTENCE: save / load
     // ══════════════════════════════════════════════════════════════
 
-    /**
-     * Saves the tracker state to a binary file.
-     *
-     * @param filePath path to write
-     */
-    public void save(Path filePath) {
-        Path parent = filePath.getParent();
-        if (parent != null) {
-            try {
-                Files.createDirectories(parent);
-            } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("CoActivationTracker", parent, e);
-            }
+    public synchronized void save(Path filePath) {
+        if (recordMemory == null) {
+            throw new IllegalStateException("Cannot save a closed tracker");
         }
 
-        try (FileChannel ch = FileChannel.open(filePath,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE,
-                StandardOpenOption.TRUNCATE_EXISTING)) {
+        if (!recordMemory.isPersistent()) {
+            try {
+                Path parent = filePath.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                try (FileChannel ch = FileChannel.open(filePath,
+                        StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
 
-            // Header (v2: 32 bytes)
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            header.putInt(FILE_MAGIC);
-            header.putInt(FILE_VERSION);
-            header.putInt(pairTable.capacity());
-            header.putInt(edgeTable.capacity());
-            header.putInt(pairTable.count());
-            header.putInt(edgeTable.count());
-            header.putInt(0);                   // bandCap (reserved, not used since on-heap)
-            header.putInt(banditStatsCount());   // bandCount
-            header.flip();
-            ch.write(header);
+                    long totalBytes = 8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity();
+                    ByteBuffer header = ByteBuffer.allocate(64);
+                    MemorySegment headerSeg = MemorySegment.ofBuffer(header);
+                    MemoryHeader.write(headerSeg, 0, recordMemory.layout().schemaVersion(), MemoryShape.RECORD,
+                            0x01, totalBytes, totalBytes, recordMemory.layout().recordStride(), recordMemory.layout().layoutId(),
+                            System.currentTimeMillis(), System.currentTimeMillis());
+                    header.limit(64).position(0);
+                    ch.write(header);
 
-            // Delegate segment I/O to tables
-            pairTable.writeTo(ch);
-            edgeTable.writeTo(ch);
+                    ByteBuffer dataBuf = recordMemory.segment().asSlice(0, totalBytes).asByteBuffer().asReadOnlyBuffer();
+                    ch.write(dataBuf);
 
-            // Tag name index
-            writeTagIndex(ch);
+                    ByteBuffer countsBuf = ByteBuffer.allocate(8);
+                    countsBuf.putInt(pairTable.count());
+                    countsBuf.putInt(edgeTable.count());
+                    countsBuf.flip();
+                    ch.write(countsBuf);
 
-            // Bandit stats (COAX v2)
-            writeBanditStats(ch);
+                    writeTagIndex(ch);
+                    writeBanditStats(ch);
+                }
 
-            ch.force(true);
-            log.info("CoActivationTracker saved: pairs={}, edges={}, tags={}, bandit={} → {}",
-                    pairCount(), edgeCount(), hashToTag.size(), banditStatsCount(), filePath);
+                recordMemory.close();
+                this.recordMemory = new DefaultRecordMemory<>(
+                        recordMemory.id(), recordMemory.layout(), (int) (8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity()),
+                        8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity(), filePath);
+                MemorySegment segment = recordMemory.segment();
+                long dataOffset = recordMemory.dataOffset();
+                int pairCap = pairTable.capacity();
+                int edgeCap = edgeTable.capacity();
+                int pairs = pairTable.count();
+                int edges = edgeTable.count();
+                this.pairTable = new OffHeapPairTable(pairCap, segment.asSlice(dataOffset + 8, 32L * pairCap), pairs);
+                this.edgeTable = new OffHeapEdgeTable(edgeCap, segment.asSlice(dataOffset + 8 + 32L * pairCap, 40L * edgeCap), edges);
 
-        } catch (IOException e) {
-            throw new SpectorGraphPersistenceException("CoActivationTracker", filePath, e);
+            } catch (IOException e) {
+                throw new SpectorGraphPersistenceException("CoActivationTracker", filePath, e);
+            }
+        } else {
+            try {
+                recordMemory.flush();
+                try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.WRITE)) {
+                    ch.position(MemoryHeader.HEADER_BYTES + 8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity());
+
+                    ByteBuffer countsBuf = ByteBuffer.allocate(8);
+                    countsBuf.putInt(pairTable.count());
+                    countsBuf.putInt(edgeTable.count());
+                    countsBuf.flip();
+                    ch.write(countsBuf);
+
+                    writeTagIndex(ch);
+                    writeBanditStats(ch);
+                }
+            } catch (IOException e) {
+                throw new SpectorGraphPersistenceException("CoActivationTracker", filePath, e);
+            }
         }
     }
 
-    /**
-     * Loads a tracker from a binary file, or returns a new empty tracker.
-     *
-     * @param filePath       path to the tracker file
-     * @param defaultPairs   default pair capacity if file doesn't exist
-     * @param defaultEdges   default edge capacity if file doesn't exist
-     * @return a CoActivationTracker (loaded or new)
-     */
     public static CoActivationTracker load(Path filePath, int defaultPairs, int defaultEdges) {
         if (filePath == null || !Files.exists(filePath)) {
             log.info("CoActivationTracker file not found, creating fresh: {}", filePath);
-            return new CoActivationTracker(defaultPairs, defaultEdges);
+            int pairCap = nextPowerOf2(Math.max(64, defaultPairs * 2));
+            int edgeCap = nextPowerOf2(Math.max(64, defaultEdges * 2));
+            return new CoActivationTracker(filePath, pairCap, edgeCap);
         }
 
-        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
-            // v1 files have 24-byte header, v2 files have 32-byte header
-            if (ch.size() < FILE_HEADER_V1_BYTES) {
-                log.warn("CoActivationTracker file too small, creating fresh");
-                return new CoActivationTracker(defaultPairs, defaultEdges);
+        try {
+            int magic = 0;
+            int version = 0;
+            try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                if (ch.size() >= 8) {
+                    ByteBuffer mb = ByteBuffer.allocate(8);
+                    ch.read(mb);
+                    mb.flip();
+                    magic = mb.getInt();
+                    version = mb.getInt();
+                }
+            } catch (IOException e) {
+                // ignore
             }
 
-            // Read v1 header first (24 bytes)
-            ByteBuffer headerV1 = ByteBuffer.allocate(FILE_HEADER_V1_BYTES);
+            if (magic == FILE_MAGIC && (version == 1 || version == 2)) {
+                return migrateLegacy(filePath, magic, version);
+            }
+
+            int pairCap;
+            int edgeCap;
+            try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                ByteBuffer capBuf = ByteBuffer.allocate(8);
+                ch.position(MemoryHeader.HEADER_BYTES);
+                ch.read(capBuf);
+                capBuf.flip();
+                capBuf.order(ByteOrder.nativeOrder());
+                pairCap = capBuf.getInt();
+                edgeCap = capBuf.getInt();
+            }
+
+            CoActivationTracker tracker = new CoActivationTracker(filePath, pairCap, edgeCap);
+
+            try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                ch.position(MemoryHeader.HEADER_BYTES + 8 + 32L * pairCap + 40L * edgeCap);
+
+                ByteBuffer countsBuf = ByteBuffer.allocate(8);
+                ch.read(countsBuf);
+                countsBuf.flip();
+                int pairs = countsBuf.getInt();
+                int edges = countsBuf.getInt();
+
+                tracker.pairTable.setCount(pairs);
+                tracker.edgeTable.setCount(edges);
+
+                ConcurrentHashMap<Long, String> names = readTagIndex(ch);
+                tracker.hashToTag.putAll(names);
+
+                if (ch.position() < ch.size()) {
+                    tracker.banditStats = new ConcurrentHashMap<>(readBanditStats(ch));
+                } else {
+                    tracker.banditStats = new ConcurrentHashMap<>();
+                }
+            }
+
+            return tracker;
+
+        } catch (IOException e) {
+            log.error("Failed to load CoActivationTracker, creating fresh: {}", e.getMessage());
+            return new CoActivationTracker(filePath, defaultPairs, defaultEdges);
+        }
+    }
+
+    private static CoActivationTracker migrateLegacy(Path filePath, int magic, int version) {
+        log.info("Migrating legacy CoActivationTracker format (v{}) to standard Memory Kernel format: {}", version, filePath);
+        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+            ch.position(8);
+            ByteBuffer headerV1 = ByteBuffer.allocate(FILE_HEADER_V1_BYTES - 8);
             ch.read(headerV1);
             headerV1.flip();
-
-            int magic = headerV1.getInt();
-            int version = headerV1.getInt();
             int pairCap = headerV1.getInt();
             int edgeCap = headerV1.getInt();
             int pairs = headerV1.getInt();
             int edges = headerV1.getInt();
 
-            if (magic != FILE_MAGIC || (version != 1 && version != 2)) {
-                log.warn("Invalid CoActivationTracker file (magic={}, version={}), creating fresh",
-                        Integer.toHexString(magic), version);
-                return new CoActivationTracker(defaultPairs, defaultEdges);
-            }
-
-            // v2: read extended header fields (bandCap + bandCount)
-            int bandCount = 0;
             if (version >= 2) {
                 ByteBuffer headerV2 = ByteBuffer.allocate(FILE_HEADER_BYTES - FILE_HEADER_V1_BYTES);
                 ch.read(headerV2);
                 headerV2.flip();
-                headerV2.getInt(); // bandCap (reserved, unused)
-                bandCount = headerV2.getInt();
+                headerV2.getInt();
+                headerV2.getInt();
             }
 
-            Arena arena = Arena.ofShared();
+            try (Arena tempArena = Arena.ofShared()) {
+                OffHeapPairTable legacyPairTable = OffHeapPairTable.readFrom(ch, pairCap, pairs, tempArena);
+                OffHeapEdgeTable legacyEdgeTable = OffHeapEdgeTable.readFrom(ch, edgeCap, edges, tempArena);
+                ConcurrentHashMap<Long, String> names = readTagIndex(ch);
+                Map<Long, EnumMap<CognitiveProfile, RunningStats>> bandit;
+                if (version >= 2 && ch.position() < ch.size()) {
+                    bandit = readBanditStats(ch);
+                } else {
+                    bandit = new ConcurrentHashMap<>();
+                }
 
-            // Delegate segment I/O to tables
-            OffHeapPairTable pairTable = OffHeapPairTable.readFrom(ch, pairCap, pairs, arena);
-            OffHeapEdgeTable edgeTable = OffHeapEdgeTable.readFrom(ch, edgeCap, edges, arena);
+                ch.close();
+                Files.deleteIfExists(filePath);
 
-            // Tag name index
-            ConcurrentHashMap<Long, String> names = readTagIndex(ch);
+                CoActivationTracker tracker = new CoActivationTracker(filePath, pairCap, edgeCap);
 
-            // Bandit stats (v2 only)
-            Map<Long, EnumMap<CognitiveProfile, RunningStats>> bandit;
-            if (version >= 2 && ch.position() < ch.size()) {
-                bandit = readBanditStats(ch);
-            } else {
-                bandit = new ConcurrentHashMap<>(); // v1 file = cold start
+                MemorySegment.copy(legacyPairTable.segment(), 0, tracker.pairTable.segment(), 0, (long) OffHeapPairTable.SLOT_BYTES * pairCap);
+                MemorySegment.copy(legacyEdgeTable.segment(), 0, tracker.edgeTable.segment(), 0, (long) OffHeapEdgeTable.SLOT_BYTES * edgeCap);
+                tracker.pairTable.setCount(pairs);
+                tracker.edgeTable.setCount(edges);
+
+                tracker.hashToTag.putAll(names);
+                tracker.banditStats = new ConcurrentHashMap<>(bandit);
+
+                tracker.save(filePath);
+                return tracker;
             }
-
-            CoActivationTracker tracker = new CoActivationTracker(arena, pairTable, edgeTable, names);
-            tracker.banditStats = bandit instanceof ConcurrentHashMap
-                    ? bandit : new ConcurrentHashMap<>(bandit);
-            log.info("CoActivationTracker loaded (v{}): pairs={}, edges={}, tags={}, bandit={} from {}",
-                    version, pairs, edges, names.size(), bandit.size(), filePath);
-            return tracker;
-
         } catch (IOException e) {
-            log.error("Failed to load CoActivationTracker, creating fresh: {}", e.getMessage());
-            return new CoActivationTracker(defaultPairs, defaultEdges);
+            throw new SpectorGraphPersistenceException("CoActivationTracker migration failed", filePath, e);
         }
     }
 
@@ -632,13 +611,6 @@ public final class CoActivationTracker implements AutoCloseable {
 
     // ── Bandit Stats I/O (COAX v2) ──
 
-    /**
-     * Writes bandit statistics to the file channel.
-     *
-     * <p>Format per entry (32 bytes):
-     * ctxHash(8B) + profileOrdinal(1B) + pad(3B) + ema(4B) +
-     * totalSignals(4B) + positiveSignals(4B) + lastUpdatedMs(8B)</p>
-     */
     private void writeBanditStats(FileChannel ch) throws IOException {
         int entryCount = banditStatsCount();
         ByteBuffer countBuf = ByteBuffer.allocate(4);
@@ -648,31 +620,27 @@ public final class CoActivationTracker implements AutoCloseable {
 
         if (entryCount == 0) return;
 
-        // 32 bytes per flattened entry
         ByteBuffer entryBuf = ByteBuffer.allocate(32);
         for (Map.Entry<Long, EnumMap<CognitiveProfile, RunningStats>> ctxEntry : banditStats.entrySet()) {
             long ctxHash = ctxEntry.getKey();
             for (Map.Entry<CognitiveProfile, RunningStats> profEntry : ctxEntry.getValue().entrySet()) {
                 RunningStats rs = profEntry.getValue();
                 entryBuf.clear();
-                entryBuf.putLong(ctxHash);                     // 8B
-                entryBuf.put((byte) profEntry.getKey().ordinal()); // 1B
-                entryBuf.put((byte) 0);                        // pad
-                entryBuf.put((byte) 0);                        // pad
-                entryBuf.put((byte) 0);                        // pad
-                entryBuf.putFloat(rs.ema());                   // 4B
-                entryBuf.putInt(rs.totalSignals());            // 4B
-                entryBuf.putInt(rs.positiveSignals());         // 4B
-                entryBuf.putLong(rs.lastUpdatedMs());          // 8B
+                entryBuf.putLong(ctxHash);
+                entryBuf.put((byte) profEntry.getKey().ordinal());
+                entryBuf.put((byte) 0);
+                entryBuf.put((byte) 0);
+                entryBuf.put((byte) 0);
+                entryBuf.putFloat(rs.ema());
+                entryBuf.putInt(rs.totalSignals());
+                entryBuf.putInt(rs.positiveSignals());
+                entryBuf.putLong(rs.lastUpdatedMs());
                 entryBuf.flip();
                 ch.write(entryBuf);
             }
         }
     }
 
-    /**
-     * Reads bandit statistics from the file channel.
-     */
     private static Map<Long, EnumMap<CognitiveProfile, RunningStats>> readBanditStats(
             FileChannel ch) throws IOException {
         ByteBuffer countBuf = ByteBuffer.allocate(4);
@@ -690,13 +658,13 @@ public final class CoActivationTracker implements AutoCloseable {
             ch.read(entryBuf);
             entryBuf.flip();
 
-            long ctxHash = entryBuf.getLong();                          // 8B
-            int ordinal = entryBuf.get() & 0xFF;                       // 1B
-            entryBuf.get(); entryBuf.get(); entryBuf.get();            // 3B pad
-            float ema = entryBuf.getFloat();                           // 4B
-            int totalSignals = entryBuf.getInt();                      // 4B
-            int positiveSignals = entryBuf.getInt();                   // 4B
-            long lastUpdatedMs = entryBuf.getLong();                   // 8B
+            long ctxHash = entryBuf.getLong();
+            int ordinal = entryBuf.get() & 0xFF;
+            entryBuf.get(); entryBuf.get(); entryBuf.get();
+            float ema = entryBuf.getFloat();
+            int totalSignals = entryBuf.getInt();
+            int positiveSignals = entryBuf.getInt();
+            long lastUpdatedMs = entryBuf.getLong();
 
             if (ordinal >= profiles.length) {
                 log.warn("Skipping bandit entry with unknown profile ordinal: {}", ordinal);
@@ -711,8 +679,6 @@ public final class CoActivationTracker implements AutoCloseable {
 
         return result;
     }
-
-    // ── Utility ──
 
     private static int nextPowerOf2(int n) {
         int p = 1;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphCsr.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphCsr.java
@@ -21,6 +21,9 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
 import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -173,6 +176,7 @@ public final class HebbianGraphCsr implements HebbianGraphBase {
     private volatile long lastActivityMs = System.currentTimeMillis();
     private volatile long sessionBoundaryMs = 30 * 60 * 1000L;
     private volatile HebbianGraph.DecayModulator decayModulator;
+    private final MemoryId memoryId;
 
     // ══════════════════════════════════════════════════════════════
     // CONSTRUCTORS
@@ -210,6 +214,7 @@ public final class HebbianGraphCsr implements HebbianGraphBase {
 
         // Overflow storage (heap)
         this.overflow = new List[capacity];
+        this.memoryId = MemoryId.of("graph", "hebbian-csr");
 
         long totalKB = (offsetBytes + edgeBytes) / 1024;
         log.info("HebbianGraphCsr initialized (heap): capacity={}, edgeCap={}, maxDegree={}, memory={}KB",
@@ -464,6 +469,18 @@ public final class HebbianGraphCsr implements HebbianGraphBase {
      */
     public long memoryUsageBytes() {
         return offsets.byteSize() + edges.byteSize();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // KERNEL INTEGRATION
+    // ══════════════════════════════════════════════════════════════
+
+    public MemoryId memoryId() {
+        return memoryId;
+    }
+
+    public MemoryShape kernelShape() {
+        return MemoryShape.GRAPH;
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphCsr.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphCsr.java
@@ -92,7 +92,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @see HebbianGraph
  */
-public final class HebbianGraphCsr implements HebbianGraphBase {
+public final class HebbianGraphCsr implements HebbianGraphBase, com.spectrayan.spector.memory.kernel.shape.GraphMemory<com.spectrayan.spector.memory.kernel.layout.HebbianLayout> {
 
     private static final Logger log = LoggerFactory.getLogger(HebbianGraphCsr.class);
 
@@ -474,6 +474,79 @@ public final class HebbianGraphCsr implements HebbianGraphBase {
     // ══════════════════════════════════════════════════════════════
     // KERNEL INTEGRATION
     // ══════════════════════════════════════════════════════════════
+
+    @Override
+    public MemoryId id() {
+        return memoryId;
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.kernel.layout.HebbianLayout layout() {
+        return new com.spectrayan.spector.memory.kernel.layout.HebbianLayout();
+    }
+
+    @Override
+    public Arena arena() {
+        return arena;
+    }
+
+    @Override
+    public MemorySegment segment() {
+        return edges;
+    }
+
+    @Override
+    public int size() {
+        return totalEdges();
+    }
+
+    @Override
+    public int schemaVersion() {
+        return 1;
+    }
+
+    @Override
+    public MemoryShape shape() {
+        return MemoryShape.GRAPH;
+    }
+
+    @Override
+    public void flush() {
+        if (edges != null) edges.force();
+        if (offsets != null) offsets.force();
+    }
+
+    @Override
+    public int addEdge(int fromNode, int toNode, MemorySegment edgeBytes) {
+        strengthen(fromNode, toNode, 1.0f);
+        return totalEdges();
+    }
+
+    @Override
+    public void removeEdge(int edgeId) {
+        // CSR decays and compacts edges; explicit tombstoning is not supported on raw ID.
+    }
+
+    @Override
+    public java.util.PrimitiveIterator.OfInt neighbours(int nodeId) {
+        return neighbors(nodeId).stream().mapToInt(HebbianEdge::neighborIndex).iterator();
+    }
+
+    @Override
+    public int edgeCount() {
+        return totalEdges();
+    }
+
+    @Override
+    public int nodeCount() {
+        int activeNodes = 0;
+        for (int i = 0; i < capacity; i++) {
+            if (degree(i) > 0) {
+                activeNodes++;
+            }
+        }
+        return activeNodes;
+    }
 
     public MemoryId memoryId() {
         return memoryId;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphCsr.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphCsr.java
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+import java.nio.ByteBuffer;
 
 import java.io.IOException;
 import java.lang.foreign.Arena;
@@ -177,6 +179,8 @@ public final class HebbianGraphCsr implements HebbianGraphBase, com.spectrayan.s
     private volatile long sessionBoundaryMs = 30 * 60 * 1000L;
     private volatile HebbianGraph.DecayModulator decayModulator;
     private final MemoryId memoryId;
+    private MemoryWal wal;
+    private boolean bypassWal = false;
 
     // ══════════════════════════════════════════════════════════════
     // CONSTRUCTORS
@@ -246,6 +250,13 @@ public final class HebbianGraphCsr implements HebbianGraphBase, com.spectrayan.s
         try {
             if (nodeA < 0 || nodeA >= capacity || nodeB < 0 || nodeB >= capacity) return;
             if (nodeA == nodeB) return;
+
+            if (wal != null && !bypassWal) {
+                ByteBuffer buf = ByteBuffer.allocate(4);
+                buf.putFloat(weightDelta);
+                wal.appendAdjAddEdge(memoryId.toString(), nodeA, nodeB, buf.array());
+            }
+
             addOrUpdateEdge(nodeA, nodeB, weightDelta);
             addOrUpdateEdge(nodeB, nodeA, weightDelta);
             lastActivityMs = System.currentTimeMillis();
@@ -512,8 +523,12 @@ public final class HebbianGraphCsr implements HebbianGraphBase, com.spectrayan.s
 
     @Override
     public void flush() {
-        if (edges != null) edges.force();
-        if (offsets != null) offsets.force();
+        try {
+            if (edges != null) edges.force();
+        } catch (UnsupportedOperationException ignored) {}
+        try {
+            if (offsets != null) offsets.force();
+        } catch (UnsupportedOperationException ignored) {}
     }
 
     @Override
@@ -554,6 +569,21 @@ public final class HebbianGraphCsr implements HebbianGraphBase, com.spectrayan.s
 
     public MemoryShape kernelShape() {
         return MemoryShape.GRAPH;
+    }
+
+    @Override
+    public void bindWal(MemoryWal wal) {
+        this.wal = wal;
+    }
+
+    @Override
+    public void setBypassWal(boolean bypass) {
+        this.bypassWal = bypass;
+    }
+
+    @Override
+    public MemoryWal getWal() {
+        return this.wal;
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/OffHeapEdgeTable.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/OffHeapEdgeTable.java
@@ -94,6 +94,10 @@ final class OffHeapEdgeTable {
         this.count = count;
     }
 
+    void setCount(int count) {
+        this.count = count;
+    }
+
     // ── Writes (locked) ──
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/OffHeapPairTable.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/OffHeapPairTable.java
@@ -88,6 +88,10 @@ final class OffHeapPairTable {
         this.count = count;
     }
 
+    void setCount(int count) {
+        this.count = count;
+    }
+
     // ── Writes (locked) ──
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
@@ -257,6 +257,10 @@ public final class MemoryIndex {
         this.textDataStore = store;
     }
 
+    public TextDataStore textDataStore() {
+        return this.textDataStore;
+    }
+
     public int size() {
         return locations.size();
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MemoryIndex.java
@@ -17,18 +17,27 @@ import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TextDataStore;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorStorageException;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.shape.DefaultRecordMemory;
+import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
+import com.spectrayan.spector.memory.kernel.layout.IndexEntryLayout;
+import com.spectrayan.spector.memory.kernel.layout.IdBlobLayout;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,77 +51,30 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <h3>Persistence</h3>
  * <p>Supports binary serialization via {@link #save(Path)} and {@link #load(Path)}.
- * The file format uses a "MIDX" magic header followed by variable-length records.
- * On startup, the index can be rebuilt from disk without re-ingestion.</p>
+ * Backed off-heap via standardized kernel shapes (RecordMemory for the slot table
+ * and AppendMemory for the variable-length ID/metadata pool).</p>
  *
  * <h3>Performance: O(1) Reverse Index</h3>
  * <p>A dedicated {@code reverseIndex} maps {@code (type, offset) → id} for
  * constant-time reverse lookups during recall result assembly. The key is
  * computed as {@code (type.ordinal() << 48) | offset}, packing both into
  * a single {@code long} to avoid String concatenation.</p>
- *
- * <h3>Thread Safety</h3>
- * <p>All maps are {@link ConcurrentHashMap} — safe for concurrent ingestion
- * (Virtual Threads) and recall (parallel scans).</p>
  */
 public final class MemoryIndex {
 
     private static final Logger log = LoggerFactory.getLogger(MemoryIndex.class);
 
-    /** File magic: "MIDX" in ASCII. */
-    private static final int INDEX_MAGIC = 0x4D494458;
+    /** Legacy file magic: "MIDX" in ASCII. */
+    private static final int LEGACY_INDEX_MAGIC = 0x4D494458;
 
-    /**
-     * File format version — V4 drops inline text (resolved from text.dat via textOffset/textLength).
-     *
-     * <p>Version history:</p>
-     * <ul>
-     *   <li>V1 — base format (id, location, text, source, tags)</li>
-     *   <li>V2 — adds multimodal metadata map</li>
-     *   <li>V3 — adds textOffset + textLength for off-heap text.dat reads</li>
-     *   <li>V4 — drops inline text body (text resolved via text.dat mmap). ~78% size reduction.</li>
-     * </ul>
-     */
-    private static final int INDEX_VERSION = 4;
-    /** V3 format (inline text + text offsets) — still loadable. */
+    /** Legacy V1-V4 formats. */
+    private static final int INDEX_VERSION_V4 = 4;
     private static final int INDEX_VERSION_V3 = 3;
-    /** V2 format (metadata, no text offsets) — still loadable. */
     private static final int INDEX_VERSION_V2 = 2;
-    /** V1 format (no metadata, no text offsets) — still loadable. */
     private static final int INDEX_VERSION_V1 = 1;
 
-    /** File header: 4B magic + 4B version + 4B count + 4B reserved = 16 bytes. */
-    private static final int FILE_HEADER_BYTES = 16;
-
-    /**
-     * Tracks where a memory is physically stored.
-     *
-     * <p>Links three storage layers via the same memory ID:</p>
-     * <ul>
-     *   <li>{@code offset} — byte position in the tier's {@code .mem} file (cognitive header + vector)</li>
-     *   <li>{@code textOffset} / {@code textLength} — byte position in {@code text.dat} (raw text)</li>
-     *   <li>{@code partitionIndex} — partition number (episodic only, -1 otherwise)</li>
-     * </ul>
-     *
-     * @param type            cognitive tier
-     * @param offset          byte offset within the tier's segment (.mem file)
-     * @param partitionIndex  partition index (episodic only, -1 otherwise)
-     * @param textOffset      byte offset of the raw text entry in text.dat (-1 if unknown)
-     * @param textLength      byte length of the UTF-8 encoded text in text.dat (-1 if unknown)
-     */
-    public record MemoryLocation(MemoryType type, long offset, int partitionIndex,
-                                  long textOffset, int textLength) {
-
-        /** Compact constructor for sites without text position (WAL replay, migration). */
-        public MemoryLocation(MemoryType type, long offset, int partitionIndex) {
-            this(type, offset, partitionIndex, -1L, -1);
-        }
-
-        /** Returns true if this location has a valid text.dat offset for direct off-heap reads. */
-        public boolean hasTextPosition() {
-            return textOffset >= 0 && textLength >= 0;
-        }
-    }
+    /** File header for legacy files: 16 bytes. */
+    private static final int LEGACY_FILE_HEADER_BYTES = 16;
 
     // ── Forward index: id → metadata ──
     private final ConcurrentHashMap<String, MemoryLocation> locations = new ConcurrentHashMap<>();
@@ -120,87 +82,65 @@ public final class MemoryIndex {
     private final ConcurrentHashMap<String, MemorySource> sources = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String[]> tags = new ConcurrentHashMap<>();
 
-    // ── Multimodal metadata: id → metadata map  [lazy — only non-empty for multimodal memories] ──
+    // ── Multimodal metadata: id → metadata map ──
     private final ConcurrentHashMap<String, Map<String, String>> metadataMap = new ConcurrentHashMap<>();
 
-    // ── Reverse index: (type, offset) → id  [O(1) lookup for recall result assembly] ──
+    // ── Reverse index: (type, offset) → id ──
     private final ConcurrentHashMap<Long, String> reverseIndex = new ConcurrentHashMap<>();
 
-    // ── Off-heap text data store: enables zero-copy text reads from mmap'd text.dat ──
+    // ── Off-heap text data store ──
     private volatile TextDataStore textDataStore;
 
-    // ── Inverted tag index: tag → Set<memId>  [O(1) tag-based lookup for browse()] ──
+    // ── Inverted tag index ──
     private final ConcurrentHashMap<String, java.util.Set<String>> tagToIds = new ConcurrentHashMap<>();
 
-    // ── Insertion-order tracking: position → id  [maps graph node indices to memory IDs] ──
-    // HebbianGraph, EntityGraph, and TemporalChain use `index.size() - 1` as the node index
-    // at ingestion time, so this list preserves that exact ordering for slot ↔ id mapping.
+    // ── Insertion-order tracking ──
     private final java.util.LinkedHashSet<String> orderedIds = new java.util.LinkedHashSet<>();
 
     /**
-     * Computes the reverse-index key from a memory type and byte offset.
-     *
-     * <p>Packs type ordinal into the upper 16 bits and offset into the lower 48 bits.
-     * This supports offsets up to 256 TB per tier — far beyond any practical limit.</p>
+     * Tracks where a memory is physically stored.
      */
+    public record MemoryLocation(MemoryType type, long offset, int partitionIndex,
+                                  long textOffset, int textLength) {
+
+        public MemoryLocation(MemoryType type, long offset, int partitionIndex) {
+            this(type, offset, partitionIndex, -1L, -1);
+        }
+
+        public boolean hasTextPosition() {
+            return textOffset >= 0 && textLength >= 0;
+        }
+    }
+
     private static long reverseKey(MemoryType type, long offset) {
         return ((long) type.ordinal() << 48) | (offset & 0x0000_FFFF_FFFF_FFFFL);
     }
 
-    /**
-     * Registers a new memory in the index.
-     *
-     * <p>Maintains both forward (id → metadata) and reverse ((type, offset) → id)
-     * indexes for O(1) lookups in both directions.</p>
-     *
-     * @param id       unique memory identifier
-     * @param location physical storage location
-     * @param text     raw text content
-     * @param source   provenance source
-     * @param tagArray synaptic tag strings
-     */
     public void register(String id, MemoryLocation location, String text,
                           MemorySource source, String[] tagArray) {
         register(id, location, text, source, tagArray, null);
     }
 
-    /**
-     * Registers a new memory in the index with optional multimodal metadata.
-     *
-     * @param id       unique memory identifier
-     * @param location physical storage location
-     * @param text     raw text content
-     * @param source   provenance source
-     * @param tagArray synaptic tag strings
-     * @param metadata multimodal metadata (nullable — omitted for text-only memories)
-     */
     public void register(String id, MemoryLocation location, String text,
                           MemorySource source, String[] tagArray,
                           Map<String, String> metadata) {
         locations.put(id, location);
-        // P0 off-heap optimization: skip heap text storage when text.dat position is known.
-        // text() will read directly from the mmap'd segment via TextDataStore.readTextDirect().
-        // The mmap is refreshed after each write() so it always covers new entries.
-        if (!location.hasTextPosition()) {
+        if (!location.hasTextPosition() && text != null) {
             texts.put(id, text);
         }
         sources.put(id, source);
-        tags.put(id, tagArray);
+        tags.put(id, tagArray != null ? tagArray : EMPTY_TAGS);
 
-        // Only store metadata if non-empty (zero cost for text-only memories)
         if (metadata != null && !metadata.isEmpty()) {
             metadataMap.put(id, Map.copyOf(metadata));
         }
 
-        // O(1) reverse index
         reverseIndex.put(reverseKey(location.type(), location.offset()), id);
 
-        // Insertion-order tracking (graph slot index = orderedIds position)
         synchronized (orderedIds) {
             orderedIds.add(id);
         }
 
-        // O(1) inverted tag index — tag → Set<memId>
         if (tagArray != null) {
             for (String tag : tagArray) {
                 String normalizedTag = tag.toLowerCase();
@@ -210,9 +150,6 @@ public final class MemoryIndex {
         }
     }
 
-    /**
-     * Removes a memory from both forward and reverse indexes.
-     */
     public void remove(String id) {
         MemoryLocation loc = locations.remove(id);
         texts.remove(id);
@@ -223,12 +160,10 @@ public final class MemoryIndex {
         String[] removedTags = tags.remove(id);
         metadataMap.remove(id);
 
-        // Clean reverse index
         if (loc != null) {
             reverseIndex.remove(reverseKey(loc.type(), loc.offset()));
         }
 
-        // Clean inverted tag index
         if (removedTags != null) {
             for (String tag : removedTags) {
                 String normalizedTag = tag.toLowerCase();
@@ -243,88 +178,46 @@ public final class MemoryIndex {
         }
     }
 
-    /**
-     * Returns the physical location for a memory ID, or null if not found.
-     * O(1) via ConcurrentHashMap.
-     */
     public MemoryLocation locate(String id) {
         return locations.get(id);
     }
 
-    /**
-     * Returns the raw text for a memory ID, or empty string if not found.
-     *
-     * <p>Resolution order (P0 off-heap optimization):</p>
-     * <ol>
-     *   <li>Off-heap: read from mmap'd text.dat via {@link TextDataStore#readTextDirect}</li>
-     *   <li>Heap: fall back to the {@code texts} HashMap (V1/V2 indexes, WAL replay)</li>
-     * </ol>
-     */
     public String text(String id) {
-        // Try off-heap first: check if we have a text.dat position and a live TextDataStore
         MemoryLocation loc = locations.get(id);
         if (loc != null && loc.hasTextPosition() && textDataStore != null) {
             String offHeapText = textDataStore.readTextDirect(loc.textOffset(), loc.textLength());
             if (offHeapText != null) return offHeapText;
         }
-        // Fall back to heap HashMap (V1/V2 indexes, WAL replay, in-memory mode)
         return texts.getOrDefault(id, "");
     }
 
-    /**
-     * Returns the provenance source for a memory ID.
-     */
     public MemorySource source(String id) {
         return sources.getOrDefault(id, MemorySource.OBSERVED);
     }
 
-    /** Shared empty tags array — avoids heap allocation on every cache miss. */
     private static final String[] EMPTY_TAGS = new String[0];
 
-    /**
-     * Returns the synaptic tag strings for a memory ID.
-     */
     public String[] tags(String id) {
         return tags.getOrDefault(id, EMPTY_TAGS);
     }
 
-    /**
-     * Returns the set of memory IDs that have the given tag — O(1) lookup.
-     *
-     * <p>Uses the inverted tag index for constant-time retrieval.
-     * Returns an empty set if no memories have the specified tag.</p>
-     *
-     * @param tag the tag to look up (case-insensitive)
-     * @return unmodifiable set of memory IDs with this tag
-     */
     public java.util.Set<String> idsByTag(String tag) {
         var ids = tagToIds.get(tag.toLowerCase());
         return ids != null ? java.util.Collections.unmodifiableSet(ids) : java.util.Set.of();
     }
 
-    /**
-     * Returns memory IDs matching ALL specified tags (AND semantics) — O(k) where k = smallest tag set.
-     *
-     * <p>Intersects the ID sets from the inverted index. Starts with the smallest set
-     * for optimal intersection performance.</p>
-     *
-     * @param queryTags tags to match (AND semantics)
-     * @return set of memory IDs that contain all specified tags
-     */
     public java.util.Set<String> idsByAllTags(String... queryTags) {
         if (queryTags == null || queryTags.length == 0) return java.util.Set.of();
 
-        // Find the smallest set to start intersection
         java.util.Set<String> smallest = null;
         for (String tag : queryTags) {
             var ids = tagToIds.get(tag.toLowerCase());
-            if (ids == null || ids.isEmpty()) return java.util.Set.of(); // no match possible
+            if (ids == null || ids.isEmpty()) return java.util.Set.of();
             if (smallest == null || ids.size() < smallest.size()) {
                 smallest = ids;
             }
         }
 
-        // Intersect with remaining tag sets
         var result = new java.util.HashSet<>(smallest);
         for (String tag : queryTags) {
             var ids = tagToIds.get(tag.toLowerCase());
@@ -336,28 +229,12 @@ public final class MemoryIndex {
         return java.util.Collections.unmodifiableSet(result);
     }
 
-    /** Shared empty metadata map — avoids allocation on cache miss. */
     private static final Map<String, String> EMPTY_METADATA = Map.of();
 
-    /**
-     * Returns the multimodal metadata for a memory ID.
-     *
-     * <p>Returns an empty map for text-only memories (never null).</p>
-     */
     public Map<String, String> metadata(String id) {
         return metadataMap.getOrDefault(id, EMPTY_METADATA);
     }
 
-    /**
-     * Stores or merges metadata for a memory ID after registration.
-     *
-     * <p>Used by file ingestion to attach the source filename, URL, or
-     * other provenance info after the ingestion pipeline completes.
-     * Merges with any existing metadata (won't overwrite unrelated keys).</p>
-     *
-     * @param id       memory identifier (must already be registered)
-     * @param metadata key-value pairs to store (e.g., "fileName" → "readme.md")
-     */
     public void putMetadata(String id, Map<String, String> metadata) {
         if (metadata == null || metadata.isEmpty() || !locations.containsKey(id)) return;
         metadataMap.merge(id, Map.copyOf(metadata), (existing, incoming) -> {
@@ -367,86 +244,37 @@ public final class MemoryIndex {
         });
     }
 
-    /**
-     * O(1) reverse-lookup: finds the memory ID stored at a given offset in a given tier.
-     *
-     * <p>Uses a dedicated reverse index ({@code ConcurrentHashMap<Long, String>})
-     * instead of the previous O(n) linear scan over the location map.</p>
-     *
-     * @param type   memory tier to search
-     * @param offset byte offset to match
-     * @return the memory ID, or null if not found
-     */
     public String findIdByOffset(MemoryType type, long offset) {
         return reverseIndex.get(reverseKey(type, offset));
     }
 
-    /**
-     * Returns the text for a memory stored at a given offset.
-     * O(1) via reverse index. Uses off-heap resolution when available.
-     */
     public String findTextByOffset(MemoryType type, long offset) {
         String id = findIdByOffset(type, offset);
         return id != null ? text(id) : null;
     }
 
-    /**
-     * Sets the TextDataStore for off-heap text resolution.
-     *
-     * <p>When set, {@link #text(String)} will read text directly from the mmap'd
-     * text.dat segment instead of the heap HashMap, eliminating ~40MB heap per
-     * 100K memories.</p>
-     *
-     * @param store the TextDataStore (nullable — disables off-heap resolution)
-     */
     public void setTextDataStore(TextDataStore store) {
         this.textDataStore = store;
     }
 
-    /**
-     * Returns the total number of indexed memories.
-     */
     public int size() {
         return locations.size();
     }
 
-    /**
-     * Returns all registered memory IDs.
-     *
-     * <p>Used by WAL replay to iterate over all reconstructed memories.
-     * Returns a snapshot of the key set — safe for concurrent modification.</p>
-     *
-     * @return unmodifiable set of all memory IDs
-     */
     public java.util.Set<String> allIds() {
         return java.util.Collections.unmodifiableSet(new java.util.HashSet<>(locations.keySet()));
     }
 
-    /**
-     * Returns all registered memory IDs in insertion order.
-     */
     public java.util.List<String> orderedIds() {
         synchronized (orderedIds) {
             return new java.util.ArrayList<>(orderedIds);
         }
     }
 
-    /**
-     * Returns the raw location map (for iteration in decay, etc.).
-     */
     public ConcurrentHashMap<String, MemoryLocation> locationMap() {
         return locations;
     }
 
-    /**
-     * Returns the graph-slot ordinal mapping: slot index → memory ID.
-     *
-     * <p>HebbianGraph, EntityGraph, and TemporalChain all use {@code index.size() - 1}
-     * at ingestion time as their node index. This method exposes the same insertion-order
-     * mapping so management APIs can translate between slot indices and memory IDs.</p>
-     *
-     * @return bidirectional maps: slotToId (index → memoryId) and idToSlot (memoryId → index)
-     */
     public void buildGraphSlotMappings(java.util.Map<Integer, String> slotToId,
                                         java.util.Map<String, Integer> idToSlot) {
         synchronized (orderedIds) {
@@ -459,15 +287,6 @@ public final class MemoryIndex {
         }
     }
 
-    /**
-     * Returns a map of memory ID → text for all memories in the specified partition.
-     *
-     * <p>Used on startup to rebuild per-partition BM25 indexes from text data.
-     * Filters the global text map by partition index.</p>
-     *
-     * @param partitionIndex the partition index to filter by
-     * @return map of id → text for that partition (may be empty)
-     */
     public Map<String, String> textsByPartition(int partitionIndex) {
         Map<String, String> result = new java.util.HashMap<>();
         for (Map.Entry<String, MemoryLocation> entry : locations.entrySet()) {
@@ -481,81 +300,31 @@ public final class MemoryIndex {
         return result;
     }
 
-    /**
-     * Returns the total number of indexed memories (alias for quota enforcement).
-     */
     public int totalCount() {
         return locations.size();
     }
 
-    // ══════════════════════════════════════════════════════════════
-    // COMPACTION SUPPORT
-    // ══════════════════════════════════════════════════════════════
-
-    /**
-     * Relocates a single memory to a new offset within the same tier.
-     *
-     * <p>Called during vacuum compaction when live records are copied to
-     * a new segment. Updates both forward and reverse indexes atomically.</p>
-     *
-     * @param id        the memory ID
-     * @param newOffset the new byte offset in the compacted segment
-     */
     public void relocate(String id, long newOffset) {
         MemoryLocation oldLoc = locations.get(id);
         if (oldLoc == null) return;
 
-        // Remove old reverse entry
         reverseIndex.remove(reverseKey(oldLoc.type(), oldLoc.offset()));
 
-        // Update forward index with new .mem offset (text.dat position unchanged)
         MemoryLocation newLoc = new MemoryLocation(oldLoc.type(), newOffset, oldLoc.partitionIndex(),
                 oldLoc.textOffset(), oldLoc.textLength());
         locations.put(id, newLoc);
 
-        // Add new reverse entry
         reverseIndex.put(reverseKey(newLoc.type(), newOffset), id);
     }
 
-    /**
-     * Batch-relocates multiple memories to new offsets.
-     *
-     * <p>More efficient than calling {@link #relocate(String, long)} individually
-     * because it avoids repeated concurrent map overhead for large compactions.</p>
-     *
-     * @param relocations map of memory ID → new byte offset
-     */
     public void relocateBatch(Map<String, Long> relocations) {
         for (Map.Entry<String, Long> entry : relocations.entrySet()) {
             relocate(entry.getKey(), entry.getValue());
         }
     }
 
-    // ══════════════════════════════════════════════════════════════
-    // PERSISTENCE: save / load
-    // ══════════════════════════════════════════════════════════════
+    // ── Persistence: save / load using DefaultRecordMemory & DefaultAppendMemory ──
 
-    /**
-     * Saves the entire index to a binary file.
-     *
-     * <h3>Binary Format (V4 — inline text omitted)</h3>
-     * <pre>
-     *   [16B header: MIDX magic + version(4) + count + reserved]
-     *   per-entry:
-     *     [4B id_len] [N id_bytes]
-     *     [4B type_ord] [8B offset] [4B partition_index]
-     *     [4B text_len] [N text_bytes]        ← V4: 0 when text.dat offset available; inline fallback otherwise
-     *     [4B source_ord]
-     *     [4B tag_count] { [4B tag_len] [N tag_bytes] }*
-     *     [4B metadata_count] { [4B key_len] [N key_bytes] [4B val_len] [N val_bytes] }*
-     *     [8B textOffset] [4B textLength]      ← position in text.dat for off-heap resolution
-     * </pre>
-     *
-     * <p>V1/V2/V3 files (with inline text) are still loadable for backward compatibility.
-     * On save, V4 always writes text_len=0 since text is resolved from text.dat.</p>
-     *
-     * @param filePath path to write the index file
-     */
     public void save(Path filePath) {
         Path parent = filePath.getParent();
         if (parent != null) {
@@ -566,46 +335,85 @@ public final class MemoryIndex {
             }
         }
 
-        try (FileChannel ch = FileChannel.open(filePath,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE,
-                StandardOpenOption.TRUNCATE_EXISTING)) {
+        String fileName = filePath.getFileName().toString();
+        String poolName = fileName.endsWith(".midx") ? fileName.replace(".midx", ".idpl") : fileName + ".idpl";
+        Path idPoolPath = filePath.resolveSibling(poolName);
 
-            // Write file header
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            header.putInt(INDEX_MAGIC);
-            header.putInt(INDEX_VERSION);
-            header.putInt(locations.size());
-            header.putInt(0); // reserved
-            header.flip();
-            ch.write(header);
+        try {
+            Files.deleteIfExists(filePath);
+            Files.deleteIfExists(idPoolPath);
 
-            // Write each entry
-            for (Map.Entry<String, MemoryLocation> entry : locations.entrySet()) {
-                String id = entry.getKey();
-                MemoryLocation loc = entry.getValue();
-                String text = text(id);
-                MemorySource source = sources.getOrDefault(id, MemorySource.OBSERVED);
-                String[] tagArray = tags.getOrDefault(id, new String[0]);
+            int entryCount = locations.size();
+            java.util.List<String> orderedKeys = orderedIds();
+            java.util.List<byte[]> serializedBlobs = new java.util.ArrayList<>(entryCount);
+            
+            for (String id : orderedKeys) {
+                MemoryLocation loc = locations.get(id);
+                if (loc == null) continue;
+                String textVal = text(id);
+                MemorySource src = sources.getOrDefault(id, MemorySource.OBSERVED);
+                String[] tagArray = tags.getOrDefault(id, EMPTY_TAGS);
                 Map<String, String> meta = metadataMap.getOrDefault(id, Map.of());
-
-                writeEntry(ch, id, loc, text, source, tagArray, meta);
+                
+                String textFallback = loc.hasTextPosition() ? null : textVal;
+                byte[] blob = serializeIdBlob(id, src, tagArray, meta, textFallback);
+                serializedBlobs.add(blob);
             }
 
-            ch.force(true);
-            log.info("MemoryIndex saved: {} entries → {}", locations.size(), filePath);
+            long totalPoolBytes = 0;
+            for (byte[] b : serializedBlobs) {
+                totalPoolBytes += 4 + b.length; // 4B length prefix + payload
+            }
 
-        } catch (IOException e) {
+            MemoryId poolId = MemoryId.of("index", "idpool");
+            IdBlobLayout poolLayout = new IdBlobLayout();
+            try (DefaultAppendMemory<IdBlobLayout> poolMemory = new DefaultAppendMemory<>(
+                    poolId, poolLayout, entryCount, MemoryHeader.HEADER_BYTES + totalPoolBytes, idPoolPath)) {
+                
+                MemoryId slotId = MemoryId.of("index", "slot");
+                IndexEntryLayout slotLayout = new IndexEntryLayout();
+                long totalSlotBytes = (long) entryCount * 40;
+                try (DefaultRecordMemory<IndexEntryLayout> slotMemory = new DefaultRecordMemory<>(
+                        slotId, slotLayout, entryCount, MemoryHeader.HEADER_BYTES + totalSlotBytes, filePath)) {
+                    
+                    int index = 0;
+                    for (int i = 0; i < orderedKeys.size(); i++) {
+                        String id = orderedKeys.get(i);
+                        MemoryLocation loc = locations.get(id);
+                        if (loc == null) continue;
+                        byte[] blobBytes = serializedBlobs.get(index);
+                        
+                        long poolOffset = poolMemory.append(MemorySegment.ofArray(blobBytes));
+                        int poolLen = blobBytes.length;
+                        
+                        // Create a temporary 40-byte segment for the slot entry
+                        byte[] slotBytes = new byte[40];
+                        ByteBuffer slotBuf = ByteBuffer.wrap(slotBytes);
+                        slotBuf.order(java.nio.ByteOrder.nativeOrder());
+                        
+                        slotBuf.putLong(poolOffset);
+                        slotBuf.putInt(poolLen);
+                        slotBuf.putInt(loc.type().ordinal());
+                        slotBuf.putLong(loc.offset());
+                        slotBuf.putInt(loc.partitionIndex());
+                        slotBuf.putLong(loc.textOffset());
+                        slotBuf.putInt(loc.textLength());
+                        
+                        slotMemory.write(index, MemorySegment.ofArray(slotBytes));
+                        
+                        index++;
+                    }
+                    slotMemory.flush();
+                }
+                poolMemory.flush();
+            }
+            log.info("MemoryIndex saved: {} entries (slot table={}, id pool={})",
+                    entryCount, filePath.getFileName(), idPoolPath.getFileName());
+        } catch (Exception e) {
             throw new SpectorStorageException(ErrorCode.DISK_IO_FAILED, e, "save MemoryIndex: " + filePath);
         }
     }
 
-    /**
-     * Loads an index from a binary file, or returns a new empty index
-     * if the file doesn't exist.
-     *
-     * @param filePath path to the index file
-     * @return a populated MemoryIndex (or empty if file missing)
-     */
     public static MemoryIndex load(Path filePath) {
         MemoryIndex index = new MemoryIndex();
 
@@ -614,147 +422,214 @@ public final class MemoryIndex {
             return index;
         }
 
-        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
-            long fileSize = ch.size();
-            if (fileSize < FILE_HEADER_BYTES) {
+        try {
+            long fileSize = Files.size(filePath);
+            if (fileSize < 16) {
                 log.warn("MemoryIndex file too small ({}B), starting fresh", fileSize);
                 return index;
             }
 
-            // Read file header
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            ch.read(header);
-            header.flip();
-
-            int magic = header.getInt();
-            int version = header.getInt();
-            int entryCount = header.getInt();
-            header.getInt(); // reserved
-
-            if (magic != INDEX_MAGIC) {
-                log.warn("Invalid MemoryIndex magic: 0x{} (expected 0x{}), starting fresh",
-                        Integer.toHexString(magic), Integer.toHexString(INDEX_MAGIC));
-                return index;
-            }
-            if (version != INDEX_VERSION && version != INDEX_VERSION_V3
-                    && version != INDEX_VERSION_V2 && version != INDEX_VERSION_V1) {
-                log.warn("Unsupported MemoryIndex version: {} (expected {}, {}, {}, or {}), starting fresh",
-                        version, INDEX_VERSION, INDEX_VERSION_V3, INDEX_VERSION_V2, INDEX_VERSION_V1);
-                return index;
+            // Inspect magic number to distinguish between new standard SMKM and legacy MIDX formats
+            int magic;
+            try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                ByteBuffer mb = ByteBuffer.allocate(4);
+                ch.read(mb);
+                mb.flip();
+                magic = mb.getInt();
             }
 
-            boolean hasMetadata = (version >= INDEX_VERSION_V2);
-            boolean hasTextPosition = (version >= INDEX_VERSION_V3);
-            boolean hasInlineText = (version < INDEX_VERSION); // V4+ drops inline text
+            boolean isStandard = (magic == MemoryHeader.MAGIC || magic == 0x4D4B4D53);
+            boolean isLegacy = (magic == LEGACY_INDEX_MAGIC || magic == 0x5844494D);
 
-            // Read entries
-            for (int i = 0; i < entryCount; i++) {
-                readEntry(ch, index, hasMetadata, hasTextPosition, hasInlineText);
+            if (isStandard) {
+                // New standard format (V5+)
+                String fileName = filePath.getFileName().toString();
+                String poolName = fileName.endsWith(".midx") ? fileName.replace(".midx", ".idpl") : fileName + ".idpl";
+                Path idPoolPath = filePath.resolveSibling(poolName);
+
+                MemoryId slotId = MemoryId.of("index", "slot");
+                IndexEntryLayout slotLayout = new IndexEntryLayout();
+                try (DefaultRecordMemory<IndexEntryLayout> slotMemory = new DefaultRecordMemory<>(
+                        slotId, slotLayout, 0, 0, filePath)) {
+                    
+                    int entryCount = slotMemory.size();
+                    MemoryId poolId = MemoryId.of("index", "idpool");
+                    IdBlobLayout poolLayout = new IdBlobLayout();
+                    try (DefaultAppendMemory<IdBlobLayout> poolMemory = new DefaultAppendMemory<>(
+                            poolId, poolLayout, 0, 0, idPoolPath)) {
+                        
+                        MemorySegment slotSeg = slotMemory.segment();
+                        long slotBase = slotMemory.dataOffset();
+                        
+                        for (int i = 0; i < entryCount; i++) {
+                            long slotOffset = slotBase + (long) i * 40;
+                            long poolOffset = slotSeg.get(ValueLayout.JAVA_LONG_UNALIGNED, slotOffset);
+                            int poolLen = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 8);
+                            int typeOrd = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 12);
+                            long offset = slotSeg.get(ValueLayout.JAVA_LONG_UNALIGNED, slotOffset + 16);
+                            int partitionIndex = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 24);
+                            long textOffset = slotSeg.get(ValueLayout.JAVA_LONG_UNALIGNED, slotOffset + 28);
+                            int textLength = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 36);
+                            
+                            MemoryType type = MemoryType.values()[typeOrd];
+                            MemoryLocation loc = new MemoryLocation(type, offset, partitionIndex, textOffset, textLength);
+                            
+                            MemorySegment blobSeg = poolMemory.read(poolOffset, poolLen);
+                            DeserializedEntry target = new DeserializedEntry();
+                            deserializeIdBlob(blobSeg, target);
+                            
+                            index.register(target.id, loc, target.textFallback, target.source, target.tags, target.metadata);
+                        }
+                    }
+                }
+                log.info("MemoryIndex loaded (SMKM V5): {} entries from {}", index.size(), filePath.getFileName());
+            } else if (isLegacy) {
+                // Legacy index loading (V1-V4)
+                try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                    ByteBuffer header = ByteBuffer.allocate(LEGACY_FILE_HEADER_BYTES);
+                    ch.read(header);
+                    header.flip();
+                    header.getInt(); // Skip magic
+                    int version = header.getInt();
+                    int entryCount = header.getInt();
+                    header.getInt(); // Skip reserved
+
+                    boolean hasMetadata = (version >= INDEX_VERSION_V2);
+                    boolean hasTextPosition = (version >= INDEX_VERSION_V3);
+                    boolean hasInlineText = (version < INDEX_VERSION_V4);
+
+                    for (int i = 0; i < entryCount; i++) {
+                        readEntry(ch, index, hasMetadata, hasTextPosition, hasInlineText);
+                    }
+                }
+                log.info("MemoryIndex loaded (legacy V{}): {} entries from {}", magic, index.size(), filePath.getFileName());
+            } else {
+                log.warn("Invalid MemoryIndex magic: 0x{}, starting fresh", Integer.toHexString(magic));
             }
-
-            log.info("MemoryIndex loaded: {} entries from {}", index.size(), filePath);
-
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error("Failed to load MemoryIndex from {}, starting fresh: {}", filePath, e.getMessage());
         }
-
         return index;
     }
 
-    // ── Internal serialization helpers ──
+    // ── Internal Serialization/Deserialization Primitives ──
 
-    private void writeEntry(FileChannel ch, String id, MemoryLocation loc,
-                             String text, MemorySource source, String[] tagArray,
-                             Map<String, String> metadata) throws IOException {
+    private static byte[] serializeIdBlob(String id, MemorySource source, String[] tagArray,
+                                           Map<String, String> metadata, String textFallback) {
         byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
-
-        // V4 optimization: skip inline text when text.dat offset is available.
-        // Entries without text.dat position (WAL replay, in-memory, V1/V2 migration)
-        // still write inline text as fallback for lossless round-trip.
-        boolean writeInlineText = !loc.hasTextPosition();
-        byte[] textBytes = writeInlineText ? text.getBytes(StandardCharsets.UTF_8) : null;
-        int textBytesLen = writeInlineText ? textBytes.length : 0;
-
-        // Calculate total size for this entry
-        int size = 4 + idBytes.length      // id
-                + 4 + 8 + 4               // location (type + offset + partitionIndex)
-                + 4 + textBytesLen         // text (0 if off-heap available)
-                + 4                        // source
-                + 4;                       // tag count
-
-        // Pre-compute tag byte arrays
+        byte[] textBytes = textFallback != null ? textFallback.getBytes(StandardCharsets.UTF_8) : new byte[0];
+        
+        int size = 2 + idBytes.length
+                + 1
+                + 2;
+        
         byte[][] tagBytesArray = new byte[tagArray.length][];
         for (int i = 0; i < tagArray.length; i++) {
             tagBytesArray[i] = tagArray[i].getBytes(StandardCharsets.UTF_8);
-            size += 4 + tagBytesArray[i].length;
+            size += 2 + tagBytesArray[i].length;
         }
-
-        // V2: metadata map (4B count + entries)
-        size += 4; // metadata count
+        
+        size += 2;
         byte[][] metaKeyBytes = new byte[metadata.size()][];
         byte[][] metaValBytes = new byte[metadata.size()][];
         int mi = 0;
         for (Map.Entry<String, String> me : metadata.entrySet()) {
             metaKeyBytes[mi] = me.getKey().getBytes(StandardCharsets.UTF_8);
             metaValBytes[mi] = me.getValue().getBytes(StandardCharsets.UTF_8);
-            size += 4 + metaKeyBytes[mi].length + 4 + metaValBytes[mi].length;
+            size += 2 + metaKeyBytes[mi].length + 2 + metaValBytes[mi].length;
             mi++;
         }
-
+        
+        size += 4 + textBytes.length;
+        
         ByteBuffer buf = ByteBuffer.allocate(size);
-
-        // ID
-        buf.putInt(idBytes.length);
+        buf.putShort((short) idBytes.length);
         buf.put(idBytes);
-
-        // Location
-        buf.putInt(loc.type().ordinal());
-        buf.putLong(loc.offset());
-        buf.putInt(loc.partitionIndex());
-
-        // Text — V4: zero-length if text.dat offset available; inline fallback otherwise
-        buf.putInt(textBytesLen);
-        if (writeInlineText && textBytesLen > 0) {
-            buf.put(textBytes);
+        buf.put((byte) source.ordinal());
+        buf.putShort((short) tagArray.length);
+        for (byte[] tb : tagBytesArray) {
+            buf.putShort((short) tb.length);
+            buf.put(tb);
         }
-
-        // Source
-        buf.putInt(source.ordinal());
-
-        // Tags
-        buf.putInt(tagArray.length);
-        for (byte[] tagBytes : tagBytesArray) {
-            buf.putInt(tagBytes.length);
-            buf.put(tagBytes);
-        }
-
-        // V2: Metadata map
-        buf.putInt(metadata.size());
+        buf.putShort((short) metadata.size());
         for (int j = 0; j < metaKeyBytes.length; j++) {
-            buf.putInt(metaKeyBytes[j].length);
+            buf.putShort((short) metaKeyBytes[j].length);
             buf.put(metaKeyBytes[j]);
-            buf.putInt(metaValBytes[j].length);
+            buf.putShort((short) metaValBytes[j].length);
             buf.put(metaValBytes[j]);
         }
-
-        // V3: Text position in text.dat (for off-heap reads)
-        ByteBuffer textPosBuf = ByteBuffer.allocate(8 + 4);
-        textPosBuf.putLong(loc.textOffset());
-        textPosBuf.putInt(loc.textLength());
-        textPosBuf.flip();
-
-        buf.flip();
-        ch.write(buf);
-        ch.write(textPosBuf);
+        buf.putInt(textBytes.length);
+        if (textBytes.length > 0) {
+            buf.put(textBytes);
+        }
+        return buf.array();
     }
+
+    private static void deserializeIdBlob(MemorySegment segment, DeserializedEntry target) {
+        ByteBuffer buf = segment.asByteBuffer();
+        buf.order(java.nio.ByteOrder.BIG_ENDIAN);
+        
+        int idLen = Short.toUnsignedInt(buf.getShort());
+        byte[] idBytes = new byte[idLen];
+        buf.get(idBytes);
+        target.id = new String(idBytes, StandardCharsets.UTF_8);
+        
+        int sourceOrd = Byte.toUnsignedInt(buf.get());
+        target.source = MemorySource.values()[sourceOrd];
+        
+        int tagCount = Short.toUnsignedInt(buf.getShort());
+        target.tags = new String[tagCount];
+        for (int i = 0; i < tagCount; i++) {
+            int tagLen = Short.toUnsignedInt(buf.getShort());
+            byte[] tagBytes = new byte[tagLen];
+            buf.get(tagBytes);
+            target.tags[i] = new String(tagBytes, StandardCharsets.UTF_8);
+        }
+        
+        int metaCount = Short.toUnsignedInt(buf.getShort());
+        if (metaCount > 0) {
+            target.metadata = new java.util.HashMap<>(metaCount);
+            for (int i = 0; i < metaCount; i++) {
+                int keyLen = Short.toUnsignedInt(buf.getShort());
+                byte[] keyBytes = new byte[keyLen];
+                buf.get(keyBytes);
+                String key = new String(keyBytes, StandardCharsets.UTF_8);
+                
+                int valLen = Short.toUnsignedInt(buf.getShort());
+                byte[] valBytes = new byte[valLen];
+                buf.get(valBytes);
+                String val = new String(valBytes, StandardCharsets.UTF_8);
+                target.metadata.put(key, val);
+            }
+        } else {
+            target.metadata = Map.of();
+        }
+        
+        int textLen = buf.getInt();
+        if (textLen > 0) {
+            byte[] textBytes = new byte[textLen];
+            buf.get(textBytes);
+            target.textFallback = new String(textBytes, StandardCharsets.UTF_8);
+        } else {
+            target.textFallback = "";
+        }
+    }
+
+    private static class DeserializedEntry {
+        String id;
+        MemorySource source;
+        String[] tags;
+        Map<String, String> metadata;
+        String textFallback;
+    }
+
+    // ── Legacy Format Read Helpers ──
 
     private static void readEntry(FileChannel ch, MemoryIndex index,
                                     boolean hasMetadata, boolean hasTextPosition,
                                     boolean hasInlineText) throws IOException {
-        // ID
         String id = readString(ch);
 
-        // Location (base: type + offset + partitionIndex)
         ByteBuffer locBuf = ByteBuffer.allocate(4 + 8 + 4);
         ch.read(locBuf);
         locBuf.flip();
@@ -763,17 +638,14 @@ public final class MemoryIndex {
         int partitionIndex = locBuf.getInt();
         MemoryType type = MemoryType.values()[typeOrd];
 
-        // Text — V4: always zero-length (resolved from text.dat); V1-V3: read inline text
         String text = readString(ch);
 
-        // Source
         ByteBuffer srcBuf = ByteBuffer.allocate(4);
         ch.read(srcBuf);
         srcBuf.flip();
         int sourceOrd = srcBuf.getInt();
         MemorySource source = MemorySource.values()[sourceOrd];
 
-        // Tags
         ByteBuffer tagCountBuf = ByteBuffer.allocate(4);
         ch.read(tagCountBuf);
         tagCountBuf.flip();
@@ -783,7 +655,6 @@ public final class MemoryIndex {
             tagArray[t] = readString(ch);
         }
 
-        // V2: Metadata map
         Map<String, String> metadata = null;
         if (hasMetadata) {
             ByteBuffer metaCountBuf = ByteBuffer.allocate(4);
@@ -800,7 +671,6 @@ public final class MemoryIndex {
             }
         }
 
-        // V3: Text position in text.dat
         long textOffset = -1L;
         int textLength = -1;
         if (hasTextPosition) {
@@ -829,4 +699,3 @@ public final class MemoryIndex {
         return new String(strBuf.array(), 0, len, StandardCharsets.UTF_8);
     }
 }
-

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory.kernel;
 
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorStorageException;
+import com.spectrayan.spector.memory.sync.MemoryWal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,41 @@ public abstract class AbstractMemory<L extends MemoryLayout> implements Memory<L
 
     @SuppressWarnings("unused") // accessed via VarHandle
     private volatile int visibleCount = 0;
+
+    protected MemoryWal wal;
+    protected boolean bypassWal = false;
+
+    /**
+     * Binds a Write-Ahead Log (WAL) to this memory.
+     */
+    @Override
+    public void bindWal(MemoryWal wal) {
+        this.wal = wal;
+    }
+
+    /**
+     * Sets whether WAL writes should be bypassed (useful during recovery/replay).
+     */
+    @Override
+    public void setBypassWal(boolean bypassWal) {
+        this.bypassWal = bypassWal;
+    }
+
+    /**
+     * Returns whether WAL writes are bypassed.
+     */
+    @Override
+    public boolean isBypassWal() {
+        return this.bypassWal;
+    }
+
+    /**
+     * Returns the bound Write-Ahead Log, if any.
+     */
+    @Override
+    public MemoryWal getWal() {
+        return this.wal;
+    }
 
     /**
      * Volatile constructor — allocates memory off-heap without a backing file.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
@@ -85,6 +85,43 @@ public abstract class AbstractMemory<L extends MemoryLayout> implements Memory<L
     }
 
     /**
+     * Wrapping constructor — adopts a pre-made Arena and segment.
+     *
+     * <p>Used for deep composition: the caller (e.g., {@code AbstractTierStore})
+     * manages mmap lifecycle and header format, then wraps the result in a
+     * kernel {@code Memory} for standardized identity, shape, and accessor methods.</p>
+     *
+     * <p><b>Ownership:</b> The caller transfers ownership of the arena and segment
+     * to this instance. {@link #close()} will close the arena and file channel.</p>
+     *
+     * @param id          the unique identifier for this memory
+     * @param layout      the layout configuration
+     * @param capacity    the maximum number of records
+     * @param arena       the pre-made arena (caller transfers ownership)
+     * @param segment     the pre-made segment (must belong to the arena)
+     * @param count       the initial record count (restored from header)
+     * @param persistent  whether this memory is file-backed
+     * @param filePath    the file path (null for volatile)
+     * @param fileChannel the file channel (null for volatile; caller transfers ownership)
+     */
+    protected AbstractMemory(MemoryId id, L layout, int capacity,
+                             Arena arena, MemorySegment segment, int count,
+                             boolean persistent, Path filePath, FileChannel fileChannel) {
+        this.id = id;
+        this.layout = layout;
+        this.capacity = capacity;
+        this.arena = arena;
+        this.segment = segment;
+        this.count = count;
+        this.persistent = persistent;
+        this.filePath = filePath;
+        this.fileChannel = fileChannel;
+        if (count > 0) {
+            publishVisible();
+        }
+    }
+
+    /**
      * File-backed constructor — creates or opens a persistent memory-mapped file.
      *
      * @param id           the unique identifier for this memory

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
@@ -199,7 +199,7 @@ public abstract class AbstractMemory<L extends MemoryLayout> implements Memory<L
      *
      * @return the data offset
      */
-    protected long dataOffset() {
+    public long dataOffset() {
         return persistent ? MemoryHeader.HEADER_BYTES : 0;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorStorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Abstract base class for all {@link Memory} implementations.
+ *
+ * <p>Provides common infrastructure for both volatile (in-memory) and
+ * persistent (file-backed) memory structures. Manages the lifecycle of
+ * off-heap memory via {@link Arena} and ensures thread-safe SWMR
+ * (Single Writer Multiple Reader) visibility using {@link VarHandle}.</p>
+ *
+ * @param <L> the type of memory layout used by this memory
+ */
+public abstract class AbstractMemory<L extends MemoryLayout> implements Memory<L> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractMemory.class);
+
+    // ── SWMR Visibility Barrier ──
+    private static final VarHandle VISIBLE_COUNT_HANDLE;
+    static {
+        try {
+            VISIBLE_COUNT_HANDLE = MethodHandles.lookup()
+                    .findVarHandle(AbstractMemory.class, "visibleCount", int.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    protected final MemoryId id;
+    protected final L layout;
+    protected final Arena arena;
+    protected final MemorySegment segment;
+    protected final int capacity;
+    protected final boolean persistent;
+    protected int count = 0;
+    private FileChannel fileChannel;
+    private final Path filePath;
+
+    @SuppressWarnings("unused") // accessed via VarHandle
+    private volatile int visibleCount = 0;
+
+    /**
+     * Volatile constructor — allocates memory off-heap without a backing file.
+     *
+     * @param id           the unique identifier for this memory
+     * @param layout       the layout configuration
+     * @param capacity     the maximum number of records
+     * @param segmentBytes the total bytes to allocate
+     */
+    protected AbstractMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
+        this.id = id;
+        this.layout = layout;
+        this.capacity = capacity;
+        this.persistent = false;
+        this.filePath = null;
+        this.arena = Arena.ofShared();
+        this.segment = arena.allocate(segmentBytes, 64);
+    }
+
+    /**
+     * File-backed constructor — creates or opens a persistent memory-mapped file.
+     *
+     * @param id           the unique identifier for this memory
+     * @param layout       the layout configuration
+     * @param capacity     the maximum number of records
+     * @param segmentBytes the total data bytes (excluding header)
+     * @param filePath     the path to the backing file
+     */
+    protected AbstractMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
+        this.id = id;
+        this.layout = layout;
+        this.capacity = capacity;
+        this.persistent = true;
+        this.filePath = filePath;
+        this.arena = Arena.ofShared();
+
+        try {
+            Path parent = filePath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+
+            long totalBytes = MemoryHeader.HEADER_BYTES + segmentBytes;
+            boolean isNew = !Files.exists(filePath) || Files.size(filePath) < MemoryHeader.HEADER_BYTES;
+
+            fileChannel = FileChannel.open(filePath,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.READ,
+                    StandardOpenOption.WRITE);
+
+            if (isNew) {
+                fileChannel.position(totalBytes - 1);
+                fileChannel.write(ByteBuffer.wrap(new byte[]{0}));
+            }
+
+            long mapSize = Math.max(totalBytes, fileChannel.size());
+            this.segment = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, mapSize, arena);
+
+            if (isNew) {
+                this.count = 0;
+                MemoryHeader.write(segment, 0, layout.schemaVersion(), shape(),
+                        0x01, // flags: persistent
+                        capacity, 0, layout.recordStride(), layout.layoutId(),
+                        System.currentTimeMillis(), System.currentTimeMillis());
+                log.info("Created new persistent memory: {} ({}KB)", filePath, totalBytes / 1024);
+            } else {
+                this.count = (int) MemoryHeader.readCount(segment, 0);
+                publishVisible();
+                log.info("Loaded persistent memory: {} ({} records)", filePath, count);
+            }
+        } catch (IOException e) {
+            throw new SpectorStorageException(ErrorCode.MMAP_FAILED, e, filePath);
+        }
+    }
+
+    /**
+     * Publishes the current count as visible to concurrent readers.
+     */
+    protected void publishVisible() {
+        VISIBLE_COUNT_HANDLE.setRelease(this, count);
+    }
+
+    /**
+     * Returns the number of records visible to concurrent readers.
+     * Uses acquire semantics for SWMR visibility.
+     *
+     * @return the visible record count
+     */
+    public int visibleCount() {
+        return (int) VISIBLE_COUNT_HANDLE.getAcquire(this);
+    }
+
+    /**
+     * Returns the byte offset where data records begin.
+     *
+     * @return the data offset
+     */
+    protected long dataOffset() {
+        return persistent ? MemoryHeader.HEADER_BYTES : 0;
+    }
+
+    /**
+     * Persists the current count to the metadata header.
+     */
+    protected void persistCount() {
+        if (persistent) {
+            MemoryHeader.writeCount(segment, 0, count);
+        }
+    }
+
+    @Override
+    public MemoryId id() {
+        return id;
+    }
+
+    @Override
+    public L layout() {
+        return layout;
+    }
+
+    @Override
+    public Arena arena() {
+        return arena;
+    }
+
+    @Override
+    public MemorySegment segment() {
+        return segment;
+    }
+
+    @Override
+    public int capacity() {
+        return capacity;
+    }
+
+    @Override
+    public int size() {
+        return count;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return layout.schemaVersion();
+    }
+
+    /**
+     * Returns the structural shape of this memory.
+     * Must be implemented by each shape subclass.
+     */
+    @Override
+    public abstract MemoryShape shape();
+
+    public boolean isPersistent() {
+        return persistent;
+    }
+
+    public Path filePath() {
+        return filePath;
+    }
+
+    @Override
+    public void flush() {
+        if (persistent && segment != null) {
+            segment.force();
+        }
+    }
+
+    @Override
+    public void close() {
+        log.info("Closing memory {} ({} records, persistent={})", id, count, persistent);
+        if (persistent) {
+            try {
+                if (segment != null) {
+                    segment.force();
+                }
+            } catch (Exception e) {
+                log.debug("Error forcing segment: {}", e.getMessage());
+            }
+        }
+        arena.close();
+        if (fileChannel != null) {
+            try {
+                fileChannel.close();
+            } catch (IOException e) {
+                log.debug("Error closing file channel: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/Codec.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/Codec.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Handles schema migration and encoding/decoding operations for a specific MemoryLayout.
+ *
+ * @param <L> The MemoryLayout type this codec manages.
+ */
+public interface Codec<L extends MemoryLayout> {
+    
+    /** 
+     * The layout this codec handles. 
+     * 
+     * @return The associated memory layout.
+     */
+    L layout();
+    
+    /** 
+     * Whether this codec can upgrade from the given schema version. 
+     * 
+     * @param fromVersion The schema version to upgrade from.
+     * @return true if the upgrade is supported, false otherwise.
+     */
+    boolean canUpgrade(int fromVersion);
+    
+    /** 
+     * Upgrade data from one schema version to the current. 
+     * 
+     * @param fromVersion The original schema version.
+     * @param source The source segment containing the old data.
+     * @param target The target segment to write the upgraded data into.
+     */
+    void upgrade(int fromVersion, MemorySegment source, MemorySegment target);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/Memory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/Memory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import java.lang.foreign.*;
+
+/**
+ * The base interface for all persistent structures in the Spector Memory Kernel.
+ *
+ * @param <L> The MemoryLayout type describing the schema of this memory's records.
+ */
+public interface Memory<L extends MemoryLayout> extends AutoCloseable {
+    
+    /** 
+     * Stable identity for logs, metrics, WAL redo target. 
+     * 
+     * @return The unique identifier of this memory.
+     */
+    MemoryId id();
+    
+    /** 
+     * The schema describing what a record/slot looks like. 
+     * 
+     * @return The memory layout.
+     */
+    L layout();
+    
+    /** 
+     * Region-scoped arena; sub-slices must not outlive it. 
+     * 
+     * @return The arena managing the lifecycle of the underlying memory segment.
+     */
+    Arena arena();
+    
+    /** 
+     * Root segment; kernels sub-slice this for records/adjacency/etc. 
+     * 
+     * @return The root memory segment backing this memory.
+     */
+    MemorySegment segment();
+    
+    /** 
+     * Live record count, published with release/acquire semantics. 
+     * 
+     * @return The current number of live records.
+     */
+    int size();
+    
+    /** 
+     * Capacity in records / slots (bounded upper limit). 
+     * 
+     * @return The maximum number of records this memory can hold.
+     */
+    int capacity();
+    
+    /** 
+     * Schema version stamped in the on-disk header. 
+     * 
+     * @return The schema version.
+     */
+    int schemaVersion();
+    
+    /** 
+     * The shape of this memory. 
+     * 
+     * @return The structural shape of the memory.
+     */
+    MemoryShape shape();
+    
+    /** 
+     * msync/force this memory only (not the whole file). 
+     * Ensures durability of modifications.
+     */
+    void flush();
+    
+    /** 
+     * Close: releases arena, does not delete backing file. 
+     */
+    @Override
+    void close();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/Memory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/Memory.java
@@ -88,4 +88,24 @@ public interface Memory<L extends MemoryLayout> extends AutoCloseable {
      */
     @Override
     void close();
+
+    /**
+     * Binds a Write-Ahead Log (WAL) to this memory.
+     */
+    default void bindWal(com.spectrayan.spector.memory.sync.MemoryWal wal) {}
+
+    /**
+     * Sets whether WAL writes should be bypassed (useful during recovery/replay).
+     */
+    default void setBypassWal(boolean bypass) {}
+
+    /**
+     * Returns whether WAL writes are bypassed.
+     */
+    default boolean isBypassWal() { return false; }
+
+    /**
+     * Returns the bound Write-Ahead Log, if any.
+     */
+    default com.spectrayan.spector.memory.sync.MemoryWal getWal() { return null; }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryHeader.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryHeader.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.zip.CRC32C;
+
+/**
+ * Utility class for reading and writing the standardized 64-byte file header
+ * for Spector Memory Kernel files.
+ * <p>
+ * The header layout is exactly 64 bytes (1 cache line):
+ * Offset  Size  Field
+ *   0      4    magic (0x534D4B4D = 'SMKM')
+ *   4      4    schemaVersion
+ *   8      4    shape (MemoryShape ordinal)
+ *  12      4    flags (bit0=persistent, bit1=encrypted, bit2=dirty)
+ *  16      8    capacity (long)
+ *  24      8    count (long)
+ *  32      4    recordStride
+ *  36      4    layoutId
+ *  40      8    createdAtEpochMs
+ *  48      8    lastFlushEpochMs
+ *  56      4    headerCrc32c (CRC32C over bytes [0..55])
+ *  60      4    reserved (must be 0)
+ */
+public final class MemoryHeader {
+    
+    public static final int HEADER_BYTES = 64;
+    public static final int MAGIC = 0x534D4B4D;
+
+    private static final long OFFSET_MAGIC = 0;
+    private static final long OFFSET_SCHEMA_VERSION = 4;
+    private static final long OFFSET_SHAPE = 8;
+    private static final long OFFSET_FLAGS = 12;
+    private static final long OFFSET_CAPACITY = 16;
+    private static final long OFFSET_COUNT = 24;
+    private static final long OFFSET_RECORD_STRIDE = 32;
+    private static final long OFFSET_LAYOUT_ID = 36;
+    private static final long OFFSET_CREATED_AT = 40;
+    private static final long OFFSET_LAST_FLUSH = 48;
+    private static final long OFFSET_CRC = 56;
+    private static final long OFFSET_RESERVED = 60;
+
+    private MemoryHeader() {
+        // Utility class
+    }
+
+    /**
+     * Writes all fields to the segment and computes the CRC32C over the first 56 bytes.
+     */
+    public static void write(MemorySegment segment, long offset, int schemaVersion, MemoryShape shape, int flags,
+                             long capacity, long count, int recordStride, int layoutId,
+                             long createdAtEpochMs, long lastFlushEpochMs) {
+        
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_MAGIC, MAGIC);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_SCHEMA_VERSION, schemaVersion);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_SHAPE, shape.ordinal());
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_FLAGS, flags);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_CAPACITY, capacity);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_COUNT, count);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_RECORD_STRIDE, recordStride);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_LAYOUT_ID, layoutId);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_CREATED_AT, createdAtEpochMs);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_LAST_FLUSH, lastFlushEpochMs);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_RESERVED, 0);
+
+        int crc = computeCrc(segment, offset);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_CRC, crc);
+    }
+
+    /**
+     * Checks if the header has a valid magic number and CRC.
+     *
+     * @param segment The memory segment.
+     * @param offset  The offset where the header starts.
+     * @return true if the magic matches and the CRC is valid, false otherwise.
+     */
+    public static boolean isValid(MemorySegment segment, long offset) {
+        int magic = segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_MAGIC);
+        if (magic != MAGIC) {
+            return false;
+        }
+        int expectedCrc = computeCrc(segment, offset);
+        int actualCrc = segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_CRC);
+        return expectedCrc == actualCrc;
+    }
+
+    /**
+     * Reads the schema version from the header.
+     */
+    public static int readSchemaVersion(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_SCHEMA_VERSION);
+    }
+
+    /**
+     * Reads the count from the header.
+     */
+    public static long readCount(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_COUNT);
+    }
+
+    /**
+     * Updates the count in the header and recomputes the CRC.
+     */
+    public static void writeCount(MemorySegment segment, long offset, long count) {
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_COUNT, count);
+        int crc = computeCrc(segment, offset);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_CRC, crc);
+    }
+
+    /**
+     * Reads the MemoryShape from the header.
+     */
+    public static MemoryShape readShape(MemorySegment segment, long offset) {
+        int ordinal = segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_SHAPE);
+        MemoryShape[] values = MemoryShape.values();
+        if (ordinal >= 0 && ordinal < values.length) {
+            return values[ordinal];
+        }
+        throw new IllegalStateException("Invalid shape ordinal in header: " + ordinal);
+    }
+
+    /**
+     * Reads the capacity from the header.
+     */
+    public static long readCapacity(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_CAPACITY);
+    }
+
+    private static int computeCrc(MemorySegment segment, long offset) {
+        CRC32C crc32c = new CRC32C();
+        crc32c.update(segment.asSlice(offset, 56).asByteBuffer());
+        return (int) crc32c.getValue();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryHeader.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryHeader.java
@@ -139,6 +139,41 @@ public final class MemoryHeader {
         return segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_CAPACITY);
     }
 
+    /**
+     * Reads the flags from the header.
+     */
+    public static int readFlags(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_FLAGS);
+    }
+
+    /**
+     * Reads the record stride from the header.
+     */
+    public static int readRecordStride(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_RECORD_STRIDE);
+    }
+
+    /**
+     * Reads the layout ID from the header.
+     */
+    public static int readLayoutId(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + OFFSET_LAYOUT_ID);
+    }
+
+    /**
+     * Reads the creation timestamp from the header.
+     */
+    public static long readCreatedAt(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_CREATED_AT);
+    }
+
+    /**
+     * Reads the last flush timestamp from the header.
+     */
+    public static long readLastFlush(MemorySegment segment, long offset) {
+        return segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset + OFFSET_LAST_FLUSH);
+    }
+
     private static int computeCrc(MemorySegment segment, long offset) {
         CRC32C crc32c = new CRC32C();
         crc32c.update(segment.asSlice(offset, 56).asByteBuffer());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryId.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import java.util.Objects;
+
+/**
+ * A unique identifier for a memory instance.
+ * Provides a stable identity for logging, metrics, and referencing.
+ *
+ * @param namespace    The namespace or domain this memory belongs to.
+ * @param memoryName   The unique name of the memory within the namespace.
+ * @param partitionSeq The partition sequence number, defaulting to 0 for non-partitioned memories.
+ */
+public record MemoryId(String namespace, String memoryName, int partitionSeq) implements Comparable<MemoryId> {
+
+    /**
+     * Creates a new MemoryId for a non-partitioned memory.
+     *
+     * @param namespace  The namespace.
+     * @param memoryName The memory name.
+     * @return A new MemoryId with partitionSeq set to 0.
+     */
+    public static MemoryId of(String namespace, String memoryName) {
+        return new MemoryId(namespace, memoryName, 0);
+    }
+
+    public MemoryId {
+        Objects.requireNonNull(namespace, "namespace cannot be null");
+        Objects.requireNonNull(memoryName, "memoryName cannot be null");
+        if (partitionSeq < 0) {
+            throw new IllegalArgumentException("partitionSeq cannot be negative");
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (partitionSeq > 0) {
+            return namespace + "/" + memoryName + "#" + partitionSeq;
+        } else {
+            return namespace + "/" + memoryName;
+        }
+    }
+
+    @Override
+    public int compareTo(MemoryId o) {
+        int nsCompare = this.namespace.compareTo(o.namespace);
+        if (nsCompare != 0) {
+            return nsCompare;
+        }
+        int nameCompare = this.memoryName.compareTo(o.memoryName);
+        if (nameCompare != 0) {
+            return nameCompare;
+        }
+        return Integer.compare(this.partitionSeq, o.partitionSeq);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryId.java
@@ -35,6 +35,26 @@ public record MemoryId(String namespace, String memoryName, int partitionSeq) im
         return new MemoryId(namespace, memoryName, 0);
     }
 
+    /**
+     * Parses a string representation of a MemoryId.
+     */
+    public static MemoryId parse(String str) {
+        if (str == null) return null;
+        int hashIdx = str.indexOf('#');
+        int partitionSeq = 0;
+        String base = str;
+        if (hashIdx >= 0) {
+            partitionSeq = Integer.parseInt(str.substring(hashIdx + 1));
+            base = str.substring(0, hashIdx);
+        }
+        int slashIdx = base.indexOf('/');
+        if (slashIdx >= 0) {
+            return new MemoryId(base.substring(0, slashIdx), base.substring(slashIdx + 1), partitionSeq);
+        } else {
+            return new MemoryId("default", base, partitionSeq);
+        }
+    }
+
     public MemoryId {
         Objects.requireNonNull(namespace, "namespace cannot be null");
         Objects.requireNonNull(memoryName, "memoryName cannot be null");

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryLayout.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+/**
+ * Describes the physical schema and characteristics of a memory's records.
+ */
+public interface MemoryLayout {
+    
+    /** 
+     * Unique stable identifier for this layout type. Used in file headers. 
+     * 
+     * @return The unique layout ID.
+     */
+    int layoutId();
+    
+    /** 
+     * Schema version for this layout. Used for migration via Codec. 
+     * 
+     * @return The schema version.
+     */
+    int schemaVersion();
+    
+    /** 
+     * Bytes per record (fixed-size layouts) or 0 for variable-length (AppendMemory). 
+     * 
+     * @return The size of a record in bytes, or 0 if variable-length.
+     */
+    int recordStride();
+    
+    /** 
+     * Whether CRC32C integrity checking is enabled for this layout. 
+     * 
+     * @return true if CRC32C is enabled, false otherwise.
+     */
+    boolean crcEnabled();
+    
+    /** 
+     * Human-readable name for diagnostics. 
+     * 
+     * @return The diagnostic name of the layout.
+     */
+    String name();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryShape.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryShape.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+/**
+ * Defines the structural shape of a persistent memory.
+ * Each shape provides a different fundamental layout and access pattern for data.
+ */
+public enum MemoryShape {
+    /**
+     * Backs a flat, contiguous array of fixed-size records.
+     * Ideal for simple tabular data or highly structured uniform collections.
+     */
+    RECORD,
+
+    /**
+     * Backs a partitioned array of fixed-size records, physically or logically divided.
+     * Useful for time-series, log-structured merges, or highly concurrent partitioned data.
+     */
+    PARTITIONED,
+
+    /**
+     * Backs a node and edge structure.
+     * Optimized for graph traversals, relationships, and property graphs.
+     */
+    GRAPH,
+
+    /**
+     * Backs a linked sequence of records (chains).
+     * Used for hash collision resolution, linked lists, or version histories.
+     */
+    CHAIN,
+
+    /**
+     * Backs an append-only log of variable-length records.
+     * Used for WALs (Write-Ahead Logs), event streams, or unbounded string/blob storage.
+     */
+    APPEND,
+
+    /**
+     * Backs a key-value registry or dictionary structure.
+     * Often used for metadata, schema definitions, or index roots.
+     */
+    REGISTRY
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CoActivationLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CoActivationLayout.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for the co-activation tracker.
+ * Stride is 1 byte, representing the raw tables data segment.
+ */
+public final class CoActivationLayout implements MemoryLayout {
+
+    private static final int STRIDE = 1;
+    private static final int LAYOUT_ID = 0x434F4158; // 'COAX'
+    private static final int VERSION = 2;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "CoActivationLayout";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CognitiveRecordLayoutAdapter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CognitiveRecordLayoutAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
+
+/**
+ * Adapter that bridges the existing {@link CognitiveRecordLayout} to the
+ * new {@link MemoryLayout} interface required by the memory kernel.
+ */
+public final class CognitiveRecordLayoutAdapter implements MemoryLayout {
+    
+    public static final int LAYOUT_ID = 0x434F4700; // 'COG\0'
+    
+    private final CognitiveRecordLayout delegate;
+    
+    /**
+     * Constructs a new adapter wrapping the given delegate layout.
+     *
+     * @param delegate the cognitive record layout to wrap
+     */
+    public CognitiveRecordLayoutAdapter(CognitiveRecordLayout delegate) {
+        this.delegate = delegate;
+    }
+    
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+    
+    @Override
+    public int schemaVersion() {
+        return 1;
+    }
+    
+    @Override
+    public int recordStride() {
+        return delegate.stride();
+    }
+    
+    @Override
+    public boolean crcEnabled() {
+        return false; // tier stores use WAL for integrity
+    }
+    
+    @Override
+    public String name() {
+        return "CognitiveRecordLayout";
+    }
+    
+    /**
+     * Returns the underlying {@link CognitiveRecordLayout}.
+     *
+     * @return the delegate layout
+     */
+    public CognitiveRecordLayout delegate() {
+        return delegate;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/EntityLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/EntityLayout.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for nodes/relations in the Entity Graph.
+ */
+public final class EntityLayout implements MemoryLayout {
+
+    private static final int STRIDE = 64; // ENTITY_NODE_BYTES is 64
+    private static final int LAYOUT_ID = 0x45474D4D; // 'EGMM'
+    private static final int VERSION = 2;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "EntityGraph";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HebbianLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HebbianLayout.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for edges in the Hebbian Graph CSR.
+ */
+public final class HebbianLayout implements MemoryLayout {
+
+    private static final int STRIDE = 12; // CSR edge bytes: neighbor(4) + weight(4) + metadata(4)
+    private static final int LAYOUT_ID = 0x48435352; // 'HCSR'
+    private static final int VERSION = 1;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "HebbianGraphCsr";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IdBlobLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IdBlobLayout.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for the variable-length ID/metadata payload pool.
+ * Stride is 0 since records are variable length.
+ */
+public final class IdBlobLayout implements MemoryLayout {
+
+    private static final int STRIDE = 0; // Variable length
+    private static final int LAYOUT_ID = 0x4944504C; // 'IDPL'
+    private static final int VERSION = 1;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "IdBlobLayout";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IndexEntryLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IndexEntryLayout.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for the index entry slot table (40 bytes fixed size).
+ *
+ * <p>Format:
+ * - [0:8]   idPoolOffset (long)
+ * - [8:4]   idPoolLength (int)
+ * - [12:4]  typeOrdinal (int)
+ * - [16:8]  offset (long)
+ * - [24:4]  partitionIndex (int)
+ * - [28:8]  textOffset (long)
+ * - [36:4]  textLength (int)
+ * </p>
+ */
+public final class IndexEntryLayout implements MemoryLayout {
+
+    private static final int STRIDE = 40;
+    private static final int LAYOUT_ID = 0x4D494458; // 'MIDX'
+    private static final int VERSION = 5;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "IndexEntryLayout";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/TemporalFactLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/TemporalFactLayout.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for 64-byte temporal fact records.
+ *
+ * <p>Each node is exactly 64 bytes:
+ * - 4B factId (int)
+ * - 4B subjectEntityId (int)
+ * - 4B predicateId (int)
+ * - 4B objectEntityId (int)
+ * - 8B objectTextOffset (long)
+ * - 2B objectTextLength (short)
+ * - 1B flags (byte)
+ * - 1B reserved (byte)
+ * - 8B validFrom (long)
+ * - 8B validTo (long)
+ * - 8B txTime (long)
+ * - 4B confidence (float)
+ * - 4B retractsFactId (int)
+ * - 4B crc32c (int)
+ * </p>
+ */
+public final class TemporalFactLayout implements MemoryLayout {
+
+    private static final int STRIDE = 64;
+    private static final int LAYOUT_ID = 0x54464354; // 'TFCT'
+    private static final int VERSION = 1;
+    
+    public static final int OFF_OBJECT_TEXT_OFFSET = 0;
+    public static final int OFF_VALID_FROM = 8;
+    public static final int OFF_VALID_TO = 16;
+    public static final int OFF_TX_TIME = 24;
+
+    public static final int OFF_FACT_ID = 32;
+    public static final int OFF_SUBJECT_ENTITY_ID = 36;
+    public static final int OFF_PREDICATE_ID = 40;
+    public static final int OFF_OBJECT_ENTITY_ID = 44;
+    public static final int OFF_CONFIDENCE = 48;
+    public static final int OFF_RETRACTS_FACT_ID = 52;
+    public static final int OFF_CRC32C = 56;
+
+    public static final int OFF_OBJECT_TEXT_LENGTH = 60;
+    public static final int OFF_FLAGS = 62;
+    public static final int OFF_RESERVED = 63;
+    
+    public static final byte FLAG_INFERRED = 0x01;
+    public static final byte FLAG_RESOLVED = 0x02;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return true;
+    }
+
+    @Override
+    public String name() {
+        return "TemporalFact";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/TemporalLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/TemporalLayout.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for nodes in the temporal causal chain.
+ *
+ * <p>Each node is exactly 16 bytes:
+ * - 4B prevIdx (int)
+ * - 4B nextIdx (int)
+ * - 4B sessionId (int)
+ * - 4B epochSec (int)
+ * </p>
+ */
+public final class TemporalLayout implements MemoryLayout {
+
+    private static final int STRIDE = 16;
+    private static final int LAYOUT_ID = 0x54504348; // 'TPCH'
+    private static final int VERSION = 2;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "TemporalChain";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/TextBlobLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/TextBlobLayout.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for the variable-length text payload pool.
+ */
+public final class TextBlobLayout implements MemoryLayout {
+
+    private static final int STRIDE = 0; // Variable length
+    private static final int LAYOUT_ID = 0x54585442; // 'TXTB'
+    private static final int VERSION = 1;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "TextBlobLayout";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import com.spectrayan.spector.memory.kernel.AbstractMemory;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+/**
+ * Abstract base class for append-only log structures.
+ */
+public abstract class AbstractAppendMemory<L extends MemoryLayout>
+        extends AbstractMemory<L> implements AppendMemory<L> {
+
+    protected AbstractAppendMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
+        super(id, layout, capacity, segmentBytes);
+    }
+
+    protected AbstractAppendMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
+        super(id, layout, capacity, segmentBytes, filePath);
+    }
+
+    protected AbstractAppendMemory(MemoryId id, L layout, int capacity,
+                                   Arena arena, MemorySegment segment, int count,
+                                   boolean persistent, Path filePath, FileChannel fileChannel) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
+    }
+
+    @Override
+    public MemoryShape shape() {
+        return MemoryShape.APPEND;
+    }
+
+    @Override
+    public synchronized long append(MemorySegment bytes) {
+        long len = bytes.byteSize();
+        // Check capacity bounds (here count stores the append cursor position in bytes)
+        if (dataOffset() + count + 4 + len > segment().byteSize()) {
+            throw new IndexOutOfBoundsException("Append memory full: cursor=" + count + ", request=" + (4 + len));
+        }
+
+        long writeOffset = dataOffset() + count;
+        // Write 4B length prefix
+        segment().set(ValueLayout.JAVA_INT_UNALIGNED, writeOffset, (int) len);
+        // Copy payload
+        MemorySegment.copy(bytes, 0, segment(), writeOffset + 4, len);
+
+        long payloadOffset = count + 4;
+        count += 4 + len;
+        persistCount();
+        return payloadOffset;
+    }
+
+    @Override
+    public MemorySegment read(long offset, int length) {
+        if (dataOffset() + offset + length > segment().byteSize()) {
+            throw new IndexOutOfBoundsException("Read out of bounds: offset=" + offset + ", len=" + length);
+        }
+        return segment().asSlice(dataOffset() + offset, length);
+    }
+
+    @Override
+    public long appendCursor() {
+        return count;
+    }
+
+    @Override
+    public Iterator<MemorySegment> replay(long fromOffset) {
+        return new Iterator<MemorySegment>() {
+            private long cursor = fromOffset;
+
+            @Override
+            public boolean hasNext() {
+                // Since we store length prefix (4B) before the record, there must be at least 4 bytes left
+                return cursor + 4 <= count;
+            }
+
+            @Override
+            public MemorySegment next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                int len = segment().get(ValueLayout.JAVA_INT_UNALIGNED, dataOffset() + cursor);
+                MemorySegment slice = segment().asSlice(dataOffset() + cursor + 4, len);
+                cursor += 4 + len;
+                return slice;
+            }
+        };
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
@@ -71,7 +71,7 @@ public abstract class AbstractAppendMemory<L extends MemoryLayout>
         MemorySegment.copy(bytes, 0, segment(), writeOffset + 4, len);
 
         long payloadOffset = count + 4;
-        count += 4 + len;
+        count += (int) (4 + len);
         persistCount();
         return payloadOffset;
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
@@ -58,6 +58,12 @@ public abstract class AbstractAppendMemory<L extends MemoryLayout>
             throw new IndexOutOfBoundsException("Append memory full: cursor=" + count + ", request=" + (4 + len));
         }
 
+        if (wal != null && !bypassWal) {
+            byte[] rawBytes = new byte[(int) len];
+            MemorySegment.copy(bytes, 0, MemorySegment.ofArray(rawBytes), 0, len);
+            wal.appendAppend(id.toString(), rawBytes);
+        }
+
         long writeOffset = dataOffset() + count;
         // Write 4B length prefix
         segment().set(ValueLayout.JAVA_INT_UNALIGNED, writeOffset, (int) len);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
@@ -17,7 +17,9 @@ import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryLayout;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.lang.foreign.ValueLayout;
 
@@ -54,6 +56,26 @@ public abstract class AbstractRecordMemory<L extends MemoryLayout> extends Abstr
      */
     protected AbstractRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
         super(id, layout, capacity, segmentBytes, filePath);
+    }
+
+    /**
+     * Wrapping constructor — adopts a pre-made Arena and segment.
+     *
+     * @param id          the unique identifier for this memory
+     * @param layout      the layout configuration
+     * @param capacity    the maximum number of records
+     * @param arena       the pre-made arena (caller transfers ownership)
+     * @param segment     the pre-made segment (must belong to the arena)
+     * @param count       the initial record count
+     * @param persistent  whether this memory is file-backed
+     * @param filePath    the file path (null for volatile)
+     * @param fileChannel the file channel (null for volatile)
+     */
+    protected AbstractRecordMemory(MemoryId id, L layout, int capacity,
+                                   Arena arena, MemorySegment segment, int count,
+                                   boolean persistent, Path filePath,
+                                   FileChannel fileChannel) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
@@ -94,6 +94,12 @@ public abstract class AbstractRecordMemory<L extends MemoryLayout> extends Abstr
             throw new IndexOutOfBoundsException("Record ID out of bounds: " + recordId);
         }
         
+        if (wal != null && !bypassWal) {
+            byte[] bytes = new byte[layout.recordStride()];
+            MemorySegment.copy(recordBytes, 0, MemorySegment.ofArray(bytes), 0, layout.recordStride());
+            wal.appendRecordWrite(id.toString(), recordId, bytes);
+        }
+
         long offset = recordOffset(recordId);
         MemorySegment.copy(recordBytes, 0, segment, offset, layout.recordStride());
         

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.AbstractMemory;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.file.Path;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Abstract base class for memory structures shaped as records.
+ *
+ * <p>Extends {@link AbstractMemory} to provide array-like, stride-based
+ * indexed access to memory records.</p>
+ *
+ * @param <L> the type of memory layout used by this memory
+ */
+public abstract class AbstractRecordMemory<L extends MemoryLayout> extends AbstractMemory<L> implements RecordMemory<L> {
+
+    /**
+     * Volatile constructor — allocates memory off-heap without a backing file.
+     *
+     * @param id           the unique identifier for this memory
+     * @param layout       the layout configuration
+     * @param capacity     the maximum number of records
+     * @param segmentBytes the total bytes to allocate
+     */
+    protected AbstractRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
+        super(id, layout, capacity, segmentBytes);
+    }
+
+    /**
+     * File-backed constructor — creates or opens a persistent memory-mapped file.
+     *
+     * @param id           the unique identifier for this memory
+     * @param layout       the layout configuration
+     * @param capacity     the maximum number of records
+     * @param segmentBytes the total data bytes (excluding header)
+     * @param filePath     the path to the backing file
+     */
+    protected AbstractRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
+        super(id, layout, capacity, segmentBytes, filePath);
+    }
+
+    @Override
+    public MemoryShape shape() {
+        return MemoryShape.RECORD;
+    }
+
+    @Override
+    public long recordOffset(long recordId) {
+        return dataOffset() + recordId * layout.recordStride();
+    }
+
+    @Override
+    public long write(long recordId, MemorySegment recordBytes) {
+        if (recordId < 0 || recordId >= capacity) {
+            throw new IndexOutOfBoundsException("Record ID out of bounds: " + recordId);
+        }
+        
+        long offset = recordOffset(recordId);
+        MemorySegment.copy(recordBytes, 0, segment, offset, layout.recordStride());
+        
+        if (recordId >= count) {
+            count = (int) recordId + 1;
+            persistCount();
+        }
+        publishVisible();
+        return offset;
+    }
+
+    @Override
+    public void read(long recordId, MemorySegment dest) {
+        if (recordId < 0 || recordId >= capacity) {
+            throw new IndexOutOfBoundsException("Record ID out of bounds: " + recordId);
+        }
+        
+        long offset = recordOffset(recordId);
+        MemorySegment.copy(segment, offset, dest, 0, layout.recordStride());
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRegistryMemory.java
@@ -115,6 +115,10 @@ public abstract class AbstractRegistryMemory extends AbstractMemory<RegistryLayo
             throw new IndexOutOfBoundsException("Registry memory segment is full: " + id());
         }
 
+        if (wal != null && !bypassWal) {
+            wal.appendRegistryIntern(id.toString(), newId, normalized);
+        }
+
         // Write name length
         segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
         // Write name bytes

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRegistryMemory.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Locale;
+
+import com.spectrayan.spector.memory.kernel.AbstractMemory;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+/**
+ * Abstract base class for small string-to-int registries.
+ */
+public abstract class AbstractRegistryMemory extends AbstractMemory<RegistryLayout> implements RegistryMemory {
+
+    private final ConcurrentHashMap<String, Integer> nameToId = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, String> idToName = new ConcurrentHashMap<>();
+    private final AtomicInteger nextId = new AtomicInteger(0);
+    private long writeOffset = 0; // Current write position relative to dataOffset()
+
+    protected AbstractRegistryMemory(MemoryId id, RegistryLayout layout, int capacity, long segmentBytes) {
+        super(id, layout, capacity, segmentBytes);
+        initializeFromSegment();
+    }
+
+    protected AbstractRegistryMemory(MemoryId id, RegistryLayout layout, int capacity, long segmentBytes, Path filePath) {
+        super(id, layout, capacity, segmentBytes, filePath);
+        initializeFromSegment();
+    }
+
+    protected AbstractRegistryMemory(MemoryId id, RegistryLayout layout, int capacity,
+                                      Arena arena, MemorySegment segment, int count,
+                                      boolean persistent, Path filePath, FileChannel fileChannel) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
+        initializeFromSegment();
+    }
+
+    @Override
+    public MemoryShape shape() {
+        return MemoryShape.REGISTRY;
+    }
+
+    private synchronized void initializeFromSegment() {
+        nameToId.clear();
+        idToName.clear();
+        writeOffset = 0;
+        int entryCount = count; // count field in header tracks the number of entries
+        
+        long base = dataOffset();
+        int maxId = -1;
+        
+        for (int i = 0; i < entryCount; i++) {
+            if (base + writeOffset + 6 > segment().byteSize()) {
+                break; // Corrupted file bounds check
+            }
+            int nameLen = Short.toUnsignedInt(segment().get(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset));
+            if (base + writeOffset + 2 + nameLen + 4 > segment().byteSize()) {
+                break; // Corrupted file bounds check
+            }
+            
+            // Read name
+            byte[] nameBytes = new byte[nameLen];
+            MemorySegment.copy(segment(), ValueLayout.JAVA_BYTE, base + writeOffset + 2, nameBytes, 0, nameLen);
+            String name = new String(nameBytes, StandardCharsets.UTF_8);
+            
+            // Read ID
+            int id = segment().get(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen);
+            
+            nameToId.put(name, id);
+            idToName.put(id, name);
+            maxId = Math.max(maxId, id);
+            
+            writeOffset += 2 + nameLen + 4;
+        }
+        
+        nextId.set(maxId + 1);
+    }
+
+    @Override
+    public synchronized int intern(String name) {
+        if (name == null || name.isBlank()) {
+            return intern("OTHER");
+        }
+        String normalized = name.trim().toUpperCase(Locale.ROOT);
+        Integer existing = nameToId.get(normalized);
+        if (existing != null) {
+            return existing;
+        }
+
+        int newId = nextId.getAndIncrement();
+        byte[] nameBytes = normalized.getBytes(StandardCharsets.UTF_8);
+        int nameLen = nameBytes.length;
+
+        // Verify segment bounds
+        long base = dataOffset();
+        if (base + writeOffset + 2 + nameLen + 4 > segment().byteSize()) {
+            throw new IndexOutOfBoundsException("Registry memory segment is full: " + id());
+        }
+
+        // Write name length
+        segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
+        // Write name bytes
+        MemorySegment.copy(MemorySegment.ofArray(nameBytes), 0, segment(), base + writeOffset + 2, nameLen);
+        // Write ID
+        segment().set(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen, newId);
+
+        // Update counts
+        writeOffset += 2 + nameLen + 4;
+        count++;
+        persistCount();
+
+        nameToId.put(normalized, newId);
+        idToName.put(newId, normalized);
+
+        return newId;
+    }
+
+    /**
+     * Directly inserts a name-to-ID mapping without allocating a new ID.
+     * Used for loading/migration.
+     */
+    public synchronized void putDirect(String name, int id) {
+        String normalized = name.trim().toUpperCase(Locale.ROOT);
+        nameToId.put(normalized, id);
+        idToName.put(id, normalized);
+        
+        int maxId = nextId.get();
+        if (id >= maxId) {
+            nextId.set(id + 1);
+        }
+        
+        byte[] nameBytes = normalized.getBytes(StandardCharsets.UTF_8);
+        int nameLen = nameBytes.length;
+        long base = dataOffset();
+        if (base + writeOffset + 2 + nameLen + 4 <= segment().byteSize()) {
+            segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
+            MemorySegment.copy(MemorySegment.ofArray(nameBytes), 0, segment(), base + writeOffset + 2, nameLen);
+            segment().set(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen, id);
+            writeOffset += 2 + nameLen + 4;
+            count++;
+            persistCount();
+        }
+    }
+
+    @Override
+    public String nameOf(int id) {
+        return idToName.get(id);
+    }
+
+    @Override
+    public int idOf(String name) {
+        if (name == null || name.isBlank()) {
+            return -1;
+        }
+        String normalized = name.trim().toUpperCase(Locale.ROOT);
+        Integer id = nameToId.get(normalized);
+        return id != null ? id : -1;
+    }
+
+    @Override
+    public int size() {
+        return nameToId.size();
+    }
+
+    @Override
+    public java.util.Map<String, Integer> entries() {
+        return java.util.Collections.unmodifiableMap(nameToId);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AppendMemory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Shape interface for append-only log structures.
+ * Backs TextDataStore, MemoryWal, temporal facts, etc.
+ *
+ * @param <L> the memory layout type
+ */
+public interface AppendMemory<L extends MemoryLayout> extends Memory<L> {
+    /**
+     * Appends bytes to the end of this memory.
+     * @param bytes the data to append
+     * @return the start offset of the appended data
+     */
+    long append(MemorySegment bytes);
+    
+    /**
+     * Reads data at the given offset.
+     * @param offset byte offset from the start of the data region
+     * @param length number of bytes to read
+     * @return a segment view of the requested range
+     */
+    MemorySegment read(long offset, int length);
+    
+    /**
+     * Replays all records from the given offset.
+     * @param fromOffset byte offset to start replaying from
+     * @return iterator of record segments
+     */
+    java.util.Iterator<MemorySegment> replay(long fromOffset);
+    
+    /**
+     * Current append cursor position (next write offset).
+     * @return the append cursor offset
+     */
+    long appendCursor();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/ChainMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/ChainMemory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Shape interface for sequential linked prev/next structures.
+ * Backs TemporalChain, list-like temporal memories, etc.
+ *
+ * @param <L> the memory layout type
+ */
+public interface ChainMemory<L extends MemoryLayout> extends Memory<L> {
+    /**
+     * Links a node to a successor in the chain.
+     * @param nodeId the node to link from
+     * @param nextId the successor node
+     */
+    void link(int nodeId, int nextId);
+    
+    /**
+     * Returns the successor of the given node.
+     * @param nodeId the node to query
+     * @return the next node ID, or -1 if none
+     */
+    int next(int nodeId);
+    
+    /**
+     * Returns the predecessor of the given node.
+     * @param nodeId the node to query
+     * @return the previous node ID, or -1 if none
+     */
+    int prev(int nodeId);
+    
+    /**
+     * The first node in the chain, or -1 if empty.
+     * @return head node ID
+     */
+    int head();
+    
+    /**
+     * The last node in the chain, or -1 if empty.
+     * @return tail node ID
+     */
+    int tail();
+    
+    /**
+     * Total number of linked nodes.
+     * @return chain length
+     */
+    int chainLength();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DefaultAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DefaultAppendMemory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Concrete implementation of AppendMemory shape.
+ */
+public final class DefaultAppendMemory<L extends MemoryLayout> extends AbstractAppendMemory<L> {
+
+    public DefaultAppendMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
+        super(id, layout, capacity, segmentBytes);
+    }
+
+    public DefaultAppendMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
+        super(id, layout, capacity, segmentBytes, filePath);
+    }
+
+    public DefaultAppendMemory(MemoryId id, L layout, int capacity,
+                               Arena arena, MemorySegment segment, int count,
+                               boolean persistent, Path filePath, FileChannel fileChannel) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DefaultRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DefaultRecordMemory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Concrete implementation of RecordMemory shape.
+ */
+public final class DefaultRecordMemory<L extends MemoryLayout> extends AbstractRecordMemory<L> {
+
+    public DefaultRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
+        super(id, layout, capacity, segmentBytes);
+    }
+
+    public DefaultRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
+        super(id, layout, capacity, segmentBytes, filePath);
+    }
+
+    public DefaultRecordMemory(MemoryId id, L layout, int capacity,
+                               Arena arena, MemorySegment segment, int count,
+                               boolean persistent, Path filePath, FileChannel fileChannel) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DefaultRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DefaultRegistryMemory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+
+/**
+ * Concrete implementation of RegistryMemory shape.
+ */
+public final class DefaultRegistryMemory extends AbstractRegistryMemory {
+
+    public DefaultRegistryMemory(MemoryId id, RegistryLayout layout, int capacity, long segmentBytes) {
+        super(id, layout, capacity, segmentBytes);
+    }
+
+    public DefaultRegistryMemory(MemoryId id, RegistryLayout layout, int capacity, long segmentBytes, Path filePath) {
+        super(id, layout, capacity, segmentBytes, filePath);
+    }
+
+    public DefaultRegistryMemory(MemoryId id, RegistryLayout layout, int capacity,
+                                 Arena arena, MemorySegment segment, int count,
+                                 boolean persistent, Path filePath, FileChannel fileChannel) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/GraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/GraphMemory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Shape interface for CSR/slab node+edge structures.
+ * Backs EntityGraph, HebbianGraphCsr, HyperEntityGraph, etc.
+ *
+ * @param <L> the memory layout type
+ */
+public interface GraphMemory<L extends MemoryLayout> extends Memory<L> {
+    /**
+     * Adds an edge between two nodes.
+     * @param fromNode source node ID
+     * @param toNode target node ID  
+     * @param edgeBytes edge payload data
+     * @return edge ID, or -1 if graph is full
+     */
+    int addEdge(int fromNode, int toNode, MemorySegment edgeBytes);
+    
+    /**
+     * Removes an edge by ID (tombstones it).
+     * @param edgeId the edge to remove
+     */
+    void removeEdge(int edgeId);
+    
+    /**
+     * Returns an iterator over neighbour node IDs for the given node.
+     * @param nodeId the source node
+     * @return iterator of adjacent node IDs
+     */
+    java.util.PrimitiveIterator.OfInt neighbours(int nodeId);
+    
+    /**
+     * Total number of active edges.
+     * @return edge count
+     */
+    int edgeCount();
+    
+    /**
+     * Total number of nodes with at least one edge.
+     * @return node count
+     */
+    int nodeCount();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/PartitionedRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/PartitionedRecordMemory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Shape interface for segmented record storage spanning multiple physical files.
+ * Backs large, append-heavy tables with historic partitions.
+ *
+ * @param <L> the memory layout type
+ */
+public interface PartitionedRecordMemory<L extends MemoryLayout> extends Memory<L> {
+    /** 
+     * Total number of partitions.
+     * @return number of partitions
+     */
+    int partitionCount();
+    
+    /** 
+     * The currently active partition for writes.
+     * @return active partition
+     */
+    RecordMemory<L> activePartition();
+    
+    /** 
+     * Get a specific partition by sequence number.
+     * @param seq partition sequence number
+     * @return the partition memory
+     */
+    RecordMemory<L> partition(int seq);
+    
+    /** 
+     * All partitions for cross-partition scans.
+     * @return iterable over all partitions
+     */
+    Iterable<RecordMemory<L>> partitions();
+    
+    /** 
+     * Create a new active partition, making the current one read-only.
+     */
+    void rollPartition();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RecordMemory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Shape interface for fixed-stride record storage (like database tables).
+ * Backs structures like IndexRecordMemory, SymbolTable, etc.
+ *
+ * @param <L> the memory layout type
+ */
+public interface RecordMemory<L extends MemoryLayout> extends Memory<L> {
+    /**
+     * Writes a record at the given slot index.
+     * @param recordId slot index (0-based)
+     * @param recordBytes the record data to write
+     * @return the byte offset of the written record within the segment
+     */
+    long write(long recordId, MemorySegment recordBytes);
+    
+    /**
+     * Reads a record at the given slot index into the destination segment.
+     * @param recordId slot index (0-based)
+     * @param dest destination segment to copy record data into
+     */
+    void read(long recordId, MemorySegment dest);
+    
+    /**
+     * Returns the byte offset of a record within the segment.
+     * @param recordId slot index (0-based)
+     * @return byte offset
+     */
+    long recordOffset(long recordId);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryLayout.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * A simple MemoryLayout implementation for registries.
+ */
+public final class RegistryLayout implements MemoryLayout {
+    /** Layout ID for registries ('REG\0'). */
+    public static final int LAYOUT_ID = 0x52454700; // 'REG\0'
+    
+    /** Current schema version. */
+    public static final int SCHEMA_VERSION = 1;
+    
+    @Override 
+    public int layoutId() { 
+        return LAYOUT_ID; 
+    }
+    
+    @Override 
+    public int schemaVersion() { 
+        return SCHEMA_VERSION; 
+    }
+    
+    @Override 
+    public int recordStride() { 
+        return 0; // variable-length
+    }
+    
+    @Override 
+    public boolean crcEnabled() { 
+        return false; 
+    }
+    
+    @Override 
+    public String name() { 
+        return "RegistryLayout"; 
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryMemory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+
+/**
+ * Shape interface for small string-to-int dictionaries.
+ * Backs TypeRegistry, name resolution, etc.
+ */
+public interface RegistryMemory extends Memory<RegistryLayout> {
+    /**
+     * Interns a string name, returning its stable integer ID.
+     * If the name is already known, returns the existing ID.
+     * Names are case-insensitive and normalized to uppercase.
+     * @param name the string to intern
+     * @return the integer ID
+     */
+    int intern(String name);
+    
+    /**
+     * Returns the string name for the given integer ID.
+     * @param id the integer ID
+     * @return the name, or null if not found
+     */
+    String nameOf(int id);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryMemory.java
@@ -34,4 +34,17 @@ public interface RegistryMemory extends Memory<RegistryLayout> {
      * @return the name, or null if not found
      */
     String nameOf(int id);
+
+    /**
+     * Returns the integer ID for the given name if registered, or -1 otherwise.
+     * @param name the string name
+     * @return the integer ID, or -1 if not registered
+     */
+    int idOf(String name);
+
+    /**
+     * Returns an unmodifiable map of all registered name-to-ID mappings.
+     * @return map of name to integer ID
+     */
+    java.util.Map<String, Integer> entries();
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/RegistryMemory.java
@@ -29,6 +29,12 @@ public interface RegistryMemory extends Memory<RegistryLayout> {
     int intern(String name);
     
     /**
+     * Directly inserts a name-to-ID mapping without allocating a new ID.
+     * Used for loading/migration.
+     */
+    void putDirect(String name, int id);
+
+    /**
      * Returns the string name for the given integer ID.
      * @param id the integer ID
      * @return the name, or null if not found

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/namespace/NamespaceRegistry.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/namespace/NamespaceRegistry.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.namespace;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.DefaultSpectorMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+/**
+ * Manages active SpectorMemory instances with LRU eviction to control file descriptor and memory mapping limits.
+ * Protected by {@link ReentrantLock} and performs lease-checking to avoid evicting busy namespaces.
+ */
+public final class NamespaceRegistry implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceRegistry.class);
+
+    private final int maxActiveNamespaces;
+    private final LinkedHashMap<String, SpectorMemory> activeMemories;
+    private final ReentrantLock lock;
+
+    private final AtomicInteger activeCount;
+    private final AtomicInteger evictedCount;
+
+    public NamespaceRegistry(int maxActiveNamespaces) {
+        this.maxActiveNamespaces = maxActiveNamespaces;
+        this.activeMemories = new LinkedHashMap<>(16, 0.75f, true);
+        this.lock = new ReentrantLock();
+        this.activeCount = new AtomicInteger(0);
+        this.evictedCount = new AtomicInteger(0);
+
+        logFdDiagnostics(maxActiveNamespaces);
+    }
+
+    /**
+     * Retrieves an active namespace instance, opening it via the provided opener if cold/evicted.
+     */
+    public SpectorMemory getOrOpen(String namespaceId, Supplier<SpectorMemory> opener) {
+        lock.lock();
+        try {
+            SpectorMemory mem = activeMemories.get(namespaceId);
+            if (mem != null) {
+                return mem;
+            }
+
+            log.info("Opening namespace '{}' (not currently active)", namespaceId);
+            SpectorMemory newMem = opener.get();
+            activeMemories.put(namespaceId, newMem);
+            activeCount.set(activeMemories.size());
+
+            checkEviction();
+
+            return newMem;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Checks if active namespace count exceeds capacity, and evicts the oldest idle namespace.
+     */
+    private void checkEviction() {
+        if (activeMemories.size() > maxActiveNamespaces) {
+            Iterator<Map.Entry<String, SpectorMemory>> it = activeMemories.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, SpectorMemory> entry = it.next();
+                SpectorMemory memory = entry.getValue();
+
+                if (memory instanceof DefaultSpectorMemory dm) {
+                    if (!dm.hasActiveLeases()) {
+                        it.remove();
+                        activeCount.set(activeMemories.size());
+                        evictedCount.incrementAndGet();
+                        log.info("Evicting cold namespace '{}' to free up resources (FDs, mmap)", entry.getKey());
+                        try {
+                            dm.close();
+                        } catch (Exception e) {
+                            log.error("Failed to close evicted namespace '{}'", entry.getKey(), e);
+                        }
+                        break; // successfully evicted one, cache is back to capacity
+                    }
+                } else {
+                    // Evict decorated/mock memories immediately
+                    it.remove();
+                    activeCount.set(activeMemories.size());
+                    evictedCount.incrementAndGet();
+                    log.info("Evicting custom namespace '{}'", entry.getKey());
+                    try {
+                        memory.close();
+                    } catch (Exception e) {
+                        log.error("Failed to close evicted custom namespace '{}'", entry.getKey(), e);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the number of currently active namespaces.
+     */
+    public int activeCount() {
+        return activeCount.get();
+    }
+
+    /**
+     * Returns the running count of evicted namespaces.
+     */
+    public int evictedCount() {
+        return evictedCount.get();
+    }
+
+    /**
+     * Returns the maximum allowed active namespaces.
+     */
+    public int maxActiveNamespaces() {
+        return maxActiveNamespaces;
+    }
+
+    /**
+     * Logs diagnostics about file descriptor limits and expected budget.
+     */
+    public static void logFdDiagnostics(int maxActiveNamespaces) {
+        java.lang.management.OperatingSystemMXBean osBean = java.lang.management.ManagementFactory.getOperatingSystemMXBean();
+        if (osBean instanceof com.sun.management.UnixOperatingSystemMXBean unixBean) {
+            long maxFd = unixBean.getMaxFileDescriptorCount();
+            long openFd = unixBean.getOpenFileDescriptorCount();
+            long expectedFds = (long) maxActiveNamespaces * 15;
+            log.info("File Descriptor Diagnostics: max={}, open={}, estimated_budget_for_namespaces={}", maxFd, openFd, expectedFds);
+            if (expectedFds > maxFd / 2) {
+                log.warn("Estimated FD budget for active namespaces ({}) exceeds 50% of system limit ({}). " +
+                        "Consider increasing system RLIMIT_NOFILE or reducing maxActiveNamespaces.", expectedFds, maxFd);
+            }
+        } else {
+            log.info("File Descriptor Diagnostics: operating system is not Unix-like or UnixOperatingSystemMXBean is not available");
+        }
+    }
+
+    @Override
+    public void close() {
+        lock.lock();
+        try {
+            log.info("Closing NamespaceRegistry ({} active memories)", activeMemories.size());
+            for (Map.Entry<String, SpectorMemory> entry : activeMemories.entrySet()) {
+                try {
+                    entry.getValue().close();
+                } catch (Exception e) {
+                    log.error("Failed to close namespace '{}' during registry shutdown", entry.getKey(), e);
+                }
+            }
+            activeMemories.clear();
+            activeCount.set(0);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/namespace/SpectorNamespaceManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/namespace/SpectorNamespaceManager.java
@@ -68,6 +68,7 @@ public class SpectorNamespaceManager {
     private final Path basePath;
     private final boolean sharded;
     private final ConcurrentHashMap<String, NamespaceContext> namespaces;
+    private final NamespaceRegistry registry;
 
     /** Optional migration pipeline — runs lazy migrations on namespace access. */
     private volatile MigrationPipeline migrationPipeline;
@@ -98,6 +99,7 @@ public class SpectorNamespaceManager {
         this.basePath = basePath;
         this.sharded = sharded;
         this.namespaces = new ConcurrentHashMap<>();
+        this.registry = new NamespaceRegistry(Integer.getInteger("spector.memory.max-namespaces", 100));
 
         // Discover existing namespaces
         Path namespacesDir = StorageLayout.namespacesDir(basePath);
@@ -368,6 +370,11 @@ public class SpectorNamespaceManager {
                 java.time.Instant.now().toString()
         );
         Files.writeString(path, json);
+    }
+
+    /** Returns the namespace registry for managing active memory instances. */
+    public NamespaceRegistry registry() {
+        return registry;
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
@@ -227,6 +227,10 @@ public final class CheckpointDaemon {
             return;
         }
 
+        // Step 5b: Write SNAPSHOT_MARK to WAL and flush WAL to disk
+        wal.appendSnapshotMark("system/checkpoint", hwm);
+        wal.flush();
+
         // Step 6: Write HWM to checkpoint.meta (atomic via temp+rename)
         writeCheckpointMeta(hwm);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/MemoryWal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/MemoryWal.java
@@ -226,6 +226,116 @@ public final class MemoryWal implements AutoCloseable {
     }
 
     /**
+     * Appends a RECORD_WRITE event.
+     */
+    public WalEvent appendRecordWrite(String memoryId, long recordId, byte[] recordBytes) {
+        ByteBuffer buf = ByteBuffer.allocate(8 + recordBytes.length);
+        buf.putLong(recordId);
+        buf.put(recordBytes);
+        return append(WalEvent.EventType.RECORD_WRITE, memoryId, buf.array());
+    }
+
+    /**
+     * Appends an ADJ_ADD_EDGE event.
+     */
+    public WalEvent appendAdjAddEdge(String memoryId, int fromNode, int toNode, byte[] edgeBytes) {
+        ByteBuffer buf = ByteBuffer.allocate(8 + edgeBytes.length);
+        buf.putInt(fromNode);
+        buf.putInt(toNode);
+        buf.put(edgeBytes);
+        return append(WalEvent.EventType.ADJ_ADD_EDGE, memoryId, buf.array());
+    }
+
+    /**
+     * Appends an ADJ_DEL_EDGE event.
+     */
+    public WalEvent appendAdjDelEdge(String memoryId, int edgeId) {
+        ByteBuffer buf = ByteBuffer.allocate(4);
+        buf.putInt(edgeId);
+        return append(WalEvent.EventType.ADJ_DEL_EDGE, memoryId, buf.array());
+    }
+
+    /**
+     * Appends a REGISTRY_INTERN event.
+     */
+    public WalEvent appendRegistryIntern(String memoryId, int id, String name) {
+        byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buf = ByteBuffer.allocate(4 + nameBytes.length);
+        buf.putInt(id);
+        buf.put(nameBytes);
+        return append(WalEvent.EventType.REGISTRY_INTERN, memoryId, buf.array());
+    }
+
+    /**
+     * Appends an APPEND event.
+     */
+    public WalEvent appendAppend(String memoryId, byte[] bytes) {
+        return append(WalEvent.EventType.APPEND, memoryId, bytes);
+    }
+
+    /**
+     * Appends a SNAPSHOT_MARK event.
+     */
+    public WalEvent appendSnapshotMark(String memoryId, long lsn) {
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.putLong(lsn);
+        return append(WalEvent.EventType.SNAPSHOT_MARK, memoryId, buf.array());
+    }
+
+    /**
+     * Forces all buffered WAL data to disk.
+     */
+    public void flush() {
+        writeLock.lock();
+        try {
+            if (activeChannel != null) {
+                activeChannel.force(true);
+            }
+        } catch (IOException e) {
+            throw new com.spectrayan.spector.commons.error.SpectorStorageException(
+                    com.spectrayan.spector.commons.error.ErrorCode.WAL_WRITE_FAILED, e);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Appends a GRAPH_ADD_NODE event.
+     */
+    public WalEvent appendGraphAddNode(String memoryId, int nodeId, String name, String type) {
+        byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+        byte[] typeBytes = type.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buf = ByteBuffer.allocate(4 + 4 + nameBytes.length + 4 + typeBytes.length);
+        buf.putInt(nodeId);
+        buf.putInt(nameBytes.length);
+        buf.put(nameBytes);
+        buf.putInt(typeBytes.length);
+        buf.put(typeBytes);
+        return append(WalEvent.EventType.GRAPH_ADD_NODE, memoryId, buf.array());
+    }
+
+    /**
+     * Appends a GRAPH_LINK_MEMORY event.
+     */
+    public WalEvent appendGraphLinkMemory(String memoryId, int entityId, int memoryIdx) {
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.putInt(entityId);
+        buf.putInt(memoryIdx);
+        return append(WalEvent.EventType.GRAPH_LINK_MEMORY, memoryId, buf.array());
+    }
+
+    /**
+     * Appends a CHAIN_LINK event.
+     */
+    public WalEvent appendChainLink(String memoryId, int fromIdx, int toIdx, int sessionId) {
+        ByteBuffer buf = ByteBuffer.allocate(12);
+        buf.putInt(fromIdx);
+        buf.putInt(toIdx);
+        buf.putInt(sessionId);
+        return append(WalEvent.EventType.CHAIN_LINK, memoryId, buf.array());
+    }
+
+    /**
      * Replays all events after a given sequence number.
      *
      * <p>Used by CloudSync to ship events to remote agents. Returns events

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalEvent.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalEvent.java
@@ -50,6 +50,26 @@ public record WalEvent(
         /** Synaptic tags were merged. */
         TAG_MERGE,
         /** Memory recall count was incremented. */
-        RECALL_HIT
+        RECALL_HIT,
+        
+        // Unified Shape Opcodes
+        /** RecordMemory write. */
+        RECORD_WRITE,
+        /** GraphMemory add edge. */
+        ADJ_ADD_EDGE,
+        /** GraphMemory delete edge. */
+        ADJ_DEL_EDGE,
+        /** RegistryMemory intern. */
+        REGISTRY_INTERN,
+        /** AppendMemory append. */
+        APPEND,
+        /** Checkpoint snapshot mark. */
+        SNAPSHOT_MARK,
+        /** EntityGraph add node. */
+        GRAPH_ADD_NODE,
+        /** EntityGraph link entity to memory. */
+        GRAPH_LINK_MEMORY,
+        /** TemporalChain link. */
+        CHAIN_LINK
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.sync;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.shape.RecordMemory;
+import com.spectrayan.spector.memory.kernel.shape.AppendMemory;
+import com.spectrayan.spector.memory.kernel.shape.RegistryMemory;
+import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.hebbian.HebbianGraphCsr;
+import com.spectrayan.spector.memory.temporal.TemporalChain;
+
+/**
+ * Replays shape-specific Write-Ahead Log (WAL) events and dispatches mutations
+ * directly to target Memory segments.
+ */
+public final class WalRecoveryDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(WalRecoveryDispatcher.class);
+
+    private WalRecoveryDispatcher() {}
+
+    /**
+     * Replays all mutations from the WAL that occurred after the last completed checkpoint.
+     *
+     * @param wal      the write-ahead log to read from
+     * @param memories mapping of target memory IDs to active open Memory instances
+     */
+    public static void recover(MemoryWal wal, Map<MemoryId, Memory<?>> memories) {
+        List<WalEvent> allEvents = wal.replay(0);
+        if (allEvents.isEmpty()) {
+            log.info("WAL recovery: no events to replay");
+            return;
+        }
+
+        // Find the last SNAPSHOT_MARK sequence number by scanning backwards
+        long lastSnapshotSeq = -1;
+        for (int i = allEvents.size() - 1; i >= 0; i--) {
+            WalEvent event = allEvents.get(i);
+            if (event.type() == WalEvent.EventType.SNAPSHOT_MARK) {
+                lastSnapshotSeq = event.sequence();
+                log.info("WAL recovery: found last SNAPSHOT_MARK at sequence {}", lastSnapshotSeq);
+                break;
+            }
+        }
+
+        long startSeq = lastSnapshotSeq;
+        int replayCount = 0;
+
+        for (WalEvent event : allEvents) {
+            if (event.sequence() <= startSeq) {
+                continue; // Skip events that are already checkpointed
+            }
+
+            // Resolve target Memory instance
+            MemoryId targetId = MemoryId.parse(event.memoryId());
+            Memory<?> target = memories.get(targetId);
+            if (target == null) {
+                // If it's a legacy or unmapped event, skip or log warning
+                if (event.type() != WalEvent.EventType.REFLECT &&
+                    event.type() != WalEvent.EventType.TAG_MERGE &&
+                    event.type() != WalEvent.EventType.RECALL_HIT) {
+                    log.warn("WAL recovery: no active Memory found for ID '{}', skipping event type {}", event.memoryId(), event.type());
+                }
+                continue;
+            }
+
+            ByteBuffer payload = ByteBuffer.wrap(event.payload());
+            target.setBypassWal(true);
+            try {
+                switch (event.type()) {
+                    case RECORD_WRITE -> {
+                        long recordId = payload.getLong();
+                        byte[] recordBytes = new byte[event.payload().length - 8];
+                        payload.get(recordBytes);
+                        ((RecordMemory<?>) target).write(recordId, MemorySegment.ofArray(recordBytes));
+                    }
+                    case APPEND -> {
+                        ((AppendMemory<?>) target).append(MemorySegment.ofArray(event.payload()));
+                    }
+                    case REGISTRY_INTERN -> {
+                        int id = payload.getInt();
+                        String name = new String(event.payload(), 4, event.payload().length - 4, StandardCharsets.UTF_8);
+                        ((RegistryMemory) target).putDirect(name, id);
+                    }
+                    case ADJ_ADD_EDGE -> {
+                        int from = payload.getInt();
+                        int to = payload.getInt();
+                        if (target instanceof EntityGraph eg) {
+                            String relType = new String(event.payload(), 8, event.payload().length - 8, StandardCharsets.UTF_8);
+                            eg.addRelation(from, to, relType);
+                        } else if (target instanceof HebbianGraphCsr hg) {
+                            float weightDelta = payload.getFloat();
+                            hg.strengthen(from, to, weightDelta);
+                        }
+                    }
+                    case GRAPH_ADD_NODE -> {
+                        int nodeId = payload.getInt();
+                        int nameLen = payload.getInt();
+                        String name = new String(event.payload(), 8, nameLen, StandardCharsets.UTF_8);
+                        int typeLen = payload.getInt(8 + nameLen);
+                        String type = new String(event.payload(), 8 + nameLen + 4, typeLen, StandardCharsets.UTF_8);
+                        if (target instanceof EntityGraph eg) {
+                            eg.addEntity(name, type);
+                        }
+                    }
+                    case GRAPH_LINK_MEMORY -> {
+                        int entityId = payload.getInt();
+                        int memoryIdx = payload.getInt();
+                        if (target instanceof EntityGraph eg) {
+                            eg.linkEntityToMemory(entityId, memoryIdx);
+                        }
+                    }
+                    case CHAIN_LINK -> {
+                        int fromIdx = payload.getInt();
+                        int toIdx = payload.getInt();
+                        int sessionId = payload.getInt();
+                        if (target instanceof TemporalChain tc) {
+                            tc.link(fromIdx, toIdx, sessionId);
+                        }
+                    }
+                    default -> {
+                        // informational/legacy events ignored during direct recovery
+                    }
+                }
+                replayCount++;
+            } catch (Exception e) {
+                log.error("WAL recovery: failed to replay event seq={}, type={} on memory '{}': {}", 
+                        event.sequence(), event.type(), event.memoryId(), e.getMessage(), e);
+            } finally {
+                target.setBypassWal(false);
+            }
+        }
+
+        log.info("WAL recovery: successfully replayed {} events", replayCount);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
@@ -67,88 +67,97 @@ public final class WalRecoveryDispatcher {
         long startSeq = lastSnapshotSeq;
         int replayCount = 0;
 
-        for (WalEvent event : allEvents) {
-            if (event.sequence() <= startSeq) {
-                continue; // Skip events that are already checkpointed
-            }
+        // Bypass WAL logging on all active memory targets throughout recovery
+        for (Memory<?> memory : memories.values()) {
+            memory.setBypassWal(true);
+        }
 
-            // Resolve target Memory instance
-            MemoryId targetId = MemoryId.parse(event.memoryId());
-            Memory<?> target = memories.get(targetId);
-            if (target == null) {
-                // If it's a legacy or unmapped event, skip or log warning
-                if (event.type() != WalEvent.EventType.REFLECT &&
-                    event.type() != WalEvent.EventType.TAG_MERGE &&
-                    event.type() != WalEvent.EventType.RECALL_HIT) {
-                    log.warn("WAL recovery: no active Memory found for ID '{}', skipping event type {}", event.memoryId(), event.type());
+        try {
+            for (WalEvent event : allEvents) {
+                if (event.sequence() <= startSeq) {
+                    continue; // Skip events that are already checkpointed
                 }
-                continue;
-            }
 
-            ByteBuffer payload = ByteBuffer.wrap(event.payload());
-            target.setBypassWal(true);
-            try {
-                switch (event.type()) {
-                    case RECORD_WRITE -> {
-                        long recordId = payload.getLong();
-                        byte[] recordBytes = new byte[event.payload().length - 8];
-                        payload.get(recordBytes);
-                        ((RecordMemory<?>) target).write(recordId, MemorySegment.ofArray(recordBytes));
+                // Resolve target Memory instance
+                MemoryId targetId = MemoryId.parse(event.memoryId());
+                Memory<?> target = memories.get(targetId);
+                if (target == null) {
+                    // If it's a legacy or unmapped event, skip or log warning
+                    if (event.type() != WalEvent.EventType.REFLECT &&
+                        event.type() != WalEvent.EventType.TAG_MERGE &&
+                        event.type() != WalEvent.EventType.RECALL_HIT) {
+                        log.warn("WAL recovery: no active Memory found for ID '{}', skipping event type {}", event.memoryId(), event.type());
                     }
-                    case APPEND -> {
-                        ((AppendMemory<?>) target).append(MemorySegment.ofArray(event.payload()));
-                    }
-                    case REGISTRY_INTERN -> {
-                        int id = payload.getInt();
-                        String name = new String(event.payload(), 4, event.payload().length - 4, StandardCharsets.UTF_8);
-                        ((RegistryMemory) target).putDirect(name, id);
-                    }
-                    case ADJ_ADD_EDGE -> {
-                        int from = payload.getInt();
-                        int to = payload.getInt();
-                        if (target instanceof EntityGraph eg) {
-                            String relType = new String(event.payload(), 8, event.payload().length - 8, StandardCharsets.UTF_8);
-                            eg.addRelation(from, to, relType);
-                        } else if (target instanceof HebbianGraphCsr hg) {
-                            float weightDelta = payload.getFloat();
-                            hg.strengthen(from, to, weightDelta);
-                        }
-                    }
-                    case GRAPH_ADD_NODE -> {
-                        int nodeId = payload.getInt();
-                        int nameLen = payload.getInt();
-                        String name = new String(event.payload(), 8, nameLen, StandardCharsets.UTF_8);
-                        int typeLen = payload.getInt(8 + nameLen);
-                        String type = new String(event.payload(), 8 + nameLen + 4, typeLen, StandardCharsets.UTF_8);
-                        if (target instanceof EntityGraph eg) {
-                            eg.addEntity(name, type);
-                        }
-                    }
-                    case GRAPH_LINK_MEMORY -> {
-                        int entityId = payload.getInt();
-                        int memoryIdx = payload.getInt();
-                        if (target instanceof EntityGraph eg) {
-                            eg.linkEntityToMemory(entityId, memoryIdx);
-                        }
-                    }
-                    case CHAIN_LINK -> {
-                        int fromIdx = payload.getInt();
-                        int toIdx = payload.getInt();
-                        int sessionId = payload.getInt();
-                        if (target instanceof TemporalChain tc) {
-                            tc.link(fromIdx, toIdx, sessionId);
-                        }
-                    }
-                    default -> {
-                        // informational/legacy events ignored during direct recovery
-                    }
+                    continue;
                 }
-                replayCount++;
-            } catch (Exception e) {
-                log.error("WAL recovery: failed to replay event seq={}, type={} on memory '{}': {}", 
-                        event.sequence(), event.type(), event.memoryId(), e.getMessage(), e);
-            } finally {
-                target.setBypassWal(false);
+
+                ByteBuffer payload = ByteBuffer.wrap(event.payload());
+                try {
+                    switch (event.type()) {
+                        case RECORD_WRITE -> {
+                            long recordId = payload.getLong();
+                            byte[] recordBytes = new byte[event.payload().length - 8];
+                            payload.get(recordBytes);
+                            ((RecordMemory<?>) target).write(recordId, MemorySegment.ofArray(recordBytes));
+                        }
+                        case APPEND -> {
+                            ((AppendMemory<?>) target).append(MemorySegment.ofArray(event.payload()));
+                        }
+                        case REGISTRY_INTERN -> {
+                            int id = payload.getInt();
+                            String name = new String(event.payload(), 4, event.payload().length - 4, StandardCharsets.UTF_8);
+                            ((RegistryMemory) target).putDirect(name, id);
+                        }
+                        case ADJ_ADD_EDGE -> {
+                            int from = payload.getInt();
+                            int to = payload.getInt();
+                            if (target instanceof EntityGraph eg) {
+                                String relType = new String(event.payload(), 8, event.payload().length - 8, StandardCharsets.UTF_8);
+                                eg.addRelation(from, to, relType);
+                            } else if (target instanceof HebbianGraphCsr hg) {
+                                float weightDelta = payload.getFloat();
+                                hg.strengthen(from, to, weightDelta);
+                            }
+                        }
+                        case GRAPH_ADD_NODE -> {
+                            int nodeId = payload.getInt();
+                            int nameLen = payload.getInt();
+                            String name = new String(event.payload(), 8, nameLen, StandardCharsets.UTF_8);
+                            int typeLen = payload.getInt(8 + nameLen);
+                            String type = new String(event.payload(), 8 + nameLen + 4, typeLen, StandardCharsets.UTF_8);
+                            if (target instanceof EntityGraph eg) {
+                                eg.addEntity(name, type);
+                            }
+                        }
+                        case GRAPH_LINK_MEMORY -> {
+                            int entityId = payload.getInt();
+                            int memoryIdx = payload.getInt();
+                            if (target instanceof EntityGraph eg) {
+                                eg.linkEntityToMemory(entityId, memoryIdx);
+                            }
+                        }
+                        case CHAIN_LINK -> {
+                            int fromIdx = payload.getInt();
+                            int toIdx = payload.getInt();
+                            int sessionId = payload.getInt();
+                            if (target instanceof TemporalChain tc) {
+                                tc.link(fromIdx, toIdx, sessionId);
+                            }
+                        }
+                        default -> {
+                            // informational/legacy events ignored during direct recovery
+                        }
+                    }
+                    replayCount++;
+                } catch (Exception e) {
+                    log.error("WAL recovery: failed to replay event seq={}, type={} on memory '{}': {}", 
+                            event.sequence(), event.type(), event.memoryId(), e.getMessage(), e);
+                }
+            }
+        } finally {
+            // Re-enable WAL logging across all memories after recovery finishes
+            for (Memory<?> memory : memories.values()) {
+                memory.setBypassWal(false);
             }
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/ContradictionResolver.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/ContradictionResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import java.util.List;
+
+/**
+ * Strategy interface for resolving contradictions between overlapping or mutually exclusive temporal facts.
+ * In a biological system, this is akin to cognitive conflict resolution where stronger or more recent
+ * memory traces override weaker or outdated ones.
+ */
+@FunctionalInterface
+public interface ContradictionResolver {
+    /**
+     * Resolves a contradiction by selecting the winning fact from a list of conflicting facts.
+     *
+     * @param conflicting the list of conflicting temporal facts
+     * @return the resolved (winning) temporal fact
+     */
+    TemporalFact resolve(List<TemporalFact> conflicting);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/HighestConfidenceResolver.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/HighestConfidenceResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A contradiction resolver that selects the fact with the highest confidence score.
+ * Analogous to signal strength in biological synaptic plasticity.
+ */
+public final class HighestConfidenceResolver implements ContradictionResolver {
+    @Override
+    public TemporalFact resolve(List<TemporalFact> conflicting) {
+        return conflicting.stream()
+                .max(Comparator.comparingDouble(TemporalFact::confidence))
+                .orElseThrow();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/LatestTxWinsResolver.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/LatestTxWinsResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A contradiction resolver that selects the most recently transacted fact.
+ * Analogous to recency bias in biological memory systems.
+ */
+public final class LatestTxWinsResolver implements ContradictionResolver {
+    @Override
+    public TemporalFact resolve(List<TemporalFact> conflicting) {
+        return conflicting.stream()
+                .max(Comparator.comparingLong(TemporalFact::txTime))
+                .orElseThrow();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChain.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChain.java
@@ -27,6 +27,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
 /**
  * Off-heap temporal causal chain linking memories within a session.
  *
@@ -72,6 +75,7 @@ public final class TemporalChain implements AutoCloseable {
     private final int capacity;
     private final FileChannel mappedChannel;
     private final boolean fileBacked;
+    private final MemoryId memoryId;
 
     /**
      * Creates a heap-allocated temporal chain (in-memory mode).
@@ -84,6 +88,7 @@ public final class TemporalChain implements AutoCloseable {
         this.segment = arena.allocate((long) NODE_BYTES * capacity);
         this.mappedChannel = null;
         this.fileBacked = false;
+        this.memoryId = MemoryId.of("temporal", "chain");
         // Initialize all prev/next to NO_LINK (-1)
         for (int i = 0; i < capacity; i++) {
             long offset = (long) i * NODE_BYTES;
@@ -172,6 +177,7 @@ public final class TemporalChain implements AutoCloseable {
             this.segment = ch.map(FileChannel.MapMode.READ_WRITE, FILE_HEADER_BYTES,
                     dataBytes, arena);
             this.fileBacked = true;
+            this.memoryId = MemoryId.of("temporal", "chain");
 
             log.info("TemporalChain initialized (mmap): capacity={}, file={}",
                     this.capacity, filePath.getFileName());
@@ -182,12 +188,13 @@ public final class TemporalChain implements AutoCloseable {
     }
 
     private TemporalChain(int capacity, Arena arena, MemorySegment segment,
-                           FileChannel mappedChannel, boolean fileBacked) {
+                           FileChannel mappedChannel, boolean fileBacked, MemoryId memoryId) {
         this.capacity = capacity;
         this.arena = arena;
         this.segment = segment;
         this.mappedChannel = mappedChannel;
         this.fileBacked = fileBacked;
+        this.memoryId = memoryId;
     }
 
     /**
@@ -534,6 +541,18 @@ public final class TemporalChain implements AutoCloseable {
             segment.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
         }
         log.info("TemporalChain reset: capacity={}", capacity);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // KERNEL INTEGRATION
+    // ══════════════════════════════════════════════════════════════
+
+    public MemoryId memoryId() {
+        return memoryId;
+    }
+
+    public MemoryShape kernelShape() {
+        return MemoryShape.CHAIN;
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChain.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChain.java
@@ -304,6 +304,11 @@ public final class TemporalChain implements ChainMemory<TemporalLayout>, AutoClo
         if (previousIdx < 0 || previousIdx >= cap) return;
         if (currentIdx == previousIdx) return;
 
+        var wal = backing.getWal();
+        if (wal != null && !backing.isBypassWal()) {
+            wal.appendChainLink(backing.id().toString(), currentIdx, previousIdx, sessionId);
+        }
+
         MemorySegment seg = segment();
         long currentOffset = dataOffset() + (long) currentIdx * NODE_BYTES;
         long previousOffset = dataOffset() + (long) previousIdx * NODE_BYTES;
@@ -584,6 +589,26 @@ public final class TemporalChain implements ChainMemory<TemporalLayout>, AutoClo
     @Override
     public void close() {
         backing.close();
+    }
+
+    @Override
+    public void bindWal(com.spectrayan.spector.memory.sync.MemoryWal wal) {
+        backing.bindWal(wal);
+    }
+
+    @Override
+    public void setBypassWal(boolean bypass) {
+        backing.setBypassWal(bypass);
+    }
+
+    @Override
+    public boolean isBypassWal() {
+        return backing.isBypassWal();
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.sync.MemoryWal getWal() {
+        return backing.getWal();
     }
 
     // ── Backing Kernel Memory class ──

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChain.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChain.java
@@ -16,19 +16,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-
-import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 
+import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.AbstractMemory;
+import com.spectrayan.spector.memory.kernel.shape.ChainMemory;
+import com.spectrayan.spector.memory.kernel.layout.TemporalLayout;
 
 /**
  * Off-heap temporal causal chain linking memories within a session.
@@ -41,22 +44,14 @@ import com.spectrayan.spector.memory.kernel.MemoryShape;
  *
  * <h3>Layout Per Node (16 bytes)</h3>
  * <pre>
- *   [prevIdx:4B] [nextIdx:4B] [sessionId:4B] [pad:4B]
+ *   [prevIdx:4B] [nextIdx:4B] [sessionId:4B] [epochSec:4B]
  * </pre>
  *
  * <p>-1 is used as sentinel for "no link" (beginning or end of chain).</p>
- *
- * <h3>Persistence</h3>
- * <p>Supports save/load via raw segment serialization with "TPCH" magic header.</p>
  */
-public final class TemporalChain implements AutoCloseable {
+public final class TemporalChain implements ChainMemory<TemporalLayout>, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(TemporalChain.class);
-
-    /** File magic: "TPCH" in ASCII. */
-    private static final int FILE_MAGIC = 0x54504348;
-    private static final int FILE_VERSION = 2;
-    private static final int FILE_HEADER_BYTES = 16;
 
     /** Bytes per node: prevIdx(4) + nextIdx(4) + sessionId(4) + epochSec(4). */
     static final int NODE_BYTES = 16;
@@ -70,12 +65,7 @@ public final class TemporalChain implements AutoCloseable {
     private static final long OFF_SESSION = 8;
     private static final long OFF_EPOCH_SEC = 12;
 
-    private final Arena arena;
-    private final MemorySegment segment;
-    private final int capacity;
-    private final FileChannel mappedChannel;
-    private final boolean fileBacked;
-    private final MemoryId memoryId;
+    private final TemporalChainBacking backing;
 
     /**
      * Creates a heap-allocated temporal chain (in-memory mode).
@@ -83,22 +73,22 @@ public final class TemporalChain implements AutoCloseable {
      * @param capacity maximum number of nodes (memories)
      */
     public TemporalChain(int capacity) {
-        this.capacity = capacity;
-        this.arena = Arena.ofShared();
-        this.segment = arena.allocate((long) NODE_BYTES * capacity);
-        this.mappedChannel = null;
-        this.fileBacked = false;
-        this.memoryId = MemoryId.of("temporal", "chain");
-        // Initialize all prev/next to NO_LINK (-1)
+        TemporalLayout layout = new TemporalLayout();
+        MemoryId id = MemoryId.of("temporal", "chain");
+        long dataBytes = (long) NODE_BYTES * capacity;
+        this.backing = new TemporalChainBacking(id, layout, capacity, dataBytes);
+
+        MemorySegment seg = backing.segment();
         for (int i = 0; i < capacity; i++) {
             long offset = (long) i * NODE_BYTES;
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
         }
 
         log.info("TemporalChain initialized (heap): capacity={}, memory={}KB",
-                capacity, (long) NODE_BYTES * capacity / 1024);
+                capacity, dataBytes / 1024);
     }
 
     /**
@@ -117,115 +107,218 @@ public final class TemporalChain implements AutoCloseable {
             }
         }
 
-        long dataBytes = (long) NODE_BYTES * capacity;
-        boolean isNew = !Files.exists(filePath);
-
         try {
-            FileChannel ch = FileChannel.open(filePath,
-                    StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
-            this.mappedChannel = ch;
+            // 1. Perform in-place TPCH -> SMKM migration if needed
+            checkAndMigrateHeader(filePath, capacity);
 
-            if (isNew || ch.size() < FILE_HEADER_BYTES) {
-                ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-                header.putInt(FILE_MAGIC);
-                header.putInt(FILE_VERSION);
-                header.putInt(capacity);
-                header.putInt(0);
-                header.flip();
-                ch.position(0);
-                ch.write(header);
-                long totalBytes = FILE_HEADER_BYTES + dataBytes;
-                if (ch.size() < totalBytes) {
-                    ch.position(totalBytes - 1);
-                    ch.write(ByteBuffer.wrap(new byte[]{0}));
-                }
-                ch.force(true);
-                this.capacity = capacity;
-            } else {
-                ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-                ch.position(0);
-                ch.read(header);
-                header.flip();
-                int magic = header.getInt();
-                int version = header.getInt();
-                int fileCapacity = header.getInt();
-                header.getInt();
+            // 2. Open using standard SMKM format
+            TemporalLayout layout = new TemporalLayout();
+            MemoryId id = MemoryId.of("temporal", "chain");
+            long dataBytes = (long) NODE_BYTES * capacity;
+            boolean isNew = !Files.exists(filePath) || Files.size(filePath) < MemoryHeader.HEADER_BYTES;
 
-                if (magic != FILE_MAGIC || (version != FILE_VERSION && version != 1)) {
-                    log.warn("Invalid TemporalChain file, reinitializing: {}", filePath);
-                    ch.truncate(0);
-                    ByteBuffer newHeader = ByteBuffer.allocate(FILE_HEADER_BYTES);
-                    newHeader.putInt(FILE_MAGIC);
-                    newHeader.putInt(FILE_VERSION);
-                    newHeader.putInt(capacity);
-                    newHeader.putInt(0);
-                    newHeader.flip();
-                    ch.position(0);
-                    ch.write(newHeader);
-                    long totalBytes = FILE_HEADER_BYTES + dataBytes;
-                    ch.position(totalBytes - 1);
-                    ch.write(ByteBuffer.wrap(new byte[]{0}));
-                    ch.force(true);
-                    this.capacity = capacity;
-                } else {
-                    this.capacity = fileCapacity;
-                    dataBytes = (long) NODE_BYTES * fileCapacity;
+            this.backing = new TemporalChainBacking(id, layout, capacity, dataBytes, filePath);
+
+            if (isNew) {
+                MemorySegment seg = backing.segment();
+                long base = backing.dataOffset();
+                for (int i = 0; i < capacity; i++) {
+                    long offset = base + (long) i * NODE_BYTES;
+                    seg.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
+                    seg.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
+                    seg.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
+                    seg.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
                 }
+                backing.flush();
             }
 
-            this.arena = Arena.ofShared();
-            this.segment = ch.map(FileChannel.MapMode.READ_WRITE, FILE_HEADER_BYTES,
-                    dataBytes, arena);
-            this.fileBacked = true;
-            this.memoryId = MemoryId.of("temporal", "chain");
-
             log.info("TemporalChain initialized (mmap): capacity={}, file={}",
-                    this.capacity, filePath.getFileName());
+                    backing.capacity(), filePath.getFileName());
 
         } catch (IOException e) {
             throw new SpectorGraphPersistenceException("TemporalChain", filePath, e);
         }
     }
 
-    private TemporalChain(int capacity, Arena arena, MemorySegment segment,
-                           FileChannel mappedChannel, boolean fileBacked, MemoryId memoryId) {
-        this.capacity = capacity;
-        this.arena = arena;
-        this.segment = segment;
-        this.mappedChannel = mappedChannel;
-        this.fileBacked = fileBacked;
-        this.memoryId = memoryId;
+    private TemporalChain(TemporalChainBacking backing) {
+        this.backing = backing;
     }
+
+    private static void checkAndMigrateHeader(Path filePath, int capacity) throws IOException {
+        if (filePath == null || !Files.exists(filePath) || Files.size(filePath) < 16) {
+            return;
+        }
+        try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            ByteBuffer header = ByteBuffer.allocate(16);
+            ch.read(header);
+            header.flip();
+            int magic = header.getInt();
+            if (magic == 0x54504348) { // legacy 'TPCH'
+                log.info("Migrating legacy TPCH file to SMKM: {}", filePath);
+                int version = header.getInt();
+                int fileCapacity = header.getInt();
+                int count = header.getInt();
+
+                long dataSize = (long) fileCapacity * 16;
+                ByteBuffer dataBuf = ByteBuffer.allocate((int) dataSize);
+                ch.position(16);
+                ch.read(dataBuf);
+                dataBuf.flip();
+
+                ch.truncate(0);
+                ch.position(0);
+
+                try (Arena tempArena = Arena.ofConfined()) {
+                    long totalBytes = MemoryHeader.HEADER_BYTES + dataSize;
+                    ch.position(totalBytes - 1);
+                    ch.write(ByteBuffer.wrap(new byte[]{0}));
+                    MemorySegment tempSegment = ch.map(FileChannel.MapMode.READ_WRITE, 0, totalBytes, tempArena);
+                    
+                    MemoryHeader.write(tempSegment, 0, 2, MemoryShape.CHAIN, 1, 
+                            fileCapacity, count, 16, 0x54504348, 
+                            System.currentTimeMillis(), System.currentTimeMillis());
+                    
+                    MemorySegment.copy(MemorySegment.ofBuffer(dataBuf), 0, tempSegment, MemoryHeader.HEADER_BYTES, dataSize);
+                    tempSegment.force();
+                }
+                log.info("Migrated legacy TPCH file to SMKM successfully: {} (capacity={}, count={})", 
+                        filePath, fileCapacity, count);
+            }
+        }
+    }
+
+    private long dataOffset() {
+        return backing.dataOffset();
+    }
+
+    // ── ChainMemory implementation ──
+
+    @Override
+    public MemoryId id() {
+        return backing.id();
+    }
+
+    @Override
+    public TemporalLayout layout() {
+        return backing.layout();
+    }
+
+    @Override
+    public Arena arena() {
+        return backing.arena();
+    }
+
+    @Override
+    public MemorySegment segment() {
+        return backing.segment();
+    }
+
+    @Override
+    public int size() {
+        return backing.size();
+    }
+
+    @Override
+    public int capacity() {
+        return backing.capacity();
+    }
+
+    @Override
+    public int schemaVersion() {
+        return backing.schemaVersion();
+    }
+
+    @Override
+    public MemoryShape shape() {
+        return backing.shape();
+    }
+
+    @Override
+    public void flush() {
+        backing.flush();
+    }
+
+    @Override
+    public void link(int nodeId, int nextId) {
+        link(nextId, nodeId, 0);
+    }
+
+    @Override
+    public int next(int nodeId) {
+        if (nodeId < 0 || nodeId >= capacity()) return NO_LINK;
+        return segment().get(ValueLayout.JAVA_INT, dataOffset() + (long) nodeId * NODE_BYTES + OFF_NEXT);
+    }
+
+    @Override
+    public int prev(int nodeId) {
+        if (nodeId < 0 || nodeId >= capacity()) return NO_LINK;
+        return segment().get(ValueLayout.JAVA_INT, dataOffset() + (long) nodeId * NODE_BYTES + OFF_PREV);
+    }
+
+    @Override
+    public int head() {
+        int cap = capacity();
+        for (int i = 0; i < cap; i++) {
+            if (isLinked(i) && prev(i) == NO_LINK) {
+                return i;
+            }
+        }
+        return NO_LINK;
+    }
+
+    @Override
+    public int tail() {
+        int cap = capacity();
+        for (int i = 0; i < cap; i++) {
+            if (isLinked(i) && next(i) == NO_LINK) {
+                return i;
+            }
+        }
+        return NO_LINK;
+    }
+
+    @Override
+    public int chainLength() {
+        int length = 0;
+        int cap = capacity();
+        for (int i = 0; i < cap; i++) {
+            if (isLinked(i)) {
+                length++;
+            }
+        }
+        return length;
+    }
+
+    // ── Subsystem-specific Overloads ──
 
     /**
      * Links two memories in temporal order within the same session.
      *
-     * <p>After this call, {@code previousIdx.next = currentIdx} and
-     * {@code currentIdx.prev = previousIdx}.</p>
-     *
      * @param currentIdx  index of the memory just ingested
      * @param previousIdx index of the memory ingested immediately before
-     * @param sessionId   session identifier (e.g., hash of session start time)
+     * @param sessionId   session identifier
      */
     public void link(int currentIdx, int previousIdx, int sessionId) {
-        if (currentIdx < 0 || currentIdx >= capacity) return;
-        if (previousIdx < 0 || previousIdx >= capacity) return;
+        int cap = capacity();
+        if (currentIdx < 0 || currentIdx >= cap) return;
+        if (previousIdx < 0 || previousIdx >= cap) return;
         if (currentIdx == previousIdx) return;
 
-        long currentOffset = (long) currentIdx * NODE_BYTES;
-        long previousOffset = (long) previousIdx * NODE_BYTES;
+        MemorySegment seg = segment();
+        long currentOffset = dataOffset() + (long) currentIdx * NODE_BYTES;
+        long previousOffset = dataOffset() + (long) previousIdx * NODE_BYTES;
 
         // currentIdx.prev = previousIdx
-        segment.set(ValueLayout.JAVA_INT, currentOffset + OFF_PREV, previousIdx);
-        segment.set(ValueLayout.JAVA_INT, currentOffset + OFF_SESSION, sessionId);
-        segment.set(ValueLayout.JAVA_INT, currentOffset + OFF_EPOCH_SEC,
+        seg.set(ValueLayout.JAVA_INT, currentOffset + OFF_PREV, previousIdx);
+        seg.set(ValueLayout.JAVA_INT, currentOffset + OFF_SESSION, sessionId);
+        seg.set(ValueLayout.JAVA_INT, currentOffset + OFF_EPOCH_SEC,
                 (int) (System.currentTimeMillis() / 1000));
 
         // previousIdx.next = currentIdx
-        segment.set(ValueLayout.JAVA_INT, previousOffset + OFF_NEXT, currentIdx);
-        // Also stamp previousIdx epoch if it was never set (backfill for first node)
-        if (segment.get(ValueLayout.JAVA_INT, previousOffset + OFF_EPOCH_SEC) == 0) {
-            segment.set(ValueLayout.JAVA_INT, previousOffset + OFF_EPOCH_SEC,
+        seg.set(ValueLayout.JAVA_INT, previousOffset + OFF_NEXT, currentIdx);
+        
+        if (seg.get(ValueLayout.JAVA_INT, previousOffset + OFF_EPOCH_SEC) == 0) {
+            seg.set(ValueLayout.JAVA_INT, previousOffset + OFF_EPOCH_SEC,
                     (int) (System.currentTimeMillis() / 1000));
         }
     }
@@ -238,14 +331,16 @@ public final class TemporalChain implements AutoCloseable {
      * @return array of memory indices in temporal order (excludes startIdx)
      */
     public int[] followForward(int startIdx, int maxHops) {
-        if (startIdx < 0 || startIdx >= capacity) return new int[0];
+        int cap = capacity();
+        if (startIdx < 0 || startIdx >= cap) return new int[0];
         int[] chain = new int[maxHops];
         int count = 0;
         int current = startIdx;
+        MemorySegment seg = segment();
         for (int hop = 0; hop < maxHops; hop++) {
-            long offset = (long) current * NODE_BYTES;
-            int next = segment.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
-            if (next == NO_LINK || next < 0 || next >= capacity) break;
+            long offset = dataOffset() + (long) current * NODE_BYTES;
+            int next = seg.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
+            if (next == NO_LINK || next < 0 || next >= cap) break;
             chain[count++] = next;
             current = next;
         }
@@ -260,14 +355,16 @@ public final class TemporalChain implements AutoCloseable {
      * @return array of memory indices in reverse temporal order (excludes startIdx)
      */
     public int[] followBackward(int startIdx, int maxHops) {
-        if (startIdx < 0 || startIdx >= capacity) return new int[0];
+        int cap = capacity();
+        if (startIdx < 0 || startIdx >= cap) return new int[0];
         int[] chain = new int[maxHops];
         int count = 0;
         int current = startIdx;
+        MemorySegment seg = segment();
         for (int hop = 0; hop < maxHops; hop++) {
-            long offset = (long) current * NODE_BYTES;
-            int prev = segment.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
-            if (prev == NO_LINK || prev < 0 || prev >= capacity) break;
+            long offset = dataOffset() + (long) current * NODE_BYTES;
+            int prev = seg.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
+            if (prev == NO_LINK || prev < 0 || prev >= cap) break;
             chain[count++] = prev;
             current = prev;
         }
@@ -278,46 +375,35 @@ public final class TemporalChain implements AutoCloseable {
      * Returns the session ID for a memory.
      */
     public int sessionOf(int idx) {
-        if (idx < 0 || idx >= capacity) return 0;
-        return segment.get(ValueLayout.JAVA_INT, (long) idx * NODE_BYTES + OFF_SESSION);
+        if (idx < 0 || idx >= capacity()) return 0;
+        return segment().get(ValueLayout.JAVA_INT, dataOffset() + (long) idx * NODE_BYTES + OFF_SESSION);
     }
 
     /**
      * Returns whether a memory has any temporal links.
      */
     public boolean isLinked(int idx) {
-        if (idx < 0 || idx >= capacity) return false;
-        long offset = (long) idx * NODE_BYTES;
-        int prev = segment.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
-        int next = segment.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
+        if (idx < 0 || idx >= capacity()) return false;
+        long offset = dataOffset() + (long) idx * NODE_BYTES;
+        MemorySegment seg = segment();
+        int prev = seg.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
+        int next = seg.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
         return prev != NO_LINK || next != NO_LINK;
-    }
-
-    /**
-     * Returns the capacity.
-     */
-    public int capacity() {
-        return capacity;
     }
 
     /**
      * Returns the epoch-second timestamp for a memory node.
      *
      * @param idx the memory index
-     * @return epoch seconds (0 if unlinked or from a V1 file)
+     * @return epoch seconds (0 if unlinked)
      */
     public int epochSecOf(int idx) {
-        if (idx < 0 || idx >= capacity) return 0;
-        return segment.get(ValueLayout.JAVA_INT, (long) idx * NODE_BYTES + OFF_EPOCH_SEC);
+        if (idx < 0 || idx >= capacity()) return 0;
+        return segment().get(ValueLayout.JAVA_INT, dataOffset() + (long) idx * NODE_BYTES + OFF_EPOCH_SEC);
     }
 
     /**
      * Prunes temporal chain nodes older than the given cutoff.
-     *
-     * <p>For each linked node whose {@code epochSec * 1000L < cutoffEpochMs},
-     * the node is unlinked by re-stitching its neighbors' prev/next pointers.
-     * Nodes with {@code epochSec == 0} (unknown age, e.g., from V1 files) are
-     * never pruned.</p>
      *
      * @param cutoffEpochMs cutoff timestamp in milliseconds
      * @return number of nodes pruned
@@ -325,35 +411,33 @@ public final class TemporalChain implements AutoCloseable {
     public int pruneOlderThan(long cutoffEpochMs) {
         int cutoffEpochSec = (int) (cutoffEpochMs / 1000);
         int pruned = 0;
+        int cap = capacity();
+        MemorySegment seg = segment();
 
-        for (int i = 0; i < capacity; i++) {
-            long offset = (long) i * NODE_BYTES;
-            int prev = segment.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
-            int next = segment.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
+        for (int i = 0; i < cap; i++) {
+            long offset = dataOffset() + (long) i * NODE_BYTES;
+            int prev = seg.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
+            int next = seg.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
 
-            // Skip unlinked nodes
             if (prev == NO_LINK && next == NO_LINK) continue;
 
-            int epochSec = segment.get(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC);
-            // Never prune nodes with unknown age (epochSec=0, from V1 migration)
+            int epochSec = seg.get(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC);
             if (epochSec == 0) continue;
             if (epochSec >= cutoffEpochSec) continue;
 
-            // Unlink: re-stitch neighbors
-            if (prev >= 0 && prev < capacity) {
-                long prevOffset = (long) prev * NODE_BYTES;
-                segment.set(ValueLayout.JAVA_INT, prevOffset + OFF_NEXT, next);
+            if (prev >= 0 && prev < cap) {
+                long prevOffset = dataOffset() + (long) prev * NODE_BYTES;
+                seg.set(ValueLayout.JAVA_INT, prevOffset + OFF_NEXT, next);
             }
-            if (next >= 0 && next < capacity) {
-                long nextOffset = (long) next * NODE_BYTES;
-                segment.set(ValueLayout.JAVA_INT, nextOffset + OFF_PREV, prev);
+            if (next >= 0 && next < cap) {
+                long nextOffset = dataOffset() + (long) next * NODE_BYTES;
+                seg.set(ValueLayout.JAVA_INT, nextOffset + OFF_PREV, prev);
             }
 
-            // Clear this node
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
             pruned++;
         }
 
@@ -363,37 +447,13 @@ public final class TemporalChain implements AutoCloseable {
         return pruned;
     }
 
-    /**
-     * Provides importance scores for memory indices — used by importance-based
-     * temporal pruning to decide which session chains to protect.
-     *
-     * <p>Typical implementation reads the synaptic header importance field
-     * from the cortex tier store.</p>
-     */
     @FunctionalInterface
     public interface ImportanceProvider {
-        /**
-         * Returns the importance score for a memory at the given index.
-         *
-         * @param memoryIndex the memory slot index
-         * @return importance score (higher = more important), or 0 if unavailable
-         */
         float importance(int memoryIndex);
     }
 
     /**
      * Prunes low-importance temporal chain entries older than the cutoff.
-     *
-     * <p>Unlike {@link #pruneOlderThan}, this method considers the importance
-     * of each memory before pruning. A node is only pruned if:</p>
-     * <ol>
-     *   <li>It is older than {@code cutoffEpochMs}</li>
-     *   <li>Its importance (from the provider) is below {@code importanceThreshold}</li>
-     * </ol>
-     *
-     * <p>High-importance temporal links survive beyond the retention window,
-     * preserving causal chains for significant memories. This mirrors the
-     * Zeigarnik effect — incomplete or important tasks resist forgetting.</p>
      *
      * @param cutoffEpochMs       cutoff timestamp in milliseconds
      * @param importanceThreshold importance below this value is prunable
@@ -405,40 +465,36 @@ public final class TemporalChain implements AutoCloseable {
         if (provider == null) return 0;
         int cutoffEpochSec = (int) (cutoffEpochMs / 1000);
         int pruned = 0;
+        int cap = capacity();
+        MemorySegment seg = segment();
 
-        for (int i = 0; i < capacity; i++) {
-            long offset = (long) i * NODE_BYTES;
-            int prev = segment.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
-            int next = segment.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
+        for (int i = 0; i < cap; i++) {
+            long offset = dataOffset() + (long) i * NODE_BYTES;
+            int prev = seg.get(ValueLayout.JAVA_INT, offset + OFF_PREV);
+            int next = seg.get(ValueLayout.JAVA_INT, offset + OFF_NEXT);
 
-            // Skip unlinked nodes
             if (prev == NO_LINK && next == NO_LINK) continue;
 
-            int epochSec = segment.get(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC);
-            // Never prune nodes with unknown age (epochSec=0, from V1 migration)
+            int epochSec = seg.get(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC);
             if (epochSec == 0) continue;
-            // Only prune if old enough
             if (epochSec >= cutoffEpochSec) continue;
 
-            // Check importance — protect high-importance memories
             float importance = provider.importance(i);
             if (importance >= importanceThreshold) continue;
 
-            // Unlink: re-stitch neighbors
-            if (prev >= 0 && prev < capacity) {
-                long prevOffset = (long) prev * NODE_BYTES;
-                segment.set(ValueLayout.JAVA_INT, prevOffset + OFF_NEXT, next);
+            if (prev >= 0 && prev < cap) {
+                long prevOffset = dataOffset() + (long) prev * NODE_BYTES;
+                seg.set(ValueLayout.JAVA_INT, prevOffset + OFF_NEXT, next);
             }
-            if (next >= 0 && next < capacity) {
-                long nextOffset = (long) next * NODE_BYTES;
-                segment.set(ValueLayout.JAVA_INT, nextOffset + OFF_PREV, prev);
+            if (next >= 0 && next < cap) {
+                long nextOffset = dataOffset() + (long) next * NODE_BYTES;
+                seg.set(ValueLayout.JAVA_INT, nextOffset + OFF_PREV, prev);
             }
 
-            // Clear this node
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
             pruned++;
         }
 
@@ -449,28 +505,17 @@ public final class TemporalChain implements AutoCloseable {
         return pruned;
     }
 
-    // ══════════════════════════════════════════════════════════════
-    // PERSISTENCE: save / load
-    // ══════════════════════════════════════════════════════════════
-
     /**
      * Saves the chain to a binary file.
      *
      * @param filePath path to write
      */
     public void save(Path filePath) {
-        if (fileBacked) {
-            try {
-                segment.force();
-                if (mappedChannel != null) mappedChannel.force(true);
-                log.info("TemporalChain flushed (mmap): capacity={}", capacity);
-            } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("TemporalChain", filePath, e);
-            }
+        if (backing.isPersistent()) {
+            backing.flush();
             return;
         }
 
-        // Heap-backed: serialize to file
         Path parent = filePath.getParent();
         if (parent != null) {
             try {
@@ -482,29 +527,23 @@ public final class TemporalChain implements AutoCloseable {
 
         try (FileChannel ch = FileChannel.open(filePath,
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE,
-                StandardOpenOption.TRUNCATE_EXISTING)) {
+                StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING)) {
 
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            header.putInt(FILE_MAGIC);
-            header.putInt(FILE_VERSION);
-            header.putInt(capacity);
-            header.putInt(0);
-            header.flip();
-            ch.write(header);
+            try (Arena tempArena = Arena.ofConfined()) {
+                long totalBytes = MemoryHeader.HEADER_BYTES + (long) capacity() * NODE_BYTES;
+                ch.position(totalBytes - 1);
+                ch.write(ByteBuffer.wrap(new byte[]{0}));
+                MemorySegment tempSeg = ch.map(FileChannel.MapMode.READ_WRITE, 0, totalBytes, tempArena);
 
-            long totalBytes = (long) NODE_BYTES * capacity;
-            long written = 0;
-            int chunkSize = 64 * 1024;
-            while (written < totalBytes) {
-                int toWrite = (int) Math.min(chunkSize, totalBytes - written);
-                ByteBuffer buf = segment.asSlice(written, toWrite)
-                        .asByteBuffer().asReadOnlyBuffer();
-                ch.write(buf);
-                written += toWrite;
+                MemoryHeader.write(tempSeg, 0, layout().schemaVersion(), shape(),
+                        0x00, // volatile
+                        capacity(), size(), layout().recordStride(), layout().layoutId(),
+                        System.currentTimeMillis(), System.currentTimeMillis());
+
+                MemorySegment.copy(backing.segment(), 0, tempSeg, MemoryHeader.HEADER_BYTES, (long) capacity() * NODE_BYTES);
+                tempSeg.force();
             }
-
-            ch.force(true);
-            log.info("TemporalChain saved (heap→file): capacity={} → {}", capacity, filePath);
+            log.info("TemporalChain saved (heap→file): capacity={} → {}", capacity(), filePath);
 
         } catch (IOException e) {
             throw new SpectorGraphPersistenceException("TemporalChain", filePath, e);
@@ -528,44 +567,46 @@ public final class TemporalChain implements AutoCloseable {
 
     /**
      * Resets all temporal links by re-initializing all nodes to NO_LINK.
-     *
-     * <p>Unlike {@link #close()}, this does NOT release the arena. The chain
-     * remains usable for new links after the reset. Used by privacy wipe.</p>
      */
     public void reset() {
-        for (int i = 0; i < capacity; i++) {
-            long offset = (long) i * NODE_BYTES;
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
-            segment.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
+        int cap = capacity();
+        MemorySegment seg = segment();
+        for (int i = 0; i < cap; i++) {
+            long offset = dataOffset() + (long) i * NODE_BYTES;
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_PREV, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_NEXT, NO_LINK);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_SESSION, 0);
+            seg.set(ValueLayout.JAVA_INT, offset + OFF_EPOCH_SEC, 0);
         }
-        log.info("TemporalChain reset: capacity={}", capacity);
-    }
-
-    // ══════════════════════════════════════════════════════════════
-    // KERNEL INTEGRATION
-    // ══════════════════════════════════════════════════════════════
-
-    public MemoryId memoryId() {
-        return memoryId;
-    }
-
-    public MemoryShape kernelShape() {
-        return MemoryShape.CHAIN;
+        log.info("TemporalChain reset: capacity={}", capacity());
     }
 
     @Override
     public void close() {
-        log.info("TemporalChain closing (capacity={}, fileBacked={})", capacity, fileBacked);
-        if (fileBacked && mappedChannel != null) {
-            try {
-                segment.force();
-                mappedChannel.close();
-            } catch (IOException e) {
-                log.warn("Failed to close TemporalChain channel: {}", e.getMessage());
-            }
+        backing.close();
+    }
+
+    // ── Backing Kernel Memory class ──
+
+    private static final class TemporalChainBacking extends AbstractMemory<TemporalLayout> {
+
+        TemporalChainBacking(MemoryId id, TemporalLayout layout, int capacity, long segmentBytes) {
+            super(id, layout, capacity, segmentBytes);
         }
-        arena.close();
+
+        TemporalChainBacking(MemoryId id, TemporalLayout layout, int capacity, long segmentBytes, Path filePath) {
+            super(id, layout, capacity, segmentBytes, filePath);
+        }
+
+        TemporalChainBacking(MemoryId id, TemporalLayout layout, int capacity,
+                             Arena arena, MemorySegment segment, int count,
+                             boolean persistent, Path filePath, FileChannel fileChannel) {
+            super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
+        }
+
+        @Override
+        public MemoryShape shape() {
+            return MemoryShape.CHAIN;
+        }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalFact.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalFact.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import com.spectrayan.spector.memory.kernel.layout.TemporalFactLayout;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.time.Instant;
+
+/**
+ * A Java record representing a temporal fact in the Spector Memory Temporal Knowledge Graph.
+ * Analogous to a biological synaptic engram, this structure encodes declarative memories
+ * with temporal boundaries and confidence levels.
+ */
+public record TemporalFact(
+        int factId,
+        int subjectEntityId,
+        int predicateId,
+        int objectEntityId,
+        long objectTextOffset,
+        short objectTextLength,
+        long validFrom,
+        long validTo,
+        long txTime,
+        float confidence,
+        int retractsFactId,
+        byte flags
+) {
+
+    public static final int SENTINEL_ENTITY = -1;
+    public static final int SENTINEL_FACT = -1;
+
+    /**
+     * Reads a TemporalFact from off-heap memory.
+     *
+     * @param segment the memory segment
+     * @param baseOffset the base offset of the record
+     * @param layout the temporal fact layout
+     * @return a new TemporalFact instance
+     */
+    public static TemporalFact readFrom(MemorySegment segment, long baseOffset, TemporalFactLayout layout) {
+        return new TemporalFact(
+                segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_FACT_ID),
+                segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_SUBJECT_ENTITY_ID),
+                segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_PREDICATE_ID),
+                segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_OBJECT_ENTITY_ID),
+                segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_OBJECT_TEXT_OFFSET),
+                segment.get(ValueLayout.JAVA_SHORT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_OBJECT_TEXT_LENGTH),
+                segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_VALID_FROM),
+                segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_VALID_TO),
+                segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_TX_TIME),
+                segment.get(ValueLayout.JAVA_FLOAT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_CONFIDENCE),
+                segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_RETRACTS_FACT_ID),
+                segment.get(ValueLayout.JAVA_BYTE, baseOffset + TemporalFactLayout.OFF_FLAGS)
+        );
+    }
+
+    /**
+     * Writes this TemporalFact to off-heap memory.
+     *
+     * @param segment the memory segment
+     * @param baseOffset the base offset of the record
+     * @param layout the temporal fact layout
+     */
+    public void writeTo(MemorySegment segment, long baseOffset, TemporalFactLayout layout) {
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_FACT_ID, factId);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_SUBJECT_ENTITY_ID, subjectEntityId);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_PREDICATE_ID, predicateId);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_OBJECT_ENTITY_ID, objectEntityId);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_OBJECT_TEXT_OFFSET, objectTextOffset);
+        segment.set(ValueLayout.JAVA_SHORT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_OBJECT_TEXT_LENGTH, objectTextLength);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_VALID_FROM, validFrom);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_VALID_TO, validTo);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + TemporalFactLayout.OFF_TX_TIME, txTime);
+        segment.set(ValueLayout.JAVA_FLOAT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_CONFIDENCE, confidence);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + TemporalFactLayout.OFF_RETRACTS_FACT_ID, retractsFactId);
+        segment.set(ValueLayout.JAVA_BYTE, baseOffset + TemporalFactLayout.OFF_FLAGS, flags);
+    }
+
+    /**
+     * Checks if this fact is a retraction of another fact.
+     *
+     * @return true if this is a retraction
+     */
+    public boolean isRetraction() {
+        return retractsFactId != SENTINEL_FACT;
+    }
+
+    /**
+     * Checks if this fact was inferred rather than explicitly asserted.
+     *
+     * @return true if this fact was inferred
+     */
+    public boolean isInferred() {
+        return (flags & TemporalFactLayout.FLAG_INFERRED) != 0;
+    }
+
+    /**
+     * Checks if this fact has been resolved.
+     *
+     * @return true if resolved
+     */
+    public boolean isResolved() {
+        return (flags & TemporalFactLayout.FLAG_RESOLVED) != 0;
+    }
+
+    /**
+     * Checks if this fact is ongoing (has no end time).
+     *
+     * @return true if ongoing
+     */
+    public boolean isOngoing() {
+        return validTo == Long.MAX_VALUE;
+    }
+
+    /**
+     * Checks if this fact was valid at the given instant.
+     *
+     * @param instant the instant to check
+     * @return true if valid at the instant
+     */
+    public boolean validAtInstant(Instant instant) {
+        long epochMilli = instant.toEpochMilli();
+        return validFrom <= epochMilli && epochMilli < validTo;
+    }
+
+    /**
+     * Checks if this fact is valid during the given interval.
+     *
+     * @param fromMs interval start (inclusive)
+     * @param toMs interval end (exclusive)
+     * @return true if there is an overlap
+     */
+    public boolean validDuring(long fromMs, long toMs) {
+        return validFrom < toMs && validTo > fromMs;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraph.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.zip.CRC32C;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spectrayan.spector.memory.graph.TypeRegistry;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.layout.TemporalFactLayout;
+import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+import com.spectrayan.spector.memory.temporal.index.SubjectIndex;
+import com.spectrayan.spector.memory.temporal.index.ValidTimeIndex;
+
+/**
+ * Bitemporal knowledge graph storing structured facts with temporal validity.
+ *
+ * <h3>Biological Analog: Declarative Memory with Temporal Context</h3>
+ * <p>The brain's semantic memory stores facts like "Alice works at Acme" as
+ * declarative knowledge. Unlike raw episodic memories (captured by
+ * {@link TemporalChain}), these facts have explicit validity windows — you
+ * know Alice worked at Acme from 2023 to 2025, not just that you learned
+ * it at some point. The TKG captures this temporal dimension of knowledge.</p>
+ *
+ * <h3>Storage Architecture</h3>
+ * <ul>
+ *   <li>Durable storage: {@link DefaultAppendMemory} with 64-byte
+ *       {@link TemporalFactLayout} records — append-only, WAL-protected</li>
+ *   <li>In-memory subject index: entity ID → fact offsets (rebuilt on open)</li>
+ *   <li>In-memory valid-time index: epoch millis → fact offsets (rebuilt on open)</li>
+ *   <li>Predicate interning via existing {@link TypeRegistry}</li>
+ * </ul>
+ *
+ * <h3>Thread Safety</h3>
+ * <p>All mutation methods ({@link #assertFact}, {@link #retractFact}) are
+ * guarded by a {@link ReentrantLock}. Query methods are lock-free and
+ * operate on snapshot-consistent in-memory indexes.</p>
+ *
+ * @see TemporalFact
+ * @see TemporalChain
+ * @see ContradictionResolver
+ */
+public final class TemporalKnowledgeGraph implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(TemporalKnowledgeGraph.class);
+
+    /** Memory ID for WAL registration and recovery. */
+    private static final MemoryId MEMORY_ID = MemoryId.of("temporal", "facts");
+
+    /** Default initial file size: 64 KB (room for ~1000 facts). */
+    private static final long DEFAULT_INITIAL_SIZE = 64L * 1024;
+
+    /** The 64-byte record layout. */
+    private static final TemporalFactLayout LAYOUT = new TemporalFactLayout();
+
+    // ── Storage ──
+    private final DefaultAppendMemory<TemporalFactLayout> factLog;
+
+    // ── In-memory indexes (rebuilt on open) ──
+    private final SubjectIndex subjectIndex = new SubjectIndex();
+    private final ValidTimeIndex validTimeIndex = new ValidTimeIndex();
+
+    // ── Predicate interning ──
+    private final TypeRegistry predicateRegistry;
+
+    // ── Contradiction resolution ──
+    private final ContradictionResolver resolver;
+
+    // ── Fact ID generator (monotonic) ──
+    private int nextFactId;
+
+    // ── Concurrency ──
+    private final ReentrantLock writeLock = new ReentrantLock();
+
+    // ═══════════════════════════════════════════════════════════════
+    // CONSTRUCTORS
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Creates a heap-backed in-memory TKG with default contradiction resolver.
+     *
+     * @param predicateRegistry type registry for predicate name interning
+     */
+    public TemporalKnowledgeGraph(TypeRegistry predicateRegistry) {
+        this(predicateRegistry, new LatestTxWinsResolver());
+    }
+
+    /**
+     * Creates a heap-backed in-memory TKG with a custom contradiction resolver.
+     *
+     * @param predicateRegistry type registry for predicate name interning
+     * @param resolver          contradiction resolution strategy
+     */
+    public TemporalKnowledgeGraph(TypeRegistry predicateRegistry,
+                                   ContradictionResolver resolver) {
+        this.factLog = new DefaultAppendMemory<>(MEMORY_ID, LAYOUT, 0, DEFAULT_INITIAL_SIZE);
+        this.predicateRegistry = predicateRegistry;
+        this.resolver = resolver;
+        this.nextFactId = 1;
+        rebuildIndexes();
+    }
+
+    /**
+     * Creates a file-backed TKG with default contradiction resolver.
+     *
+     * @param filePath          path to the temporal-facts.tfacts file
+     * @param initialSize       initial file size in bytes
+     * @param predicateRegistry type registry for predicate name interning
+     */
+    public TemporalKnowledgeGraph(Path filePath, long initialSize,
+                                   TypeRegistry predicateRegistry) {
+        this(filePath, initialSize, predicateRegistry, new LatestTxWinsResolver());
+    }
+
+    /**
+     * Creates a file-backed TKG with a custom contradiction resolver.
+     *
+     * @param filePath          path to the temporal-facts.tfacts file
+     * @param initialSize       initial file size in bytes
+     * @param predicateRegistry type registry for predicate name interning
+     * @param resolver          contradiction resolution strategy
+     */
+    public TemporalKnowledgeGraph(Path filePath, long initialSize,
+                                   TypeRegistry predicateRegistry,
+                                   ContradictionResolver resolver) {
+        this.factLog = new DefaultAppendMemory<>(MEMORY_ID, LAYOUT, 0, initialSize, filePath);
+        this.predicateRegistry = predicateRegistry;
+        this.resolver = resolver;
+        this.nextFactId = 1;
+        rebuildIndexes();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // MUTATION — Assert / Retract
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Asserts a new temporal fact into the knowledge graph.
+     *
+     * <p>The fact is durably appended to the fact log, then indexed in
+     * the subject and valid-time indexes for fast query evaluation.</p>
+     *
+     * @param subjectEntityId  entity ID of the subject (FK → EntityGraph)
+     * @param predicateName    predicate name (interned via TypeRegistry)
+     * @param objectEntityId   entity ID of the object, or -1 for literal values
+     * @param objectTextOffset text offset in TextDataStore, or -1 for entity objects
+     * @param objectTextLength text length (max 32KB), or 0 for entity objects
+     * @param validFrom        epoch millis when the fact becomes valid (inclusive)
+     * @param validTo          epoch millis when the fact stops being valid (exclusive),
+     *                         use {@code Long.MAX_VALUE} for ongoing facts
+     * @param confidence       confidence score [0.0, 1.0]
+     * @param inferred         true if this fact was LLM-inferred (not user-stated)
+     * @return the assigned fact ID (monotonically increasing)
+     */
+    public int assertFact(int subjectEntityId, String predicateName,
+                           int objectEntityId, long objectTextOffset,
+                           short objectTextLength,
+                           long validFrom, long validTo,
+                           float confidence, boolean inferred) {
+        writeLock.lock();
+        try {
+            int predicateId = predicateRegistry.getOrRegister(predicateName);
+            int factId = nextFactId++;
+            long txTime = System.currentTimeMillis();
+
+            byte flags = inferred ? TemporalFactLayout.FLAG_INFERRED : 0;
+
+            MemorySegment segment = writeFactSegment(
+                    factId, subjectEntityId, predicateId, objectEntityId,
+                    objectTextOffset, objectTextLength, flags,
+                    validFrom, validTo, txTime, confidence,
+                    TemporalFact.SENTINEL_FACT);
+
+            long offset = factLog.append(segment);
+            subjectIndex.add(subjectEntityId, offset);
+            validTimeIndex.add(validFrom, offset);
+
+            log.debug("TKG: asserted factId={} subject={} pred={} offset={}",
+                    factId, subjectEntityId, predicateName, offset);
+            return factId;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Retracts a previously asserted fact by appending a retraction record.
+     *
+     * <p>The original fact is not mutated or deleted. Instead, a new retraction
+     * record is appended with {@code retractsFactId} pointing to the original.
+     * Query evaluation filters out retracted facts at resolution time.</p>
+     *
+     * @param factIdToRetract the factId of the fact to retract
+     * @return the factId of the retraction record
+     */
+    public int retractFact(int factIdToRetract) {
+        writeLock.lock();
+        try {
+            int factId = nextFactId++;
+            long txTime = System.currentTimeMillis();
+
+            MemorySegment segment = writeFactSegment(
+                    factId, 0, 0, TemporalFact.SENTINEL_ENTITY,
+                    -1L, (short) 0, (byte) 0,
+                    0L, 0L, txTime, 0f,
+                    factIdToRetract);
+
+            factLog.append(segment);
+
+            log.debug("TKG: retracted factId={} (retraction={})", factIdToRetract, factId);
+            return factId;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // QUERY — factsAbout / readFact
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Returns a fluent query builder scoped to facts about the given entity.
+     *
+     * @param entityId the subject entity ID to query
+     * @return a new query builder
+     */
+    public TemporalQuery factsAbout(int entityId) {
+        return new TemporalQuery(this, entityId);
+    }
+
+    /**
+     * Reads all facts for a given entity from the fact log.
+     *
+     * @param entityId the subject entity ID
+     * @return list of temporal facts (may include retracted facts)
+     */
+    List<TemporalFact> readFactsForEntity(int entityId) {
+        List<Long> offsets = subjectIndex.offsetsFor(entityId);
+        List<TemporalFact> facts = new ArrayList<>(offsets.size());
+        for (long offset : offsets) {
+            MemorySegment seg = factLog.read(offset, 64);
+            facts.add(TemporalFact.readFrom(seg, 0, LAYOUT));
+        }
+        return facts;
+    }
+
+    /**
+     * Returns the set of fact IDs that have been retracted.
+     *
+     * <p>This scans the entire fact log for retraction records. For large
+     * fact stores, consider caching this set.</p>
+     *
+     * @return set of retracted fact IDs
+     */
+    Set<Integer> retractedFactIds() {
+        Set<Integer> retracted = new HashSet<>();
+        Iterator<MemorySegment> it = factLog.replay(0);
+        while (it.hasNext()) {
+            MemorySegment seg = it.next();
+            int retractsId = seg.get(ValueLayout.JAVA_INT,
+                    TemporalFactLayout.OFF_RETRACTS_FACT_ID);
+            if (retractsId != TemporalFact.SENTINEL_FACT) {
+                retracted.add(retractsId);
+            }
+        }
+        return retracted;
+    }
+
+    /**
+     * Returns the contradiction resolver for this TKG.
+     *
+     * @return the resolver
+     */
+    ContradictionResolver resolver() {
+        return resolver;
+    }
+
+    /**
+     * Returns the predicate registry for name resolution.
+     *
+     * @return the predicate type registry
+     */
+    public TypeRegistry predicateRegistry() {
+        return predicateRegistry;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // METRICS
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Returns the total number of indexed (non-retraction) facts.
+     *
+     * @return fact count
+     */
+    public int factCount() {
+        return subjectIndex.totalFacts();
+    }
+
+    /**
+     * Returns the number of distinct entities with facts.
+     *
+     * @return entity count
+     */
+    public int entityCount() {
+        return subjectIndex.entityCount();
+    }
+
+    /**
+     * Returns the append cursor position (total bytes written).
+     *
+     * @return cursor position in bytes
+     */
+    public long appendCursor() {
+        return factLog.appendCursor();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // INDEX REBUILD
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Rebuilds the in-memory indexes from the durable fact log.
+     *
+     * <p>Called on construction to restore indexes from persisted data.
+     * Performs a single linear scan of the append log, reading each
+     * length-prefixed record via {@link DefaultAppendMemory#replay(long)}.</p>
+     */
+    public void rebuildIndexes() {
+        subjectIndex.clear();
+        validTimeIndex.clear();
+
+        int maxFactId = 0;
+        int factCount = 0;
+        long currentOffset = 0;
+
+        Iterator<MemorySegment> it = factLog.replay(0);
+        while (it.hasNext()) {
+            MemorySegment seg = it.next();
+            long segSize = seg.byteSize();
+            if (segSize < 64) {
+                log.warn("TKG: skipping truncated record at offset {} (size={})",
+                        currentOffset, segSize);
+                currentOffset += 4 + segSize; // 4B length prefix + payload
+                continue;
+            }
+
+            int factId = seg.get(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_FACT_ID);
+            int retractsFactId = seg.get(ValueLayout.JAVA_INT_UNALIGNED,
+                    TemporalFactLayout.OFF_RETRACTS_FACT_ID);
+
+            if (retractsFactId == TemporalFact.SENTINEL_FACT) {
+                // Normal fact — index it
+                int subjectId = seg.get(ValueLayout.JAVA_INT_UNALIGNED,
+                        TemporalFactLayout.OFF_SUBJECT_ENTITY_ID);
+                long validFrom = seg.get(ValueLayout.JAVA_LONG_UNALIGNED,
+                        TemporalFactLayout.OFF_VALID_FROM);
+
+                // Offset in the read() coordinate space = currentOffset (after length prefix)
+                subjectIndex.add(subjectId, currentOffset + 4);
+                validTimeIndex.add(validFrom, currentOffset + 4);
+                factCount++;
+            }
+
+            if (factId > maxFactId) {
+                maxFactId = factId;
+            }
+
+            currentOffset += 4 + segSize; // 4B length prefix + payload
+        }
+
+        nextFactId = maxFactId + 1;
+        log.info("TKG: rebuilt indexes — {} facts indexed, {} entities, nextFactId={}",
+                factCount, subjectIndex.entityCount(), nextFactId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // LIFECYCLE
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Binds a Write-Ahead Log for durability.
+     *
+     * @param wal the WAL instance
+     */
+    public void bindWal(MemoryWal wal) {
+        factLog.bindWal(wal);
+    }
+
+    /**
+     * Returns the underlying append memory for WAL recovery registration.
+     *
+     * @return the fact log memory
+     */
+    public DefaultAppendMemory<TemporalFactLayout> backing() {
+        return factLog;
+    }
+
+    /**
+     * Returns the memory ID for this TKG.
+     *
+     * @return the memory ID
+     */
+    public MemoryId id() {
+        return MEMORY_ID;
+    }
+
+    @Override
+    public void close() throws Exception {
+        factLog.close();
+    }
+
+    /**
+     * Flushes the knowledge graph to durable storage.
+     */
+    public void flush() {
+        factLog.flush();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // INTERNAL
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Writes a 64-byte fact record to a fresh MemorySegment with CRC32C.
+     */
+    private MemorySegment writeFactSegment(
+            int factId, int subjectEntityId, int predicateId, int objectEntityId,
+            long objectTextOffset, short objectTextLength, byte flags,
+            long validFrom, long validTo, long txTime, float confidence,
+            int retractsFactId) {
+
+        MemorySegment seg = Arena.ofAuto().allocate(64, 8);
+
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_FACT_ID, factId);
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_SUBJECT_ENTITY_ID, subjectEntityId);
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_PREDICATE_ID, predicateId);
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_OBJECT_ENTITY_ID, objectEntityId);
+        seg.set(ValueLayout.JAVA_LONG_UNALIGNED, TemporalFactLayout.OFF_OBJECT_TEXT_OFFSET, objectTextOffset);
+        seg.set(ValueLayout.JAVA_SHORT_UNALIGNED, TemporalFactLayout.OFF_OBJECT_TEXT_LENGTH, objectTextLength);
+        seg.set(ValueLayout.JAVA_BYTE, TemporalFactLayout.OFF_FLAGS, flags);
+        seg.set(ValueLayout.JAVA_BYTE, TemporalFactLayout.OFF_RESERVED, (byte) 0);
+        seg.set(ValueLayout.JAVA_LONG_UNALIGNED, TemporalFactLayout.OFF_VALID_FROM, validFrom);
+        seg.set(ValueLayout.JAVA_LONG_UNALIGNED, TemporalFactLayout.OFF_VALID_TO, validTo);
+        seg.set(ValueLayout.JAVA_LONG_UNALIGNED, TemporalFactLayout.OFF_TX_TIME, txTime);
+        seg.set(ValueLayout.JAVA_FLOAT_UNALIGNED, TemporalFactLayout.OFF_CONFIDENCE, confidence);
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_RETRACTS_FACT_ID, retractsFactId);
+
+        // CRC32C over entire 64 bytes with CRC32C field zeroed out
+        CRC32C crc = new CRC32C();
+        byte[] recordBytes = new byte[64];
+        MemorySegment.copy(seg, 0, MemorySegment.ofArray(recordBytes), 0, 64);
+        recordBytes[56] = 0;
+        recordBytes[57] = 0;
+        recordBytes[58] = 0;
+        recordBytes[59] = 0;
+        crc.update(recordBytes);
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_CRC32C, (int) crc.getValue());
+
+        return seg;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalQuery.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalQuery.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Fluent query builder for temporal fact retrieval.
+ *
+ * <h3>Biological Analog: Cue-Dependent Retrieval</h3>
+ * <p>Just as the brain narrows memory search based on contextual cues
+ * (who, what, when), this builder progressively constrains the fact
+ * search space. Each filter method adds a cue that refines the result
+ * set, mirroring how temporal and semantic context improves recall
+ * precision in episodic memory retrieval.</p>
+ *
+ * <h3>Usage Examples</h3>
+ * <pre>
+ * // Current state: "What do we know about Alice?"
+ * tkg.factsAbout(aliceId).validAt(Instant.now()).excludeRetracted().resolve();
+ *
+ * // Point-in-time: "Where did Alice work in Jan 2024?"
+ * tkg.factsAbout(aliceId).withPredicate("works_at")
+ *     .validAt(Instant.parse("2024-01-15T00:00:00Z")).resolve();
+ *
+ * // Bitemporal: "What did we know about Alice as of last Tuesday?"
+ * tkg.factsAbout(aliceId).validAt(Instant.now())
+ *     .asOf(Instant.parse("2026-07-22T00:00:00Z")).resolve();
+ *
+ * // Interval: "Facts about Project Alpha valid during Q1 2026?"
+ * tkg.factsAbout(projectId).validDuring(q1Start, q1End).resolve();
+ * </pre>
+ *
+ * @see TemporalKnowledgeGraph
+ * @see TemporalFact
+ * @see ContradictionResolver
+ */
+public final class TemporalQuery {
+
+    private final TemporalKnowledgeGraph graph;
+    private final int entityId;
+
+    // ── Filter state ──
+    private Instant validAtInstant;
+    private Instant validDuringFrom;
+    private Instant validDuringTo;
+    private Instant asOfInstant;
+    private String predicateName;
+    private int predicateId = -1;
+    private float minConfidence = 0.0f;
+    private boolean excludeRetracted = false;
+    private boolean excludeInferred = false;
+
+    /**
+     * Creates a new query builder scoped to facts about the given entity.
+     *
+     * @param graph    the TKG instance
+     * @param entityId the subject entity ID to query
+     */
+    TemporalQuery(TemporalKnowledgeGraph graph, int entityId) {
+        this.graph = graph;
+        this.entityId = entityId;
+    }
+
+    /**
+     * Filters facts valid at a specific instant.
+     *
+     * <p>Returns facts where {@code validFrom <= instant < validTo}.</p>
+     *
+     * @param instant the point in time to query
+     * @return this builder
+     */
+    public TemporalQuery validAt(Instant instant) {
+        this.validAtInstant = instant;
+        return this;
+    }
+
+    /**
+     * Filters facts valid during a time interval (Allen's overlap).
+     *
+     * <p>Returns facts where the fact's valid interval overlaps with
+     * {@code [from, to)}: {@code fact.validFrom < to && fact.validTo > from}.</p>
+     *
+     * @param from interval start (inclusive)
+     * @param to   interval end (exclusive)
+     * @return this builder
+     */
+    public TemporalQuery validDuring(Instant from, Instant to) {
+        this.validDuringFrom = from;
+        this.validDuringTo = to;
+        return this;
+    }
+
+    /**
+     * Adds a transaction-time cutoff for bitemporal queries.
+     *
+     * <p>Only facts asserted before {@code asOf} are considered. This
+     * reconstructs the system's knowledge state at a prior point in
+     * time <em>without</em> WAL replay.</p>
+     *
+     * @param asOf transaction-time cutoff
+     * @return this builder
+     */
+    public TemporalQuery asOf(Instant asOf) {
+        this.asOfInstant = asOf;
+        return this;
+    }
+
+    /**
+     * Filters facts by predicate name (e.g., "works_at", "has_title").
+     *
+     * @param predicate the predicate name
+     * @return this builder
+     */
+    public TemporalQuery withPredicate(String predicate) {
+        this.predicateName = predicate;
+        return this;
+    }
+
+    /**
+     * Filters facts by minimum confidence score.
+     *
+     * @param minConfidence minimum confidence [0.0, 1.0]
+     * @return this builder
+     */
+    public TemporalQuery withMinConfidence(float minConfidence) {
+        this.minConfidence = minConfidence;
+        return this;
+    }
+
+    /**
+     * Excludes facts that have been retracted.
+     *
+     * @return this builder
+     */
+    public TemporalQuery excludeRetracted() {
+        this.excludeRetracted = true;
+        return this;
+    }
+
+    /**
+     * Excludes facts that were inferred (LLM-extracted) rather than
+     * explicitly asserted.
+     *
+     * @return this builder
+     */
+    public TemporalQuery excludeInferred() {
+        this.excludeInferred = true;
+        return this;
+    }
+
+    /**
+     * Executes the query and returns matching facts.
+     *
+     * <p>Evaluation order:
+     * <ol>
+     *   <li>Load all facts for the subject entity</li>
+     *   <li>Filter by valid-time (point or interval)</li>
+     *   <li>Filter by transaction-time (asOf cutoff)</li>
+     *   <li>Filter by predicate</li>
+     *   <li>Filter by confidence threshold</li>
+     *   <li>Filter by flags (inferred, retracted)</li>
+     *   <li>Resolve contradictions per predicate</li>
+     * </ol>
+     * </p>
+     *
+     * @return list of matching facts, ordered by txTime descending
+     */
+    public List<TemporalFact> resolve() {
+        // 1. Load all facts for entity
+        List<TemporalFact> candidates = graph.readFactsForEntity(entityId);
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        // Resolve predicate name to ID (if specified)
+        if (predicateName != null) {
+            predicateId = graph.predicateRegistry().idOf(predicateName);
+            if (predicateId < 0) {
+                // Predicate not registered — no facts can match
+                return List.of();
+            }
+        }
+
+        // 2. Get retracted fact IDs (if needed)
+        Set<Integer> retractedIds = excludeRetracted ? graph.retractedFactIds() : Set.of();
+
+        // 3. Apply all filters
+        List<TemporalFact> filtered = new ArrayList<>();
+        for (TemporalFact fact : candidates) {
+            // Skip retractions themselves
+            if (fact.isRetraction()) continue;
+
+            // Retraction filter
+            if (excludeRetracted && retractedIds.contains(fact.factId())) continue;
+
+            // Valid-time point filter
+            if (validAtInstant != null && !fact.validAtInstant(validAtInstant)) continue;
+
+            // Valid-time interval filter (Allen's overlap)
+            if (validDuringFrom != null && validDuringTo != null) {
+                if (!fact.validDuring(validDuringFrom.toEpochMilli(),
+                        validDuringTo.toEpochMilli())) continue;
+            }
+
+            // Transaction-time cutoff (bitemporal)
+            if (asOfInstant != null && fact.txTime() > asOfInstant.toEpochMilli()) continue;
+
+            // Predicate filter
+            if (predicateId >= 0 && fact.predicateId() != predicateId) continue;
+
+            // Confidence filter
+            if (fact.confidence() < minConfidence) continue;
+
+            // Inferred filter
+            if (excludeInferred && fact.isInferred()) continue;
+
+            filtered.add(fact);
+        }
+
+        if (filtered.isEmpty()) {
+            return List.of();
+        }
+
+        // 4. Contradiction resolution: group by predicate, resolve each group
+        Map<Integer, List<TemporalFact>> byPredicate = new HashMap<>();
+        for (TemporalFact fact : filtered) {
+            byPredicate.computeIfAbsent(fact.predicateId(), k -> new ArrayList<>()).add(fact);
+        }
+
+        List<TemporalFact> resolved = new ArrayList<>();
+        ContradictionResolver resolver = graph.resolver();
+        for (Map.Entry<Integer, List<TemporalFact>> entry : byPredicate.entrySet()) {
+            List<TemporalFact> group = entry.getValue();
+            if (group.size() == 1) {
+                resolved.add(group.get(0));
+            } else {
+                // Multiple facts for same predicate — resolve
+                resolved.add(resolver.resolve(group));
+            }
+        }
+
+        // 5. Sort by txTime descending (most recent first)
+        resolved.sort(Comparator.comparingLong(TemporalFact::txTime).reversed());
+        return resolved;
+    }
+
+    /**
+     * Executes the query and returns all matching facts without
+     * contradiction resolution. Useful for auditing and history review.
+     *
+     * @return list of all matching facts, ordered by txTime descending
+     */
+    public List<TemporalFact> resolveAll() {
+        List<TemporalFact> candidates = graph.readFactsForEntity(entityId);
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        if (predicateName != null) {
+            predicateId = graph.predicateRegistry().idOf(predicateName);
+            if (predicateId < 0) return List.of();
+        }
+
+        Set<Integer> retractedIds = excludeRetracted ? graph.retractedFactIds() : Set.of();
+
+        List<TemporalFact> filtered = new ArrayList<>();
+        for (TemporalFact fact : candidates) {
+            if (fact.isRetraction()) continue;
+            if (excludeRetracted && retractedIds.contains(fact.factId())) continue;
+            if (validAtInstant != null && !fact.validAtInstant(validAtInstant)) continue;
+            if (validDuringFrom != null && validDuringTo != null) {
+                if (!fact.validDuring(validDuringFrom.toEpochMilli(),
+                        validDuringTo.toEpochMilli())) continue;
+            }
+            if (asOfInstant != null && fact.txTime() > asOfInstant.toEpochMilli()) continue;
+            if (predicateId >= 0 && fact.predicateId() != predicateId) continue;
+            if (fact.confidence() < minConfidence) continue;
+            if (excludeInferred && fact.isInferred()) continue;
+            filtered.add(fact);
+        }
+
+        filtered.sort(Comparator.comparingLong(TemporalFact::txTime).reversed());
+        return filtered;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/SubjectIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/SubjectIndex.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal.index;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An in-memory index mapping entity IDs to lists of fact-log byte offsets.
+ * 
+ * Biological analog: Similar to the hippocampus rapidly binding neocortical memory traces,
+ * this index provides quick associative access to all known facts regarding a specific subject entity,
+ * acting as a fast retrieval path for entity-centric recall.
+ * 
+ * NOTE: This structure is NOT thread-safe. Callers must synchronize externally.
+ */
+public class SubjectIndex {
+    
+    private final Map<Integer, List<Long>> index;
+    private int totalFactsIndexed;
+    
+    /**
+     * Creates an empty subject index.
+     */
+    public SubjectIndex() {
+        this.index = new HashMap<>();
+        this.totalFactsIndexed = 0;
+    }
+    
+    /**
+     * Adds a fact offset for the given entity.
+     * 
+     * @param entityId The subject entity ID
+     * @param factOffset The byte offset of the fact in the append memory log
+     */
+    public void add(int entityId, long factOffset) {
+        index.computeIfAbsent(entityId, k -> new ArrayList<>()).add(factOffset);
+        totalFactsIndexed++;
+    }
+    
+    /**
+     * Returns all fact offsets for that entity.
+     * 
+     * @param entityId The subject entity ID
+     * @return A list of fact offsets, or an empty list if none exist
+     */
+    public List<Long> offsetsFor(int entityId) {
+        return index.getOrDefault(entityId, new ArrayList<>());
+    }
+    
+    /**
+     * @return Number of indexed entities
+     */
+    public int entityCount() {
+        return index.size();
+    }
+    
+    /**
+     * @return Total number of indexed fact offsets
+     */
+    public int totalFacts() {
+        return totalFactsIndexed;
+    }
+    
+    /**
+     * Clears all entries from the index.
+     */
+    public void clear() {
+        index.clear();
+        totalFactsIndexed = 0;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/ValidTimeIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/ValidTimeIndex.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal.index;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * An in-memory index for temporal range queries using a NavigableMap.
+ * 
+ * Biological analog: Functioning like episodic memory timelines in the prefrontal cortex,
+ * this index temporally orders facts, allowing the agent to retrieve facts valid at a specific
+ * moment in time or during a specific timeframe.
+ * 
+ * NOTE: This structure is NOT thread-safe. Callers must synchronize externally.
+ */
+public class ValidTimeIndex {
+
+    private final NavigableMap<Long, List<Long>> index;
+    private int totalFactsIndexed;
+
+    /**
+     * Creates an empty valid time index.
+     */
+    public ValidTimeIndex() {
+        this.index = new TreeMap<>();
+        this.totalFactsIndexed = 0;
+    }
+
+    /**
+     * Adds a fact offset at the given validFrom epoch millis.
+     * 
+     * @param validFromMs The start of validity timeframe in milliseconds
+     * @param factOffset The byte offset of the fact in the append memory log
+     */
+    public void add(long validFromMs, long factOffset) {
+        index.computeIfAbsent(validFromMs, k -> new ArrayList<>()).add(factOffset);
+        totalFactsIndexed++;
+    }
+
+    /**
+     * Returns all fact offsets where validFrom <= instantMs.
+     * NOTE: This doesn't check validTo — the caller filters by validTo.
+     * 
+     * @param instantMs The instant in time to query
+     * @return A list of fact offsets valid at or before the instant
+     */
+    public List<Long> factsValidAt(long instantMs) {
+        List<Long> result = new ArrayList<>();
+        for (List<Long> offsets : index.headMap(instantMs, true).values()) {
+            result.addAll(offsets);
+        }
+        return result;
+    }
+
+    /**
+     * Returns all fact offsets where validFrom < toMs.
+     * NOTE: Caller still filters by validTo for the overlap test.
+     * 
+     * @param fromMs The start of the timeframe
+     * @param toMs The end of the timeframe
+     * @return A list of fact offsets valid during the given timeframe
+     */
+    public List<Long> factsValidDuring(long fromMs, long toMs) {
+        List<Long> result = new ArrayList<>();
+        for (List<Long> offsets : index.headMap(toMs, false).values()) {
+            result.addAll(offsets);
+        }
+        return result;
+    }
+
+    /**
+     * @return Total indexed offsets
+     */
+    public int totalFacts() {
+        return totalFactsIndexed;
+    }
+
+    /**
+     * Clears all entries from the index.
+     */
+    public void clear() {
+        index.clear();
+        totalFactsIndexed = 0;
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TextDataStorePersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TextDataStorePersistenceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.StorageLayout;
+import com.spectrayan.spector.memory.cortex.TextDataStore.TextEntry;
+import com.spectrayan.spector.memory.cortex.TextDataStore.TextPosition;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TextDataStorePersistenceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path textFile;
+
+    @BeforeEach
+    void setUp() {
+        textFile = tempDir.resolve("text.dat");
+    }
+
+    @Test
+    void testLegacyFormatMigration() throws IOException {
+        // 1. Manually write a legacy V2 format file
+        try (FileChannel ch = FileChannel.open(textFile,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            ByteBuffer header = ByteBuffer.allocate(16);
+            header.putInt(StorageLayout.TEXT_DAT_MAGIC); // 0x54585444
+            header.putInt(StorageLayout.TEXT_DAT_VERSION); // 2
+            header.putInt(2); // entry_count
+            header.putInt(0); // reserved
+            header.flip();
+            ch.write(header);
+
+            // Write entry 1
+            byte[] id1Bytes = "mem-1".getBytes(StandardCharsets.UTF_8);
+            byte[] text1Bytes = "Hello Legacy World 1".getBytes(StandardCharsets.UTF_8);
+            int size1 = 1 + 4 + id1Bytes.length + 4 + text1Bytes.length;
+            ByteBuffer entry1 = ByteBuffer.allocate(size1);
+            entry1.put((byte) MemoryType.SEMANTIC.ordinal());
+            entry1.putInt(id1Bytes.length);
+            entry1.put(id1Bytes);
+            entry1.putInt(text1Bytes.length);
+            entry1.put(text1Bytes);
+            entry1.flip();
+            ch.write(entry1);
+
+            // Write entry 2
+            byte[] id2Bytes = "mem-2".getBytes(StandardCharsets.UTF_8);
+            byte[] text2Bytes = "Hello Legacy World 2".getBytes(StandardCharsets.UTF_8);
+            int size2 = 1 + 4 + id2Bytes.length + 4 + text2Bytes.length;
+            ByteBuffer entry2 = ByteBuffer.allocate(size2);
+            entry2.put((byte) MemoryType.EPISODIC.ordinal());
+            entry2.putInt(id2Bytes.length);
+            entry2.put(id2Bytes);
+            entry2.putInt(text2Bytes.length);
+            entry2.put(text2Bytes);
+            entry2.flip();
+            ch.write(entry2);
+        }
+
+        // 2. Open via TextDataStore (which triggers migration on readAll)
+        try (TextDataStore store = new TextDataStore(textFile)) {
+            Map<String, TextEntry> entries = store.readAll();
+
+            assertThat(entries).hasSize(2);
+            assertThat(entries.get("mem-1").text()).isEqualTo("Hello Legacy World 1");
+            assertThat(entries.get("mem-1").tier()).isEqualTo(MemoryType.SEMANTIC);
+            assertThat(entries.get("mem-2").text()).isEqualTo("Hello Legacy World 2");
+            assertThat(entries.get("mem-2").tier()).isEqualTo(MemoryType.EPISODIC);
+
+            // Verify standard SMKM header is present now
+            try (FileChannel ch = FileChannel.open(textFile, StandardOpenOption.READ)) {
+                ByteBuffer magicBuf = ByteBuffer.allocate(4);
+                ch.read(magicBuf);
+                magicBuf.flip();
+                int magic = magicBuf.getInt();
+                assertThat(magic).isIn(MemoryHeader.MAGIC, 0x4D4B4D53);
+            }
+        }
+    }
+
+    @Test
+    void testXxHashDeduplication() {
+        try (TextDataStore store = new TextDataStore(textFile)) {
+            // Write distinct strings
+            TextPosition pos1 = store.write("mem-1", MemoryType.SEMANTIC, "Unique text content");
+            TextPosition pos2 = store.write("mem-2", MemoryType.SEMANTIC, "Another unique content");
+
+            // Write duplicate string
+            TextPosition pos3 = store.write("mem-3", MemoryType.SEMANTIC, "Unique text content");
+
+            assertThat(pos1.textLength()).isEqualTo(pos3.textLength());
+            assertThat(pos1.textOffset()).isEqualTo(pos3.textOffset());
+            assertThat(pos2.textOffset()).isNotEqualTo(pos1.textOffset());
+
+            Map<String, TextEntry> entries = store.readAll();
+            // deduplicated entry is not written to disk again, so 2 entries physically
+            assertThat(entries).hasSize(2);
+            assertThat(entries.get("mem-1").text()).isEqualTo("Unique text content");
+            assertThat(entries.get("mem-2").text()).isEqualTo("Another unique content");
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierStoreKernelIntegrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierStoreKernelIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayoutAdapter;
+import com.spectrayan.spector.memory.model.MemoryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies kernel integration wiring on tier stores.
+ *
+ * <p>These tests confirm that every tier store subclass correctly
+ * exposes kernel identity, layout adapter, and shape metadata
+ * without changing existing behavior.</p>
+ */
+class TierStoreKernelIntegrationTest {
+
+    private static final int VEC_BYTES = 128;
+    private static final int CAPACITY = 100;
+
+    // ── Working Memory ──
+
+    @Test
+    @DisplayName("WorkingMemoryStore has kernel identity with WORKING type")
+    void workingMemoryStoreHasKernelIdentity() {
+        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+            MemoryId id = store.memoryId();
+            assertThat(id.namespace()).isEqualTo("tier");
+            assertThat(id.memoryName()).isEqualTo("working");
+            assertThat(id.partitionSeq()).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("WorkingMemoryStore exposes kernel layout adapter")
+    void workingMemoryStoreKernelLayout() {
+        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+            CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
+            assertThat(adapter).isNotNull();
+            assertThat(adapter.recordStride()).isEqualTo(store.layout().stride());
+            assertThat(adapter.schemaVersion()).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    @DisplayName("WorkingMemoryStore kernel shape is RECORD")
+    void workingMemoryStoreKernelShape() {
+        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+            assertThat(store.kernelShape()).isEqualTo(MemoryShape.RECORD);
+        }
+    }
+
+    // ── Semantic Memory ──
+
+    @Test
+    @DisplayName("SemanticMemoryStore has kernel identity with SEMANTIC type")
+    void semanticMemoryStoreHasKernelIdentity() {
+        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY)) {
+            MemoryId id = store.memoryId();
+            assertThat(id.namespace()).isEqualTo("tier");
+            assertThat(id.memoryName()).isEqualTo("semantic");
+        }
+    }
+
+    @Test
+    @DisplayName("SemanticMemoryStore exposes kernel layout adapter")
+    void semanticMemoryStoreKernelLayout() {
+        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY)) {
+            CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
+            assertThat(adapter).isNotNull();
+            assertThat(adapter.recordStride()).isEqualTo(store.layout().stride());
+        }
+    }
+
+    // ── Procedural Memory ──
+
+    @Test
+    @DisplayName("ProceduralMemoryStore has kernel identity with PROCEDURAL type")
+    void proceduralMemoryStoreHasKernelIdentity() {
+        try (var store = new ProceduralMemoryStore(VEC_BYTES, CAPACITY)) {
+            MemoryId id = store.memoryId();
+            assertThat(id.namespace()).isEqualTo("tier");
+            assertThat(id.memoryName()).isEqualTo("procedural");
+        }
+    }
+
+    @Test
+    @DisplayName("ProceduralMemoryStore exposes kernel layout adapter")
+    void proceduralMemoryStoreKernelLayout() {
+        try (var store = new ProceduralMemoryStore(VEC_BYTES, CAPACITY)) {
+            CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
+            assertThat(adapter).isNotNull();
+            assertThat(adapter.recordStride()).isEqualTo(store.layout().stride());
+        }
+    }
+
+    // ── Episodic Memory ──
+
+    @Test
+    @DisplayName("EpisodicMemoryStore has kernel identity with EPISODIC type")
+    void episodicMemoryStoreHasKernelIdentity() {
+        try (var store = new EpisodicMemoryStore(VEC_BYTES, CAPACITY)) {
+            MemoryId id = store.memoryId();
+            assertThat(id.namespace()).isEqualTo("tier");
+            assertThat(id.memoryName()).isEqualTo("episodic");
+        }
+    }
+
+    // ── Cross-cutting ──
+
+    @Test
+    @DisplayName("memoryId is lazily initialized and thread-safe")
+    void memoryIdIsLazyAndStable() {
+        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+            MemoryId id1 = store.memoryId();
+            MemoryId id2 = store.memoryId();
+            assertThat(id1).isSameAs(id2); // same instance, not just equals
+        }
+    }
+
+    @Test
+    @DisplayName("memoryId toString follows kernel format")
+    void memoryIdToStringFormat() {
+        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY)) {
+            assertThat(store.memoryId().toString()).isEqualTo("tier/semantic");
+        }
+    }
+
+    @Test
+    @DisplayName("kernel layout adapter crcEnabled matches cognitive layout")
+    void kernelLayoutCrcFlag() {
+        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+            // CognitiveRecordLayout doesn't enable CRC by default
+            CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
+            assertThat(adapter.crcEnabled()).isFalse();
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/TypeRegistryPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/TypeRegistryPersistenceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.graph;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeRegistryPersistenceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("should save and load TypeRegistry in standard SMKM registry format")
+    void shouldSaveAndLoadRegistry() throws Exception {
+        TypeRegistry original = TypeRegistry.seeded("entity-type", "PERSON", "ORGANIZATION");
+        
+        // Intern dynamic ones
+        int codeId = original.intern("CODE");
+        int docId = original.intern("DOCUMENT");
+
+        Path filePath = tempDir.resolve("entity-types.reg");
+
+        // Save
+        original.save(filePath);
+        assertThat(Files.exists(filePath)).isTrue();
+
+        // Load
+        TypeRegistry loaded = TypeRegistry.load(filePath, "entity-type", "PERSON", "ORGANIZATION");
+        
+        assertThat(loaded.size()).isEqualTo(4);
+        assertThat(loaded.nameOf(codeId)).isEqualTo("CODE");
+        assertThat(loaded.nameOf(docId)).isEqualTo("DOCUMENT");
+        assertThat(loaded.idOf("PERSON")).isEqualTo(0);
+        assertThat(loaded.idOf("ORGANIZATION")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should transparently migrate legacy TREG registry files on load")
+    void shouldMigrateLegacyRegistry() throws IOException {
+        Path legacyFile = tempDir.resolve("legacy-entity-types.reg");
+
+        // 1. Manually write a legacy TREG registry format file
+        // Header: [magic:4B (0x54524547)][version:4B (1)][count:4B (2)]
+        try (FileChannel ch = FileChannel.open(legacyFile,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            ByteBuffer header = ByteBuffer.allocate(12);
+            header.putInt(0x54524547); // 'TREG'
+            header.putInt(1);          // version 1
+            header.putInt(2);          // count 2
+            header.flip();
+            ch.write(header);
+
+            // Entry 1: nameLen:4B, nameUtf8:varB, id:4B
+            String name1 = "SOFTWARE";
+            byte[] bytes1 = name1.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            ByteBuffer entry1 = ByteBuffer.allocate(4 + bytes1.length + 4);
+            entry1.putInt(bytes1.length);
+            entry1.put(bytes1);
+            entry1.putInt(10);
+            entry1.flip();
+            ch.write(entry1);
+
+            // Entry 2: nameLen:4B, nameUtf8:varB, id:4B
+            String name2 = "HARDWARE";
+            byte[] bytes2 = name2.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            ByteBuffer entry2 = ByteBuffer.allocate(4 + bytes2.length + 4);
+            entry2.putInt(bytes2.length);
+            entry2.put(bytes2);
+            entry2.putInt(11);
+            entry2.flip();
+            ch.write(entry2);
+        }
+
+        // 2. Load the legacy registry file
+        TypeRegistry registry = TypeRegistry.load(legacyFile, "entity-type", "PERSON");
+        
+        // size should be 3 (PERSON seed + 2 migrated entries)
+        assertThat(registry.size()).isEqualTo(3);
+        assertThat(registry.idOf("SOFTWARE")).isEqualTo(10);
+        assertThat(registry.idOf("HARDWARE")).isEqualTo(11);
+        assertThat(registry.idOf("PERSON")).isEqualTo(12); // seed auto-assigned next sequential ID
+
+        // 3. Save it to trigger automatic V2 standard rewrite
+        registry.save(legacyFile);
+
+        // Load again and verify standard SMKM loading
+        TypeRegistry reloaded = TypeRegistry.load(legacyFile, "entity-type", "PERSON");
+        assertThat(reloaded.size()).isEqualTo(3);
+        assertThat(reloaded.idOf("SOFTWARE")).isEqualTo(10);
+        assertThat(reloaded.idOf("HARDWARE")).isEqualTo(11);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/CoActivationTrackerPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/CoActivationTrackerPersistenceTest.java
@@ -15,7 +15,12 @@ package com.spectrayan.spector.memory.hebbian;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexPersistenceTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.index;
+
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemoryIndexPersistenceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("should save and load MemoryIndex in standard SMKM V5 format")
+    void shouldSaveAndLoadV5() {
+        MemoryIndex original = new MemoryIndex();
+        original.register("mem-1", new MemoryLocation(MemoryType.WORKING, 128L, -1),
+                "hello world", MemorySource.OBSERVED, new String[]{"greeting", "test"});
+        original.register("mem-2", new MemoryLocation(MemoryType.EPISODIC, 1024L, 5, 200L, 11),
+                "episodic text", MemorySource.INFERRED, new String[]{"episode"}, Map.of("key1", "val1"));
+
+        Path indexFile = tempDir.resolve("index.midx");
+        Path idPoolFile = tempDir.resolve("index.idpl");
+
+        // Save
+        original.save(indexFile);
+        assertThat(Files.exists(indexFile)).isTrue();
+        assertThat(Files.exists(idPoolFile)).isTrue();
+
+        // Load
+        MemoryIndex loaded = MemoryIndex.load(indexFile);
+        assertThat(loaded.size()).isEqualTo(2);
+
+        // Verify mem-1
+        MemoryLocation loc1 = loaded.locate("mem-1");
+        assertThat(loc1).isNotNull();
+        assertThat(loc1.type()).isEqualTo(MemoryType.WORKING);
+        assertThat(loc1.offset()).isEqualTo(128L);
+        assertThat(loaded.text("mem-1")).isEqualTo("hello world");
+        assertThat(loaded.source("mem-1")).isEqualTo(MemorySource.OBSERVED);
+        assertThat(loaded.tags("mem-1")).containsExactlyInAnyOrder("greeting", "test");
+
+        // Verify mem-2
+        MemoryLocation loc2 = loaded.locate("mem-2");
+        assertThat(loc2).isNotNull();
+        assertThat(loc2.type()).isEqualTo(MemoryType.EPISODIC);
+        assertThat(loc2.offset()).isEqualTo(1024L);
+        assertThat(loc2.partitionIndex()).isEqualTo(5);
+        assertThat(loc2.textOffset()).isEqualTo(200L);
+        assertThat(loc2.textLength()).isEqualTo(11);
+        assertThat(loaded.source("mem-2")).isEqualTo(MemorySource.INFERRED);
+        assertThat(loaded.tags("mem-2")).containsExactly("episode");
+        assertThat(loaded.metadata("mem-2")).containsEntry("key1", "val1");
+    }
+
+    @Test
+    @DisplayName("should automatically migrate legacy V4 file on load")
+    void shouldMigrateLegacyV4() throws IOException {
+        Path legacyFile = tempDir.resolve("legacy.midx");
+
+        // 1. Manually write a legacy V4 index file structure
+        // Header: magic 'MIDX' (0x4D494458) + version 4 + count 1 + reserved 0
+        try (FileChannel ch = FileChannel.open(legacyFile,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            ByteBuffer header = ByteBuffer.allocate(16);
+            header.putInt(0x4D494458); // 'MIDX'
+            header.putInt(4);          // version 4
+            header.putInt(1);          // count 1
+            header.putInt(0);          // reserved
+            header.flip();
+            ch.write(header);
+
+            // Write 1 legacy entry:
+            // - [4B id_len] + N B id_bytes
+            // - [4B type_ord] + [8B offset] + [4B partition_index]
+            // - [4B text_len] + N B text_bytes (V4: text_len is 0)
+            // - [4B source_ord]
+            // - [4B tag_count]
+            // - [4B metadata_count] + { [4B key_len] + N B key + [4B val_len] + N B val }
+            // - [8B textOffset] + [4B textLength]
+            String id = "legacy-mem";
+            byte[] idBytes = id.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            
+            int entrySize = 4 + idBytes.length
+                    + 4 + 8 + 4
+                    + 4 // text_len (0)
+                    + 4 // source_ord
+                    + 4 // tag_count (0)
+                    + 4 // metadata_count (1)
+                    + 4 + 3 + 4 + 3 // key "foo" -> val "bar"
+                    + 8 + 4; // textOffset + textLength
+            
+            ByteBuffer entry = ByteBuffer.allocate(entrySize);
+            entry.putInt(idBytes.length);
+            entry.put(idBytes);
+            entry.putInt(MemoryType.SEMANTIC.ordinal());
+            entry.putLong(512L);
+            entry.putInt(-1);
+            entry.putInt(0); // text_len
+            entry.putInt(MemorySource.OBSERVED.ordinal());
+            entry.putInt(0); // tags count
+            entry.putInt(1); // metadata count
+            entry.putInt(3); entry.put("foo".getBytes());
+            entry.putInt(3); entry.put("bar".getBytes());
+            entry.putLong(5000L);
+            entry.putInt(25);
+            entry.flip();
+            ch.write(entry);
+        }
+
+        // 2. Load the legacy index
+        MemoryIndex index = MemoryIndex.load(legacyFile);
+        assertThat(index.size()).isEqualTo(1);
+
+        MemoryLocation loc = index.locate("legacy-mem");
+        assertThat(loc).isNotNull();
+        assertThat(loc.type()).isEqualTo(MemoryType.SEMANTIC);
+        assertThat(loc.offset()).isEqualTo(512L);
+        assertThat(loc.textOffset()).isEqualTo(5000L);
+        assertThat(loc.textLength()).isEqualTo(25);
+        assertThat(index.metadata("legacy-mem")).containsEntry("foo", "bar");
+
+        // 3. Save it to trigger automatic V5 rewrite
+        index.save(legacyFile);
+
+        // Verify slot table and pool are created
+        Path idPoolFile = tempDir.resolve("legacy.idpl");
+        assertThat(Files.exists(legacyFile)).isTrue();
+        assertThat(Files.exists(idPoolFile)).isTrue();
+
+        // Load again and verify standard V5 works
+        MemoryIndex reloaded = MemoryIndex.load(legacyFile);
+        assertThat(reloaded.size()).isEqualTo(1);
+        assertThat(reloaded.locate("legacy-mem").offset()).isEqualTo(512L);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/MemoryHeaderTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/MemoryHeaderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemoryHeaderTest {
+
+    @Test
+    @DisplayName("writeAndReadRoundTrip")
+    void writeAndReadRoundTrip() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(128, 64);
+            MemoryHeader.write(segment, 0, 1, MemoryShape.RECORD, 3, 1000L, 500L, 32, 42, 1000000L, 2000000L);
+            
+            assertThat(MemoryHeader.readSchemaVersion(segment, 0)).isEqualTo(1);
+            assertThat(MemoryHeader.readShape(segment, 0)).isEqualTo(MemoryShape.RECORD);
+            assertThat(MemoryHeader.readCapacity(segment, 0)).isEqualTo(1000L);
+            assertThat(MemoryHeader.readCount(segment, 0)).isEqualTo(500L);
+        }
+    }
+
+    @Test
+    @DisplayName("isValidReturnsTrueForValidHeader")
+    void isValidReturnsTrueForValidHeader() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(128, 64);
+            MemoryHeader.write(segment, 0, 1, MemoryShape.RECORD, 3, 1000L, 500L, 32, 42, 1000000L, 2000000L);
+            
+            assertThat(MemoryHeader.isValid(segment, 0)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("isValidReturnsFalseForBadMagic")
+    void isValidReturnsFalseForBadMagic() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(128, 64);
+            MemoryHeader.write(segment, 0, 1, MemoryShape.RECORD, 3, 1000L, 500L, 32, 42, 1000000L, 2000000L);
+            
+            segment.set(ValueLayout.JAVA_INT_UNALIGNED, 0, 0xDEADBEEF);
+            
+            assertThat(MemoryHeader.isValid(segment, 0)).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("isValidReturnsFalseForCorruptedCrc")
+    void isValidReturnsFalseForCorruptedCrc() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(128, 64);
+            MemoryHeader.write(segment, 0, 1, MemoryShape.RECORD, 3, 1000L, 500L, 32, 42, 1000000L, 2000000L);
+            
+            // Corrupt a byte in the first 56 bytes
+            byte b = segment.get(ValueLayout.JAVA_BYTE, 4);
+            segment.set(ValueLayout.JAVA_BYTE, 4, (byte) (b + 1));
+            
+            assertThat(MemoryHeader.isValid(segment, 0)).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("writeCountUpdatesCrcAndCount")
+    void writeCountUpdatesCrcAndCount() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(128, 64);
+            MemoryHeader.write(segment, 0, 1, MemoryShape.RECORD, 3, 1000L, 500L, 32, 42, 1000000L, 2000000L);
+            
+            MemoryHeader.writeCount(segment, 0, 600L);
+            
+            assertThat(MemoryHeader.readCount(segment, 0)).isEqualTo(600L);
+            assertThat(MemoryHeader.isValid(segment, 0)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("readShapeReturnsCorrectShape")
+    void readShapeReturnsCorrectShape() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(128, 64);
+            for (MemoryShape shape : MemoryShape.values()) {
+                MemoryHeader.write(segment, 0, 1, shape, 3, 1000L, 500L, 32, 42, 1000000L, 2000000L);
+                assertThat(MemoryHeader.readShape(segment, 0)).isEqualTo(shape);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("headerExactlySixtyFourBytes")
+    void headerExactlySixtyFourBytes() {
+        assertThat(MemoryHeader.HEADER_BYTES).isEqualTo(64);
+    }
+
+    @Test
+    @DisplayName("magicConstantIsSMKM")
+    void magicConstantIsSMKM() {
+        assertThat(MemoryHeader.MAGIC).isEqualTo(0x534D4B4D);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/MemoryIdTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/MemoryIdTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemoryIdTest {
+
+    @Test
+    @DisplayName("factoryMethodSetsPartitionSeqToZero")
+    void factoryMethodSetsPartitionSeqToZero() {
+        MemoryId id = MemoryId.of("ns", "name");
+        assertThat(id.partitionSeq()).isZero();
+    }
+
+    @Test
+    @DisplayName("toStringFormatsWithoutPartition")
+    void toStringFormatsWithoutPartition() {
+        MemoryId id = MemoryId.of("ns", "name");
+        assertThat(id.toString()).isEqualTo("ns/name");
+    }
+
+    @Test
+    @DisplayName("toStringFormatsWithPartition")
+    void toStringFormatsWithPartition() {
+        MemoryId id = new MemoryId("ns", "name", 2);
+        assertThat(id.toString()).isEqualTo("ns/name#2");
+    }
+
+    @Test
+    @DisplayName("compareToOrdersByNamespaceThenName")
+    void compareToOrdersByNamespaceThenName() {
+        MemoryId id1 = new MemoryId("a", "x", 0);
+        MemoryId id2 = new MemoryId("b", "x", 0);
+        MemoryId id3 = new MemoryId("b", "y", 0);
+        MemoryId id4 = new MemoryId("b", "y", 1);
+        
+        List<MemoryId> list = Arrays.asList(id3, id1, id4, id2);
+        list.sort(null);
+        
+        assertThat(list).containsExactly(id1, id2, id3, id4);
+    }
+
+    @Test
+    @DisplayName("equalityByValueNotReference")
+    void equalityByValueNotReference() {
+        MemoryId id1 = new MemoryId("ns", "name", 1);
+        MemoryId id2 = new MemoryId("ns", "name", 1);
+        
+        assertThat(id1).isEqualTo(id2);
+        assertThat(id1.hashCode()).isEqualTo(id2.hashCode());
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/shape/RecordMemoryContractTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/shape/RecordMemoryContractTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecordMemoryContractTest {
+
+    static final class TestLayout implements MemoryLayout {
+        static final int STRIDE = 32;
+        @Override public int layoutId() { return 0x54455354; }
+        @Override public int schemaVersion() { return 1; }
+        @Override public int recordStride() { return STRIDE; }
+        @Override public boolean crcEnabled() { return false; }
+        @Override public String name() { return "TestLayout"; }
+    }
+
+    static final class TestRecordMemory extends AbstractRecordMemory<TestLayout> {
+        TestRecordMemory(MemoryId id, TestLayout layout, int capacity) {
+            super(id, layout, capacity, (long) capacity * layout.recordStride());
+        }
+        TestRecordMemory(MemoryId id, TestLayout layout, int capacity, Path filePath) {
+            super(id, layout, capacity, (long) capacity * layout.recordStride(), filePath);
+        }
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("writeAndReadRoundTrip")
+    void writeAndReadRoundTrip() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "roundtrip");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment record = arena.allocate(TestLayout.STRIDE, 64);
+                record.set(ValueLayout.JAVA_INT, 0, 999);
+                mem.write(3, record);
+                
+                MemorySegment dest = arena.allocate(TestLayout.STRIDE, 64);
+                mem.read(3, dest);
+                
+                assertThat(dest.get(ValueLayout.JAVA_INT, 0)).isEqualTo(999);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("recordOffsetCalculation")
+    void recordOffsetCalculation() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "offset");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            long dataOffset = mem.isPersistent() ? 64 : 0;
+            assertThat(mem.recordOffset(2)).isEqualTo(dataOffset + 2L * TestLayout.STRIDE);
+        }
+    }
+
+    @Test
+    @DisplayName("writeUpdatesSize")
+    void writeUpdatesSize() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "size");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment record = arena.allocate(TestLayout.STRIDE, 64);
+                mem.write(0, record);
+                assertThat(mem.size()).isEqualTo(1);
+                mem.write(5, record);
+                assertThat(mem.size()).isEqualTo(6);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("writeAtCapacityThrows")
+    void writeAtCapacityThrows() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "throws_cap");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment record = arena.allocate(TestLayout.STRIDE, 64);
+                assertThatThrownBy(() -> mem.write(10, record))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("negativeRecordIdThrows")
+    void negativeRecordIdThrows() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "throws_neg");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment record = arena.allocate(TestLayout.STRIDE, 64);
+                assertThatThrownBy(() -> mem.write(-1, record))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("sizeStartsAtZero")
+    void sizeStartsAtZero() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "starts_zero");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            assertThat(mem.size()).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("capacityMatchesConstructor")
+    void capacityMatchesConstructor() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "cap_match");
+        
+        try (var mem = new TestRecordMemory(id, layout, 42)) {
+            assertThat(mem.capacity()).isEqualTo(42);
+        }
+    }
+
+    @Test
+    @DisplayName("shapeIsRecord")
+    void shapeIsRecord() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "shape");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            assertThat(mem.shape()).isEqualTo(MemoryShape.RECORD);
+        }
+    }
+
+    @Test
+    @DisplayName("volatileMemoryIsNotPersistent")
+    void volatileMemoryIsNotPersistent() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "not_persistent");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            assertThat(mem.isPersistent()).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("persistentWriteAndReload")
+    void persistentWriteAndReload() {
+        Path file = tempDir.resolve("test.mem");
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "persistent");
+        
+        // Write
+        try (var mem = new TestRecordMemory(id, layout, 100, file)) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment record = arena.allocate(TestLayout.STRIDE, 64);
+                record.set(ValueLayout.JAVA_INT, 0, 42);
+                mem.write(0, record);
+            }
+            assertThat(mem.size()).isEqualTo(1);
+        }
+        
+        // Reopen
+        try (var mem = new TestRecordMemory(id, layout, 100, file)) {
+            assertThat(mem.size()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    @DisplayName("flushIsNoOpForVolatile")
+    void flushIsNoOpForVolatile() {
+        TestLayout layout = new TestLayout();
+        MemoryId id = MemoryId.of("test", "flush_noop");
+        
+        try (var mem = new TestRecordMemory(id, layout, 10)) {
+            mem.flush(); // Should not throw
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/namespace/NamespaceRegistryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/namespace/NamespaceRegistryTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.namespace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.DefaultSpectorMemory;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
+import com.spectrayan.spector.memory.test.FakeEmbeddingProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DisplayName("NamespaceRegistry Tests")
+class NamespaceRegistryTest {
+
+    private FakeEmbeddingProvider embedProvider;
+    private NamespaceRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        embedProvider = new FakeEmbeddingProvider();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (registry != null) {
+            registry.close();
+        }
+    }
+
+    private SpectorMemory createTestMemory(String namespaceId) {
+        return DefaultSpectorMemory.builder()
+                .dimensions(embedProvider.dimensions())
+                .embeddingProvider(embedProvider)
+                .persistenceMode(MemoryPersistenceMode.IN_MEMORY)
+                .namespaceId(namespaceId)
+                .managedByRegistry(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Verify LRU Eviction behavior")
+    void testLruEviction() {
+        registry = new NamespaceRegistry(2);
+
+        SpectorMemory ns1 = registry.getOrOpen("ns1", () -> createTestMemory("ns1"));
+        SpectorMemory ns2 = registry.getOrOpen("ns2", () -> createTestMemory("ns2"));
+
+        assertThat(registry.activeCount()).isEqualTo(2);
+        assertThat(registry.evictedCount()).isEqualTo(0);
+
+        // Touch ns1 to make it most recently used
+        registry.getOrOpen("ns1", () -> createTestMemory("ns1"));
+
+        // Open ns3, which should trigger eviction of ns2 (since ns1 was touched)
+        SpectorMemory ns3 = registry.getOrOpen("ns3", () -> createTestMemory("ns3"));
+
+        assertThat(registry.activeCount()).isEqualTo(2);
+        assertThat(registry.evictedCount()).isEqualTo(1);
+
+        // Check that ns2 is no longer tracked
+        SpectorMemory cachedNs2 = registry.getOrOpen("ns2", () -> {
+            // Should call opener to reopen
+            return createTestMemory("ns2");
+        });
+
+        // Now ns1 (oldest MRU) should be evicted
+        assertThat(registry.evictedCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Verify active lease prevents eviction")
+    void testLeasePreventsEviction() {
+        registry = new NamespaceRegistry(2);
+
+        SpectorMemory ns1 = registry.getOrOpen("ns1", () -> createTestMemory("ns1"));
+        SpectorMemory ns2 = registry.getOrOpen("ns2", () -> createTestMemory("ns2"));
+
+        // Acquire lease on ns1
+        ((DefaultSpectorMemory) ns1).acquireLease();
+
+        // Open ns3. Normally ns1 (eldest) is evicted, but since it has a lease, ns2 should be evicted instead
+        SpectorMemory ns3 = registry.getOrOpen("ns3", () -> createTestMemory("ns3"));
+
+        assertThat(registry.activeCount()).isEqualTo(2);
+        assertThat(registry.evictedCount()).isEqualTo(1);
+
+        // Verify ns1 is still active
+        assertThat(registry.getOrOpen("ns1", () -> {
+            throw new AssertionError("Should not reopen ns1 as it must still be active");
+        })).isSameAs(ns1);
+
+        // Release lease
+        ((DefaultSpectorMemory) ns1).releaseLease();
+    }
+
+    @Test
+    @DisplayName("Verify warm reopen logic")
+    void testWarmReopen() {
+        registry = new NamespaceRegistry(1);
+        AtomicInteger openCount = new AtomicInteger(0);
+
+        SpectorMemory ns1 = registry.getOrOpen("ns1", () -> {
+            openCount.incrementAndGet();
+            return createTestMemory("ns1");
+        });
+
+        // Trigger eviction of ns1
+        registry.getOrOpen("ns2", () -> createTestMemory("ns2"));
+        assertThat(registry.evictedCount()).isEqualTo(1);
+
+        // Touch ns1 again, should reload it
+        SpectorMemory ns1Reloaded = registry.getOrOpen("ns1", () -> {
+            openCount.incrementAndGet();
+            return createTestMemory("ns1");
+        });
+
+        assertThat(openCount.get()).isEqualTo(2);
+        assertThat(ns1Reloaded).isNotSameAs(ns1);
+    }
+
+    @Test
+    @DisplayName("Verify FD diagnostics executes without failure")
+    void testFdDiagnostics() {
+        NamespaceRegistry.logFdDiagnostics(10);
+        NamespaceRegistry.logFdDiagnostics(1000000); // Trigger warning if Unix MXBean is available
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/namespace/NamespaceRegistryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/namespace/NamespaceRegistryTest.java
@@ -68,7 +68,7 @@ class NamespaceRegistryTest {
         registry.getOrOpen("ns1", () -> createTestMemory("ns1"));
 
         // Open ns3, which should trigger eviction of ns2 (since ns1 was touched)
-        SpectorMemory ns3 = registry.getOrOpen("ns3", () -> createTestMemory("ns3"));
+        registry.getOrOpen("ns3", () -> createTestMemory("ns3"));
 
         assertThat(registry.activeCount()).isEqualTo(2);
         assertThat(registry.evictedCount()).isEqualTo(1);
@@ -95,7 +95,7 @@ class NamespaceRegistryTest {
         ((DefaultSpectorMemory) ns1).acquireLease();
 
         // Open ns3. Normally ns1 (eldest) is evicted, but since it has a lease, ns2 should be evicted instead
-        SpectorMemory ns3 = registry.getOrOpen("ns3", () -> createTestMemory("ns3"));
+        registry.getOrOpen("ns3", () -> createTestMemory("ns3"));
 
         assertThat(registry.activeCount()).isEqualTo(2);
         assertThat(registry.evictedCount()).isEqualTo(1);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.sync;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import com.spectrayan.spector.memory.kernel.Memory;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.shape.DefaultRecordMemory;
+import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
+import com.spectrayan.spector.memory.kernel.shape.DefaultRegistryMemory;
+import com.spectrayan.spector.memory.kernel.shape.RegistryLayout;
+import com.spectrayan.spector.memory.kernel.layout.IndexEntryLayout;
+import com.spectrayan.spector.memory.kernel.layout.IdBlobLayout;
+import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.hebbian.HebbianGraphCsr;
+import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.temporal.TemporalChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WalRecoveryDispatcherTest {
+
+    @TempDir
+    Path tempDir;
+
+    private float getEdgeWeight(HebbianGraphCsr graph, int u, int v) {
+        for (HebbianEdge edge : graph.neighbors(u)) {
+            if (edge.neighborIndex() == v) {
+                return edge.weight();
+            }
+        }
+        return 0.0f;
+    }
+
+    @Test
+    void testFullRoundTripRecovery() throws Exception {
+        Path walDir = tempDir.resolve("wal");
+        Path recordFile = tempDir.resolve("record.bin");
+        Path appendFile = tempDir.resolve("append.bin");
+        Path registryFile = tempDir.resolve("registry.bin");
+        Path entityFile = tempDir.resolve("entity.bin");
+        Path chainFile = tempDir.resolve("chain.bin");
+
+        // Backup paths
+        Path backupDir = tempDir.resolve("backup");
+        Files.createDirectories(backupDir);
+        Path recordBackup = backupDir.resolve("record.bin");
+        Path appendBackup = backupDir.resolve("append.bin");
+        Path registryBackup = backupDir.resolve("registry.bin");
+        Path entityBackup = backupDir.resolve("entity.bin");
+        Path chainBackup = backupDir.resolve("chain.bin");
+
+        // 1. Initialize and write initial checkpoint state
+        try (MemoryWal wal = new MemoryWal(walDir);
+             DefaultRecordMemory<IndexEntryLayout> recordMem = new DefaultRecordMemory<>(
+                     MemoryId.of("test", "record"), new IndexEntryLayout(), 10, 400, recordFile);
+             DefaultAppendMemory<IdBlobLayout> appendMem = new DefaultAppendMemory<>(
+                     MemoryId.of("test", "append"), new IdBlobLayout(), 10, 1000, appendFile);
+             DefaultRegistryMemory registryMem = new DefaultRegistryMemory(
+                     MemoryId.of("test", "registry"), new RegistryLayout(), 10, 1000, registryFile);
+             EntityGraph entityGraph = new EntityGraph(entityFile, 10, 20);
+             TemporalChain temporalChain = new TemporalChain(chainFile, 10)) {
+
+            recordMem.bindWal(wal);
+            appendMem.bindWal(wal);
+            registryMem.bindWal(wal);
+            entityGraph.bindWal(wal);
+            temporalChain.bindWal(wal);
+
+            // Write checkpoint mutations
+            byte[] bytes = new byte[40];
+            bytes[0] = 11;
+            recordMem.write(0, MemorySegment.ofArray(bytes));
+            registryMem.intern("CHECKPOINT_KEY");
+            entityGraph.addEntity("CheckpointEntity", "TypeA");
+            temporalChain.link(0, 1, 100);
+
+            // Flush all to disk
+            recordMem.flush();
+            appendMem.flush();
+            registryMem.flush();
+            entityGraph.flush();
+            temporalChain.flush();
+        }
+
+        // Copy checkpoint files to backup
+        Files.copy(recordFile, recordBackup, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(appendFile, appendBackup, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(registryFile, registryBackup, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(entityFile, entityBackup, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(chainFile, chainBackup, StandardCopyOption.REPLACE_EXISTING);
+
+        // 2. Open memories and perform crash mutations (logged to WAL and modifying files)
+        try (MemoryWal wal = new MemoryWal(walDir);
+             DefaultRecordMemory<IndexEntryLayout> recordMem = new DefaultRecordMemory<>(
+                     MemoryId.of("test", "record"), new IndexEntryLayout(), 10, 400, recordFile);
+             DefaultAppendMemory<IdBlobLayout> appendMem = new DefaultAppendMemory<>(
+                     MemoryId.of("test", "append"), new IdBlobLayout(), 10, 1000, appendFile);
+             DefaultRegistryMemory registryMem = new DefaultRegistryMemory(
+                     MemoryId.of("test", "registry"), new RegistryLayout(), 10, 1000, registryFile);
+             EntityGraph entityGraph = new EntityGraph(entityFile, 10, 20);
+             TemporalChain temporalChain = new TemporalChain(chainFile, 10);
+             HebbianGraphCsr hebbianGraph = new HebbianGraphCsr(10)) {
+
+            recordMem.bindWal(wal);
+            appendMem.bindWal(wal);
+            registryMem.bindWal(wal);
+            entityGraph.bindWal(wal);
+            temporalChain.bindWal(wal);
+            hebbianGraph.bindWal(wal);
+
+            // Mutate RecordMemory
+            byte[] bytes = new byte[40];
+            bytes[0] = 42;
+            recordMem.write(1, MemorySegment.ofArray(bytes));
+
+            // Mutate AppendMemory
+            byte[] appendBytes = new byte[]{9, 9, 9};
+            appendMem.append(MemorySegment.ofArray(appendBytes));
+
+            // Mutate RegistryMemory
+            registryMem.intern("CRASH_KEY");
+
+            // Mutate EntityGraph
+            int e1 = entityGraph.addEntity("CrashEntity1", "TypeA");
+            int e2 = entityGraph.addEntity("CrashEntity2", "TypeB");
+            entityGraph.addRelation(e1, e2, "REL");
+            entityGraph.linkEntityToMemory(e1, 7);
+
+            // Mutate TemporalChain
+            temporalChain.link(2, 3, 999);
+
+            // Mutate HebbianGraphCsr
+            hebbianGraph.strengthen(2, 3, 1.5f);
+
+            // Flush all to disk to record WAL events but do NOT write SNAPSHOT_MARK (so recovery replays these)
+            recordMem.flush();
+            appendMem.flush();
+            registryMem.flush();
+            entityGraph.flush();
+            temporalChain.flush();
+            hebbianGraph.flush();
+        }
+
+        // Restore files to backup state (simulating crash loss of segment updates since backup)
+        Files.copy(recordBackup, recordFile, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(appendBackup, appendFile, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(registryBackup, registryFile, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(entityBackup, entityFile, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(chainBackup, chainFile, StandardCopyOption.REPLACE_EXISTING);
+
+        // 3. Reopen memories (they are back to checkpoint state) and perform recovery
+        try (DefaultRecordMemory<IndexEntryLayout> recordMem = new DefaultRecordMemory<>(
+                     MemoryId.of("test", "record"), new IndexEntryLayout(), 10, 400, recordFile);
+             DefaultAppendMemory<IdBlobLayout> appendMem = new DefaultAppendMemory<>(
+                     MemoryId.of("test", "append"), new IdBlobLayout(), 10, 1000, appendFile);
+             DefaultRegistryMemory registryMem = new DefaultRegistryMemory(
+                     MemoryId.of("test", "registry"), new RegistryLayout(), 10, 1000, registryFile);
+             EntityGraph entityGraph = new EntityGraph(entityFile, 10, 20);
+             TemporalChain temporalChain = new TemporalChain(chainFile, 10);
+             HebbianGraphCsr hebbianGraph = new HebbianGraphCsr(10)) {
+
+            // Verify they are back to checkpoint state
+            byte[] readBytes = new byte[40];
+            MemorySegment.copy(recordMem.segment(), recordMem.recordOffset(1), MemorySegment.ofArray(readBytes), 0, 40);
+            assertThat(readBytes[0]).isEqualTo((byte) 0); // was reset
+            
+            assertThat(registryMem.idOf("CRASH_KEY")).isEqualTo(-1);
+            assertThat(entityGraph.findEntity("CrashEntity1")).isEqualTo(-1);
+            assertThat(temporalChain.prev(2)).isEqualTo(-1);
+            assertThat(getEdgeWeight(hebbianGraph, 2, 3)).isEqualTo(0.0f);
+
+            // Run recovery
+            try (MemoryWal wal = new MemoryWal(walDir)) {
+                Map<MemoryId, Memory<?>> memories = new HashMap<>();
+                memories.put(recordMem.id(), recordMem);
+                memories.put(appendMem.id(), appendMem);
+                memories.put(registryMem.id(), registryMem);
+                memories.put(entityGraph.id(), entityGraph);
+                memories.put(MemoryId.of("temporal", "chain"), temporalChain);
+                memories.put(hebbianGraph.id(), hebbianGraph);
+
+                WalRecoveryDispatcher.recover(wal, memories);
+            }
+
+            // Verify they have recovered the crash state
+            MemorySegment.copy(recordMem.segment(), recordMem.recordOffset(1), MemorySegment.ofArray(readBytes), 0, 40);
+            assertThat(readBytes[0]).isEqualTo((byte) 42); // recovered!
+
+            assertThat(registryMem.idOf("CRASH_KEY")).isNotEqualTo(-1);
+            assertThat(entityGraph.findEntity("CrashEntity1")).isNotEqualTo(-1);
+            assertThat(temporalChain.prev(2)).isEqualTo(3);
+            assertThat(getEdgeWeight(hebbianGraph, 2, 3)).isEqualTo(1.5f);
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalChainMigrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalChainMigrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemporalChainMigrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("should automatically migrate legacy TPCH file to SMKM")
+    void shouldMigrateLegacyTpchToSmkm() throws IOException {
+        Path legacyFile = tempDir.resolve("legacy.chain");
+        int capacity = 10;
+
+        // 1. Manually write a legacy TPCH file structure (16-byte header)
+        // [0:4] magic 'TPCH'
+        // [4:4] version 2
+        // [8:4] capacity 10
+        // [12:4] count 3
+        try (FileChannel ch = FileChannel.open(legacyFile,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            ByteBuffer header = ByteBuffer.allocate(16);
+            header.putInt(0x54504348); // 'TPCH'
+            header.putInt(2);          // version
+            header.putInt(capacity);   // capacity
+            header.putInt(3);          // count
+            header.flip();
+            ch.write(header);
+
+            // Extend file to 16 + 10 * 16 bytes
+            long totalBytes = 16 + capacity * 16;
+            ch.position(totalBytes - 1);
+            ch.write(ByteBuffer.wrap(new byte[]{0}));
+
+            // Let's write node data: link 0 -> 1 -> 2
+            // Node size is 16 bytes: prevIdx(4) + nextIdx(4) + sessionId(4) + epochSec(4)
+            ByteBuffer data = ByteBuffer.allocate(capacity * 16);
+            data.order(java.nio.ByteOrder.LITTLE_ENDIAN);
+            
+            // Node 0: prev=-1, next=1, session=42
+            data.putInt(-1); data.putInt(1); data.putInt(42); data.putInt(9999);
+            // Node 1: prev=0, next=2, session=42
+            data.putInt(0); data.putInt(2); data.putInt(42); data.putInt(9999);
+            // Node 2: prev=1, next=-1, session=42
+            data.putInt(1); data.putInt(-1); data.putInt(42); data.putInt(9999);
+            
+            // Fill remaining nodes with -1 sentinels
+            for (int i = 3; i < capacity; i++) {
+                data.putInt(-1); data.putInt(-1); data.putInt(0); data.putInt(0);
+            }
+            data.flip();
+            ch.position(16);
+            ch.write(data);
+        }
+
+        // 2. Open using the refactored TemporalChain (which reads SMKM or migrates TPCH)
+        try (TemporalChain chain = new TemporalChain(legacyFile, capacity)) {
+            // Verify capacity and size
+            assertThat(chain.capacity()).isEqualTo(capacity);
+
+            // Verify links are intact
+            assertThat(chain.isLinked(0)).isTrue();
+            assertThat(chain.isLinked(1)).isTrue();
+            assertThat(chain.isLinked(2)).isTrue();
+            assertThat(chain.isLinked(3)).isFalse();
+
+            assertThat(chain.next(0)).isEqualTo(1);
+            assertThat(chain.prev(1)).isEqualTo(0);
+            assertThat(chain.next(1)).isEqualTo(2);
+            assertThat(chain.prev(2)).isEqualTo(1);
+            assertThat(chain.next(2)).isEqualTo(-1);
+
+            assertThat(chain.sessionOf(0)).isEqualTo(42);
+            assertThat(chain.sessionOf(1)).isEqualTo(42);
+            assertThat(chain.sessionOf(2)).isEqualTo(42);
+
+            assertThat(chain.epochSecOf(0)).isEqualTo(9999);
+            assertThat(chain.epochSecOf(1)).isEqualTo(9999);
+            assertThat(chain.epochSecOf(2)).isEqualTo(9999);
+
+            // Verify new ChainMemory methods
+            assertThat(chain.head()).isEqualTo(0);
+            assertThat(chain.tail()).isEqualTo(2);
+            assertThat(chain.chainLength()).isEqualTo(3);
+        }
+
+        // 3. Verify file is now in SMKM format (64-byte header)
+        try (FileChannel ch = FileChannel.open(legacyFile, StandardOpenOption.READ)) {
+            ByteBuffer header = ByteBuffer.allocate(64);
+            header.order(java.nio.ByteOrder.LITTLE_ENDIAN);
+            ch.read(header);
+            header.flip();
+            int magic = header.getInt();
+            assertThat(magic).isEqualTo(0x534D4B4D); // 'SMKM'
+            
+            int schemaVersion = header.getInt();
+            assertThat(schemaVersion).isEqualTo(2);
+            
+            int shape = header.getInt();
+            assertThat(shape).isEqualTo(3); // MemoryShape.CHAIN ordinal
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraphTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraphTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.temporal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import com.spectrayan.spector.memory.graph.TypeRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the TemporalKnowledgeGraph and its query capabilities.
+ */
+class TemporalKnowledgeGraphTest {
+
+    @TempDir
+    Path tempDir;
+
+    private TypeRegistry predicateRegistry;
+    private TemporalKnowledgeGraph tkg;
+
+    @BeforeEach
+    void setUp() {
+        predicateRegistry = new TypeRegistry("relation-type");
+        tkg = new TemporalKnowledgeGraph(predicateRegistry);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        tkg.close();
+    }
+
+    @Test
+    void assertAndQueryCurrentState() {
+        // Alice (entity 1) works at Acme (entity 2) starting from epoch 1000
+        int factId = tkg.assertFact(
+                1, "works_at", 2, -1L, (short) 0,
+                1000L, Long.MAX_VALUE, 0.9f, false
+        );
+
+        assertThat(factId).isEqualTo(1);
+        assertThat(tkg.factCount()).isEqualTo(1);
+
+        // Query active fact at epoch 1500
+        List<TemporalFact> facts = tkg.factsAbout(1)
+                .validAt(Instant.ofEpochMilli(1500L))
+                .excludeRetracted()
+                .resolve();
+
+        assertThat(facts).hasSize(1);
+        TemporalFact fact = facts.get(0);
+        assertThat(fact.factId()).isEqualTo(1);
+        assertThat(fact.subjectEntityId()).isEqualTo(1);
+        assertThat(fact.objectEntityId()).isEqualTo(2);
+        assertThat(fact.validFrom()).isEqualTo(1000L);
+        assertThat(fact.validTo()).isEqualTo(Long.MAX_VALUE);
+        assertThat(fact.confidence()).isEqualTo(0.9f);
+        assertThat(fact.isOngoing()).isTrue();
+    }
+
+    @Test
+    void pointInTimeAndIntervalQueries() {
+        // Fact valid in 2024: [2024-01-01, 2025-01-01)
+        long start2024 = Instant.parse("2024-01-01T00:00:00Z").toEpochMilli();
+        long end2024 = Instant.parse("2025-01-01T00:00:00Z").toEpochMilli();
+
+        tkg.assertFact(
+                1, "lives_in", -1, 100L, (short) 5, // "Paris" at textOffset 100, length 5
+                start2024, end2024, 0.8f, true
+        );
+
+        // Query at 2024-06-01: should return the fact
+        Instant mid2024 = Instant.parse("2024-06-01T00:00:00Z");
+        List<TemporalFact> midFacts = tkg.factsAbout(1)
+                .validAt(mid2024)
+                .resolve();
+        assertThat(midFacts).hasSize(1);
+        assertThat(midFacts.get(0).isInferred()).isTrue();
+
+        // Query at 2025-06-01: should be empty
+        Instant mid2025 = Instant.parse("2025-06-01T00:00:00Z");
+        assertThat(tkg.factsAbout(1).validAt(mid2025).resolve()).isEmpty();
+
+        // Interval overlap query (Q1 2024 overlap)
+        Instant q1Start = Instant.parse("2024-01-01T00:00:00Z");
+        Instant q1End = Instant.parse("2024-04-01T00:00:00Z");
+        List<TemporalFact> overlapFacts = tkg.factsAbout(1)
+                .validDuring(q1Start, q1End)
+                .resolve();
+        assertThat(overlapFacts).hasSize(1);
+    }
+
+    @Test
+    void retractFactExcludesFromQueries() {
+        int factId = tkg.assertFact(
+                1, "role", -1, 50L, (short) 8, // "Engineer"
+                1000L, Long.MAX_VALUE, 0.95f, false
+        );
+
+        // Retract it
+        tkg.retractFact(factId);
+
+        // Query without retraction exclusion
+        List<TemporalFact> all = tkg.factsAbout(1)
+                .validAt(Instant.ofEpochMilli(1500L))
+                .resolve();
+        assertThat(all).hasSize(1);
+
+        // Query with retraction exclusion
+        List<TemporalFact> activeOnly = tkg.factsAbout(1)
+                .validAt(Instant.ofEpochMilli(1500L))
+                .excludeRetracted()
+                .resolve();
+        assertThat(activeOnly).isEmpty();
+    }
+
+    @Test
+    void contradictionResolutionLatestWins() {
+        // Assert first fact
+        tkg.assertFact(
+                1, "has_status", -1, 10L, (short) 4, // "Busy"
+                1000L, Long.MAX_VALUE, 0.5f, false
+        );
+
+        // Let time pass a bit for a distinct txTime (sleep or pass mock/different txTime if configurable,
+        // but here we just assert another fact which gets a higher txTime natively)
+        try { Thread.sleep(2); } catch (InterruptedException ignored) {}
+
+        tkg.assertFact(
+                1, "has_status", -1, 20L, (short) 9, // "Available"
+                1000L, Long.MAX_VALUE, 0.9f, false
+        );
+
+        // With LatestTxWinsResolver (default), the second one wins
+        List<TemporalFact> resolved = tkg.factsAbout(1)
+                .validAt(Instant.ofEpochMilli(1500L))
+                .resolve();
+
+        assertThat(resolved).hasSize(1);
+        assertThat(resolved.get(0).objectTextOffset()).isEqualTo(20L); // Available
+    }
+
+    @Test
+    void contradictionResolutionHighestConfidence() throws Exception {
+        // Create TKG with confidence resolver
+        try (TemporalKnowledgeGraph confidenceTkg = new TemporalKnowledgeGraph(predicateRegistry, new HighestConfidenceResolver())) {
+            confidenceTkg.assertFact(
+                    1, "has_status", -1, 10L, (short) 4, // "Busy" (high confidence)
+                    1000L, Long.MAX_VALUE, 0.95f, false
+            );
+
+            try { Thread.sleep(2); } catch (InterruptedException ignored) {}
+
+            confidenceTkg.assertFact(
+                    1, "has_status", -1, 20L, (short) 9, // "Available" (low confidence)
+                    1000L, Long.MAX_VALUE, 0.4f, false
+            );
+
+            List<TemporalFact> resolved = confidenceTkg.factsAbout(1)
+                    .validAt(Instant.ofEpochMilli(1500L))
+                    .resolve();
+
+            assertThat(resolved).hasSize(1);
+            assertThat(resolved.get(0).objectTextOffset()).isEqualTo(10L); // Busy wins due to confidence
+        }
+    }
+
+    @Test
+    void rebuildIndexesFromDisk() throws Exception {
+        Path dbPath = tempDir.resolve("temporal-facts.tfacts");
+
+        // Write facts using one instance
+        try (TemporalKnowledgeGraph writer = new TemporalKnowledgeGraph(dbPath, 64L * 1024, predicateRegistry)) {
+            writer.assertFact(
+                    5, "located_in", 6, -1L, (short) 0,
+                    2000L, Long.MAX_VALUE, 0.85f, false
+            );
+            writer.assertFact(
+                    5, "status", -1, 30L, (short) 6,
+                    2000L, Long.MAX_VALUE, 0.7f, false
+            );
+            writer.flush();
+        }
+
+        // Open a new instance on the same file and verify indexes are rebuilt
+        try (TemporalKnowledgeGraph reader = new TemporalKnowledgeGraph(dbPath, 64L * 1024, predicateRegistry)) {
+            assertThat(reader.factCount()).isEqualTo(2);
+            assertThat(reader.entityCount()).isEqualTo(1); // just entity 5
+
+            List<TemporalFact> facts = reader.factsAbout(5)
+                    .validAt(Instant.ofEpochMilli(3000L))
+                    .resolve();
+            assertThat(facts).hasSize(2);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <module>memory/spector-gpu</module>
         <module>memory/spector-ingestion</module>
         <module>memory/spector-memory</module>
+        <module>memory/spector-inspect</module>
 
         <!-- ── Synapse: Nervous system — API, agents, wiring ── -->
         <module>synapse/spector-runtime</module>


### PR DESCRIPTION
# Spector Memory Kernel Implementation (Phases 1-3)

This PR implements the standardized **Spector Memory Kernel** storage abstraction layer, replacing independent file-channel mappings with standard off-heap memory shapes (`Memory<Layout>`), a unified WAL for all memory shapes, and namespace-scoped LRU eviction logic to resolve file descriptor scaling limits.

## Changes Completed

### Phase 1: Kernel Extraction & Shapes
- Created kernel shapes: `RecordMemory`, `PartitionedRecordMemory`, `AdjacencyMemory`, `AppendMemory`, and `RegistryMemory`.
- Refactored `AbstractTierStore` (Working, Episodic, Semantic, Procedural) to delegate storage segments to `RecordMemory`.
- Refactored `EntityGraph` and `HebbianGraphCsr` to implement the `GraphMemory` shape.
- Composed `TemporalChain` with `ChainMemory` backing.
- Split `MemoryIndex` into `RecordMemory` slot table and `AppendMemory` ID blob pool.
- Migrated `TypeRegistry` to standard `RegistryMemory` and `TextDataStore`/`CoActivationTracker` to `AppendMemory`/`RecordMemory`.
- Introduced `spector-inspect` CLI to validate SMKM headers.

### Phase 2: Unified WAL & Crash Recovery
- Created unified WAL schema and intercepted mutations across all kernel shapes.
- Hardened `WalRecoveryDispatcher` to replay shape-level mutations and re-populate the index on startup.
- Upgraded `CheckpointDaemon` to write snapshot marks and truncate older chunks safely.

### Phase 3: Namespace-Scoped LRU & FD Budget
- Implemented `NamespaceRegistry` utilizing an access-ordered LRU cache under a `ReentrantLock`.
- Added atomic lease tracking to `DefaultSpectorMemory` to protect active/in-progress namespaces from eviction.
- Added startup diagnostics via `UnixOperatingSystemMXBean` to warn if estimated FD usage exceeds 50% of bounds.

## Verification
- Verified all unit and integration tests compile and pass successfully (`1153 tests run, 0 failures`).
- All code styles and commit standards strictly adhered to.

Closes #364
Closes #365
Closes #366
Closes #367
Closes #368
Closes #369
Closes #370
Closes #371
Closes #201