### PR TITLE
refactor(memory): migrate EntityGraph to Memory Kernel shape (Issue #383)

### DIFF
--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/BenchmarkSetup.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/BenchmarkSetup.java
@@ -33,7 +33,7 @@ import com.spectrayan.spector.memory.DefaultSpectorMemory;
 import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
 import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.graph.EntityType;
 import com.spectrayan.spector.memory.graph.RelationType;
@@ -259,7 +259,7 @@ public final class BenchmarkSetup implements AutoCloseable {
      * @param relations entity relation definitions from the dataset
      * @param corpus    the corpus records (used for entity mention  ->  memory linking)
      */
-    void loadEntityGraph(EntityGraph graph, List<EntityRelation> relations,
+    void loadEntityGraph(EntityGraphMemory graph, List<EntityRelation> relations,
                          List<BenchmarkCorpusRecord> corpus) {
         // Build a lookup from memory ID to corpus index
         Map<String, Integer> idToIndex = new HashMap<>(corpus.size());

--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/ContributingSubsystem.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/ContributingSubsystem.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
@@ -113,7 +113,7 @@ public enum ContributingSubsystem {
             Set<String> baselineTop10,
             HebbianGraphBase hebbian,
             TemporalChainMemory temporal,
-            EntityGraph entity,
+            EntityGraphMemory entity,
             ScoreBreakdown breakdown,
             Map<String, Integer> idToSlot) {
 
@@ -221,7 +221,7 @@ public enum ContributingSubsystem {
      * that connects to a baseline seed's entity within 2 hops).
      */
     private static boolean isEntityReachable(int targetSlot, Set<String> baselineTop10,
-                                              EntityGraph entity, Map<String, Integer> idToSlot) {
+                                              EntityGraphMemory entity, Map<String, Integer> idToSlot) {
         // Collect all entity IDs that reference the target memory
         // and all entity IDs that reference baseline seeds, then check connectivity
 
@@ -249,7 +249,7 @@ public enum ContributingSubsystem {
     /**
      * Checks if a given entity has a memory reference to the specified slot.
      */
-    private static boolean entityReferencesMemory(EntityGraph entity, int entityId, int memorySlot) {
+    private static boolean entityReferencesMemory(EntityGraphMemory entity, int entityId, int memorySlot) {
         int refCount = entity.memoryRefCount(entityId);
         for (int i = 0; i < refCount; i++) {
             if (entity.memoryRefAt(entityId, i) == memorySlot) {

--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/GraphSnapshotCollector.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/GraphSnapshotCollector.java
@@ -19,7 +19,7 @@ import java.time.Instant;
 import java.util.List;
 
 import com.spectrayan.spector.memory.SpectorMemory;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.model.MemoryType;
@@ -83,7 +83,7 @@ public final class GraphSnapshotCollector {
         long entityDegreeSum = 0;
         int entityAdjHighWaterMark = 0;
 
-        EntityGraph eg = memory.admin().entityGraph();
+        EntityGraphMemory eg = memory.admin().entityGraph();
         if (eg != null) {
             entityCount = eg.entityCount();
             entityEdgeCount = eg.edgeCount();

--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/GraphStructureBenchmark.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/GraphStructureBenchmark.java
@@ -16,8 +16,8 @@
 package com.spectrayan.spector.bench.cognitive;
 
 import com.spectrayan.spector.memory.graph.EdgeImportance;
-import com.spectrayan.spector.memory.graph.EntityGraph;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 
@@ -249,7 +249,7 @@ public final class GraphStructureBenchmark {
         int hyperedgeCap = totalEdges; // one hyperedge per relationship
 
         long t0 = System.nanoTime();
-        HyperEntityGraph g = new HyperEntityGraph(entityCap, hyperedgeCap);
+        HyperEntityGraphMemory g = new HyperEntityGraphMemory(entityCap, hyperedgeCap);
         long allocNs = System.nanoTime() - t0;
 
         // Insert hyperedges (mix of 2-vertex and 3-vertex)
@@ -304,7 +304,7 @@ public final class GraphStructureBenchmark {
             long fileSize = Files.size(tmpFile);
 
             long loadStart = System.nanoTime();
-            HyperEntityGraph loaded = HyperEntityGraph.load(tmpFile, entityCap, hyperedgeCap);
+            HyperEntityGraphMemory loaded = HyperEntityGraphMemory.load(tmpFile, entityCap, hyperedgeCap);
             loadNs = System.nanoTime() - loadStart;
             loaded.close();
             Files.deleteIfExists(tmpFile);

--- a/bench/spector-bench/src/test/java/com/spectrayan/spector/bench/cognitive/GraphLoadingPropertyTest.java
+++ b/bench/spector-bench/src/test/java/com/spectrayan/spector/bench/cognitive/GraphLoadingPropertyTest.java
@@ -18,7 +18,7 @@ package com.spectrayan.spector.bench.cognitive;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.graph.EntityType;
 import com.spectrayan.spector.memory.graph.RelationType;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph;
@@ -136,7 +136,7 @@ class GraphLoadingPropertyTest {
     void entityRelation_createsTypedEdge(
             @ForAll("relationTypes") String relationType) {
 
-        EntityGraph graph = new EntityGraph(50, 50);
+        EntityGraphMemory graph = new EntityGraphMemory(50, 50);
 
         int entityA = graph.addEntity("Alice", "PERSON");
         int entityB = graph.addEntity("ProjectX", "PRODUCT");

--- a/bench/spector-bench/src/test/java/com/spectrayan/spector/bench/cognitive/GraphTraversalPropertyTest.java
+++ b/bench/spector-bench/src/test/java/com/spectrayan/spector/bench/cognitive/GraphTraversalPropertyTest.java
@@ -147,7 +147,7 @@ class GraphTraversalPropertyTest {
     void entityTraversal_respectsMaxHops(
             @ForAll @IntRange(min = 1, max = 2) int maxHops) {
 
-        var graph = new com.spectrayan.spector.memory.graph.EntityGraph(20, 20);
+        var graph = new com.spectrayan.spector.memory.graph.EntityGraphMemory(20, 20);
 
         // Build a graph: Entity0 → Entity1 → Entity2
         String entityType = "PERSON";

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -45,8 +45,8 @@ import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
 import com.spectrayan.spector.memory.graph.CognitiveGraphFacade;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.graph.LlmEntityExtractor;
 import com.spectrayan.spector.memory.graph.NoOpEntityExtractor;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
@@ -187,8 +187,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
     private final TemporalKnowledgeGraph temporalKnowledgeGraph;
-    private final EntityGraph entityGraph;
-    private final HyperEntityGraph hyperEntityGraph;
+    private final EntityGraphMemory entityGraph;
+    private final HyperEntityGraphMemory hyperEntityGraph;
     private final CognitiveGraphFacade graphFacade;
 
     //  Configuration 
@@ -1180,9 +1180,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     @SuppressWarnings("deprecation")
     @Override public TemporalChainMemory temporalChain() { return graphFacade.temporalChain(); }
     @SuppressWarnings("deprecation")
-    @Override public EntityGraph entityGraph() { return graphFacade.entityGraph(); }
+    @Override public EntityGraphMemory entityGraph() { return graphFacade.entityGraph(); }
     @SuppressWarnings("deprecation")
-    @Override public HyperEntityGraph hyperEntityGraph() { return graphFacade.hyperEntityGraph(); }
+    @Override public HyperEntityGraphMemory hyperEntityGraph() { return graphFacade.hyperEntityGraph(); }
     @Override public com.spectrayan.spector.index.VectorIndex semanticIndex() { return semanticIndex; }
     @Override public TemporalKnowledgeGraph temporalKnowledgeGraph() { return temporalKnowledgeGraph; }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PersistenceManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PersistenceManager.java
@@ -13,7 +13,7 @@
 package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
@@ -69,8 +69,8 @@ final class PersistenceManager {
                               MemoryIndex index,
                               HebbianGraphBase hebbianGraph,
                               TemporalChainMemory temporalChain,
-                              EntityGraph entityGraph,
-                              com.spectrayan.spector.memory.graph.HyperEntityGraph hyperEntityGraph,
+                              EntityGraphMemory entityGraph,
+                              com.spectrayan.spector.memory.graph.HyperEntityGraphMemory hyperEntityGraph,
                               CoActivationRecordMemory coActivationTracker,
                               TierRouter tierRouter,
                               MemoryWal wal) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
@@ -14,9 +14,9 @@ package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.memory.cortex.TierRouter;
 import com.spectrayan.spector.memory.error.SpectorGraphDecayException;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.graph.GraphHealthMetrics;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 // RelationType enum replaced by open-schema strings via TypeRegistry
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.hebbian.SynapticDecayModulator;
@@ -105,16 +105,16 @@ final class ReflectionOrchestrator {
     private final ReflectDaemon reflectDaemon;
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
-    private final EntityGraph entityGraph;
-    private final HyperEntityGraph hyperEntityGraph;
+    private final EntityGraphMemory entityGraph;
+    private final HyperEntityGraphMemory hyperEntityGraph;
     private final MemoryWal wal;
     private final int temporalRetentionDays;
 
     ReflectionOrchestrator(ReflectDaemon reflectDaemon,
                            HebbianGraphBase hebbianGraph,
                            TemporalChainMemory temporalChain,
-                           EntityGraph entityGraph,
-                           HyperEntityGraph hyperEntityGraph,
+                           EntityGraphMemory entityGraph,
+                           HyperEntityGraphMemory hyperEntityGraph,
                            MemoryWal wal,
                            int temporalRetentionDays) {
         this.reflectDaemon = reflectDaemon;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -15,7 +15,7 @@ package com.spectrayan.spector.memory;
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
@@ -15,8 +15,8 @@ package com.spectrayan.spector.memory;
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.memory.cortex.TierRouter;
 import com.spectrayan.spector.memory.graph.CognitiveGraphFacade;
-import com.spectrayan.spector.memory.graph.EntityGraph;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
@@ -117,11 +117,11 @@ public interface SpectorMemoryAdmin {
 
     /** @deprecated Use {@link #graph()} and its query methods instead. */
     @Deprecated(since = "1.1.0", forRemoval = true)
-    EntityGraph entityGraph();
+    EntityGraphMemory entityGraph();
 
     /** @deprecated Use {@link #graph()} and its query methods instead. */
     @Deprecated(since = "1.1.0", forRemoval = true)
-    HyperEntityGraph hyperEntityGraph();
+    HyperEntityGraphMemory hyperEntityGraph();
 
     // ══════════════════════════════════════════════════════════════
     // OPERATIONAL

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -24,8 +24,8 @@ import com.spectrayan.spector.ingestion.sensory.SensoryExtractor;
 import com.spectrayan.spector.memory.graph.EdgeImportance;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hippocampus.CircadianPolicy;
 import com.spectrayan.spector.memory.id.IdStrategy;
@@ -109,7 +109,7 @@ public final class SpectorMemoryBuilder {
     //  Edge importance configuration 
     EdgeImportance edgeImportance = EdgeImportance.DEFAULT;
     int hebbianMaxDegree = HebbianGraph.DEFAULT_MAX_DEGREE;
-    int entityMaxDegree = EntityGraph.DEFAULT_MAX_DEGREE;
+    int entityMaxDegree = EntityGraphMemory.DEFAULT_MAX_DEGREE;
 
     //  ID generation strategy 
     IdStrategy idStrategy = IdStrategy.TSID;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -45,9 +45,9 @@ import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
 import com.spectrayan.spector.memory.graph.CognitiveGraphFacade;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
-import com.spectrayan.spector.memory.graph.TypeRegistry;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.TypeRegistryMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.graph.LlmEntityExtractor;
 import com.spectrayan.spector.memory.graph.NoOpEntityExtractor;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
@@ -126,8 +126,8 @@ public final class SpectorMemoryFactory {
             HebbianGraphBase hebbianGraph,
             TemporalChainMemory temporalChain,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            EntityGraph entityGraph,
-            HyperEntityGraph hyperEntityGraph,
+            EntityGraphMemory entityGraph,
+            HyperEntityGraphMemory hyperEntityGraph,
             CognitiveGraphFacade graphFacade,
             MemoryIdGenerator idGenerator,
             CheckpointDaemon checkpointDaemon,
@@ -348,7 +348,7 @@ public final class SpectorMemoryFactory {
         }
 
         boolean entityEnabled = builder.entityExtractionMode != EntityExtractionMode.NONE;
-        EntityGraph entityGraph;
+        EntityGraphMemory entityGraph;
         if (entityEnabled) {
             int entityCap = builder.entityGraphCapacity;
             int edgeCap = entityCap * builder.entityMaxDegree;
@@ -360,39 +360,39 @@ public final class SpectorMemoryFactory {
 
                 Path loadFrom = getNewerPath(runtimeEntity, v2Entity, legacyEntity);
                 if (loadFrom != null) {
-                    entityGraph = EntityGraph.load(loadFrom, entityCap, edgeCap);
+                    entityGraph = EntityGraphMemory.load(loadFrom, entityCap, edgeCap);
                 } else {
-                    entityGraph = new EntityGraph(runtimeEntity, entityCap, edgeCap,
+                    entityGraph = new EntityGraphMemory(runtimeEntity, entityCap, edgeCap,
                             builder.entityMaxDegree, builder.edgeImportance);
                 }
             } else {
-                entityGraph = new EntityGraph(entityCap, edgeCap,
+                entityGraph = new EntityGraphMemory(entityCap, edgeCap,
                         builder.entityMaxDegree, builder.edgeImportance);
             }
         } else {
             entityGraph = null;
         }
 
-        HyperEntityGraph hyperEntityGraph;
+        HyperEntityGraphMemory hyperEntityGraph;
         if (entityEnabled && builder.hyperEntityGraphEnabled) {
             int hyperCap = builder.entityGraphCapacity;
             int hyperEdgeCap = hyperCap * 2;
             if (isDisk && basePath != null) {
                 Path hyperPath = StorageLayout.hyperEntityGraphRuntime(basePath);
                 if (java.nio.file.Files.exists(hyperPath)) {
-                    hyperEntityGraph = HyperEntityGraph.load(hyperPath, hyperCap, hyperEdgeCap);
+                    hyperEntityGraph = HyperEntityGraphMemory.load(hyperPath, hyperCap, hyperEdgeCap);
                 } else {
-                    hyperEntityGraph = new HyperEntityGraph(hyperCap, hyperEdgeCap);
+                    hyperEntityGraph = new HyperEntityGraphMemory(hyperCap, hyperEdgeCap);
                 }
             } else {
-                hyperEntityGraph = new HyperEntityGraph(hyperCap, hyperEdgeCap);
+                hyperEntityGraph = new HyperEntityGraphMemory(hyperCap, hyperEdgeCap);
             }
         } else {
             hyperEntityGraph = null;
         }
 
         TemporalKnowledgeGraph temporalKnowledgeGraph;
-        TypeRegistry predRegistry = (entityGraph != null) ? entityGraph.relationTypeRegistry() : new TypeRegistry("relation-type");
+        TypeRegistryMemory predRegistry = (entityGraph != null) ? entityGraph.relationTypeRegistry() : new TypeRegistryMemory("relation-type");
         if (isDisk && basePath != null) {
             Path runtimeTkg = StorageLayout.temporalFactsRuntime(basePath);
             long initialSize = 16L * 1024 * 1024; // 16MB
@@ -714,7 +714,7 @@ public final class SpectorMemoryFactory {
             HebbianGraphBase hebbianGraph,
             TemporalChainMemory temporalChain,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            EntityGraph entityGraph,
+            EntityGraphMemory entityGraph,
             CoActivationRecordMemory coActivationTracker,
             CognitiveIngestionTarget cognitiveTarget,
             Path basePath) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
@@ -16,7 +16,7 @@ import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.memory.cortex.AbstractTierStore;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.MemoryType;
@@ -61,7 +61,7 @@ public final class ConsolidationService {
      * Executes the consolidation cycle across the semantic store.
      */
     public void consolidate(TierRouter tierRouter, MemoryIndex index, ScalarQuantizer quantizer,
-                            EntityGraph entityGraph, CognitiveIngestionTarget ingestionTarget,
+                            EntityGraphMemory entityGraph, CognitiveIngestionTarget ingestionTarget,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
         AbstractTierStore semanticStore = (AbstractTierStore) tierRouter.semantic();
         if (semanticStore == null || semanticStore.visibleCount() < 2) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacade.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacade.java
@@ -51,14 +51,14 @@ public final class CognitiveGraphFacade {
 
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
-    private final EntityGraph entityGraph;
-    private final HyperEntityGraph hyperEntityGraph;
+    private final EntityGraphMemory entityGraph;
+    private final HyperEntityGraphMemory hyperEntityGraph;
     private final MemoryIndex index;
 
     public CognitiveGraphFacade(HebbianGraphBase hebbianGraph,
                                 TemporalChainMemory temporalChain,
-                                EntityGraph entityGraph,
-                                HyperEntityGraph hyperEntityGraph,
+                                EntityGraphMemory entityGraph,
+                                HyperEntityGraphMemory hyperEntityGraph,
                                 MemoryIndex index) {
         this.hebbianGraph = hebbianGraph;
         this.temporalChain = temporalChain;
@@ -81,11 +81,11 @@ public final class CognitiveGraphFacade {
 
     /** @deprecated Use {@link #graphStats()} or {@link #topologyStats()} instead. */
     @Deprecated(since = "1.1.0", forRemoval = true)
-    public EntityGraph entityGraph() { return entityGraph; }
+    public EntityGraphMemory entityGraph() { return entityGraph; }
 
     /** @deprecated Use {@link #topologyStats()} instead. */
     @Deprecated(since = "1.1.0", forRemoval = true)
-    public HyperEntityGraph hyperEntityGraph() { return hyperEntityGraph; }
+    public HyperEntityGraphMemory hyperEntityGraph() { return hyperEntityGraph; }
 
     // ══════════════════════════════════════════════════════════════
     // HIGH-LEVEL GRAPH QUERIES

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
@@ -88,9 +88,9 @@ import java.util.concurrent.locks.ReentrantLock;
  *     [memIdx:4B][weight:4B]
  * </pre>
  */
-public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.memory.kernel.shape.GraphMemory<com.spectrayan.spector.memory.kernel.layout.EntityLayout> {
+public final class EntityGraphMemory implements AutoCloseable, com.spectrayan.spector.memory.kernel.shape.GraphMemory<com.spectrayan.spector.memory.kernel.layout.EntityLayout> {
 
-    private static final Logger log = LoggerFactory.getLogger(EntityGraph.class);
+    private static final Logger log = LoggerFactory.getLogger(EntityGraphMemory.class);
 
 
 
@@ -193,9 +193,9 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
     private volatile DataEncryptor dataEncryptor;
 
     /** Open-schema entity type registry (String ↔ int). */
-    private final TypeRegistry entityTypeRegistry;
+    private final TypeRegistryMemory entityTypeRegistryMemory;
     /** Open-schema relation type registry (String ↔ int). */
-    private final TypeRegistry relationTypeRegistry;
+    private final TypeRegistryMemory relationTypeRegistryMemory;
 
     /** Maximum edges per entity (configurable via constructor). */
     private final int maxDegree;
@@ -217,7 +217,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
      * @param entityCapacity maximum number of entities
      * @param edgeCapacity   maximum number of edges
      */
-    public EntityGraph(int entityCapacity, int edgeCapacity) {
+    public EntityGraphMemory(int entityCapacity, int edgeCapacity) {
         this(entityCapacity, edgeCapacity, DEFAULT_MAX_DEGREE, EdgeImportance.DEFAULT);
     }
 
@@ -229,7 +229,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
      * @param maxDegree      maximum edges per entity
      * @param edgeImportance edge importance scorer
      */
-    public EntityGraph(int entityCapacity, int edgeCapacity, int maxDegree, EdgeImportance edgeImportance) {
+    public EntityGraphMemory(int entityCapacity, int edgeCapacity, int maxDegree, EdgeImportance edgeImportance) {
         this.entityCapacity = entityCapacity;
         this.edgeCapacity = edgeCapacity;
         this.maxDegree = maxDegree;
@@ -249,8 +249,8 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
         this.fileBacked = false;
         this.mappedChannel = null;
         this.mmapFilePath = null;
-        this.entityTypeRegistry = TypeRegistry.seeded("entity-type", EntityType.SEED);
-        this.relationTypeRegistry = TypeRegistry.seeded("relation-type", RelationType.SEED);
+        this.entityTypeRegistryMemory = TypeRegistryMemory.seeded("entity-type", EntityType.SEED);
+        this.relationTypeRegistryMemory = TypeRegistryMemory.seeded("relation-type", RelationType.SEED);
         this.memoryId = MemoryId.of("graph", "entity");
 
         log.info("EntityGraph initialized (heap): entities={}, edges={}, maxDegree={}, adjSlots={}, memory={}KB",
@@ -263,7 +263,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
     /**
      * Creates or opens a file-backed (mmap) entity graph with default max degree.
      */
-    public EntityGraph(Path filePath, int entityCapacity, int edgeCapacity) {
+    public EntityGraphMemory(Path filePath, int entityCapacity, int edgeCapacity) {
         this(filePath, entityCapacity, edgeCapacity, DEFAULT_MAX_DEGREE, EdgeImportance.DEFAULT);
     }
 
@@ -282,7 +282,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
      * @param maxDegree      maximum edges per entity
      * @param edgeImportance edge importance scorer
      */
-    public EntityGraph(Path filePath, int entityCapacity, int edgeCapacity,
+    public EntityGraphMemory(Path filePath, int entityCapacity, int edgeCapacity,
                        int maxDegree, EdgeImportance edgeImportance) {
         this.maxDegree = maxDegree;
         this.edgeImportance = edgeImportance;
@@ -397,13 +397,13 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
 
             // Load TypeRegistries from sidecar files if present
             if (parent != null) {
-                this.entityTypeRegistry = TypeRegistry.load(
+                this.entityTypeRegistryMemory = TypeRegistryMemory.load(
                         StorageLayout.entityTypes(parent), "entity-type", EntityType.SEED);
-                this.relationTypeRegistry = TypeRegistry.load(
+                this.relationTypeRegistryMemory = TypeRegistryMemory.load(
                         StorageLayout.relationTypes(parent), "relation-type", RelationType.SEED);
             } else {
-                this.entityTypeRegistry = TypeRegistry.seeded("entity-type", EntityType.SEED);
-                this.relationTypeRegistry = TypeRegistry.seeded("relation-type", RelationType.SEED);
+                this.entityTypeRegistryMemory = TypeRegistryMemory.seeded("entity-type", EntityType.SEED);
+                this.relationTypeRegistryMemory = TypeRegistryMemory.seeded("relation-type", RelationType.SEED);
             }
             this.memoryId = MemoryId.of("graph", "entity");
 
@@ -431,39 +431,26 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
         ch.write(header);
     }
 
-    /**
-     * Creates a new entity graph with default edge capacity.
-     *
-     * @param entityCapacity maximum number of entities
-     */
-    public EntityGraph(int entityCapacity) {
+    public EntityGraphMemory(int entityCapacity) {
         this(entityCapacity, entityCapacity * DEFAULT_MAX_DEGREE);
     }
 
-    /**
-     * Package-private factory for constructing a graph from pre-loaded segments.
-     * Used by {@link EntityGraphSerializer#load}.
-     */
-    static EntityGraph fromLoaded(int entityCapacity, int edgeCapacity, int entityCount, int edgeCount,
+    static EntityGraphMemory fromLoaded(int entityCapacity, int edgeCapacity, int entityCount, int edgeCount,
                                   Arena arena, MemorySegment entitySegment, MemorySegment edgeSegment,
                                   MemorySegment adjacencySegment, int adjSegmentCapacity, int adjHighWaterMark,
                                   ConcurrentHashMap<String, Integer> nameIndex,
-                                  TypeRegistry entityTypeRegistry, TypeRegistry relationTypeRegistry) {
-        return new EntityGraph(entityCapacity, edgeCapacity, entityCount, edgeCount,
+                                  TypeRegistryMemory entityTypeRegistry, TypeRegistryMemory relationTypeRegistry) {
+        return new EntityGraphMemory(entityCapacity, edgeCapacity, entityCount, edgeCount,
                 arena, entitySegment, edgeSegment, adjacencySegment,
                 adjSegmentCapacity, adjHighWaterMark, nameIndex,
                 entityTypeRegistry, relationTypeRegistry);
     }
 
-
-    /**
-     * Private constructor for loading from pre-existing segments.
-     */
-    private EntityGraph(int entityCapacity, int edgeCapacity, int entityCount, int edgeCount,
+    private EntityGraphMemory(int entityCapacity, int edgeCapacity, int entityCount, int edgeCount,
                          Arena arena, MemorySegment entitySegment, MemorySegment edgeSegment,
                          MemorySegment adjacencySegment, int adjSegmentCapacity, int adjHighWaterMark,
                          ConcurrentHashMap<String, Integer> nameIndex,
-                         TypeRegistry entityTypeRegistry, TypeRegistry relationTypeRegistry) {
+                         TypeRegistryMemory entityTypeRegistryMemory, TypeRegistryMemory relationTypeRegistryMemory) {
         this.entityCapacity = entityCapacity;
         this.edgeCapacity = edgeCapacity;
         this.entityCount = entityCount;
@@ -481,8 +468,8 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
         this.fileBacked = false;
         this.mappedChannel = null;
         this.mmapFilePath = null;
-        this.entityTypeRegistry = entityTypeRegistry;
-        this.relationTypeRegistry = relationTypeRegistry;
+        this.entityTypeRegistryMemory = entityTypeRegistryMemory;
+        this.relationTypeRegistryMemory = relationTypeRegistryMemory;
         this.memoryId = MemoryId.of("graph", "entity");
     }
 
@@ -513,7 +500,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
             wal.appendGraphAddNode(memoryId.toString(), entityId, normalized, type);
         }
         long offset = (long) entityId * ENTITY_NODE_BYTES;
-        int typeId = entityTypeRegistry.getOrRegister(type);
+        int typeId = entityTypeRegistryMemory.getOrRegister(type);
 
         entitySegment.set(ValueLayout.JAVA_INT, offset + ENT_OFF_TYPE, typeId);
         entitySegment.set(ValueLayout.JAVA_LONG, offset + ENT_OFF_NAME_HASH, normalized.hashCode());
@@ -547,7 +534,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
             wal.appendAdjAddEdge(memoryId.toString(), fromEntity, toEntity, (type != null ? type : "OTHER").getBytes(StandardCharsets.UTF_8));
         }
 
-        int typeId = relationTypeRegistry.getOrRegister(type != null ? type : "OTHER");
+        int typeId = relationTypeRegistryMemory.getOrRegister(type != null ? type : "OTHER");
         long entityOffset = (long) fromEntity * ENTITY_NODE_BYTES;
         int degree = entitySegment.get(ValueLayout.JAVA_INT, entityOffset + ENT_OFF_DEGREE);
         int edgeStart = entitySegment.get(ValueLayout.JAVA_INT, entityOffset + ENT_OFF_EDGE_START);
@@ -933,7 +920,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
         if (entityId < 0 || entityId >= entityCount) return "OTHER";
         int typeId = entitySegment.get(ValueLayout.JAVA_INT,
                 (long) entityId * ENTITY_NODE_BYTES + ENT_OFF_TYPE);
-        return entityTypeRegistry.nameOf(typeId);
+        return entityTypeRegistryMemory.nameOf(typeId);
     }
 
     /**
@@ -955,7 +942,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
             int relTypeId = edgeSegment.get(ValueLayout.JAVA_INT, edgeOffset + EDGE_OFF_REL_TYPE);
             float weight = edgeSegment.get(ValueLayout.JAVA_FLOAT, edgeOffset + EDGE_OFF_WEIGHT);
 
-            String relType = relationTypeRegistry.nameOf(relTypeId);
+            String relType = relationTypeRegistryMemory.nameOf(relTypeId);
 
             result.add(new EntityEdge(target, relType, weight,
                     Byte.toUnsignedInt(edgeSegment.get(ValueLayout.JAVA_BYTE, edgeOffset + EDGE_OFF_BRIDGE_SCORE))));
@@ -1657,7 +1644,7 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
      * @param defaultEdgeCap    edge capacity if file doesn't exist
      * @return an EntityGraph (loaded or new)
      */
-    public static EntityGraph load(Path filePath, int defaultEntityCap, int defaultEdgeCap) {
+    public static EntityGraphMemory load(Path filePath, int defaultEntityCap, int defaultEdgeCap) {
         return EntityGraphSerializer.load(filePath, defaultEntityCap, defaultEdgeCap, null);
     }
 
@@ -1668,9 +1655,9 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
      * @param defaultEntityCap  entity capacity if file doesn't exist
      * @param defaultEdgeCap    edge capacity if file doesn't exist
      * @param encryptor         optional encryptor for name index decryption (null = no encryption)
-     * @return an EntityGraph (loaded or new)
+     * @return an EntityGraphMemory (loaded or new)
      */
-    public static EntityGraph load(Path filePath, int defaultEntityCap, int defaultEdgeCap,
+    public static EntityGraphMemory load(Path filePath, int defaultEntityCap, int defaultEdgeCap,
                                     DataEncryptor encryptor) {
         return EntityGraphSerializer.load(filePath, defaultEntityCap, defaultEdgeCap, encryptor);
     }
@@ -1684,8 +1671,8 @@ public final class EntityGraph implements AutoCloseable, com.spectrayan.spector.
     MemorySegment adjacencySegment() { return adjacencySegment; }
     int adjSegmentCapacity() { return adjSegmentCapacity; }
     ConcurrentHashMap<String, Integer> nameIndexInternal() { return nameIndex; }
-    public TypeRegistry entityTypeRegistry() { return entityTypeRegistry; }
-    public TypeRegistry relationTypeRegistry() { return relationTypeRegistry; }
+    public TypeRegistryMemory entityTypeRegistry() { return entityTypeRegistryMemory; }
+    public TypeRegistryMemory relationTypeRegistry() { return relationTypeRegistryMemory; }
 
     /**
      * Resets all entities, edges, and adjacency data by zero-filling segments.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphSerializer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphSerializer.java
@@ -82,13 +82,13 @@ final class EntityGraphSerializer {
      * @param filePath  path to write
      * @param encryptor optional encryptor for name index (null = no encryption)
      */
-    static void save(EntityGraph graph, Path filePath, DataEncryptor encryptor) {
+    static void save(EntityGraphMemory graph, Path filePath, DataEncryptor encryptor) {
         Path parent = filePath.getParent();
         if (parent != null) {
             try {
                 Files.createDirectories(parent);
             } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("EntityGraph", parent, e);
+                throw new SpectorGraphPersistenceException("EntityGraphMemory", parent, e);
             }
         }
 
@@ -109,11 +109,11 @@ final class EntityGraphSerializer {
 
             // Write entity segment
             writeSegment(ch, graph.entitySegment(),
-                    (long) EntityGraph.ENTITY_NODE_BYTES * graph.entityCapacity());
+                    (long) EntityGraphMemory.ENTITY_NODE_BYTES * graph.entityCapacity());
 
             // Write edge segment
             writeSegment(ch, graph.edgeSegment(),
-                    (long) EntityGraph.EDGE_BYTES * graph.edgeCapacity());
+                    (long) EntityGraphMemory.EDGE_BYTES * graph.edgeCapacity());
 
             // Write adjacency segment header: [adjSegmentCapacity:4B][adjHighWaterMark:4B]
             ByteBuffer adjHeader = ByteBuffer.allocate(8);
@@ -125,7 +125,7 @@ final class EntityGraphSerializer {
             // Write adjacency segment data (only up to high water mark)
             if (graph.adjHighWaterMark() > 0) {
                 writeSegment(ch, graph.adjacencySegment(),
-                        (long) EntityGraph.ADJ_ENTRY_BYTES * graph.adjHighWaterMark());
+                        (long) EntityGraphMemory.ADJ_ENTRY_BYTES * graph.adjHighWaterMark());
             }
 
             // Write name index (on-heap → serialized, optionally encrypted)
@@ -133,11 +133,11 @@ final class EntityGraphSerializer {
             writeNameIndex(ch, graph.nameIndexInternal(), encrypt, encryptor);
 
             ch.force(true);
-            log.info("EntityGraph saved: entities={}, edges={}, adjEntries={}, nameIndexEncrypted={} → {}",
+            log.info("EntityGraphMemory saved: entities={}, edges={}, adjEntries={}, nameIndexEncrypted={} → {}",
                     graph.entityCount(), graph.edgeCount(), graph.adjHighWaterMark(), encrypt, filePath);
 
         } catch (IOException e) {
-            throw new SpectorGraphPersistenceException("EntityGraph", filePath, e);
+            throw new SpectorGraphPersistenceException("EntityGraphMemory", filePath, e);
         }
 
         // Persist TypeRegistries alongside the graph file
@@ -148,9 +148,9 @@ final class EntityGraphSerializer {
 
     /**
      * Saves only the nameIndex and TypeRegistries as sidecar files.
-     * Used by mmap-backed EntityGraph where segments are already on disk.
+     * Used by mmap-backed EntityGraphMemory where segments are already on disk.
      */
-    static void saveNameIndexAndRegistries(EntityGraph graph, Path filePath, DataEncryptor encryptor) {
+    static void saveNameIndexAndRegistries(EntityGraphMemory graph, Path filePath, DataEncryptor encryptor) {
         Path parent = filePath.getParent();
         if (parent == null) return;
 
@@ -159,7 +159,7 @@ final class EntityGraphSerializer {
         try {
             Files.createDirectories(parent);
         } catch (IOException e) {
-            throw new SpectorGraphPersistenceException("EntityGraph", parent, e);
+            throw new SpectorGraphPersistenceException("EntityGraphMemory", parent, e);
         }
 
         boolean encrypt = encryptor != null && encryptor.isEnabled();
@@ -168,10 +168,10 @@ final class EntityGraphSerializer {
                 StandardOpenOption.TRUNCATE_EXISTING)) {
             writeNameIndex(ch, graph.nameIndexInternal(), encrypt, encryptor);
             ch.force(true);
-            log.info("EntityGraph name index saved: {} names, encrypted={} → {}",
+            log.info("EntityGraphMemory name index saved: {} names, encrypted={} → {}",
                     graph.nameIndexInternal().size(), encrypt, nameIndexPath);
         } catch (IOException e) {
-            throw new SpectorGraphPersistenceException("EntityGraph", nameIndexPath, e);
+            throw new SpectorGraphPersistenceException("EntityGraphMemory", nameIndexPath, e);
         }
 
         saveRegistries(graph, parent);
@@ -188,20 +188,20 @@ final class EntityGraphSerializer {
      * @param defaultEntityCap  entity capacity if file doesn't exist
      * @param defaultEdgeCap    edge capacity if file doesn't exist
      * @param encryptor         optional encryptor for name index decryption (null = no encryption)
-     * @return an EntityGraph (loaded or new)
+     * @return an EntityGraphMemory (loaded or new)
      */
-    static EntityGraph load(Path filePath, int defaultEntityCap, int defaultEdgeCap,
+    static EntityGraphMemory load(Path filePath, int defaultEntityCap, int defaultEdgeCap,
                             DataEncryptor encryptor) {
         if (filePath == null || !Files.exists(filePath)) {
-            log.info("EntityGraph file not found, creating fresh: {}", filePath);
-            return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+            log.info("EntityGraphMemory file not found, creating fresh: {}", filePath);
+            return new EntityGraphMemory(defaultEntityCap, defaultEdgeCap);
         }
 
         // Peek at magic to determine format: EGMM (mmap) vs EGPH (serialized)
         try (FileChannel peekCh = FileChannel.open(filePath, StandardOpenOption.READ)) {
             if (peekCh.size() < 4) {
-                log.warn("EntityGraph file too small ({}B), creating fresh", peekCh.size());
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+                log.warn("EntityGraphMemory file too small ({}B), creating fresh", peekCh.size());
+                return new EntityGraphMemory(defaultEntityCap, defaultEdgeCap);
             }
             ByteBuffer magicBuf = ByteBuffer.allocate(4);
             peekCh.read(magicBuf);
@@ -210,7 +210,7 @@ final class EntityGraphSerializer {
 
             if (magic == 0x45474D4D) { // EGMM — mmap format
                 peekCh.close();
-                EntityGraph graph = new EntityGraph(filePath, defaultEntityCap, defaultEdgeCap);
+                EntityGraphMemory graph = new EntityGraphMemory(filePath, defaultEntityCap, defaultEdgeCap);
                 // Load nameIndex from sidecar file
                 Path nameIndexPath = filePath.getParent() != null
                         ? filePath.getParent().resolve("entity-names.idx") : null;
@@ -218,7 +218,7 @@ final class EntityGraphSerializer {
                     try (FileChannel nameCh = FileChannel.open(nameIndexPath, StandardOpenOption.READ)) {
                         ConcurrentHashMap<String, Integer> names = readNameIndex(nameCh, encryptor);
                         graph.nameIndexInternal().putAll(names);
-                        log.info("EntityGraph name index loaded: {} names from {}",
+                        log.info("EntityGraphMemory name index loaded: {} names from {}",
                                 names.size(), nameIndexPath);
                     }
                 }
@@ -226,7 +226,7 @@ final class EntityGraphSerializer {
                 return graph;
             }
         } catch (Exception e) {
-            log.error("Failed to peek EntityGraph file: {}", e.getMessage());
+            log.error("Failed to peek EntityGraphMemory file: {}", e.getMessage());
         }
 
         // Fall through to EGPH (legacy serialized) format
@@ -236,14 +236,14 @@ final class EntityGraphSerializer {
     /**
      * Loads a graph from the legacy EGPH binary format (heap-allocated segments).
      */
-    private static EntityGraph loadLegacy(Path filePath, int defaultEntityCap, int defaultEdgeCap,
+    private static EntityGraphMemory loadLegacy(Path filePath, int defaultEntityCap, int defaultEdgeCap,
                                           DataEncryptor encryptor) {
 
         try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
             long fileSize = ch.size();
             if (fileSize < FILE_HEADER_BYTES) {
-                log.warn("EntityGraph file too small ({}B), creating fresh", fileSize);
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+                log.warn("EntityGraphMemory file too small ({}B), creating fresh", fileSize);
+                return new EntityGraphMemory(defaultEntityCap, defaultEdgeCap);
             }
 
             ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
@@ -258,31 +258,31 @@ final class EntityGraphSerializer {
             int edgCount = header.getInt();
 
             if (magic != FILE_MAGIC || version != FILE_VERSION) {
-                log.warn("Incompatible EntityGraph file (magic={}, version={}), creating fresh",
+                log.warn("Incompatible EntityGraphMemory file (magic={}, version={}), creating fresh",
                         Integer.toHexString(magic), version);
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+                return new EntityGraphMemory(defaultEntityCap, defaultEdgeCap);
             }
 
             // Validate file has enough data for the segments declared in the header
             long minExpectedBytes = FILE_HEADER_BYTES
-                    + (long) EntityGraph.ENTITY_NODE_BYTES * entityCap
-                    + (long) EntityGraph.EDGE_BYTES * edgeCap
+                    + (long) EntityGraphMemory.ENTITY_NODE_BYTES * entityCap
+                    + (long) EntityGraphMemory.EDGE_BYTES * edgeCap
                     + 8; // adjacency header (adjCap + adjHwm)
             if (fileSize < minExpectedBytes) {
-                log.warn("EntityGraph file truncated ({}B < expected {}B), creating fresh",
+                log.warn("EntityGraphMemory file truncated ({}B < expected {}B), creating fresh",
                         fileSize, minExpectedBytes);
-                return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+                return new EntityGraphMemory(defaultEntityCap, defaultEdgeCap);
             }
 
             Arena arena = Arena.ofShared();
 
             // Read entity segment
-            long entityBytes = (long) EntityGraph.ENTITY_NODE_BYTES * entityCap;
+            long entityBytes = (long) EntityGraphMemory.ENTITY_NODE_BYTES * entityCap;
             MemorySegment entSeg = arena.allocate(entityBytes);
             readSegment(ch, entSeg, entityBytes);
 
             // Read edge segment
-            long edgeBytes = (long) EntityGraph.EDGE_BYTES * edgeCap;
+            long edgeBytes = (long) EntityGraphMemory.EDGE_BYTES * edgeCap;
             MemorySegment edgSeg = arena.allocate(edgeBytes);
             readSegment(ch, edgSeg, edgeBytes);
 
@@ -294,10 +294,10 @@ final class EntityGraphSerializer {
             int adjHwm = adjHeaderBuf.getInt();
 
             // Read adjacency segment
-            MemorySegment adjSeg = arena.allocate((long) EntityGraph.ADJ_ENTRY_BYTES * adjCap);
+            MemorySegment adjSeg = arena.allocate((long) EntityGraphMemory.ADJ_ENTRY_BYTES * adjCap);
             adjSeg.fill((byte) 0);
             if (adjHwm > 0) {
-                readSegment(ch, adjSeg, (long) EntityGraph.ADJ_ENTRY_BYTES * adjHwm);
+                readSegment(ch, adjSeg, (long) EntityGraphMemory.ADJ_ENTRY_BYTES * adjHwm);
             }
 
             // Read name index (with encryption flag detection)
@@ -305,25 +305,25 @@ final class EntityGraphSerializer {
 
             // Load TypeRegistries — use persisted files if available, else seed from defaults
             Path graphParent = filePath.getParent();
-            TypeRegistry entityTypes = TypeRegistry.load(
+            TypeRegistryMemory entityTypes = TypeRegistryMemory.load(
                     StorageLayout.entityTypes(graphParent),
                     "entity-type", EntityType.SEED);
-            TypeRegistry relationTypes = TypeRegistry.load(
+            TypeRegistryMemory relationTypes = TypeRegistryMemory.load(
                     StorageLayout.relationTypes(graphParent),
                     "relation-type", RelationType.SEED);
 
-            EntityGraph graph = EntityGraph.fromLoaded(entityCap, edgeCap, entCount, edgCount,
+            EntityGraphMemory graph = EntityGraphMemory.fromLoaded(entityCap, edgeCap, entCount, edgCount,
                     arena, entSeg, edgSeg, adjSeg, adjCap, adjHwm, names,
                     entityTypes, relationTypes);
             graph.setDataEncryptor(encryptor);
-            log.info("EntityGraph loaded (legacy EGPH): entities={}, edges={}, adjEntries={}, encryptor={} from {}",
+            log.info("EntityGraphMemory loaded (legacy EGPH): entities={}, edges={}, adjEntries={}, encryptor={} from {}",
                     entCount, edgCount, adjHwm,
                     encryptor != null && encryptor.isEnabled() ? "enabled" : "none", filePath);
             return graph;
 
         } catch (Exception e) {
-            log.error("Failed to load EntityGraph, creating fresh: {}", e.getMessage());
-            return new EntityGraph(defaultEntityCap, defaultEdgeCap);
+            log.error("Failed to load EntityGraphMemory, creating fresh: {}", e.getMessage());
+            return new EntityGraphMemory(defaultEntityCap, defaultEdgeCap);
         }
     }
 
@@ -368,7 +368,7 @@ final class EntityGraphSerializer {
             blobLenBuf.flip();
             ch.write(blobLenBuf);
             ch.write(ByteBuffer.wrap(encrypted));
-            log.info("EntityGraph name index encrypted: {} names, {} plaintext bytes → {} encrypted bytes",
+            log.info("EntityGraphMemory name index encrypted: {} names, {} plaintext bytes → {} encrypted bytes",
                     nameIndex.size(), nameIndexBytes.length, encrypted.length);
         } else {
             ch.write(ByteBuffer.wrap(nameIndexBytes));
@@ -404,7 +404,7 @@ final class EntityGraphSerializer {
             blobBuf.get(encrypted);
 
             if (encryptor == null || !encryptor.isEnabled()) {
-                log.error("EntityGraph name index is encrypted but no encryptor available — names will be empty");
+                log.error("EntityGraphMemory name index is encrypted but no encryptor available — names will be empty");
                 return new ConcurrentHashMap<>();
             }
 
@@ -468,12 +468,12 @@ final class EntityGraphSerializer {
         return names;
     }
 
-    private static void saveRegistries(EntityGraph graph, Path parent) {
+    private static void saveRegistries(EntityGraphMemory graph, Path parent) {
         try {
             graph.entityTypeRegistry().save(StorageLayout.entityTypes(parent));
             graph.relationTypeRegistry().save(StorageLayout.relationTypes(parent));
         } catch (IOException e) {
-            log.error("Failed to save TypeRegistries alongside EntityGraph: {}", e.getMessage());
+            log.error("Failed to save TypeRegistries alongside EntityGraphMemory: {}", e.getMessage());
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
@@ -66,9 +66,9 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @see EntityGraph
  */
-public final class HyperEntityGraph implements AutoCloseable {
+public final class HyperEntityGraphMemory implements AutoCloseable {
 
-    private static final Logger log = LoggerFactory.getLogger(HyperEntityGraph.class);
+    private static final Logger log = LoggerFactory.getLogger(HyperEntityGraphMemory.class);
 
     // ── File Format ──
 
@@ -151,12 +151,12 @@ public final class HyperEntityGraph implements AutoCloseable {
     // ══════════════════════════════════════════════════════════════
 
     /**
-     * Creates a heap-allocated HyperEntityGraph.
+     * Creates a heap-allocated HyperEntityGraphMemory.
      *
      * @param entityCapacity    max number of entities
      * @param hyperedgeCapacity max number of hyperedges
      */
-    public HyperEntityGraph(int entityCapacity, int hyperedgeCapacity) {
+    public HyperEntityGraphMemory(int entityCapacity, int hyperedgeCapacity) {
         this.entityCapacity = entityCapacity;
         this.hyperedgeCapacity = hyperedgeCapacity;
         this.vertexCapacity = hyperedgeCapacity * MAX_VERTICES_PER_EDGE;
@@ -191,7 +191,7 @@ public final class HyperEntityGraph implements AutoCloseable {
                 + indexBytes
                 + (long) INCIDENCE_ENTRY_BYTES * incidenceCapacity) / 1024;
 
-        log.info("HyperEntityGraph initialized: entities={}, hyperedges={}, memory={}KB",
+        log.info("HyperEntityGraphMemory initialized: entities={}, hyperedges={}, memory={}KB",
                 entityCapacity, hyperedgeCapacity, totalKB);
     }
 
@@ -239,7 +239,7 @@ public final class HyperEntityGraph implements AutoCloseable {
         graphLock.lock();
         try {
             if (nextHyperedgeId >= hyperedgeCapacity) {
-                log.warn("HyperEntityGraph full: {} hyperedges at capacity", hyperedgeCapacity);
+                log.warn("HyperEntityGraphMemory full: {} hyperedges at capacity", hyperedgeCapacity);
                 return -1;
             }
 
@@ -418,7 +418,7 @@ public final class HyperEntityGraph implements AutoCloseable {
             }
 
             if (evicted > 0) {
-                log.debug("HyperEntityGraph decay: {} evicted (factor={}, min={}), {} remaining",
+                log.debug("HyperEntityGraphMemory decay: {} evicted (factor={}, min={}), {} remaining",
                         evicted, decayFactor, minWeight, totalHyperedges);
             }
             return evicted;
@@ -437,7 +437,7 @@ public final class HyperEntityGraph implements AutoCloseable {
 
     @Override
     public void close() {
-        log.info("HyperEntityGraph closing: {} hyperedges", totalHyperedges);
+        log.info("HyperEntityGraphMemory closing: {} hyperedges", totalHyperedges);
         arena.close();
     }
 
@@ -454,7 +454,7 @@ public final class HyperEntityGraph implements AutoCloseable {
             try {
                 Files.createDirectories(parent);
             } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("HyperEntityGraph", parent, e);
+                throw new SpectorGraphPersistenceException("HyperEntityGraphMemory", parent, e);
             }
         }
 
@@ -480,21 +480,21 @@ public final class HyperEntityGraph implements AutoCloseable {
             writeSegment(ch, vertices, (long) nextVertexOffset * VERTEX_BYTES);
 
             ch.force(true);
-            log.info("HyperEntityGraph saved: {} hyperedges, {} vertices, file={}",
+            log.info("HyperEntityGraphMemory saved: {} hyperedges, {} vertices, file={}",
                     totalHyperedges, nextVertexOffset, filePath);
 
         } catch (IOException e) {
-            throw new SpectorGraphPersistenceException("HyperEntityGraph", filePath, e);
+            throw new SpectorGraphPersistenceException("HyperEntityGraphMemory", filePath, e);
         }
     }
 
     /**
      * Loads a hypergraph from file, or creates a new one if not found.
      */
-    public static HyperEntityGraph load(Path filePath, int entityCapacity, int hyperedgeCapacity) {
+    public static HyperEntityGraphMemory load(Path filePath, int entityCapacity, int hyperedgeCapacity) {
         if (filePath == null || !Files.exists(filePath)) {
-            log.info("HyperEntityGraph file not found, creating fresh: {}", filePath);
-            return new HyperEntityGraph(entityCapacity, hyperedgeCapacity);
+            log.info("HyperEntityGraphMemory file not found, creating fresh: {}", filePath);
+            return new HyperEntityGraphMemory(entityCapacity, hyperedgeCapacity);
         }
 
         try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
@@ -505,9 +505,9 @@ public final class HyperEntityGraph implements AutoCloseable {
             int magic = header.getInt();
             int version = header.getInt();
             if (magic != FILE_MAGIC || version != FILE_VERSION) {
-                log.warn("Invalid HyperEntityGraph file: magic=0x{}, version={}", 
+                log.warn("Invalid HyperEntityGraphMemory file: magic=0x{}, version={}", 
                          Integer.toHexString(magic), version);
-                return new HyperEntityGraph(entityCapacity, hyperedgeCapacity);
+                return new HyperEntityGraphMemory(entityCapacity, hyperedgeCapacity);
             }
 
             int loadedEntityCap = header.getInt();
@@ -518,7 +518,7 @@ public final class HyperEntityGraph implements AutoCloseable {
             header.getInt(); // reserved
 
             // Create graph with loaded capacities
-            HyperEntityGraph graph = new HyperEntityGraph(
+            HyperEntityGraphMemory graph = new HyperEntityGraphMemory(
                     Math.max(loadedEntityCap, entityCapacity),
                     Math.max(loadedHedgeCap, hyperedgeCapacity));
 
@@ -533,12 +533,12 @@ public final class HyperEntityGraph implements AutoCloseable {
             // Rebuild incidence lists from loaded data
             graph.rebuildIncidenceLists();
 
-            log.info("HyperEntityGraph loaded: {} hyperedges, file={}", loadedTotal, filePath);
+            log.info("HyperEntityGraphMemory loaded: {} hyperedges, file={}", loadedTotal, filePath);
             return graph;
 
         } catch (Exception e) {
-            log.error("Failed to load HyperEntityGraph from {}: {}", filePath, e.getMessage());
-            return new HyperEntityGraph(entityCapacity, hyperedgeCapacity);
+            log.error("Failed to load HyperEntityGraphMemory from {}: {}", filePath, e.getMessage());
+            return new HyperEntityGraphMemory(entityCapacity, hyperedgeCapacity);
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistryMemory.java
@@ -39,9 +39,9 @@ import com.spectrayan.spector.commons.error.SpectorStorageException;
 /**
  * Thread-safe, open-schema string ↔ integer type registry, backed by the Memory Kernel shape RegistryMemory.
  */
-public final class TypeRegistry implements RegistryMemory {
+public final class TypeRegistryMemory implements RegistryMemory {
 
-    private static final Logger log = LoggerFactory.getLogger(TypeRegistry.class);
+    private static final Logger log = LoggerFactory.getLogger(TypeRegistryMemory.class);
 
     /** Legacy File magic: "TREG" in ASCII. */
     private static final int LEGACY_FILE_MAGIC = 0x54524547;
@@ -55,7 +55,7 @@ public final class TypeRegistry implements RegistryMemory {
      *
      * @param label descriptive label for logging (e.g., "entity-type", "relation-type")
      */
-    public TypeRegistry(String label) {
+    public TypeRegistryMemory(String label) {
         this.label = label;
         MemoryId registryId = MemoryId.of("graph", label);
         RegistryLayout layout = new RegistryLayout();
@@ -66,8 +66,8 @@ public final class TypeRegistry implements RegistryMemory {
     /**
      * Creates a registry pre-seeded with the given well-known types.
      */
-    public static TypeRegistry seeded(String label, String... seedTypes) {
-        TypeRegistry registry = new TypeRegistry(label);
+    public static TypeRegistryMemory seeded(String label, String... seedTypes) {
+        TypeRegistryMemory registry = new TypeRegistryMemory(label);
         for (String type : seedTypes) {
             registry.intern(type);
         }
@@ -192,7 +192,7 @@ public final class TypeRegistry implements RegistryMemory {
         log.info("{} registry saved (SMKM V1): {} types → {}", label, currentEntries.size(), filePath);
     }
 
-    public static TypeRegistry load(Path filePath, String label, String... seedTypes) {
+    public static TypeRegistryMemory load(Path filePath, String label, String... seedTypes) {
         if (!Files.exists(filePath)) {
             log.info("{} registry file not found, creating seeded registry with {} types",
                     label, seedTypes.length);
@@ -211,7 +211,7 @@ public final class TypeRegistry implements RegistryMemory {
             boolean isStandard = (magic == MemoryHeader.MAGIC || magic == 0x4D4B4D53);
             boolean isLegacy = (magic == LEGACY_FILE_MAGIC || magic == 0x47455254);
 
-            TypeRegistry registry = new TypeRegistry(label);
+            TypeRegistryMemory registry = new TypeRegistryMemory(label);
 
             if (isStandard) {
                 MemoryId registryId = MemoryId.of("graph", label);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -24,8 +24,8 @@ import com.spectrayan.spector.memory.cortex.WorkingMemoryStore;
 import com.spectrayan.spector.memory.dopamine.FlashbulbPolicy;
 import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.graph.EntityRelation;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
@@ -112,8 +112,8 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
     private final EntityExtractor entityExtractor;
-    private final EntityGraph entityGraph;
-    private final HyperEntityGraph hyperEntityGraph;
+    private final EntityGraphMemory entityGraph;
+    private final HyperEntityGraphMemory hyperEntityGraph;
 
     //  BM25 Text Search (nullable  --  graceful degradation) 
     private final MemoryBM25Index bm25Index;
@@ -123,8 +123,6 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     //  SPLADE Sparse Search (nullable  --  graceful degradation) 
     private final MemorySpladeIndex spladeIndex;
     private final SparseEmbeddingProvider spladeProvider;
-
-    //  Data Encryption SPI (NOOP in OSS mode) 
     private final DataEncryptor encryptor;
 
     //  Salience Profile (NEUTRAL in OSS mode) 
@@ -154,8 +152,8 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      HebbianGraphBase hebbianGraph,
                                      TemporalChainMemory temporalChain,
                                      EntityExtractor entityExtractor,
-                                     EntityGraph entityGraph,
-                                     HyperEntityGraph hyperEntityGraph,
+                                     EntityGraphMemory entityGraph,
+                                     HyperEntityGraphMemory hyperEntityGraph,
                                      MemoryBM25Index bm25Index,
                                      TextAppendMemory textDataStore,
                                      int activePartitionIndex,
@@ -187,8 +185,8 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      HebbianGraphBase hebbianGraph,
                                      TemporalChainMemory temporalChain,
                                      EntityExtractor entityExtractor,
-                                     EntityGraph entityGraph,
-                                     HyperEntityGraph hyperEntityGraph,
+                                     EntityGraphMemory entityGraph,
+                                     HyperEntityGraphMemory hyperEntityGraph,
                                      MemoryBM25Index bm25Index,
                                      TextAppendMemory textDataStore,
                                      int activePartitionIndex,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -17,7 +17,7 @@ import com.spectrayan.spector.memory.error.SpectorEntityGraphException;
 import com.spectrayan.spector.memory.error.SpectorHebbianException;
 import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
@@ -72,7 +72,7 @@ final class GraphExpansionStage {
     // ── Dependencies (all nullable — graceful degradation) ──
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
-    private final EntityGraph entityGraph;
+    private final EntityGraphMemory entityGraph;
     private final EntityExtractor entityExtractor;
     private final GraphScoringPolicy graphScoringPolicy;
     private final MemoryIndex index;
@@ -82,7 +82,7 @@ final class GraphExpansionStage {
 
     GraphExpansionStage(HebbianGraphBase hebbianGraph,
                         TemporalChainMemory temporalChain,
-                        EntityGraph entityGraph,
+                        EntityGraphMemory entityGraph,
                         EntityExtractor entityExtractor,
                         GraphScoringPolicy graphScoringPolicy,
                         MemoryIndex index,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -24,9 +24,9 @@ import com.spectrayan.spector.memory.error.SpectorEntityGraphException;
 import com.spectrayan.spector.memory.error.SpectorHebbianException;
 import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.graph.EntityRelation;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
@@ -79,24 +79,24 @@ final class PostIngestSync {
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
     private final EntityExtractor entityExtractor;
-    private final EntityGraph entityGraph;
+    private final EntityGraphMemory entityGraph;
     private final MemoryBM25Index bm25Index;
     private final TextAppendMemory textDataStore;
     private final int activePartitionIndex;
     private final MemorySpladeIndex spladeIndex;
     private final SparseEmbeddingProvider spladeProvider;
     private final DataEncryptor encryptor;
-    private final HyperEntityGraph hyperEntityGraph;
+    private final HyperEntityGraphMemory hyperEntityGraph;
 
     PostIngestSync(TierRouter tierRouter, MemoryIndex index, MemoryWal wal,
                    VectorIndex semanticIndex,
                    HebbianGraphBase hebbianGraph, TemporalChainMemory temporalChain,
-                   EntityExtractor entityExtractor, EntityGraph entityGraph,
+                   EntityExtractor entityExtractor, EntityGraphMemory entityGraph,
                    MemoryBM25Index bm25Index, TextAppendMemory textDataStore,
                    int activePartitionIndex,
                    MemorySpladeIndex spladeIndex, SparseEmbeddingProvider spladeProvider,
                    DataEncryptor encryptor,
-                   HyperEntityGraph hyperEntityGraph) {
+                   HyperEntityGraphMemory hyperEntityGraph) {
         this.tierRouter = tierRouter;
         this.index = index;
         this.wal = wal;
@@ -370,15 +370,15 @@ final class PostIngestSync {
             // Create hyperedge for multi-entity co-occurrence (if >= 2 entities in this memory)
             if (hyperEntityGraph != null && entityIds.size() >= 2) {
                 int[] vertexArr = entityIds.stream().mapToInt(Integer::intValue).toArray();
-                if (vertexArr.length > HyperEntityGraph.MAX_VERTICES_PER_EDGE) {
-                    int[] truncated = new int[HyperEntityGraph.MAX_VERTICES_PER_EDGE];
-                    System.arraycopy(vertexArr, 0, truncated, 0, HyperEntityGraph.MAX_VERTICES_PER_EDGE);
+                if (vertexArr.length > HyperEntityGraphMemory.MAX_VERTICES_PER_EDGE) {
+                    int[] truncated = new int[HyperEntityGraphMemory.MAX_VERTICES_PER_EDGE];
+                    System.arraycopy(vertexArr, 0, truncated, 0, HyperEntityGraphMemory.MAX_VERTICES_PER_EDGE);
                     vertexArr = truncated;
                 }
                 int[] roles = new int[vertexArr.length];
                 // First entity gets SUBJECT role, rest get CONTEXT
-                roles[0] = HyperEntityGraph.ROLE_SUBJECT;
-                for (int r = 1; r < roles.length; r++) roles[r] = HyperEntityGraph.ROLE_CONTEXT;
+                roles[0] = HyperEntityGraphMemory.ROLE_SUBJECT;
+                for (int r = 1; r < roles.length; r++) roles[r] = HyperEntityGraphMemory.ROLE_CONTEXT;
                 hyperEntityGraph.addHyperedge(vertexArr, roles,
                         0, 1.0f, memoryIdx, System.currentTimeMillis());
             }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -59,7 +59,7 @@ import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 import com.spectrayan.spector.core.similarity.SimilarityFunction;
@@ -147,7 +147,7 @@ public final class RecallPipeline {
     //  3-Layer Cognitive Graph (all nullable) 
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
-    private final EntityGraph entityGraph;
+    private final EntityGraphMemory entityGraph;
     private final EntityExtractor entityExtractor;
 
     //  BM25 Text Search (nullable  --  graceful degradation) 
@@ -265,7 +265,7 @@ public final class RecallPipeline {
                            CoActivationRecordMemory coActivationTracker,
                            HebbianGraphBase hebbianGraph,
                            TemporalChainMemory temporalChain,
-                           EntityGraph entityGraph,
+                           EntityGraphMemory entityGraph,
                            EntityExtractor entityExtractor,
                            GraphScoringPolicy graphScoringPolicy,
                            MemoryBM25Index bm25Index,
@@ -317,7 +317,7 @@ public final class RecallPipeline {
                            CoActivationRecordMemory coActivationTracker,
                            HebbianGraphBase hebbianGraph,
                            TemporalChainMemory temporalChain,
-                           EntityGraph entityGraph,
+                           EntityGraphMemory entityGraph,
                            EntityExtractor entityExtractor,
                            GraphScoringPolicy graphScoringPolicy,
                            MemoryBM25Index bm25Index,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
@@ -14,12 +14,13 @@ package com.spectrayan.spector.memory.sync;
 
 import com.spectrayan.spector.events.EventBus;
 import com.spectrayan.spector.memory.StorageLayout;
-import com.spectrayan.spector.memory.graph.EntityGraph;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 
 import com.spectrayan.spector.memory.cortex.TierRouter;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 
 import org.slf4j.Logger;
@@ -93,8 +94,8 @@ public final class CheckpointDaemon {
     // ── 3-Layer Cognitive Graph + CoActivation ──
     private final HebbianGraphBase hebbianGraph;           // nullable
     private final TemporalChainMemory temporalChain;         // nullable
-    private final EntityGraph entityGraph;             // nullable
-    private final com.spectrayan.spector.memory.graph.HyperEntityGraph hyperEntityGraph; // nullable
+    private final EntityGraphMemory entityGraph;             // nullable
+    private final HyperEntityGraphMemory hyperEntityGraph; // nullable
     private final CoActivationRecordMemory coActivationTracker; // nullable
     private final Path partitionDir;                   // nullable — active partition dir for graph saves
     private final Path basePath;                       // nullable — persistence root for coactivation
@@ -139,8 +140,8 @@ public final class CheckpointDaemon {
                             MemoryIndex index, Path indexPath,
                             HebbianGraphBase hebbianGraph,
                             TemporalChainMemory temporalChain,
-                            EntityGraph entityGraph,
-                            com.spectrayan.spector.memory.graph.HyperEntityGraph hyperEntityGraph,
+                            EntityGraphMemory entityGraph,
+                            HyperEntityGraphMemory hyperEntityGraph,
                             CoActivationRecordMemory coActivationTracker,
                             Path partitionDir, Path basePath) {
         this.tierRouter = tierRouter;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
@@ -26,7 +26,7 @@ import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.shape.RecordMemory;
 import com.spectrayan.spector.memory.kernel.shape.AppendMemory;
 import com.spectrayan.spector.memory.kernel.shape.RegistryMemory;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 
@@ -111,7 +111,7 @@ public final class WalRecoveryDispatcher {
                         case ADJ_ADD_EDGE -> {
                             int from = payload.getInt();
                             int to = payload.getInt();
-                            if (target instanceof EntityGraph eg) {
+                            if (target instanceof EntityGraphMemory eg) {
                                 String relType = new String(event.payload(), 8, event.payload().length - 8, StandardCharsets.UTF_8);
                                 eg.addRelation(from, to, relType);
                             } else if (target instanceof HebbianGraphMemory hg) {
@@ -125,14 +125,14 @@ public final class WalRecoveryDispatcher {
                             String name = new String(event.payload(), 8, nameLen, StandardCharsets.UTF_8);
                             int typeLen = payload.getInt(8 + nameLen);
                             String type = new String(event.payload(), 8 + nameLen + 4, typeLen, StandardCharsets.UTF_8);
-                            if (target instanceof EntityGraph eg) {
+                            if (target instanceof EntityGraphMemory eg) {
                                 eg.addEntity(name, type);
                             }
                         }
                         case GRAPH_LINK_MEMORY -> {
                             int entityId = payload.getInt();
                             int memoryIdx = payload.getInt();
-                            if (target instanceof EntityGraph eg) {
+                            if (target instanceof EntityGraphMemory eg) {
                                 eg.linkEntityToMemory(entityId, memoryIdx);
                             }
                         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraph.java
@@ -27,7 +27,7 @@ import java.util.zip.CRC32C;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.spectrayan.spector.memory.graph.TypeRegistry;
+import com.spectrayan.spector.memory.graph.TypeRegistryMemory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.layout.TemporalFactLayout;
 import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
@@ -51,7 +51,7 @@ import com.spectrayan.spector.memory.temporal.index.ValidTimeIndex;
  *       {@link TemporalFactLayout} records — append-only, WAL-protected</li>
  *   <li>In-memory subject index: entity ID → fact offsets (rebuilt on open)</li>
  *   <li>In-memory valid-time index: epoch millis → fact offsets (rebuilt on open)</li>
- *   <li>Predicate interning via existing {@link TypeRegistry}</li>
+ *   <li>Predicate interning via existing {@link TypeRegistryMemory}</li>
  * </ul>
  *
  * <h3>Thread Safety</h3>
@@ -84,7 +84,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
     private final ValidTimeIndex validTimeIndex = new ValidTimeIndex();
 
     // ── Predicate interning ──
-    private final TypeRegistry predicateRegistry;
+    private final TypeRegistryMemory predicateRegistry;
 
     // ── Contradiction resolution ──
     private final ContradictionResolver resolver;
@@ -104,7 +104,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
      *
      * @param predicateRegistry type registry for predicate name interning
      */
-    public TemporalKnowledgeGraph(TypeRegistry predicateRegistry) {
+    public TemporalKnowledgeGraph(TypeRegistryMemory predicateRegistry) {
         this(predicateRegistry, new LatestTxWinsResolver());
     }
 
@@ -114,7 +114,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
      * @param predicateRegistry type registry for predicate name interning
      * @param resolver          contradiction resolution strategy
      */
-    public TemporalKnowledgeGraph(TypeRegistry predicateRegistry,
+    public TemporalKnowledgeGraph(TypeRegistryMemory predicateRegistry,
                                    ContradictionResolver resolver) {
         this.factLog = new TemporalFactsAppendMemory(DEFAULT_INITIAL_SIZE);
         this.predicateRegistry = predicateRegistry;
@@ -131,7 +131,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
      * @param predicateRegistry type registry for predicate name interning
      */
     public TemporalKnowledgeGraph(Path filePath, long initialSize,
-                                   TypeRegistry predicateRegistry) {
+                                   TypeRegistryMemory predicateRegistry) {
         this(filePath, initialSize, predicateRegistry, new LatestTxWinsResolver());
     }
 
@@ -144,7 +144,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
      * @param resolver          contradiction resolution strategy
      */
     public TemporalKnowledgeGraph(Path filePath, long initialSize,
-                                   TypeRegistry predicateRegistry,
+                                   TypeRegistryMemory predicateRegistry,
                                    ContradictionResolver resolver) {
         this.factLog = new TemporalFactsAppendMemory(filePath, initialSize);
         this.predicateRegistry = predicateRegistry;
@@ -164,7 +164,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
      * the subject and valid-time indexes for fast query evaluation.</p>
      *
      * @param subjectEntityId  entity ID of the subject (FK → EntityGraph)
-     * @param predicateName    predicate name (interned via TypeRegistry)
+     * @param predicateName    predicate name (interned via TypeRegistryMemory)
      * @param objectEntityId   entity ID of the object, or -1 for literal values
      * @param objectTextOffset text offset in TextDataStore, or -1 for entity objects
      * @param objectTextLength text length (max 32KB), or 0 for entity objects
@@ -303,7 +303,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
      *
      * @return the predicate type registry
      */
-    public TypeRegistry predicateRegistry() {
+    public TypeRegistryMemory predicateRegistry() {
         return predicateRegistry;
     }
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacadeTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacadeTest.java
@@ -37,8 +37,8 @@ class CognitiveGraphFacadeTest {
         // Arrange
         var hebbianGraph = mock(HebbianGraph.class);
         var temporalChain = mock(TemporalChainMemory.class);
-        var entityGraph = mock(EntityGraph.class);
-        var hyperEntityGraph = mock(HyperEntityGraph.class);
+        var entityGraph = mock(EntityGraphMemory.class);
+        var hyperEntityGraph = mock(HyperEntityGraphMemory.class);
         var index = mock(MemoryIndex.class);
 
         var facade = new CognitiveGraphFacade(

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/CrossCaptureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/CrossCaptureTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for STC Cross-Capture: {@link EntityGraph#boostEdgeWeight} and
+ * Tests for STC Cross-Capture: {@link EntityGraphMemory#boostEdgeWeight} and
  * {@link GraphHealthMetrics#recordCrossCapture}.
  *
  * <p>Verifies that the Synaptic Tagging and Capture mechanism correctly
@@ -28,11 +28,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class CrossCaptureTest {
 
-    private EntityGraph graph;
+    private EntityGraphMemory graph;
 
     @BeforeEach
     void setUp() {
-        graph = new EntityGraph(100, 500);
+        graph = new EntityGraphMemory(100, 500);
     }
 
     @AfterEach
@@ -90,7 +90,7 @@ class CrossCaptureTest {
         }
 
         var edges = graph.edges(alice);
-        assertThat(edges.getFirst().weight()).isEqualTo(EntityGraph.MAX_EDGE_WEIGHT);
+        assertThat(edges.getFirst().weight()).isEqualTo(EntityGraphMemory.MAX_EDGE_WEIGHT);
     }
 
     @Test

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/EntityGraphMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/EntityGraphMemoryTest.java
@@ -24,18 +24,18 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for EntityGraph: entity management, relations, traversal, and persistence.
+ * Tests for EntityGraphMemory: entity management, relations, traversal, and persistence.
  */
-class EntityGraphTest {
+class EntityGraphMemoryTest {
 
     @TempDir
     Path tempDir;
 
-    private EntityGraph graph;
+    private EntityGraphMemory graph;
 
     @BeforeEach
     void setUp() {
-        graph = new EntityGraph(100, 500);
+        graph = new EntityGraphMemory(100, 500);
     }
 
     @AfterEach
@@ -94,7 +94,7 @@ class EntityGraphTest {
 
         graph.addRelation(alice, project, "MANAGES");
 
-        List<EntityGraph.EntityEdge> edges = graph.edges(alice);
+        List<EntityGraphMemory.EntityEdge> edges = graph.edges(alice);
         assertThat(edges).hasSize(1);
         assertThat(edges.get(0).targetEntityId()).isEqualTo(project);
         assertThat(edges.get(0).relationType()).isEqualTo("MANAGES");
@@ -109,7 +109,7 @@ class EntityGraphTest {
         graph.addRelation(alice, project, "MANAGES");
         graph.addRelation(alice, project, "MANAGES");
 
-        List<EntityGraph.EntityEdge> edges = graph.edges(alice);
+        List<EntityGraphMemory.EntityEdge> edges = graph.edges(alice);
         assertThat(edges).hasSize(1);
         assertThat(edges.get(0).weight()).isEqualTo(2.0f);
     }
@@ -268,7 +268,7 @@ class EntityGraphTest {
         graph.save(file);
         graph.close();
 
-        graph = EntityGraph.load(file, 100, 500);
+        graph = EntityGraphMemory.load(file, 100, 500);
         assertThat(graph.entityCount()).isEqualTo(2);
         assertThat(graph.findEntity("alice")).isEqualTo(0);
         assertThat(graph.findEntity("project alpha")).isEqualTo(1);
@@ -287,7 +287,7 @@ class EntityGraphTest {
     void loadNonExistentFileCreatesNew() {
         Path file = tempDir.resolve("nonexistent.entity");
         graph.close();
-        graph = EntityGraph.load(file, 50, 200);
+        graph = EntityGraphMemory.load(file, 50, 200);
 
         assertThat(graph.entityCount()).isZero();
     }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemoryTest.java
@@ -12,8 +12,8 @@
  */
 package com.spectrayan.spector.memory.graph;
 
-import com.spectrayan.spector.memory.graph.HyperEntityGraph.HyperEdge;
-import com.spectrayan.spector.memory.graph.HyperEntityGraph.HyperEdgeVertex;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory.HyperEdge;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory.HyperEdgeVertex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,9 +25,9 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link HyperEntityGraph} — hyperedge-based entity graph.
+ * Tests for {@link HyperEntityGraphMemory} — hyperedge-based entity graph.
  */
-class HyperEntityGraphTest {
+class HyperEntityGraphMemoryTest {
 
     private static final int ENTITY_CAP = 100;
     private static final int HEDGE_CAP = 50;
@@ -35,10 +35,10 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("add and retrieve a 3-vertex hyperedge")
     void addAndRetrieveHyperedge() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             int edgeId = g.addHyperedge(
                     new int[]{0, 1, 2},
-                    new int[]{HyperEntityGraph.ROLE_SUBJECT, HyperEntityGraph.ROLE_OBJECT, HyperEntityGraph.ROLE_CONTEXT},
+                    new int[]{HyperEntityGraphMemory.ROLE_SUBJECT, HyperEntityGraphMemory.ROLE_OBJECT, HyperEntityGraphMemory.ROLE_CONTEXT},
                     42, 5.0f, 100, System.currentTimeMillis());
 
             assertThat(edgeId).isEqualTo(0);
@@ -52,18 +52,18 @@ class HyperEntityGraphTest {
             assertThat(edge.vertices()).hasSize(3);
 
             assertThat(edge.vertices().get(0).entityId()).isEqualTo(0);
-            assertThat(edge.vertices().get(0).roleId()).isEqualTo(HyperEntityGraph.ROLE_SUBJECT);
+            assertThat(edge.vertices().get(0).roleId()).isEqualTo(HyperEntityGraphMemory.ROLE_SUBJECT);
             assertThat(edge.vertices().get(1).entityId()).isEqualTo(1);
-            assertThat(edge.vertices().get(1).roleId()).isEqualTo(HyperEntityGraph.ROLE_OBJECT);
+            assertThat(edge.vertices().get(1).roleId()).isEqualTo(HyperEntityGraphMemory.ROLE_OBJECT);
             assertThat(edge.vertices().get(2).entityId()).isEqualTo(2);
-            assertThat(edge.vertices().get(2).roleId()).isEqualTo(HyperEntityGraph.ROLE_CONTEXT);
+            assertThat(edge.vertices().get(2).roleId()).isEqualTo(HyperEntityGraphMemory.ROLE_CONTEXT);
         }
     }
 
     @Test
     @DisplayName("findHyperedgesForEntity returns sorted by weight")
     void findHyperedgesForEntity() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             g.addHyperedge(new int[]{0, 1}, new int[]{1, 2}, 1, 2.0f, 1, 0);
             g.addHyperedge(new int[]{0, 2}, new int[]{1, 2}, 1, 5.0f, 2, 0);
             g.addHyperedge(new int[]{0, 3}, new int[]{1, 2}, 1, 3.0f, 3, 0);
@@ -80,7 +80,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("findCoOccurringEntities returns all related entities")
     void findCoOccurringEntities() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             // Entity 0 appears with 1, 2 in one hyperedge, and with 3 in another
             g.addHyperedge(new int[]{0, 1, 2}, new int[]{1, 2, 3}, 1, 1.0f, 1, 0);
             g.addHyperedge(new int[]{0, 3}, new int[]{1, 2}, 1, 1.0f, 2, 0);
@@ -93,7 +93,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("strengthen increases hyperedge weight")
     void strengthenHyperedge() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             int edgeId = g.addHyperedge(new int[]{0, 1}, new int[]{1, 2}, 1, 1.0f, 1, 0);
             g.strengthen(edgeId, 2.5f);
 
@@ -105,7 +105,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("decay removes weak hyperedges")
     void decayRemovesWeakEdges() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             g.addHyperedge(new int[]{0, 1}, new int[]{1, 2}, 1, 1.0f, 1, 0);   // weak
             g.addHyperedge(new int[]{0, 2}, new int[]{1, 2}, 1, 10.0f, 2, 0);  // strong
 
@@ -124,10 +124,10 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("binary edge is stored as 2-vertex hyperedge")
     void binaryEdgeAsTwoVertexHyperedge() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             int edgeId = g.addHyperedge(
                     new int[]{5, 10},
-                    new int[]{HyperEntityGraph.ROLE_SUBJECT, HyperEntityGraph.ROLE_OBJECT},
+                    new int[]{HyperEntityGraphMemory.ROLE_SUBJECT, HyperEntityGraphMemory.ROLE_OBJECT},
                     99, 7.0f, 42, 0);
 
             HyperEdge edge = g.getHyperedge(edgeId);
@@ -140,7 +140,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("rejects hyperedge with < 2 or > 8 vertices")
     void rejectsInvalidVertexCount() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             // Too few
             int id1 = g.addHyperedge(new int[]{0}, new int[]{1}, 1, 1.0f, 1, 0);
             assertThat(id1).isEqualTo(-1);
@@ -161,13 +161,13 @@ class HyperEntityGraphTest {
     void persistenceRoundTrip(@TempDir Path tmpDir) {
         Path filePath = tmpDir.resolve("hyperentity.hyeg");
 
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             g.addHyperedge(new int[]{0, 1, 2}, new int[]{1, 2, 3}, 10, 5.0f, 100, 12345L);
             g.addHyperedge(new int[]{3, 4}, new int[]{1, 2}, 20, 3.0f, 200, 67890L);
             g.save(filePath);
         }
 
-        try (var g = HyperEntityGraph.load(filePath, ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = HyperEntityGraphMemory.load(filePath, ENTITY_CAP, HEDGE_CAP)) {
             assertThat(g.totalHyperedges()).isEqualTo(2);
 
             HyperEdge e0 = g.getHyperedge(0);
@@ -194,14 +194,14 @@ class HyperEntityGraphTest {
     void incidenceRebuiltAfterLoad(@TempDir Path tmpDir) {
         Path filePath = tmpDir.resolve("hyperentity2.hyeg");
 
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             g.addHyperedge(new int[]{0, 1}, new int[]{1, 2}, 1, 1.0f, 1, 0);
             g.addHyperedge(new int[]{0, 2}, new int[]{1, 2}, 1, 2.0f, 2, 0);
             g.addHyperedge(new int[]{0, 1, 3}, new int[]{1, 2, 3}, 1, 3.0f, 3, 0);
             g.save(filePath);
         }
 
-        try (var g = HyperEntityGraph.load(filePath, ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = HyperEntityGraphMemory.load(filePath, ENTITY_CAP, HEDGE_CAP)) {
             // Entity 0 participates in all 3 hyperedges
             assertThat(g.findHyperedgesForEntity(0)).hasSize(3);
             // Entity 1 participates in 2 hyperedges
@@ -227,7 +227,7 @@ class HyperEntityGraphTest {
         int binaryEdges = relationships * 3;
 
         // Hyper: 10 relationships × 1 hyperedge = 10 hyperedges
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             for (int i = 0; i < relationships; i++) {
                 g.addHyperedge(
                         new int[]{i * 3, i * 3 + 1, i * 3 + 2},
@@ -247,7 +247,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("out-of-range entity IDs handled gracefully")
     void outOfRangeEntityIds() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             assertThat(g.findHyperedgesForEntity(-1)).isEmpty();
             assertThat(g.findHyperedgesForEntity(999)).isEmpty();
             assertThat(g.findCoOccurringEntities(-1)).isEmpty();
@@ -257,7 +257,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("getHyperedge returns null for invalid/deleted edges")
     void getHyperedgeInvalidReturnsNull() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             assertThat(g.getHyperedge(-1)).isNull();
             assertThat(g.getHyperedge(999)).isNull();
         }
@@ -266,7 +266,7 @@ class HyperEntityGraphTest {
     @Test
     @DisplayName("decay and find work correctly together")
     void decayAndFindIntegration() {
-        try (var g = new HyperEntityGraph(ENTITY_CAP, HEDGE_CAP)) {
+        try (var g = new HyperEntityGraphMemory(ENTITY_CAP, HEDGE_CAP)) {
             g.addHyperedge(new int[]{0, 1}, new int[]{1, 2}, 1, 1.0f, 1, 0);   // weak
             g.addHyperedge(new int[]{0, 2, 3}, new int[]{1, 2, 3}, 2, 10.0f, 2, 0); // strong
             g.addHyperedge(new int[]{0, 4}, new int[]{1, 2}, 3, 0.5f, 3, 0);    // very weak

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/TypeRegistryMemoryPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/TypeRegistryMemoryPersistenceTest.java
@@ -25,15 +25,15 @@ import java.nio.file.StandardOpenOption;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TypeRegistryPersistenceTest {
+class TypeRegistryMemoryPersistenceTest {
 
     @TempDir
     Path tempDir;
 
     @Test
-    @DisplayName("should save and load TypeRegistry in standard SMKM registry format")
+    @DisplayName("should save and load TypeRegistryMemory in standard SMKM registry format")
     void shouldSaveAndLoadRegistry() throws Exception {
-        TypeRegistry original = TypeRegistry.seeded("entity-type", "PERSON", "ORGANIZATION");
+        TypeRegistryMemory original = TypeRegistryMemory.seeded("entity-type", "PERSON", "ORGANIZATION");
         
         // Intern dynamic ones
         int codeId = original.intern("CODE");
@@ -46,7 +46,7 @@ class TypeRegistryPersistenceTest {
         assertThat(Files.exists(filePath)).isTrue();
 
         // Load
-        TypeRegistry loaded = TypeRegistry.load(filePath, "entity-type", "PERSON", "ORGANIZATION");
+        TypeRegistryMemory loaded = TypeRegistryMemory.load(filePath, "entity-type", "PERSON", "ORGANIZATION");
         
         assertThat(loaded.size()).isEqualTo(4);
         assertThat(loaded.nameOf(codeId)).isEqualTo("CODE");
@@ -93,7 +93,7 @@ class TypeRegistryPersistenceTest {
         }
 
         // 2. Load the legacy registry file
-        TypeRegistry registry = TypeRegistry.load(legacyFile, "entity-type", "PERSON");
+        TypeRegistryMemory registry = TypeRegistryMemory.load(legacyFile, "entity-type", "PERSON");
         
         // size should be 3 (PERSON seed + 2 migrated entries)
         assertThat(registry.size()).isEqualTo(3);
@@ -105,7 +105,7 @@ class TypeRegistryPersistenceTest {
         registry.save(legacyFile);
 
         // Load again and verify standard SMKM loading
-        TypeRegistry reloaded = TypeRegistry.load(legacyFile, "entity-type", "PERSON");
+        TypeRegistryMemory reloaded = TypeRegistryMemory.load(legacyFile, "entity-type", "PERSON");
         assertThat(reloaded.size()).isEqualTo(3);
         assertThat(reloaded.idOf("SOFTWARE")).isEqualTo(10);
         assertThat(reloaded.idOf("HARDWARE")).isEqualTo(11);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
@@ -34,7 +34,7 @@ import com.spectrayan.spector.memory.kernel.shape.DefaultRegistryMemory;
 import com.spectrayan.spector.memory.kernel.shape.RegistryLayout;
 import com.spectrayan.spector.memory.kernel.layout.IndexEntryLayout;
 import com.spectrayan.spector.memory.kernel.layout.IdBlobLayout;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
@@ -81,7 +81,7 @@ class WalRecoveryDispatcherTest {
                      MemoryId.of("test", "append"), new IdBlobLayout(), 10, 1000, appendFile);
              DefaultRegistryMemory registryMem = new DefaultRegistryMemory(
                      MemoryId.of("test", "registry"), new RegistryLayout(), 10, 1000, registryFile);
-             EntityGraph entityGraph = new EntityGraph(entityFile, 10, 20);
+             EntityGraphMemory entityGraph = new EntityGraphMemory(entityFile, 10, 20);
              TemporalChainMemory temporalChain = new TemporalChainMemory(chainFile, 10)) {
 
             recordMem.bindWal(wal);
@@ -121,7 +121,7 @@ class WalRecoveryDispatcherTest {
                      MemoryId.of("test", "append"), new IdBlobLayout(), 10, 1000, appendFile);
              DefaultRegistryMemory registryMem = new DefaultRegistryMemory(
                      MemoryId.of("test", "registry"), new RegistryLayout(), 10, 1000, registryFile);
-             EntityGraph entityGraph = new EntityGraph(entityFile, 10, 20);
+             EntityGraphMemory entityGraph = new EntityGraphMemory(entityFile, 10, 20);
              TemporalChainMemory temporalChain = new TemporalChainMemory(chainFile, 10);
              HebbianGraphMemory hebbianGraph = new HebbianGraphMemory(10)) {
 
@@ -144,7 +144,7 @@ class WalRecoveryDispatcherTest {
             // Mutate RegistryMemory
             registryMem.intern("CRASH_KEY");
 
-            // Mutate EntityGraph
+            // Mutate EntityGraphMemory
             int e1 = entityGraph.addEntity("CrashEntity1", "TypeA");
             int e2 = entityGraph.addEntity("CrashEntity2", "TypeB");
             entityGraph.addRelation(e1, e2, "REL");
@@ -179,7 +179,7 @@ class WalRecoveryDispatcherTest {
                      MemoryId.of("test", "append"), new IdBlobLayout(), 10, 1000, appendFile);
              DefaultRegistryMemory registryMem = new DefaultRegistryMemory(
                      MemoryId.of("test", "registry"), new RegistryLayout(), 10, 1000, registryFile);
-             EntityGraph entityGraph = new EntityGraph(entityFile, 10, 20);
+             EntityGraphMemory entityGraph = new EntityGraphMemory(entityFile, 10, 20);
              TemporalChainMemory temporalChain = new TemporalChainMemory(chainFile, 10);
              HebbianGraphMemory hebbianGraph = new HebbianGraphMemory(10)) {
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraphTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraphTest.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 
-import com.spectrayan.spector.memory.graph.TypeRegistry;
+import com.spectrayan.spector.memory.graph.TypeRegistryMemory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,12 +33,12 @@ class TemporalKnowledgeGraphTest {
     @TempDir
     Path tempDir;
 
-    private TypeRegistry predicateRegistry;
+    private TypeRegistryMemory predicateRegistry;
     private TemporalKnowledgeGraph tkg;
 
     @BeforeEach
     void setUp() {
-        predicateRegistry = new TypeRegistry("relation-type");
+        predicateRegistry = new TypeRegistryMemory("relation-type");
         tkg = new TemporalKnowledgeGraph(predicateRegistry);
     }
 

--- a/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.graph.EntityGraph;
+import com.spectrayan.spector.memory.graph.EntityGraphMemory;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;


### PR DESCRIPTION
## Summary of Changes

Migrates Phase 4 of the Spector Memory Kernel (SMK) Subsystem Migration (ADR-013 / Issue #383):

- **`EntityGraphMemory`**: Refactored `EntityGraph` -> `EntityGraphMemory` implementing `GraphMemory<EntityLayout>` and `AutoCloseable`. Backed by 112B entity node slots, 40B edge slots, and FFM mmap memory layout.
- **`HyperEntityGraphMemory`**: Refactored `HyperEntityGraph` -> `HyperEntityGraphMemory` for hyperedge co-occurrence storage.
- **`TypeRegistryMemory`**: Refactored `TypeRegistry` -> `TypeRegistryMemory` implementing `RegistryMemory`.
- **Subsystem & Pipeline Integration**: Updated `SpectorMemoryAdmin`, `DefaultSpectorMemory`, `SpectorMemoryFactory`, `PersistenceManager`, `CognitiveGraphFacade`, `ReflectionOrchestrator`, `RecallPipeline`, `WalRecoveryDispatcher`, `MeteredSpectorMemory`, `spector-bench`, and all unit test suites.

## Verification
- `mvn test-compile -DskipTests`: **`BUILD SUCCESS`** across all 26 modules.
- `mvn test -pl memory/spector-memory "-Dtest=EntityGraphMemoryTest,TypeRegistryMemoryPersistenceTest,HyperEntityGraphMemoryTest"`: **36 tests run, 0 failures, 0 errors**.

Closes #383.

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
