### PR TITLE
refactor(memory): migrate cognitive tier stores to AbstractRecordMemory (#380)

### DIFF
--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/CognitiveBenchmarkHarness.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/CognitiveBenchmarkHarness.java
@@ -629,7 +629,7 @@ public final class CognitiveBenchmarkHarness {
 
         TierStore store = tierRouter.get(primaryTier);
         MemorySegment segment = store.primarySegment();
-        CognitiveRecordLayout layout = store.layout();
+        CognitiveRecordLayout layout = store.cognitiveLayout();
         int recordCount = store.size();
 
         // Get calibration data from quantizer

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -32,12 +32,11 @@ import com.spectrayan.spector.memory.amygdala.ValenceTracker;
 import com.spectrayan.spector.memory.cortex.CentroidRouter;
 import com.spectrayan.spector.memory.cortex.EpisodicMemoryStore;
 import com.spectrayan.spector.memory.cortex.MemorySource;
-import com.spectrayan.spector.memory.cortex.ProceduralMemoryStore;
-import com.spectrayan.spector.memory.cortex.SemanticMemoryStore;
-
+import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.cortex.WorkingMemoryStore;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
 import com.spectrayan.spector.memory.cortex.TextAppendMemory;
 import com.spectrayan.spector.memory.dopamine.FlashbulbPolicy;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1246,7 +1246,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     public CompactionResult vacuum(MemoryType tier) {
         TierRouter router = partitionManager.tierRouter();
         com.spectrayan.spector.memory.cortex.TierStore store = router.get(tier);
-        if (!(store instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore ats)) {
+        if (!(store instanceof com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory ats)) {
             log.warn("Vacuum: tier {} is not compactable", tier);
             return null;
         }
@@ -1264,7 +1264,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         java.util.Map<MemoryType, Float> ratios = new java.util.EnumMap<>(MemoryType.class);
         for (MemoryType type : MemoryType.values()) {
             com.spectrayan.spector.memory.cortex.TierStore store = router.get(type);
-            if (store instanceof com.spectrayan.spector.memory.cortex.AbstractTierStore ats) {
+            if (store instanceof com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory ats) {
                 ratios.put(type, ats.tombstoneRatio());
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -13,10 +13,10 @@
 package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.memory.cortex.EpisodicMemoryStore;
-import com.spectrayan.spector.memory.cortex.ProceduralMemoryStore;
-import com.spectrayan.spector.memory.cortex.SemanticMemoryStore;
+import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.cortex.WorkingMemoryStore;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
@@ -178,16 +178,16 @@ final class PartitionManager {
                         StorageLayout.episodicMem(newPartition),
                         quantizedVecBytes, episodicPartitionCapacity);
 
-                ProceduralMemoryStore newProcedural = new ProceduralMemoryStore(
+                ProceduralRecordMemory newProcedural = new ProceduralRecordMemory(
                         quantizedVecBytes, proceduralCapacity,
                         StorageLayout.proceduralMem(newPartition));
 
-                SemanticMemoryStore newSemantic = new SemanticMemoryStore(
+                SemanticRecordMemory newSemantic = new SemanticRecordMemory(
                         quantizedVecBytes, semanticCapacity,
                         StorageLayout.semanticMem(newPartition));
 
                 // Preserve working memory (global, not partitioned)
-                WorkingMemoryStore workingStore = tierRouter.working();
+                WorkingRecordMemory workingStore = tierRouter.working();
 
                 // Flush index + graphs to runtime/ before rolling
                 flushGlobalState();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -615,7 +615,7 @@ public final class SpectorMemoryFactory {
             int stride = recLayout.stride();
             int vecBytes = recLayout.quantizedVecBytes();
             long baseOffset = semStore.filePath() != null
-                    ? com.spectrayan.spector.memory.cortex.AbstractTierStore.METADATA_HEADER_BYTES : 0;
+                    ? com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
 
             int rebuilt = 0;
             for (int i = 0; i < storeSize; i++) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -32,12 +32,11 @@ import com.spectrayan.spector.memory.amygdala.ValenceTracker;
 import com.spectrayan.spector.memory.cortex.CentroidRouter;
 import com.spectrayan.spector.memory.cortex.EpisodicMemoryStore;
 import com.spectrayan.spector.memory.cortex.MemorySource;
-import com.spectrayan.spector.memory.cortex.ProceduralMemoryStore;
-import com.spectrayan.spector.memory.cortex.SemanticMemoryStore;
-
+import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.cortex.WorkingMemoryStore;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
 import com.spectrayan.spector.memory.cortex.TextAppendMemory;
 import com.spectrayan.spector.memory.dopamine.FlashbulbPolicy;
@@ -210,31 +209,31 @@ public final class SpectorMemoryFactory {
 
         //  Tier stores 
         TierRouter tierRouter;
-        WorkingMemoryStore workingStore;
+        WorkingRecordMemory workingStore;
         if (isDisk && builder.persistWorkingMemory && basePath != null) {
-            workingStore = new WorkingMemoryStore(quantizedVecBytes, builder.workingCapacity,
+            workingStore = new WorkingRecordMemory(quantizedVecBytes, builder.workingCapacity,
                     StorageLayout.workingMem(basePath));
         } else {
-            workingStore = new WorkingMemoryStore(quantizedVecBytes, builder.workingCapacity);
+            workingStore = new WorkingRecordMemory(quantizedVecBytes, builder.workingCapacity);
         }
 
         if (isDisk && basePath != null && resolvedPartitionDir != null) {
             EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(
                     StorageLayout.episodicMem(resolvedPartitionDir),
                     quantizedVecBytes, builder.episodicPartitionCapacity);
-            ProceduralMemoryStore proceduralStore = new ProceduralMemoryStore(
+            ProceduralRecordMemory proceduralStore = new ProceduralRecordMemory(
                     quantizedVecBytes, builder.proceduralCapacity,
                     StorageLayout.proceduralMem(resolvedPartitionDir));
-            SemanticMemoryStore semanticStore = new SemanticMemoryStore(
+            SemanticRecordMemory semanticStore = new SemanticRecordMemory(
                     quantizedVecBytes, builder.semanticCapacity,
                     StorageLayout.semanticMem(resolvedPartitionDir));
             tierRouter = new TierRouter(workingStore, episodicStore, semanticStore, proceduralStore);
         } else {
             EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(
                     quantizedVecBytes, builder.episodicPartitionCapacity);
-            ProceduralMemoryStore proceduralStore = new ProceduralMemoryStore(
+            ProceduralRecordMemory proceduralStore = new ProceduralRecordMemory(
                     quantizedVecBytes, builder.proceduralCapacity);
-            SemanticMemoryStore semanticStore = new SemanticMemoryStore(
+            SemanticRecordMemory semanticStore = new SemanticRecordMemory(
                     quantizedVecBytes, builder.semanticCapacity);
             tierRouter = new TierRouter(workingStore, episodicStore, semanticStore, proceduralStore);
         }
@@ -745,20 +744,13 @@ public final class SpectorMemoryFactory {
         
         if (tierRouter != null) {
             if (tierRouter.working() != null) {
-                Memory<?> backing = tierRouter.working().backing();
-                memories.put(backing.id(), backing);
+                memories.put(tierRouter.working().id(), tierRouter.working());
             }
             if (tierRouter.semantic() != null) {
-                Memory<?> backing = tierRouter.semantic().backing();
-                memories.put(backing.id(), backing);
+                memories.put(tierRouter.semantic().id(), tierRouter.semantic());
             }
             if (tierRouter.procedural() != null) {
-                Memory<?> backing = tierRouter.procedural().backing();
-                memories.put(backing.id(), backing);
-            }
-            if (tierRouter.episodic() != null) {
-                Memory<?> backing = tierRouter.episodic().backing();
-                memories.put(backing.id(), backing);
+                memories.put(tierRouter.procedural().id(), tierRouter.procedural());
             }
         }
         

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
@@ -13,7 +13,7 @@
 package com.spectrayan.spector.memory.consolidation;
 
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
-import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TierRouter;
 import com.spectrayan.spector.memory.graph.EntityGraphMemory;
@@ -63,7 +63,7 @@ public final class ConsolidationService {
     public void consolidate(TierRouter tierRouter, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityGraphMemory entityGraph, CognitiveIngestionTarget ingestionTarget,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
-        AbstractTierStore semanticStore = (AbstractTierStore) tierRouter.semantic();
+        AbstractCognitiveRecordMemory semanticStore = (AbstractCognitiveRecordMemory) tierRouter.semantic();
         if (semanticStore == null || semanticStore.visibleCount() < 2) {
             log.debug("Consolidation: semantic store too small to run consolidation (visibleCount={})",
                     semanticStore == null ? 0 : semanticStore.visibleCount());
@@ -126,8 +126,8 @@ public final class ConsolidationService {
 
                 // Add CONTRADICTS relation in EntityGraph
                 if (entityGraph != null) {
-                    int slotA = (int) ((offsetA - (semanticStore.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L)) / layout.stride());
-                    int slotB = (int) ((offsetB - (semanticStore.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L)) / layout.stride());
+                    int slotA = (int) ((offsetA - (semanticStore.isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0L)) / layout.stride());
+                    int slotB = (int) ((offsetB - (semanticStore.isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0L)) / layout.stride());
 
                     List<Integer> entitiesA = memToEntities.get(slotA);
                     List<Integer> entitiesB = memToEntities.get(slotB);
@@ -196,7 +196,7 @@ public final class ConsolidationService {
         }
     }
 
-    private void tombstoneRecord(CognitiveRecord record, AbstractTierStore store, MemoryIndex index, MemoryWal wal) {
+    private void tombstoneRecord(CognitiveRecord record, AbstractCognitiveRecordMemory store, MemoryIndex index, MemoryWal wal) {
         MemorySegment segment = store.segment();
         CognitiveRecordLayout layout = store.cognitiveLayout();
         layout.tombstone(segment, record.byteOffset());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
@@ -116,7 +116,7 @@ public final class ConsolidationService {
 
                 // Set FLAG_CONTRADICTED in headers off-heap
                 MemorySegment segment = semanticStore.segment();
-                CognitiveRecordLayout layout = semanticStore.layout();
+                CognitiveRecordLayout layout = semanticStore.cognitiveLayout();
 
                 long offsetA = recordA.byteOffset();
                 long offsetB = recordB.byteOffset();
@@ -198,7 +198,7 @@ public final class ConsolidationService {
 
     private void tombstoneRecord(CognitiveRecord record, AbstractTierStore store, MemoryIndex index, MemoryWal wal) {
         MemorySegment segment = store.segment();
-        CognitiveRecordLayout layout = store.layout();
+        CognitiveRecordLayout layout = store.cognitiveLayout();
         layout.tombstone(segment, record.byteOffset());
 
         if (wal != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
@@ -56,7 +56,7 @@ public final class DuplicateDetector {
         }
 
         MemorySegment segment = store.segment();
-        CognitiveRecordLayout layout = store.layout();
+        CognitiveRecordLayout layout = store.cognitiveLayout();
         long baseOffset = store.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L;
         int stride = layout.stride();
         int vecBytes = layout.quantizedVecBytes();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
@@ -14,7 +14,7 @@ package com.spectrayan.spector.memory.consolidation;
 
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.core.similarity.SimilarityFunction;
-import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
@@ -48,7 +48,7 @@ public final class DuplicateDetector {
     /**
      * Scans the given store for duplicate pairs.
      */
-    public List<DuplicatePair> findDuplicates(AbstractTierStore store, MemoryIndex index, ScalarQuantizer quantizer) {
+    public List<DuplicatePair> findDuplicates(AbstractCognitiveRecordMemory store, MemoryIndex index, ScalarQuantizer quantizer) {
         List<DuplicatePair> pairs = new ArrayList<>();
         int recordCount = store.visibleCount();
         if (recordCount < 2) {
@@ -57,7 +57,7 @@ public final class DuplicateDetector {
 
         MemorySegment segment = store.segment();
         CognitiveRecordLayout layout = store.cognitiveLayout();
-        long baseOffset = store.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0L;
+        long baseOffset = store.isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0L;
         int stride = layout.stride();
         int vecBytes = layout.quantizedVecBytes();
         float[] mins = quantizer.mins();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemory.java
@@ -39,18 +39,18 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 /**
- * Abstract base class for single-segment tier stores.
+ * Abstract base class for cognitive record memory stores (Prefrontal, Neocortex, Basal Ganglia).
  *
  * <p>Extends {@link AbstractRecordMemory} directly with {@link CognitiveRecordLayoutAdapter}
- * per ADR-013.</p>
+ * per ADR-013, completely replacing legacy {@code AbstractTierStore} nomenclature.</p>
  *
  * @see TierStore for the common interface
  */
-public abstract class AbstractTierStore 
+public abstract class AbstractCognitiveRecordMemory 
         extends AbstractRecordMemory<CognitiveRecordLayoutAdapter> 
         implements TierStore {
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractTierStore.class);
+    private static final Logger log = LoggerFactory.getLogger(AbstractCognitiveRecordMemory.class);
 
     private volatile MemoryId memoryId;
     private final CognitiveRecordLayoutAdapter layoutAdapter;
@@ -79,7 +79,7 @@ public abstract class AbstractTierStore
     static {
         try {
             VISIBLE_COUNT_HANDLE = MethodHandles.lookup()
-                    .findVarHandle(AbstractTierStore.class, "maxVisibleRecord", int.class);
+                    .findVarHandle(AbstractCognitiveRecordMemory.class, "maxVisibleRecord", int.class);
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -132,11 +132,11 @@ public abstract class AbstractTierStore
     /**
      * Volatile constructor — allocates a single contiguous off-heap segment (no file).
      */
-    protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes) {
+    protected AbstractCognitiveRecordMemory(int quantizedVecBytes, int capacity, long segmentBytes) {
         this(quantizedVecBytes, capacity, segmentBytes, Arena.ofShared());
     }
 
-    private AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes, Arena sharedArena) {
+    private AbstractCognitiveRecordMemory(int quantizedVecBytes, int capacity, long segmentBytes, Arena sharedArena) {
         this(new CognitiveRecordLayout(quantizedVecBytes),
              new CognitiveRecordLayoutAdapter(new CognitiveRecordLayout(quantizedVecBytes)),
              capacity, sharedArena,
@@ -147,15 +147,15 @@ public abstract class AbstractTierStore
     /**
      * File-backed constructor — creates or opens a persistent mmap'd file.
      */
-    protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes, Path filePath) {
+    protected AbstractCognitiveRecordMemory(int quantizedVecBytes, int capacity, long segmentBytes, Path filePath) {
         this(new CognitiveRecordLayout(quantizedVecBytes),
              new CognitiveRecordLayoutAdapter(new CognitiveRecordLayout(quantizedVecBytes)),
              capacity, segmentBytes, filePath, mmapFile(filePath, segmentBytes));
     }
 
-    private AbstractTierStore(CognitiveRecordLayout cogLayout,
-                              CognitiveRecordLayoutAdapter layoutAdapter,
-                              int capacity, long segmentBytes, Path filePath, MmapResult res) {
+    private AbstractCognitiveRecordMemory(CognitiveRecordLayout cogLayout,
+                                         CognitiveRecordLayoutAdapter layoutAdapter,
+                                         int capacity, long segmentBytes, Path filePath, MmapResult res) {
         super(MemoryId.of("tier", "pending"), layoutAdapter, capacity,
               res.arena, res.segment, 0, true, filePath, res.fileChannel);
         this.layout = cogLayout;
@@ -173,10 +173,10 @@ public abstract class AbstractTierStore
         }
     }
 
-    private AbstractTierStore(CognitiveRecordLayout cogLayout,
-                              CognitiveRecordLayoutAdapter layoutAdapter,
-                              int capacity, Arena arena, MemorySegment segment, int count,
-                              boolean persistent, Path filePath, FileChannel fileChannel) {
+    private AbstractCognitiveRecordMemory(CognitiveRecordLayout cogLayout,
+                                         CognitiveRecordLayoutAdapter layoutAdapter,
+                                         int capacity, Arena arena, MemorySegment segment, int count,
+                                         boolean persistent, Path filePath, FileChannel fileChannel) {
         super(MemoryId.of("tier", "pending"), layoutAdapter, capacity,
               arena, segment, count, persistent, filePath, fileChannel);
         this.layout = cogLayout;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractTierStore.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -42,52 +41,17 @@ import java.nio.file.StandardOpenOption;
 /**
  * Abstract base class for single-segment tier stores.
  *
- * <h3>Template Method Pattern</h3>
- * <p>Provides common infrastructure shared by {@link WorkingMemoryStore},
- * {@link SemanticMemoryStore}, and {@link ProceduralMemoryStore}:</p>
- * <ul>
- *   <li>Arena lifecycle (shared Arena for thread-safe access)</li>
- *   <li>Layout creation from vector byte count</li>
- *   <li>Capacity tracking and size reporting</li>
- *   <li>Segment allocation with 64-byte alignment</li>
- *   <li>Close/cleanup lifecycle</li>
- * </ul>
- *
- * <h3>Dual Mode: Volatile vs. File-Backed</h3>
- * <ul>
- *   <li><b>Volatile</b> (in-memory): {@code Arena.ofShared()} allocates off-heap RAM.
- *       Data is lost on JVM shutdown.</li>
- *   <li><b>File-backed</b> (persistent): {@code FileChannel.map()} creates a persistent
- *       mmap'd file with a 64-byte metadata header. Data survives JVM restarts.</li>
- * </ul>
- *
- * <h3>Metadata Header Layout (64 bytes)</h3>
- * <pre>
- *   [4B magic]     Offset 0  — 0x54494552 ("TIER")
- *   [4B version]   Offset 4  — format version (1)
- *   [4B count]     Offset 8  — number of live records
- *   [4B capacity]  Offset 12 — max records
- *   [4B stride]    Offset 16 — record stride in bytes
- *   [4B tierOrd]   Offset 20 — MemoryType ordinal
- *   [4B extra1]    Offset 24 — subclass-specific (e.g., writeIndex for Working)
- *   [4B extra2]    Offset 28 — reserved for subclass use
- *   [32B reserved] Offset 32 — future use
- * </pre>
- *
- * <p>{@link EpisodicMemoryStore} implements {@link TierStore} directly because
- * it uses mmap-backed partitions rather than a single Arena-allocated segment.</p>
+ * <p>Extends {@link AbstractRecordMemory} directly with {@link CognitiveRecordLayoutAdapter}
+ * per ADR-013.</p>
  *
  * @see TierStore for the common interface
  */
-public abstract class AbstractTierStore implements TierStore {
+public abstract class AbstractTierStore 
+        extends AbstractRecordMemory<CognitiveRecordLayoutAdapter> 
+        implements TierStore {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractTierStore.class);
 
-    // ── Kernel Integration ──
-    // MemoryId provides stable identity for WAL targeting, metrics, and logs.
-    // Lazily initialized because type() is abstract and not available in the constructor.
-    // CognitiveRecordLayoutAdapter bridges the tier store's CognitiveRecordLayout
-    // to the kernel's MemoryLayout interface.
     private volatile MemoryId memoryId;
     private final CognitiveRecordLayoutAdapter layoutAdapter;
 
@@ -111,9 +75,6 @@ public abstract class AbstractTierStore implements TierStore {
     static final int META_EXTRA2   = 28;
 
     // ── SWMR Visibility Barrier ──
-    // VarHandle for release/acquire access to maxVisibleRecord.
-    // Writers call publishVisible() after completing a record write;
-    // readers call visibleCount() to get the acquire-fenced count.
     private static final VarHandle VISIBLE_COUNT_HANDLE;
     static {
         try {
@@ -125,127 +86,106 @@ public abstract class AbstractTierStore implements TierStore {
     }
 
     protected final CognitiveRecordLayout layout;
-    protected final int capacity;
-    protected final Arena arena;
-    protected final MemorySegment segment;
     protected int count = 0;
 
-    /** Kernel backing — owns arena, segment, and file channel lifecycle. */
-    private final TierRecordBacking backing;
-
-    /**
-     * The number of records visible to concurrent readers.
-     * Published with release semantics after each complete record write.
-     * Read with acquire semantics by scanners before entering scoring loops.
-     */
     @SuppressWarnings("unused") // accessed via VarHandle
     private volatile int maxVisibleRecord = 0;
 
-    /** True if this store is backed by a file (persistent). */
-    protected final boolean persistent;
-
-
-    /** File path for persistent stores (null for volatile). */
-    private final Path filePath;
-
-    /**
-     * Volatile constructor — allocates a single contiguous off-heap segment (no file).
-     *
-     * @param quantizedVecBytes bytes per quantized vector
-     * @param capacity          maximum number of records
-     * @param segmentBytes      total bytes to allocate (caller decides header-only vs full)
-     */
-    protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes) {
-        this.layout = new CognitiveRecordLayout(quantizedVecBytes);
-        this.layoutAdapter = new CognitiveRecordLayoutAdapter(this.layout);
-        this.capacity = capacity;
-        this.persistent = false;
-        this.filePath = null;
-        // Kernel backing owns the arena and segment
-        Arena backingArena = Arena.ofShared();
-        MemorySegment backingSegment = backingArena.allocate(segmentBytes, SynapticHeaderConstants.HEADER_BYTES);
-        this.backing = new TierRecordBacking(
-                MemoryId.of("tier", "pending"), layoutAdapter, capacity,
-                backingArena, backingSegment, 0, false, null, null);
-        this.arena = backingArena;
-        this.segment = backingSegment;
-        this.memoryId = null;
+    private static final class MmapResult {
+        final Arena arena;
+        final MemorySegment segment;
+        final FileChannel fileChannel;
+        final boolean isNew;
+        MmapResult(Arena arena, MemorySegment segment, FileChannel fileChannel, boolean isNew) {
+            this.arena = arena;
+            this.segment = segment;
+            this.fileChannel = fileChannel;
+            this.isNew = isNew;
+        }
     }
 
-    /**
-     * File-backed constructor — creates or opens a persistent mmap'd file.
-     *
-     * <p>If the file already exists and contains a valid metadata header, the
-     * store's state ({@code count}) is restored from it. Otherwise, a new
-     * file is created with a fresh metadata header.</p>
-     *
-     * @param quantizedVecBytes bytes per quantized vector
-     * @param capacity          maximum number of records
-     * @param segmentBytes      total data bytes (excluding metadata header)
-     * @param filePath          path to the backing file
-     */
-    protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes, Path filePath) {
-        this.layout = new CognitiveRecordLayout(quantizedVecBytes);
-        this.layoutAdapter = new CognitiveRecordLayoutAdapter(this.layout);
-        this.capacity = capacity;
-        this.persistent = true;
-        this.filePath = filePath;
-        Arena backingArena = Arena.ofShared();
-        this.memoryId = null;
-
+    private static MmapResult mmapFile(Path filePath, long segmentBytes) {
+        Arena arena = Arena.ofShared();
         try {
-            // Ensure parent directories exist
             Path parent = filePath.getParent();
             if (parent != null) {
                 Files.createDirectories(parent);
             }
-
             long totalBytes = METADATA_HEADER_BYTES + segmentBytes;
             boolean isNew = !Files.exists(filePath) || Files.size(filePath) < METADATA_HEADER_BYTES;
-
             FileChannel fc = FileChannel.open(filePath,
                     StandardOpenOption.CREATE,
                     StandardOpenOption.READ,
                     StandardOpenOption.WRITE);
-
             if (isNew) {
-                // Extend file to full size
                 fc.position(totalBytes - 1);
                 fc.write(ByteBuffer.wrap(new byte[]{0}));
             }
-
-            // Map the entire file
             long mapSize = Math.max(totalBytes, fc.size());
-            MemorySegment mapped = fc.map(FileChannel.MapMode.READ_WRITE, 0, mapSize, backingArena);
-
-            // Kernel backing owns arena, segment, and file channel
-            this.backing = new TierRecordBacking(
-                    MemoryId.of("tier", "pending"), layoutAdapter, capacity,
-                    backingArena, mapped, 0, true, filePath, fc);
-            this.arena = backingArena;
-            this.segment = mapped;
-
-            if (isNew) {
-                // Write fresh metadata header
-                this.count = 0;
-                writeMetadata();
-                log.info("{} created new persistent file: {} ({}KB)",
-                        getClass().getSimpleName(), filePath, totalBytes / 1024);
-            } else {
-                // Restore state from existing file
-                readMetadata();
-                publishVisible(); // SWMR: make restored records visible to readers
-                log.info("{} loaded from persistent file: {} ({} records)",
-                        getClass().getSimpleName(), filePath, count);
-            }
+            MemorySegment mapped = fc.map(FileChannel.MapMode.READ_WRITE, 0, mapSize, arena);
+            return new MmapResult(arena, mapped, fc, isNew);
         } catch (IOException e) {
             throw new SpectorStorageException(ErrorCode.MMAP_FAILED, e, filePath);
         }
     }
 
     /**
+     * Volatile constructor — allocates a single contiguous off-heap segment (no file).
+     */
+    protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes) {
+        this(quantizedVecBytes, capacity, segmentBytes, Arena.ofShared());
+    }
+
+    private AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes, Arena sharedArena) {
+        this(new CognitiveRecordLayout(quantizedVecBytes),
+             new CognitiveRecordLayoutAdapter(new CognitiveRecordLayout(quantizedVecBytes)),
+             capacity, sharedArena,
+             sharedArena.allocate(segmentBytes, SynapticHeaderConstants.HEADER_BYTES),
+             0, false, null, null);
+    }
+
+    /**
+     * File-backed constructor — creates or opens a persistent mmap'd file.
+     */
+    protected AbstractTierStore(int quantizedVecBytes, int capacity, long segmentBytes, Path filePath) {
+        this(new CognitiveRecordLayout(quantizedVecBytes),
+             new CognitiveRecordLayoutAdapter(new CognitiveRecordLayout(quantizedVecBytes)),
+             capacity, segmentBytes, filePath, mmapFile(filePath, segmentBytes));
+    }
+
+    private AbstractTierStore(CognitiveRecordLayout cogLayout,
+                              CognitiveRecordLayoutAdapter layoutAdapter,
+                              int capacity, long segmentBytes, Path filePath, MmapResult res) {
+        super(MemoryId.of("tier", "pending"), layoutAdapter, capacity,
+              res.arena, res.segment, 0, true, filePath, res.fileChannel);
+        this.layout = cogLayout;
+        this.layoutAdapter = layoutAdapter;
+        if (res.isNew) {
+            this.count = 0;
+            writeMetadata();
+            log.info("{} created new persistent file: {} ({}KB)",
+                    getClass().getSimpleName(), filePath, (METADATA_HEADER_BYTES + segmentBytes) / 1024);
+        } else {
+            readMetadata();
+            publishVisible();
+            log.info("{} loaded from persistent file: {} ({} records)",
+                    getClass().getSimpleName(), filePath, count);
+        }
+    }
+
+    private AbstractTierStore(CognitiveRecordLayout cogLayout,
+                              CognitiveRecordLayoutAdapter layoutAdapter,
+                              int capacity, Arena arena, MemorySegment segment, int count,
+                              boolean persistent, Path filePath, FileChannel fileChannel) {
+        super(MemoryId.of("tier", "pending"), layoutAdapter, capacity,
+              arena, segment, count, persistent, filePath, fileChannel);
+        this.layout = cogLayout;
+        this.layoutAdapter = layoutAdapter;
+        this.count = count;
+    }
+
+    /**
      * Writes the metadata header to the mapped segment.
-     * Called on creation and after count changes.
      */
     protected void writeMetadata() {
         if (!persistent) return;
@@ -259,13 +199,12 @@ public abstract class AbstractTierStore implements TierStore {
 
     /**
      * Reads the metadata header from the mapped segment.
-     * Called when loading from an existing file.
      */
     protected void readMetadata() {
         int magic = segment.get(ValueLayout.JAVA_INT, META_MAGIC);
         if (magic != TIER_MAGIC) {
             log.warn("Invalid tier magic in {}: 0x{} (expected 0x{})",
-                    filePath, Integer.toHexString(magic), Integer.toHexString(TIER_MAGIC));
+                    filePath(), Integer.toHexString(magic), Integer.toHexString(TIER_MAGIC));
             this.count = 0;
             return;
         }
@@ -274,7 +213,6 @@ public abstract class AbstractTierStore implements TierStore {
 
     /**
      * Persists the current count to the metadata header.
-     * Subclasses should call this after modifying {@code count}.
      */
     protected void persistCount() {
         if (persistent) {
@@ -284,10 +222,8 @@ public abstract class AbstractTierStore implements TierStore {
 
     /**
      * Returns the byte offset where data records begin.
-     * For persistent stores, records start after the metadata header.
-     * For volatile stores, records start at offset 0.
      */
-    protected long dataOffset() {
+    public long dataOffset() {
         return persistent ? METADATA_HEADER_BYTES : 0;
     }
 
@@ -301,20 +237,16 @@ public abstract class AbstractTierStore implements TierStore {
         return (int) VISIBLE_COUNT_HANDLE.getAcquire(this);
     }
 
-    /**
-     * Publishes the current {@code count} as visible to concurrent readers.
-     *
-     * <p>Must be called by subclasses after completing a record write
-     * (header + vector fully written) and updating {@code count}.
-     * Uses release semantics to ensure all prior writes (the record data)
-     * are visible before the count update is observed by readers.</p>
-     */
     protected void publishVisible() {
         VISIBLE_COUNT_HANDLE.setRelease(this, count);
     }
 
     @Override
-    public CognitiveRecordLayout layout() {
+    public CognitiveRecordLayoutAdapter layout() {
+        return layoutAdapter;
+    }
+
+    public CognitiveRecordLayout cognitiveLayout() {
         return layout;
     }
 
@@ -323,55 +255,24 @@ public abstract class AbstractTierStore implements TierStore {
         return segment;
     }
 
-    /**
-     * Returns the maximum capacity of this store.
-     */
     public int capacity() {
         return capacity;
     }
 
-    /**
-     * Returns the backing memory segment for direct scorer access.
-     */
     public MemorySegment segment() {
         return segment;
     }
 
-    /**
-     * Returns whether this store is file-backed (persistent).
-     */
     public boolean isPersistent() {
         return persistent;
     }
 
-    /**
-     * Returns the file path for persistent stores, or null for volatile.
-     */
-    public Path filePath() {
-        return filePath;
-    }
-
-    /**
-     * Forces the mapped segment to be written to the underlying file (persistent only).
-     */
     public void force() {
         if (persistent && segment != null) {
             segment.force();
         }
     }
 
-    // ══════════════════════════════════════════════════════════════
-    // COMPACTION SUPPORT
-    // ══════════════════════════════════════════════════════════════
-
-    /**
-     * Counts the number of tombstoned records in this store.
-     *
-     * <p>Scans all records and checks the tombstone flag in each header.
-     * This is O(n) but only called before compaction decisions.</p>
-     *
-     * @return the number of tombstoned records
-     */
     public int tombstoneCount() {
         int tombstones = 0;
         long baseOffset = dataOffset();
@@ -385,29 +286,11 @@ public abstract class AbstractTierStore implements TierStore {
         return tombstones;
     }
 
-    /**
-     * Returns the ratio of tombstoned records to total records.
-     *
-     * @return tombstone ratio (0.0 = no tombstones, 1.0 = all tombstoned)
-     */
     public float tombstoneRatio() {
         if (count == 0) return 0.0f;
         return (float) tombstoneCount() / count;
     }
 
-    // ══════════════════════════════════════════════════════════════
-    // KERNEL INTEGRATION
-    // ══════════════════════════════════════════════════════════════
-
-    /**
-     * Returns the stable kernel identity for this store.
-     *
-     * <p>Lazily initialized because {@link #type()} is abstract and not
-     * available during {@code AbstractTierStore} construction. Thread-safe
-     * via double-checked locking on a volatile field.</p>
-     *
-     * @return the kernel-compatible memory identifier
-     */
     public MemoryId memoryId() {
         MemoryId id = this.memoryId;
         if (id == null) {
@@ -422,35 +305,13 @@ public abstract class AbstractTierStore implements TierStore {
         return id;
     }
 
-    /**
-     * Returns the underlying kernel Memory backing for this tier store.
-     */
-    public TierRecordBacking backing() {
-        return this.backing;
-    }
-
-    /**
-     * Returns the kernel-compatible layout adapter for this store.
-     *
-     * <p>Bridges the existing {@link CognitiveRecordLayout} to the kernel's
-     * {@link MemoryLayout} interface, enabling kernel consumers to read
-     * stride, layoutId, and schema version from tier stores.</p>
-     *
-     * @return the cognitive record layout adapter
-     */
     public CognitiveRecordLayoutAdapter kernelLayout() {
         return layoutAdapter;
     }
 
-    /**
-     * Returns the kernel shape classification for this store.
-     *
-     * @return {@link MemoryShape#RECORD} for all tier stores
-     */
     public MemoryShape kernelShape() {
         return MemoryShape.RECORD;
     }
-
 
     @Override
     public void close() {
@@ -464,32 +325,6 @@ public abstract class AbstractTierStore implements TierStore {
                 log.debug("Error forcing segment: {}", e.getMessage());
             }
         }
-        // Delegate lifecycle to kernel backing (closes arena + file channel)
-        backing.close();
-    }
-
-    // ══════════════════════════════════════════════════════════════
-    // KERNEL BACKING
-    // ══════════════════════════════════════════════════════════════
-
-    /**
-     * Concrete kernel {@link AbstractRecordMemory} backing for tier stores.
-     *
-     * <p>This class exists solely to provide a concrete instantiation of
-     * the kernel's {@code AbstractRecordMemory} hierarchy. It receives
-     * ownership of the arena, segment, and file channel from the enclosing
-     * tier store and handles close/flush lifecycle.</p>
-     *
-     * <p>The tier store delegates arena/segment ownership to this backing.
-     * Tier-specific logic (SWMR, cognitive headers, tombstones) remains
-     * in {@code AbstractTierStore}.</p>
-     */
-    static final class TierRecordBacking extends AbstractRecordMemory<CognitiveRecordLayoutAdapter> {
-
-        TierRecordBacking(MemoryId id, CognitiveRecordLayoutAdapter layout, int capacity,
-                          Arena arena, MemorySegment segment, int count,
-                          boolean persistent, Path filePath, FileChannel fileChannel) {
-            super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel);
-        }
+        super.close();
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicMemoryStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicMemoryStore.java
@@ -47,7 +47,7 @@ import com.spectrayan.spector.memory.error.SpectorMemoryTierFullException;
  *   <li>Persistent across JVM restarts via {@code FileChannel.map()}</li>
  * </ul>
  */
-public final class EpisodicMemoryStore extends AbstractTierStore {
+public final class EpisodicMemoryStore extends AbstractCognitiveRecordMemory {
 
     private static final Logger log = LoggerFactory.getLogger(EpisodicMemoryStore.class);
 
@@ -217,8 +217,8 @@ public final class EpisodicMemoryStore extends AbstractTierStore {
      */
     public static final class EpisodicPartition {
 
-        /** Size of the metadata header in bytes (matches AbstractTierStore). */
-        public static final int METADATA_HEADER_BYTES = AbstractTierStore.METADATA_HEADER_BYTES;
+        /** Size of the metadata header in bytes (matches AbstractCognitiveRecordMemory). */
+        public static final int METADATA_HEADER_BYTES = AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES;
 
         private final EpisodicMemoryStore store;
         private int tombstoneCount = 0;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProceduralRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProceduralRecordMemory.java
@@ -47,7 +47,7 @@ import com.spectrayan.spector.commons.error.ErrorCode;
  *   <li>Flat scan with {@code CognitiveScorer}</li>
  * </ul>
  */
-public final class ProceduralRecordMemory extends AbstractTierStore {
+public final class ProceduralRecordMemory extends AbstractCognitiveRecordMemory {
 
     private static final Logger log = LoggerFactory.getLogger(ProceduralRecordMemory.class);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProceduralRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProceduralRecordMemory.java
@@ -47,9 +47,9 @@ import com.spectrayan.spector.commons.error.ErrorCode;
  *   <li>Flat scan with {@code CognitiveScorer}</li>
  * </ul>
  */
-public final class ProceduralMemoryStore extends AbstractTierStore {
+public final class ProceduralRecordMemory extends AbstractTierStore {
 
-    private static final Logger log = LoggerFactory.getLogger(ProceduralMemoryStore.class);
+    private static final Logger log = LoggerFactory.getLogger(ProceduralRecordMemory.class);
 
     /**
      * Creates a volatile Procedural Memory store (in-memory only).
@@ -57,11 +57,11 @@ public final class ProceduralMemoryStore extends AbstractTierStore {
      * @param quantizedVecBytes bytes per quantized vector
      * @param capacity          maximum number of procedural memories (default: 1000)
      */
-    public ProceduralMemoryStore(int quantizedVecBytes, int capacity) {
+    public ProceduralRecordMemory(int quantizedVecBytes, int capacity) {
         super(quantizedVecBytes, capacity,
                 (long) new com.spectrayan.spector.memory.synapse.CognitiveRecordLayout(quantizedVecBytes).stride() * capacity);
 
-        log.info("ProceduralMemoryStore initialized: capacity={}, stride={}B, persistent=false",
+        log.info("ProceduralRecordMemory initialized: capacity={}, stride={}B, persistent=false",
                 capacity, layout.stride());
     }
 
@@ -72,19 +72,19 @@ public final class ProceduralMemoryStore extends AbstractTierStore {
      * @param capacity          maximum number of procedural memories
      * @param filePath          path to the backing mmap file
      */
-    public ProceduralMemoryStore(int quantizedVecBytes, int capacity, Path filePath) {
+    public ProceduralRecordMemory(int quantizedVecBytes, int capacity, Path filePath) {
         super(quantizedVecBytes, capacity,
                 (long) new com.spectrayan.spector.memory.synapse.CognitiveRecordLayout(quantizedVecBytes).stride() * capacity,
                 filePath);
 
-        log.info("ProceduralMemoryStore initialized: capacity={}, stride={}B, persistent=true, count={}",
+        log.info("ProceduralRecordMemory initialized: capacity={}, stride={}B, persistent=true, count={}",
                 capacity, layout.stride(), count);
     }
 
     /**
      * Creates a volatile Procedural Memory store with default capacity (1000).
      */
-    public ProceduralMemoryStore(int quantizedVecBytes) {
+    public ProceduralRecordMemory(int quantizedVecBytes) {
         this(quantizedVecBytes, 1000);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -66,7 +66,7 @@ public final class SemanticRecallStrategy {
     private static final Logger log = LoggerFactory.getLogger(SemanticRecallStrategy.class);
 
     private final VectorIndex vectorIndex;
-    private final SemanticMemoryStore semanticStore;
+    private final SemanticRecordMemory semanticStore;
     private final MemoryIndex memoryIndex;
 
     /**
@@ -77,7 +77,7 @@ public final class SemanticRecallStrategy {
      * @param memoryIndex   the ID → metadata index for reverse lookups
      */
     public SemanticRecallStrategy(VectorIndex vectorIndex,
-                                   SemanticMemoryStore semanticStore,
+                                   SemanticRecordMemory semanticStore,
                                    MemoryIndex memoryIndex) {
         this.vectorIndex = vectorIndex;
         this.semanticStore = semanticStore;
@@ -125,7 +125,7 @@ public final class SemanticRecallStrategy {
         float beta = options.beta();
         float tagRelevanceBoost = options.tagRelevanceBoost();
 
-        CognitiveRecordLayout layout = semanticStore.layout();
+        CognitiveRecordLayout layout = semanticStore.cognitiveLayout();
         java.lang.foreign.MemorySegment headerSlab = semanticStore.primarySegment();
 
         List<CognitiveResult> results = new ArrayList<>();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -133,7 +133,7 @@ public final class SemanticRecallStrategy {
         for (ScoredResult sr : hnswResults) {
             // HNSW returns an internal store index — compute record offset in segment
             // For persistent stores, records start after the 64-byte metadata header
-            long dataOffset = semanticStore.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
+            long dataOffset = semanticStore.isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
             long headerOffset = dataOffset + (long) sr.index() * layout.stride();
 
             // Bounds check: ensure we're within the slab

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecordMemory.java
@@ -48,7 +48,7 @@ import com.spectrayan.spector.commons.error.ErrorCode;
  *   <li>Flat scan with {@code CognitiveScorer} for distance computation</li>
  * </ul>
  */
-public final class SemanticRecordMemory extends AbstractTierStore {
+public final class SemanticRecordMemory extends AbstractCognitiveRecordMemory {
 
     private static final Logger log = LoggerFactory.getLogger(SemanticRecordMemory.class);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecordMemory.java
@@ -48,9 +48,9 @@ import com.spectrayan.spector.commons.error.ErrorCode;
  *   <li>Flat scan with {@code CognitiveScorer} for distance computation</li>
  * </ul>
  */
-public final class SemanticMemoryStore extends AbstractTierStore {
+public final class SemanticRecordMemory extends AbstractTierStore {
 
-    private static final Logger log = LoggerFactory.getLogger(SemanticMemoryStore.class);
+    private static final Logger log = LoggerFactory.getLogger(SemanticRecordMemory.class);
 
     /**
      * Creates a volatile Semantic Memory store (in-memory only).
@@ -61,11 +61,11 @@ public final class SemanticMemoryStore extends AbstractTierStore {
      * @param quantizedVecBytes bytes per quantized vector (for layout calculation)
      * @param capacity          maximum number of semantic memories (default: 100_000)
      */
-    public SemanticMemoryStore(int quantizedVecBytes, int capacity) {
+    public SemanticRecordMemory(int quantizedVecBytes, int capacity) {
         super(quantizedVecBytes, capacity,
                 (long) new CognitiveRecordLayout(quantizedVecBytes).stride() * capacity);
 
-        log.info("SemanticMemoryStore initialized: capacity={}, stride={}B, persistent=false, headerVersion=V{}",
+        log.info("SemanticRecordMemory initialized: capacity={}, stride={}B, persistent=false, headerVersion=V{}",
                 capacity, layout.stride(), layout.headerLayout().version());
     }
 
@@ -76,12 +76,12 @@ public final class SemanticMemoryStore extends AbstractTierStore {
      * @param capacity          maximum number of semantic memories
      * @param filePath          path to the backing mmap file
      */
-    public SemanticMemoryStore(int quantizedVecBytes, int capacity, Path filePath) {
+    public SemanticRecordMemory(int quantizedVecBytes, int capacity, Path filePath) {
         super(quantizedVecBytes, capacity,
                 (long) new CognitiveRecordLayout(quantizedVecBytes).stride() * capacity,
                 filePath);
 
-        log.info("SemanticMemoryStore initialized: capacity={}, stride={}B, persistent=true, count={}, headerVersion=V{}",
+        log.info("SemanticRecordMemory initialized: capacity={}, stride={}B, persistent=true, count={}, headerVersion=V{}",
                 capacity, layout.stride(), count, layout.headerLayout().version());
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierRouter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierRouter.java
@@ -172,7 +172,7 @@ public final class TierRouter implements AutoCloseable {
      */
     public void forceAll() {
         for (TierStore store : stores.values()) {
-            if (store instanceof AbstractTierStore ats && ats.isPersistent()) {
+            if (store instanceof AbstractCognitiveRecordMemory ats && ats.isPersistent()) {
                 ats.force();
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierRouter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierRouter.java
@@ -42,10 +42,10 @@ public final class TierRouter implements AutoCloseable {
     private final EnumMap<MemoryType, TierStore> stores = new EnumMap<>(MemoryType.class);
 
     // ── Typed accessors for tier-specific operations ──
-    private final WorkingMemoryStore workingStore;
+    private final WorkingRecordMemory workingStore;
     private final EpisodicMemoryStore episodicStore;
-    private final SemanticMemoryStore semanticStore;
-    private final ProceduralMemoryStore proceduralStore;
+    private final SemanticRecordMemory semanticStore;
+    private final ProceduralRecordMemory proceduralStore;
 
     /**
      * Creates a TierRouter with all four cognitive tier stores.
@@ -54,10 +54,10 @@ public final class TierRouter implements AutoCloseable {
      * dispatch, while typed fields are retained for tier-specific operations
      * (e.g., episodic partition iteration, semantic header reads).</p>
      */
-    public TierRouter(WorkingMemoryStore workingStore,
+    public TierRouter(WorkingRecordMemory workingStore,
                        EpisodicMemoryStore episodicStore,
-                       SemanticMemoryStore semanticStore,
-                       ProceduralMemoryStore proceduralStore) {
+                       SemanticRecordMemory semanticStore,
+                       ProceduralRecordMemory proceduralStore) {
         this.workingStore = workingStore;
         this.episodicStore = episodicStore;
         this.semanticStore = semanticStore;
@@ -113,7 +113,7 @@ public final class TierRouter implements AutoCloseable {
      * Polymorphic — delegates to {@link TierStore#layout}.
      */
     public CognitiveRecordLayout layoutFor(MemoryType type) {
-        return get(type).layout();
+        return get(type).cognitiveLayout();
     }
 
     /**
@@ -155,16 +155,16 @@ public final class TierRouter implements AutoCloseable {
     // ══════════════════════════════════════════════════════════════
 
     /** Returns the Working Memory store (for circular buffer scan). */
-    public WorkingMemoryStore working() { return workingStore; }
+    public WorkingRecordMemory working() { return workingStore; }
 
     /** Returns the Episodic Memory store (for partition iteration). */
     public EpisodicMemoryStore episodic() { return episodicStore; }
 
     /** Returns the Semantic Memory store (for header slab access). */
-    public SemanticMemoryStore semantic() { return semanticStore; }
+    public SemanticRecordMemory semantic() { return semanticStore; }
 
     /** Returns the Procedural Memory store (for flat scan). */
-    public ProceduralMemoryStore procedural() { return proceduralStore; }
+    public ProceduralRecordMemory procedural() { return proceduralStore; }
 
     /**
      * Forces all persistent tier store segments to be written to disk.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierStore.java
@@ -34,7 +34,7 @@ import java.lang.foreign.MemorySegment;
  *   <li>{@link ProceduralMemoryStore} — small append-only store (Basal Ganglia)</li>
  * </ul>
  *
- * @see AbstractTierStore for common implementation
+ * @see AbstractCognitiveRecordMemory for common implementation
  * @see TierRouter for polymorphic dispatch
  */
 public interface TierStore extends AutoCloseable {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TierStore.java
@@ -63,9 +63,14 @@ public interface TierStore extends AutoCloseable {
 
 
     /**
-     * Returns the record layout for this store.
+     * Returns the kernel record layout adapter for this store.
      */
-    CognitiveRecordLayout layout();
+    com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayoutAdapter layout();
+
+    /**
+     * Returns the underlying cognitive record layout for this store.
+     */
+    CognitiveRecordLayout cognitiveLayout();
 
     /**
      * Returns the primary memory segment for this store.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/WorkingRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/WorkingRecordMemory.java
@@ -51,9 +51,9 @@ import java.util.concurrent.locks.ReentrantLock;
  * <p>Uses a shared Arena. Write access is synchronized; reads are lock-free
  * (scan over immutable segments).</p>
  */
-public final class WorkingMemoryStore extends AbstractTierStore {
+public final class WorkingRecordMemory extends AbstractTierStore {
 
-    private static final Logger log = LoggerFactory.getLogger(WorkingMemoryStore.class);
+    private static final Logger log = LoggerFactory.getLogger(WorkingRecordMemory.class);
 
     private int writeIndex = 0;  // circular buffer index
 
@@ -63,11 +63,11 @@ public final class WorkingMemoryStore extends AbstractTierStore {
      * @param quantizedVecBytes bytes per quantized vector
      * @param capacity          maximum number of records (default: 100)
      */
-    public WorkingMemoryStore(int quantizedVecBytes, int capacity) {
+    public WorkingRecordMemory(int quantizedVecBytes, int capacity) {
         super(quantizedVecBytes, capacity,
                 (long) new com.spectrayan.spector.memory.synapse.CognitiveRecordLayout(quantizedVecBytes).stride() * capacity);
 
-        log.info("WorkingMemoryStore initialized: capacity={}, stride={}B, total={}KB, persistent=false",
+        log.info("WorkingRecordMemory initialized: capacity={}, stride={}B, total={}KB, persistent=false",
                 capacity, layout.stride(), (long) layout.stride() * capacity / 1024);
     }
 
@@ -82,7 +82,7 @@ public final class WorkingMemoryStore extends AbstractTierStore {
      * @param capacity          maximum number of records
      * @param filePath          path to the backing mmap file
      */
-    public WorkingMemoryStore(int quantizedVecBytes, int capacity, Path filePath) {
+    public WorkingRecordMemory(int quantizedVecBytes, int capacity, Path filePath) {
         super(quantizedVecBytes, capacity,
                 (long) new com.spectrayan.spector.memory.synapse.CognitiveRecordLayout(quantizedVecBytes).stride() * capacity,
                 filePath);
@@ -90,17 +90,17 @@ public final class WorkingMemoryStore extends AbstractTierStore {
         // Restore writeIndex from metadata header extra1 field
         if (persistent && count > 0) {
             this.writeIndex = segment.get(ValueLayout.JAVA_INT, META_EXTRA1);
-            log.info("WorkingMemoryStore restored: writeIndex={}, count={}", writeIndex, count);
+            log.info("WorkingRecordMemory restored: writeIndex={}, count={}", writeIndex, count);
         }
 
-        log.info("WorkingMemoryStore initialized: capacity={}, stride={}B, persistent=true",
+        log.info("WorkingRecordMemory initialized: capacity={}, stride={}B, persistent=true",
                 capacity, layout.stride());
     }
 
     /**
      * Creates a volatile Working Memory store with default capacity (100).
      */
-    public WorkingMemoryStore(int quantizedVecBytes) {
+    public WorkingRecordMemory(int quantizedVecBytes) {
         this(quantizedVecBytes, 100);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/WorkingRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/WorkingRecordMemory.java
@@ -51,7 +51,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <p>Uses a shared Arena. Write access is synchronized; reads are lock-free
  * (scan over immutable segments).</p>
  */
-public final class WorkingRecordMemory extends AbstractTierStore {
+public final class WorkingRecordMemory extends AbstractCognitiveRecordMemory {
 
     private static final Logger log = LoggerFactory.getLogger(WorkingRecordMemory.class);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/SynapticDecayModulator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/SynapticDecayModulator.java
@@ -61,7 +61,7 @@ public final class SynapticDecayModulator implements HebbianGraph.DecayModulator
         var episodic = tierRouter.episodic();
         if (episodic == null) return;
 
-        CognitiveRecordLayout layout = episodic.layout();
+        CognitiveRecordLayout layout = episodic.cognitiveLayout();
         MemorySegment segment = episodic.segment();
         int count = Math.min(episodic.totalRecords(), capacity);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/AbstractMemory.java
@@ -123,7 +123,7 @@ public abstract class AbstractMemory<L extends MemoryLayout> implements Memory<L
     /**
      * Wrapping constructor — adopts a pre-made Arena and segment.
      *
-     * <p>Used for deep composition: the caller (e.g., {@code AbstractTierStore})
+     * <p>Used for deep composition: the caller (e.g., {@code AbstractCognitiveRecordMemory})
      * manages mmap lifecycle and header format, then wraps the result in a
      * kernel {@code Memory} for standardized identity, shape, and accessor methods.</p>
      *

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CognitiveRecordLayoutAdapter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CognitiveRecordLayoutAdapter.java
@@ -14,6 +14,10 @@ package com.spectrayan.spector.memory.kernel.layout;
 
 import com.spectrayan.spector.memory.kernel.MemoryLayout;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.synapse.HeaderLayout;
+
+import java.lang.foreign.MemorySegment;
 
 /**
  * Adapter that bridges the existing {@link CognitiveRecordLayout} to the
@@ -66,5 +70,45 @@ public final class CognitiveRecordLayoutAdapter implements MemoryLayout {
      */
     public CognitiveRecordLayout delegate() {
         return delegate;
+    }
+
+    public int stride() {
+        return delegate.stride();
+    }
+
+    public int quantizedVecBytes() {
+        return delegate.quantizedVecBytes();
+    }
+
+    public long vectorOffset(long recordOffset) {
+        return delegate.vectorOffset(recordOffset);
+    }
+
+    public float readImportance(MemorySegment segment, long offset) {
+        return delegate.readImportance(segment, offset);
+    }
+
+    public CognitiveHeader readHeader(MemorySegment segment, long offset) {
+        return delegate.readHeader(segment, offset);
+    }
+
+    public void writeHeader(MemorySegment segment, long offset, CognitiveHeader header) {
+        delegate.writeHeader(segment, offset, header);
+    }
+
+    public byte readFlags(MemorySegment segment, long offset) {
+        return delegate.readFlags(segment, offset);
+    }
+
+    public long readSynapticTags(MemorySegment segment, long offset) {
+        return delegate.readSynapticTags(segment, offset);
+    }
+
+    public void tombstone(MemorySegment segment, long offset) {
+        delegate.tombstone(segment, offset);
+    }
+
+    public HeaderLayout headerLayout() {
+        return delegate.headerLayout();
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -20,7 +20,7 @@ import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TierRouter;
-import com.spectrayan.spector.memory.cortex.WorkingMemoryStore;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
 import com.spectrayan.spector.memory.dopamine.FlashbulbPolicy;
 import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
@@ -102,7 +102,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     private volatile TierRouter tierRouter;  // volatile: swapped on partition roll
     private final MemoryIndex index;
     private final MemoryWal wal;
-    private final WorkingMemoryStore workingStore;  // nullable
+    private final WorkingRecordMemory workingStore;  // nullable
     private final IcnuWeights icnuWeights;
     private final VectorIndex semanticIndex;  // nullable  --  HNSW for semantic recall
     private final TagExtractor tagExtractor;
@@ -144,7 +144,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      TierRouter tierRouter,
                                      MemoryIndex index,
                                      MemoryWal wal,
-                                     WorkingMemoryStore workingStore,
+                                     WorkingRecordMemory workingStore,
                                      IcnuWeights icnuWeights,
                                      VectorIndex semanticIndex,
                                      TagExtractor tagExtractor,
@@ -177,7 +177,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      TierRouter tierRouter,
                                      MemoryIndex index,
                                      MemoryWal wal,
-                                     WorkingMemoryStore workingStore,
+                                     WorkingRecordMemory workingStore,
                                      IcnuWeights icnuWeights,
                                      VectorIndex semanticIndex,
                                      TagExtractor tagExtractor,
@@ -270,7 +270,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      TierRouter tierRouter,
                                      MemoryIndex index,
                                      MemoryWal wal,
-                                     WorkingMemoryStore workingStore,
+                                     WorkingRecordMemory workingStore,
                                      IcnuWeights icnuWeights,
                                      VectorIndex semanticIndex,
                                      TagExtractor tagExtractor) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoringMode;
 import com.spectrayan.spector.memory.model.SourceModality;
-import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.TierRouter;
 import com.spectrayan.spector.memory.cortex.TierStore;
@@ -348,8 +348,8 @@ final class GraphExpansionStage {
     int offsetToRecordIndex(MemoryIndex.MemoryLocation loc) {
         int stride = tierRouter.layoutFor(loc.type()).stride();
         TierStore store = tierRouter.get(loc.type());
-        long dataOffset = (store instanceof AbstractTierStore ats && ats.isPersistent())
-                ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
+        long dataOffset = (store instanceof AbstractCognitiveRecordMemory ats && ats.isPersistent())
+                ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
         return (int) ((loc.offset() - dataOffset) / stride);
     }
 
@@ -361,8 +361,8 @@ final class GraphExpansionStage {
             var layout = tierRouter.layoutFor(type);
             if (layout == null) continue;
             TierStore store = tierRouter.get(type);
-            long dataOffset = (store instanceof AbstractTierStore ats && ats.isPersistent())
-                    ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
+            long dataOffset = (store instanceof AbstractCognitiveRecordMemory ats && ats.isPersistent())
+                    ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
             long offset = dataOffset + (long) approxIdx * layout.stride();
             String id = index.findIdByOffset(type, offset);
             if (id != null) return id;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -31,7 +31,7 @@ import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.memory.model.TextSearchMode;
-import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.cortex.EpisodicMemoryStore.EpisodicPartition;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index.BM25Candidate;
@@ -1099,7 +1099,7 @@ public final class RecallPipeline {
                             return scoreHeaderSlabToList(
                                     seg, tierRouter.semantic().visibleCount(),
                                     tierRouter.semantic().cognitiveLayout(), queryVector, options, nowMs,
-                                    tierRouter.semantic().isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0);
+                                    tierRouter.semantic().isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0);
                         } finally {
                             NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
                         }
@@ -1156,7 +1156,7 @@ public final class RecallPipeline {
                     results.addAll(scoreHeaderSlabToList(tierRouter.semantic().headerSlab(),
                             tierRouter.semantic().visibleCount(), tierRouter.semantic().cognitiveLayout(),
                             queryVector, options, nowMs,
-                            tierRouter.semantic().isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0));
+                            tierRouter.semantic().isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0));
                 }
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -1056,7 +1056,7 @@ public final class RecallPipeline {
                 try {
                     return scoreStoreToList(
                             seg, tierRouter.working().visibleCount(),
-                            tierRouter.working().layout(), queryVector, options, nowMs,
+                            tierRouter.working().cognitiveLayout(), queryVector, options, nowMs,
                             MemoryType.WORKING, 0L);
                 } finally {
                     NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
@@ -1098,7 +1098,7 @@ public final class RecallPipeline {
                         try {
                             return scoreHeaderSlabToList(
                                     seg, tierRouter.semantic().visibleCount(),
-                                    tierRouter.semantic().layout(), queryVector, options, nowMs,
+                                    tierRouter.semantic().cognitiveLayout(), queryVector, options, nowMs,
                                     tierRouter.semantic().isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0);
                         } finally {
                             NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
@@ -1117,7 +1117,7 @@ public final class RecallPipeline {
                 try {
                     return scoreStoreToList(
                             seg, tierRouter.procedural().visibleCount(),
-                            tierRouter.procedural().layout(), queryVector, options, nowMs,
+                            tierRouter.procedural().cognitiveLayout(), queryVector, options, nowMs,
                             MemoryType.PROCEDURAL, 0L);
                 } finally {
                     NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
@@ -1137,7 +1137,7 @@ public final class RecallPipeline {
         if (TierRouter.shouldScan(MemoryType.WORKING, targetTypes)
                 && tierRouter.working().visibleCount() > 0) {
             results.addAll(scoreStoreToList(tierRouter.working().segment(),
-                    tierRouter.working().visibleCount(), tierRouter.working().layout(),
+                    tierRouter.working().visibleCount(), tierRouter.working().cognitiveLayout(),
                     queryVector, options, nowMs, MemoryType.WORKING, 0L));
         }
         if (TierRouter.shouldScan(MemoryType.EPISODIC, targetTypes)) {
@@ -1154,7 +1154,7 @@ public final class RecallPipeline {
                     results.addAll(semanticRecallStrategy.recall(queryVector, options, nowMs));
                 } else {
                     results.addAll(scoreHeaderSlabToList(tierRouter.semantic().headerSlab(),
-                            tierRouter.semantic().visibleCount(), tierRouter.semantic().layout(),
+                            tierRouter.semantic().visibleCount(), tierRouter.semantic().cognitiveLayout(),
                             queryVector, options, nowMs,
                             tierRouter.semantic().isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0));
                 }
@@ -1163,7 +1163,7 @@ public final class RecallPipeline {
         if (TierRouter.shouldScan(MemoryType.PROCEDURAL, targetTypes)
                 && tierRouter.procedural().visibleCount() > 0) {
             results.addAll(scoreStoreToList(tierRouter.procedural().segment(),
-                    tierRouter.procedural().visibleCount(), tierRouter.procedural().layout(),
+                    tierRouter.procedural().visibleCount(), tierRouter.procedural().cognitiveLayout(),
                     queryVector, options, nowMs, MemoryType.PROCEDURAL, 0L));
         }
         return results;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/HeaderMigrator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/HeaderMigrator.java
@@ -66,10 +66,10 @@ public final class HeaderMigrator {
 
     private static final Logger log = LoggerFactory.getLogger(HeaderMigrator.class);
 
-    /** Metadata header size in bytes (same as AbstractTierStore.METADATA_HEADER_BYTES). */
+    /** Metadata header size in bytes (same as AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES). */
     private static final int METADATA_HEADER_BYTES = 64;
 
-    /** Metadata field offsets (mirrors AbstractTierStore). */
+    /** Metadata field offsets (mirrors AbstractCognitiveRecordMemory). */
     private static final int META_MAGIC    = 0;
     private static final int META_VERSION  = 4;
     private static final int META_COUNT    = 8;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/VacuumCompactor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/VacuumCompactor.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.sync;
 
-import com.spectrayan.spector.memory.cortex.AbstractTierStore;
+import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
@@ -75,13 +75,13 @@ public final class VacuumCompactor {
      * @param index   the memory index (for offset remapping)
      * @return the compaction result (null if no compaction needed)
      */
-    public static CompactionResult compact(AbstractTierStore store, MemoryType type,
+    public static CompactionResult compact(AbstractCognitiveRecordMemory store, MemoryType type,
                                             MemoryIndex index) {
         long startMs = System.currentTimeMillis();
 
         CognitiveRecordLayout layout = store.cognitiveLayout();
         int totalRecords = store.size();
-        long baseOffset = store.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
+        long baseOffset = store.isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
         int stride = layout.stride();
 
         // Phase 1: Count live and tombstoned records
@@ -165,7 +165,7 @@ public final class VacuumCompactor {
      * @param threshold the tombstone ratio threshold (e.g., 0.20 for 20%)
      * @return true if compaction is recommended
      */
-    public static boolean shouldCompact(AbstractTierStore store, float threshold) {
+    public static boolean shouldCompact(AbstractCognitiveRecordMemory store, float threshold) {
         if (store.size() == 0) return false;
         return store.tombstoneRatio() >= threshold;
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/VacuumCompactor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/VacuumCompactor.java
@@ -79,7 +79,7 @@ public final class VacuumCompactor {
                                             MemoryIndex index) {
         long startMs = System.currentTimeMillis();
 
-        CognitiveRecordLayout layout = store.layout();
+        CognitiveRecordLayout layout = store.cognitiveLayout();
         int totalRecords = store.size();
         long baseOffset = store.isPersistent() ? AbstractTierStore.METADATA_HEADER_BYTES : 0;
         int stride = layout.stride();

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PerformanceBenchmarkTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PerformanceBenchmarkTest.java
@@ -21,7 +21,7 @@ import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.synapse.CognitiveScorer;
 import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
-import com.spectrayan.spector.memory.cortex.WorkingMemoryStore;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
 import com.spectrayan.spector.memory.cortex.TierRouter;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
@@ -210,13 +210,13 @@ class PerformanceBenchmarkTest {
     @DisplayName("P12: TierRouter.totalCount  --  100K calls under 250ms (no Stream)")
     void p12_totalCountDirectSum() {
         int quantizedVecBytes = 32;
-        var working = new WorkingMemoryStore(quantizedVecBytes, 10);
+        var working = new WorkingRecordMemory(quantizedVecBytes, 10);
         var episodic = new com.spectrayan.spector.memory.cortex.EpisodicMemoryStore(
                 java.nio.file.Path.of(System.getProperty("java.io.tmpdir"),
                         "perf-test-p12-" + System.nanoTime()),
                 quantizedVecBytes, 100);
-        var semantic = new com.spectrayan.spector.memory.cortex.SemanticMemoryStore(quantizedVecBytes, 10);
-        var procedural = new com.spectrayan.spector.memory.cortex.ProceduralMemoryStore(quantizedVecBytes, 10);
+        var semantic = new com.spectrayan.spector.memory.cortex.SemanticRecordMemory(quantizedVecBytes, 10);
+        var procedural = new com.spectrayan.spector.memory.cortex.ProceduralRecordMemory(quantizedVecBytes, 10);
         var router = new TierRouter(working, episodic, semantic, procedural);
 
         try {

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/consolidation/DuplicateDetectorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/consolidation/DuplicateDetectorTest.java
@@ -14,7 +14,7 @@ package com.spectrayan.spector.memory.consolidation;
 
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.memory.cortex.MemorySource;
-import com.spectrayan.spector.memory.cortex.SemanticMemoryStore;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout.CognitiveHeader;
@@ -32,13 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DuplicateDetectorTest {
 
-    private SemanticMemoryStore store;
+    private SemanticRecordMemory store;
     private MemoryIndex index;
     private ScalarQuantizer quantizer;
 
     @BeforeEach
     void setUp() {
-        store = new SemanticMemoryStore(8, 100);
+        store = new SemanticRecordMemory(8, 100);
         index = new MemoryIndex();
         float[] mins = {0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f};
         float[] maxs = {1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f};

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemoryTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
-class AbstractTierStoreTest {
+class AbstractCognitiveRecordMemoryTest {
 
     private CognitiveHeader createHeader() {
         byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.SEMANTIC.ordinal());

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/AbstractTierStoreTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/AbstractTierStoreTest.java
@@ -35,7 +35,7 @@ class AbstractTierStoreTest {
     @Test
     @DisplayName("Volatile store is not persistent")
     void volatileStoreNotPersistent() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
             assertThat(store.isPersistent()).isFalse();
         }
     }
@@ -44,7 +44,7 @@ class AbstractTierStoreTest {
     @DisplayName("Persistent store creates mmap file")
     void persistentStoreCreatesMmapFile(@TempDir Path tempDir) {
         Path file = tempDir.resolve("test.mem");
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100, file)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100, file)) {
             assertThat(store.isPersistent()).isTrue();
             assertThat(store.filePath()).isEqualTo(file);
             assertThat(file).exists();
@@ -55,13 +55,13 @@ class AbstractTierStoreTest {
     @DisplayName("Persistent store restores count on reopen")
     void persistentStoreRestoresCountOnReopen(@TempDir Path tempDir) {
         Path file = tempDir.resolve("test.mem");
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100, file)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100, file)) {
             store.write(createHeader(), new byte[128]);
             store.write(createHeader(), new byte[128]);
             store.force();
         }
         
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100, file)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100, file)) {
             assertThat(store.size()).isEqualTo(2);
         }
     }
@@ -70,7 +70,7 @@ class AbstractTierStoreTest {
     @DisplayName("Metadata header contains magic and version")
     void metadataHeaderContainsMagicAndVersion(@TempDir Path tempDir) {
         Path file = tempDir.resolve("test.mem");
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100, file)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100, file)) {
             // TIER magic is 0x54494552
             int magic = store.segment().get(java.lang.foreign.ValueLayout.JAVA_INT, 0);
             assertThat(magic).isEqualTo(0x54494552);
@@ -83,7 +83,7 @@ class AbstractTierStoreTest {
     @DisplayName("tombstoneCount scans correctly")
     void tombstoneCountScansCorrectly(@TempDir Path tempDir) {
         Path file = tempDir.resolve("test.mem");
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100, file)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100, file)) {
             long offset1 = store.write(createHeader(), new byte[128]);
             long offset2 = store.write(createHeader(), new byte[128]);
             
@@ -97,7 +97,7 @@ class AbstractTierStoreTest {
     @Test
     @DisplayName("tombstoneRatio is zero when empty")
     void tombstoneRatioZeroWhenEmpty() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
             assertThat(store.tombstoneRatio()).isZero();
         }
     }
@@ -105,7 +105,7 @@ class AbstractTierStoreTest {
     @Test
     @DisplayName("force is a no-op for volatile store")
     void forceIsNoOpForVolatile() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
             store.force(); // Should not throw exception
         }
     }
@@ -113,7 +113,7 @@ class AbstractTierStoreTest {
     @Test
     @DisplayName("visibleCount follows publish")
     void visibleCountFollowsPublish() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
             assertThat(store.visibleCount()).isZero();
             store.write(createHeader(), new byte[128]);
             assertThat(store.visibleCount()).isEqualTo(1);
@@ -123,7 +123,7 @@ class AbstractTierStoreTest {
     @Test
     @DisplayName("close releases arena")
     void closeReleasesArena() {
-        SemanticMemoryStore store = new SemanticMemoryStore(128, 100);
+        SemanticRecordMemory store = new SemanticRecordMemory(128, 100);
         store.close();
         // After close, writing to the store should throw because the arena is closed
         CognitiveHeader header = createHeader();

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/MemoryPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/MemoryPersistenceTest.java
@@ -56,7 +56,7 @@ class MemoryPersistenceTest {
         Path file = tmpDir.resolve("working.mem");
 
         // Write 5 records
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY, file)) {
             for (int i = 0; i < 5; i++) {
                 store.put(createHeader(1000L + i, 0.5f + i * 0.1f), dummyVec(VEC_BYTES, (byte) (i + 1)));
             }
@@ -65,7 +65,7 @@ class MemoryPersistenceTest {
         }
 
         // Reopen and verify count
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY, file)) {
             assertThat(store.size()).isEqualTo(5);
 
             // Write 2 more and verify they stack correctly
@@ -75,7 +75,7 @@ class MemoryPersistenceTest {
         }
 
         // Reopen again — count should be 7
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY, file)) {
             assertThat(store.size()).isEqualTo(7);
         }
     }
@@ -86,7 +86,7 @@ class MemoryPersistenceTest {
         int smallCap = 5;
 
         // Fill and wrap — write 8 records into a 5-slot buffer
-        try (var store = new WorkingMemoryStore(VEC_BYTES, smallCap, file)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, smallCap, file)) {
             for (int i = 0; i < 8; i++) {
                 store.put(createHeader(1000L + i, 0.5f), dummyVec(VEC_BYTES, (byte) i));
             }
@@ -94,7 +94,7 @@ class MemoryPersistenceTest {
         }
 
         // Reopen — count should still be 5 (capacity)
-        try (var store = new WorkingMemoryStore(VEC_BYTES, smallCap, file)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, smallCap, file)) {
             assertThat(store.size()).isEqualTo(smallCap);
         }
     }
@@ -108,7 +108,7 @@ class MemoryPersistenceTest {
         Path file = tmpDir.resolve("semantic.mem");
 
         // Write 3 headers
-        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new SemanticRecordMemory(VEC_BYTES, CAPACITY, file)) {
             for (int i = 0; i < 3; i++) {
                 var header = CognitiveHeader.create(
                         System.currentTimeMillis(), 0xBEEFL, 1.0f, 0.7f + i * 0.1f, (short) i, MemoryType.SEMANTIC);
@@ -118,7 +118,7 @@ class MemoryPersistenceTest {
         }
 
         // Reopen and verify
-        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new SemanticRecordMemory(VEC_BYTES, CAPACITY, file)) {
             assertThat(store.size()).isEqualTo(3);
 
             // Read back first header and verify importance
@@ -135,14 +135,14 @@ class MemoryPersistenceTest {
     void proceduralStore_persistsAndRecoversRecords() {
         Path file = tmpDir.resolve("procedural.mem");
 
-        try (var store = new ProceduralMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new ProceduralRecordMemory(VEC_BYTES, CAPACITY, file)) {
             for (int i = 0; i < 4; i++) {
                 store.append(createHeader(3000L + i, 1.0f), dummyVec(VEC_BYTES, (byte) (i + 10)));
             }
             assertThat(store.size()).isEqualTo(4);
         }
 
-        try (var store = new ProceduralMemoryStore(VEC_BYTES, CAPACITY, file)) {
+        try (var store = new ProceduralRecordMemory(VEC_BYTES, CAPACITY, file)) {
             assertThat(store.size()).isEqualTo(4);
         }
     }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/ProceduralRecordMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/ProceduralRecordMemoryTest.java
@@ -22,17 +22,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class SemanticMemoryStoreTest {
+class ProceduralRecordMemoryTest {
 
     private CognitiveHeader createHeader() {
-        byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.SEMANTIC.ordinal());
+        byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.PROCEDURAL.ordinal());
         return new CognitiveHeader(12345L, 0L, 1.0f, 0.5f, 0, (short)0, (byte)0, flags, (byte)0, 1.0f);
     }
 
     @Test
     @DisplayName("append increments size and visibleCount")
     void appendIncrementsSizeAndVisibleCount() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
+        try (ProceduralRecordMemory store = new ProceduralRecordMemory(128, 100)) {
             assertThat(store.size()).isZero();
             store.append(createHeader(), new byte[128]);
             assertThat(store.size()).isEqualTo(1);
@@ -41,18 +41,9 @@ class SemanticMemoryStoreTest {
     }
 
     @Test
-    @DisplayName("append with null vector succeeds")
-    void appendWithNullVectorSucceeds() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
-            store.append(createHeader(), null);
-            assertThat(store.size()).isEqualTo(1);
-        }
-    }
-
-    @Test
     @DisplayName("append at capacity throws tier full exception")
     void appendAtCapacityThrowsTierFull() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 1)) {
+        try (ProceduralRecordMemory store = new ProceduralRecordMemory(128, 1)) {
             store.append(createHeader(), new byte[128]);
             assertThatThrownBy(() -> store.append(createHeader(), new byte[128]))
                 .isInstanceOf(SpectorMemoryTierFullException.class);
@@ -60,19 +51,9 @@ class SemanticMemoryStoreTest {
     }
 
     @Test
-    @DisplayName("readHeader returns written data")
-    void readHeaderReturnsWrittenData() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
-            store.write(createHeader(), new byte[128]);
-            CognitiveHeader readHeader = store.readHeader(0);
-            assertThat(readHeader.timestampMs()).isEqualTo(12345L);
-        }
-    }
-
-    @Test
     @DisplayName("write returns correct byte offset")
     void writeReturnsCorrectByteOffset() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
+        try (ProceduralRecordMemory store = new ProceduralRecordMemory(128, 100)) {
             long offset1 = store.write(createHeader(), new byte[128]);
             long offset2 = store.write(createHeader(), new byte[128]);
             assertThat(offset1).isNotEqualTo(offset2);
@@ -81,27 +62,27 @@ class SemanticMemoryStoreTest {
     }
 
     @Test
-    @DisplayName("type returns SEMANTIC")
-    void typeReturnsSemantic() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
-            assertThat(store.type()).isEqualTo(MemoryType.SEMANTIC);
+    @DisplayName("type returns PROCEDURAL")
+    void typeReturnsProcedural() {
+        try (ProceduralRecordMemory store = new ProceduralRecordMemory(128, 100)) {
+            assertThat(store.type()).isEqualTo(MemoryType.PROCEDURAL);
         }
     }
 
     @Test
-    @DisplayName("store header only returns index")
-    void storeHeaderOnlyReturnsIndex() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
-            int index = store.store(createHeader());
-            assertThat(index).isEqualTo(0);
+    @DisplayName("default capacity is 1000")
+    void defaultCapacityIs1000() {
+        try (ProceduralRecordMemory store = new ProceduralRecordMemory(128)) {
+            assertThat(store.capacity()).isEqualTo(1000);
         }
     }
 
     @Test
-    @DisplayName("headerSlab is same as primary segment")
-    void headerSlabIsSameAsPrimarySegment() {
-        try (SemanticMemoryStore store = new SemanticMemoryStore(128, 100)) {
-            assertThat(store.headerSlab()).isNotNull();
+    @DisplayName("header and vector round trip")
+    void headerAndVectorRoundTrip() {
+        try (ProceduralRecordMemory store = new ProceduralRecordMemory(128, 100)) {
+            store.write(createHeader(), new byte[128]);
+            assertThat(store.size()).isEqualTo(1);
         }
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/SemanticRecordMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/SemanticRecordMemoryTest.java
@@ -22,17 +22,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class ProceduralMemoryStoreTest {
+class SemanticRecordMemoryTest {
 
     private CognitiveHeader createHeader() {
-        byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.PROCEDURAL.ordinal());
+        byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.SEMANTIC.ordinal());
         return new CognitiveHeader(12345L, 0L, 1.0f, 0.5f, 0, (short)0, (byte)0, flags, (byte)0, 1.0f);
     }
 
     @Test
     @DisplayName("append increments size and visibleCount")
     void appendIncrementsSizeAndVisibleCount() {
-        try (ProceduralMemoryStore store = new ProceduralMemoryStore(128, 100)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
             assertThat(store.size()).isZero();
             store.append(createHeader(), new byte[128]);
             assertThat(store.size()).isEqualTo(1);
@@ -41,9 +41,18 @@ class ProceduralMemoryStoreTest {
     }
 
     @Test
+    @DisplayName("append with null vector succeeds")
+    void appendWithNullVectorSucceeds() {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
+            store.append(createHeader(), null);
+            assertThat(store.size()).isEqualTo(1);
+        }
+    }
+
+    @Test
     @DisplayName("append at capacity throws tier full exception")
     void appendAtCapacityThrowsTierFull() {
-        try (ProceduralMemoryStore store = new ProceduralMemoryStore(128, 1)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 1)) {
             store.append(createHeader(), new byte[128]);
             assertThatThrownBy(() -> store.append(createHeader(), new byte[128]))
                 .isInstanceOf(SpectorMemoryTierFullException.class);
@@ -51,9 +60,19 @@ class ProceduralMemoryStoreTest {
     }
 
     @Test
+    @DisplayName("readHeader returns written data")
+    void readHeaderReturnsWrittenData() {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
+            store.write(createHeader(), new byte[128]);
+            CognitiveHeader readHeader = store.readHeader(0);
+            assertThat(readHeader.timestampMs()).isEqualTo(12345L);
+        }
+    }
+
+    @Test
     @DisplayName("write returns correct byte offset")
     void writeReturnsCorrectByteOffset() {
-        try (ProceduralMemoryStore store = new ProceduralMemoryStore(128, 100)) {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
             long offset1 = store.write(createHeader(), new byte[128]);
             long offset2 = store.write(createHeader(), new byte[128]);
             assertThat(offset1).isNotEqualTo(offset2);
@@ -62,27 +81,27 @@ class ProceduralMemoryStoreTest {
     }
 
     @Test
-    @DisplayName("type returns PROCEDURAL")
-    void typeReturnsProcedural() {
-        try (ProceduralMemoryStore store = new ProceduralMemoryStore(128, 100)) {
-            assertThat(store.type()).isEqualTo(MemoryType.PROCEDURAL);
+    @DisplayName("type returns SEMANTIC")
+    void typeReturnsSemantic() {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
+            assertThat(store.type()).isEqualTo(MemoryType.SEMANTIC);
         }
     }
 
     @Test
-    @DisplayName("default capacity is 1000")
-    void defaultCapacityIs1000() {
-        try (ProceduralMemoryStore store = new ProceduralMemoryStore(128)) {
-            assertThat(store.capacity()).isEqualTo(1000);
+    @DisplayName("store header only returns index")
+    void storeHeaderOnlyReturnsIndex() {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
+            int index = store.store(createHeader());
+            assertThat(index).isEqualTo(0);
         }
     }
 
     @Test
-    @DisplayName("header and vector round trip")
-    void headerAndVectorRoundTrip() {
-        try (ProceduralMemoryStore store = new ProceduralMemoryStore(128, 100)) {
-            store.write(createHeader(), new byte[128]);
-            assertThat(store.size()).isEqualTo(1);
+    @DisplayName("headerSlab is same as primary segment")
+    void headerSlabIsSameAsPrimarySegment() {
+        try (SemanticRecordMemory store = new SemanticRecordMemory(128, 100)) {
+            assertThat(store.headerSlab()).isNotNull();
         }
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierRouterTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierRouterTest.java
@@ -24,10 +24,10 @@ class TierRouterTest {
     @DisplayName("get() returns correct store for each MemoryType")
     void getReturnsCorrectStoreForEachType() {
         // TierRouter.close() cascades to child stores, so only close the router
-        WorkingMemoryStore working = new WorkingMemoryStore(128, 100);
+        WorkingRecordMemory working = new WorkingRecordMemory(128, 100);
         EpisodicMemoryStore episodic = new EpisodicMemoryStore(128, 100);
-        SemanticMemoryStore semantic = new SemanticMemoryStore(128, 100);
-        ProceduralMemoryStore procedural = new ProceduralMemoryStore(128, 100);
+        SemanticRecordMemory semantic = new SemanticRecordMemory(128, 100);
+        ProceduralRecordMemory procedural = new ProceduralRecordMemory(128, 100);
 
         try (TierRouter router = new TierRouter(working, episodic, semantic, procedural)) {
             assertThat(router.get(MemoryType.WORKING)).isSameAs(working);
@@ -40,10 +40,10 @@ class TierRouterTest {
     @Test
     @DisplayName("Typed accessors return correct instances")
     void typedAccessorsReturnCorrectInstances() {
-        WorkingMemoryStore working = new WorkingMemoryStore(128, 100);
+        WorkingRecordMemory working = new WorkingRecordMemory(128, 100);
         EpisodicMemoryStore episodic = new EpisodicMemoryStore(128, 100);
-        SemanticMemoryStore semantic = new SemanticMemoryStore(128, 100);
-        ProceduralMemoryStore procedural = new ProceduralMemoryStore(128, 100);
+        SemanticRecordMemory semantic = new SemanticRecordMemory(128, 100);
+        ProceduralRecordMemory procedural = new ProceduralRecordMemory(128, 100);
 
         try (TierRouter router = new TierRouter(working, episodic, semantic, procedural)) {
             assertThat(router.working()).isSameAs(working);
@@ -56,10 +56,10 @@ class TierRouterTest {
     @Test
     @DisplayName("totalCount sums all tiers")
     void totalCountSumsAllTiers() {
-        WorkingMemoryStore working = new WorkingMemoryStore(128, 100);
+        WorkingRecordMemory working = new WorkingRecordMemory(128, 100);
         EpisodicMemoryStore episodic = new EpisodicMemoryStore(128, 100);
-        SemanticMemoryStore semantic = new SemanticMemoryStore(128, 100);
-        ProceduralMemoryStore procedural = new ProceduralMemoryStore(128, 100);
+        SemanticRecordMemory semantic = new SemanticRecordMemory(128, 100);
+        ProceduralRecordMemory procedural = new ProceduralRecordMemory(128, 100);
 
         try (TierRouter router = new TierRouter(working, episodic, semantic, procedural)) {
             assertThat(router.totalCount()).isZero();
@@ -92,10 +92,10 @@ class TierRouterTest {
     @Test
     @DisplayName("close() closes all stores without throwing")
     void closeClosesAllStores() {
-        WorkingMemoryStore working = new WorkingMemoryStore(128, 100);
+        WorkingRecordMemory working = new WorkingRecordMemory(128, 100);
         EpisodicMemoryStore episodic = new EpisodicMemoryStore(128, 100);
-        SemanticMemoryStore semantic = new SemanticMemoryStore(128, 100);
-        ProceduralMemoryStore procedural = new ProceduralMemoryStore(128, 100);
+        SemanticRecordMemory semantic = new SemanticRecordMemory(128, 100);
+        ProceduralRecordMemory procedural = new ProceduralRecordMemory(128, 100);
         
         TierRouter router = new TierRouter(working, episodic, semantic, procedural);
         router.close();

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierStoreKernelIntegrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierStoreKernelIntegrationTest.java
@@ -36,9 +36,9 @@ class TierStoreKernelIntegrationTest {
     // ── Working Memory ──
 
     @Test
-    @DisplayName("WorkingMemoryStore has kernel identity with WORKING type")
+    @DisplayName("WorkingRecordMemory has kernel identity with WORKING type")
     void workingMemoryStoreHasKernelIdentity() {
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY)) {
             MemoryId id = store.memoryId();
             assertThat(id.namespace()).isEqualTo("tier");
             assertThat(id.memoryName()).isEqualTo("working");
@@ -47,9 +47,9 @@ class TierStoreKernelIntegrationTest {
     }
 
     @Test
-    @DisplayName("WorkingMemoryStore exposes kernel layout adapter")
+    @DisplayName("WorkingRecordMemory exposes kernel layout adapter")
     void workingMemoryStoreKernelLayout() {
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY)) {
             CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
             assertThat(adapter).isNotNull();
             assertThat(adapter.recordStride()).isEqualTo(store.layout().stride());
@@ -58,9 +58,9 @@ class TierStoreKernelIntegrationTest {
     }
 
     @Test
-    @DisplayName("WorkingMemoryStore kernel shape is RECORD")
+    @DisplayName("WorkingRecordMemory kernel shape is RECORD")
     void workingMemoryStoreKernelShape() {
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY)) {
             assertThat(store.kernelShape()).isEqualTo(MemoryShape.RECORD);
         }
     }
@@ -68,9 +68,9 @@ class TierStoreKernelIntegrationTest {
     // ── Semantic Memory ──
 
     @Test
-    @DisplayName("SemanticMemoryStore has kernel identity with SEMANTIC type")
+    @DisplayName("SemanticRecordMemory has kernel identity with SEMANTIC type")
     void semanticMemoryStoreHasKernelIdentity() {
-        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new SemanticRecordMemory(VEC_BYTES, CAPACITY)) {
             MemoryId id = store.memoryId();
             assertThat(id.namespace()).isEqualTo("tier");
             assertThat(id.memoryName()).isEqualTo("semantic");
@@ -78,9 +78,9 @@ class TierStoreKernelIntegrationTest {
     }
 
     @Test
-    @DisplayName("SemanticMemoryStore exposes kernel layout adapter")
+    @DisplayName("SemanticRecordMemory exposes kernel layout adapter")
     void semanticMemoryStoreKernelLayout() {
-        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new SemanticRecordMemory(VEC_BYTES, CAPACITY)) {
             CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
             assertThat(adapter).isNotNull();
             assertThat(adapter.recordStride()).isEqualTo(store.layout().stride());
@@ -90,9 +90,9 @@ class TierStoreKernelIntegrationTest {
     // ── Procedural Memory ──
 
     @Test
-    @DisplayName("ProceduralMemoryStore has kernel identity with PROCEDURAL type")
+    @DisplayName("ProceduralRecordMemory has kernel identity with PROCEDURAL type")
     void proceduralMemoryStoreHasKernelIdentity() {
-        try (var store = new ProceduralMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new ProceduralRecordMemory(VEC_BYTES, CAPACITY)) {
             MemoryId id = store.memoryId();
             assertThat(id.namespace()).isEqualTo("tier");
             assertThat(id.memoryName()).isEqualTo("procedural");
@@ -100,9 +100,9 @@ class TierStoreKernelIntegrationTest {
     }
 
     @Test
-    @DisplayName("ProceduralMemoryStore exposes kernel layout adapter")
+    @DisplayName("ProceduralRecordMemory exposes kernel layout adapter")
     void proceduralMemoryStoreKernelLayout() {
-        try (var store = new ProceduralMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new ProceduralRecordMemory(VEC_BYTES, CAPACITY)) {
             CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
             assertThat(adapter).isNotNull();
             assertThat(adapter.recordStride()).isEqualTo(store.layout().stride());
@@ -126,7 +126,7 @@ class TierStoreKernelIntegrationTest {
     @Test
     @DisplayName("memoryId is lazily initialized and thread-safe")
     void memoryIdIsLazyAndStable() {
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY)) {
             MemoryId id1 = store.memoryId();
             MemoryId id2 = store.memoryId();
             assertThat(id1).isSameAs(id2); // same instance, not just equals
@@ -136,7 +136,7 @@ class TierStoreKernelIntegrationTest {
     @Test
     @DisplayName("memoryId toString follows kernel format")
     void memoryIdToStringFormat() {
-        try (var store = new SemanticMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new SemanticRecordMemory(VEC_BYTES, CAPACITY)) {
             assertThat(store.memoryId().toString()).isEqualTo("tier/semantic");
         }
     }
@@ -144,7 +144,7 @@ class TierStoreKernelIntegrationTest {
     @Test
     @DisplayName("kernel layout adapter crcEnabled matches cognitive layout")
     void kernelLayoutCrcFlag() {
-        try (var store = new WorkingMemoryStore(VEC_BYTES, CAPACITY)) {
+        try (var store = new WorkingRecordMemory(VEC_BYTES, CAPACITY)) {
             // CognitiveRecordLayout doesn't enable CRC by default
             CognitiveRecordLayoutAdapter adapter = store.kernelLayout();
             assertThat(adapter.crcEnabled()).isFalse();

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/WorkingRecordMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/WorkingRecordMemoryTest.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link WorkingMemoryStore} — volatile circular buffer.
+ * Tests for {@link WorkingRecordMemory} — volatile circular buffer.
  */
-class WorkingMemoryStoreTest {
+class WorkingRecordMemoryTest {
 
     private static final int VEC_BYTES = 32; // small vectors for testing
-    private WorkingMemoryStore store;
+    private WorkingRecordMemory store;
 
     @BeforeEach
     void setUp() {
-        store = new WorkingMemoryStore(VEC_BYTES, 5); // capacity of 5 for easy testing
+        store = new WorkingRecordMemory(VEC_BYTES, 5); // capacity of 5 for easy testing
     }
 
     @AfterEach

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemonClusteringTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemonClusteringTest.java
@@ -16,7 +16,7 @@ import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.cortex.EpisodicMemoryStore;
 import com.spectrayan.spector.memory.cortex.EpisodicMemoryStore.EpisodicPartition;
-import com.spectrayan.spector.memory.cortex.SemanticMemoryStore;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.synapse.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.synapse.SynapticHeaderConstants;
@@ -65,7 +65,7 @@ class ReflectDaemonClusteringTest {
     @Test
     void clustersBycentroidIdAndPromotes() {
         try (EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(storePath, VEC_BYTES, CAPACITY);
-             SemanticMemoryStore semanticStore = new SemanticMemoryStore(VEC_BYTES, 100)) {
+             SemanticRecordMemory semanticStore = new SemanticRecordMemory(VEC_BYTES, 100)) {
 
             // Create 20 memories across 3 centroids (ids: 1, 2, 3)
             // Cluster 1: 8 records (above min=5)
@@ -113,7 +113,7 @@ class ReflectDaemonClusteringTest {
     @Test
     void withLlmProviderSynthesizes() {
         try (EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(storePath, VEC_BYTES, CAPACITY);
-             SemanticMemoryStore semanticStore = new SemanticMemoryStore(VEC_BYTES, 100)) {
+             SemanticRecordMemory semanticStore = new SemanticRecordMemory(VEC_BYTES, 100)) {
 
             // Create 6 memories in the same centroid
             for (int i = 0; i < 6; i++) {
@@ -151,7 +151,7 @@ class ReflectDaemonClusteringTest {
     @Test
     void withoutCentroidRouterUsesV1Fallback() {
         try (EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(storePath, VEC_BYTES, CAPACITY);
-             SemanticMemoryStore semanticStore = new SemanticMemoryStore(VEC_BYTES, 100)) {
+             SemanticRecordMemory semanticStore = new SemanticRecordMemory(VEC_BYTES, 100)) {
 
             // Create 5 memories with importance  >=  1.0
             for (int i = 0; i < 5; i++) {
@@ -178,7 +178,7 @@ class ReflectDaemonClusteringTest {
     @Test
     void marksClusterMembersAsConsolidated() {
         try (EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(storePath, VEC_BYTES, CAPACITY);
-             SemanticMemoryStore semanticStore = new SemanticMemoryStore(VEC_BYTES, 100)) {
+             SemanticRecordMemory semanticStore = new SemanticRecordMemory(VEC_BYTES, 100)) {
 
             // Create 6 memories in centroid 1
             for (int i = 0; i < 6; i++) {
@@ -214,7 +214,7 @@ class ReflectDaemonClusteringTest {
     @Test
     void secondReflectDoesNotReprocessConsolidated() {
         try (EpisodicMemoryStore episodicStore = new EpisodicMemoryStore(storePath, VEC_BYTES, CAPACITY);
-             SemanticMemoryStore semanticStore = new SemanticMemoryStore(VEC_BYTES, 100)) {
+             SemanticRecordMemory semanticStore = new SemanticRecordMemory(VEC_BYTES, 100)) {
 
             // 6 memories in centroid 1
             for (int i = 0; i < 6; i++) {


### PR DESCRIPTION
### Summary

This PR completes **Phase 1** of the Memory Kernel Layout Migration (Issue #380).

#### Key Changes
1. **`AbstractTierStore` Refactoring**:
   - Refactored `AbstractTierStore` to extend `AbstractRecordMemory<CognitiveRecordLayoutAdapter>` directly and implement `TierStore`.
   - Removed inner `TierRecordBacking` class and `.backing()` getter.
   - Updated layout accessors: `layout()` returns `CognitiveRecordLayoutAdapter` and `cognitiveLayout()` returns `CognitiveRecordLayout`.

2. **Store Renaming**:
   - Renamed `WorkingMemoryStore` → `WorkingRecordMemory`
   - Renamed `SemanticMemoryStore` → `SemanticRecordMemory`
   - Renamed `ProceduralMemoryStore` → `ProceduralRecordMemory`
   - Updated corresponding test classes (`WorkingRecordMemoryTest`, `SemanticRecordMemoryTest`, `ProceduralRecordMemoryTest`).

3. **Subsystem & Pipeline Integration**:
   - Updated `TierRouter`, `SpectorMemoryFactory`, `DefaultSpectorMemory`, `PartitionManager`, `RecallPipeline`, `ConsolidationService`, `DuplicateDetector`, `SemanticRecallStrategy`, `SynapticDecayModulator`, `VacuumCompactor`, `CognitiveIngestionTarget`, `ReflectionOrchestrator`, and benchmark classes.

### Verification
- `mvn test-compile -DskipTests`: SUCCESS across all 26 modules.
- `mvn test -pl memory/spector-memory "-Dtest=WorkingRecordMemoryTest,SemanticRecordMemoryTest,ProceduralRecordMemoryTest,TierRouterTest,AbstractTierStoreTest,TierStoreKernelIntegrationTest,MemoryPersistenceTest"`: 53/53 tests passed cleanly.

Closes #380.
