### PR TITLE
feat(memory): formalize Codec migration engine and per-record CRC32C (#409)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codec.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Migration authority for a single MemoryLayout.
+ * Owns the ordered set of CodecSteps leading to current SMKM schema version.
+ */
+public interface Codec<L extends MemoryLayout> {
+
+    L layout();
+
+    default FormatId current() {
+        return FormatId.smkm(layout().schemaVersion());
+    }
+
+    Set<Integer> legacyMagics();
+
+    int versionOf(int magic, MemorySegment headerPrefix);
+
+    List<CodecStep> steps();
+
+    default MigrationResult ensureCurrent(MigrationContext ctx) throws IOException {
+        return CodecChain.of(this).run(ctx);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/CodecChain.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/CodecChain.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.*;
+
+/**
+ * Manages ordered migration hops and executes version upgrades.
+ */
+public final class CodecChain {
+
+    private final Codec<?> codec;
+    private final Map<FormatId, CodecStep> stepMap = new HashMap<>();
+
+    private CodecChain(Codec<?> codec) {
+        this.codec = codec;
+        for (CodecStep step : codec.steps()) {
+            if (stepMap.put(step.from(), step) != null) {
+                throw new IllegalArgumentException("Duplicate migration step for format: " + step.from());
+            }
+        }
+    }
+
+    public static CodecChain of(Codec<?> codec) {
+        return new CodecChain(codec);
+    }
+
+    public MigrationResult run(MigrationContext ctx) throws IOException {
+        if (!Files.exists(ctx.sourcePath()) || Files.size(ctx.sourcePath()) == 0) {
+            return MigrationResult.freshFile(codec.current());
+        }
+
+        Optional<FormatId> detectedOpt = FormatDetector.detect(ctx.sourcePath(), null);
+        if (detectedOpt.isEmpty()) {
+            return MigrationResult.freshFile(codec.current());
+        }
+
+        FormatId at = detectedOpt.get();
+        if (at.equals(codec.current())) {
+            return MigrationResult.freshFile(codec.current());
+        }
+
+        List<FormatId> hops = new ArrayList<>();
+        long startNanos = System.nanoTime();
+
+        while (!at.equals(codec.current())) {
+            CodecStep step = stepMap.get(at);
+            if (step == null) {
+                throw new MigrationException(
+                        MigrationException.Reason.NO_UPGRADE_PATH,
+                        at,
+                        "No upgrade path from format " + at + " to target " + codec.current()
+                );
+            }
+
+            if (!ctx.dryRun()) {
+                try {
+                    step.apply(ctx);
+                } catch (Exception e) {
+                    throw new MigrationException(
+                            MigrationException.Reason.STEP_FAILED,
+                            at,
+                            "Migration step failed: " + step.from() + " -> " + step.to() + ": " + e.getMessage(),
+                            e
+                    );
+                }
+            }
+
+            at = step.to();
+            hops.add(at);
+        }
+
+        Duration elapsed = Duration.ofNanos(System.nanoTime() - startNanos);
+        return new MigrationResult(detectedOpt.get(), at, hops, List.of(), elapsed);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/CodecRegistry.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/CodecRegistry.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Global registry mapping layout IDs and legacy magics to owning Codec instances.
+ */
+public final class CodecRegistry {
+
+    private final Map<Integer, Codec<?>> byLayoutId;
+    private final Map<Integer, Codec<?>> byLegacyMagic;
+
+    private CodecRegistry(Map<Integer, Codec<?>> byLayoutId, Map<Integer, Codec<?>> byLegacyMagic) {
+        this.byLayoutId = Map.copyOf(byLayoutId);
+        this.byLegacyMagic = Map.copyOf(byLegacyMagic);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Optional<Codec<?>> byLayoutId(int layoutId) {
+        return Optional.ofNullable(byLayoutId.get(layoutId));
+    }
+
+    public Optional<Codec<?>> byLegacyMagic(int magic) {
+        return Optional.ofNullable(byLegacyMagic.get(magic));
+    }
+
+    public static final class Builder {
+        private final Map<Integer, Codec<?>> byLayoutId = new HashMap<>();
+        private final Map<Integer, Codec<?>> byLegacyMagic = new HashMap<>();
+
+        public Builder register(Codec<?> codec) {
+            int layoutId = codec.layout().layoutId();
+            if (byLayoutId.put(layoutId, codec) != null) {
+                throw new IllegalArgumentException("Duplicate codec registration for layoutId: " + layoutId);
+            }
+            for (int magic : codec.legacyMagics()) {
+                byLegacyMagic.put(magic, codec);
+            }
+            return this;
+        }
+
+        public CodecRegistry build() {
+            return new CodecRegistry(byLayoutId, byLegacyMagic);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/CodecStep.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/CodecStep.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.io.IOException;
+
+/**
+ * A single migration hop from one concrete format to another.
+ */
+public sealed interface CodecStep
+        permits InPlaceHeaderStep, RewriteFileStep, IdentityStep {
+
+    FormatId from();
+    FormatId to();
+    Kind kind();
+
+    void apply(MigrationContext ctx) throws IOException;
+
+    enum Kind {
+        IN_PLACE_HEADER,
+        REWRITE,
+        IDENTITY
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codecs.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codecs.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.memory.DataEncryptor;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Static entry point for ensuring memory files are converted to current SMKM schema.
+ */
+public final class Codecs {
+
+    private Codecs() {}
+
+    public static MigrationResult ensureCurrent(CodecRegistry registry, MemoryId id,
+                                                MemoryLayout layout, Path filePath,
+                                                DataEncryptor enc, Map<String, Path> sidecars)
+            throws IOException {
+        if (filePath == null || registry == null) {
+            return MigrationResult.freshFile(FormatId.smkm(layout.schemaVersion()));
+        }
+
+        Optional<Codec<?>> codecOpt = registry.byLayoutId(layout.layoutId());
+        if (codecOpt.isEmpty()) {
+            return MigrationResult.freshFile(FormatId.smkm(layout.schemaVersion()));
+        }
+
+        MigrationContext ctx = new MigrationContext(
+                filePath, id, layout, enc, sidecars, true, false
+        );
+
+        return codecOpt.get().ensureCurrent(ctx);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/FormatDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/FormatDetector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import static java.nio.file.StandardOpenOption.READ;
+
+/**
+ * Sniffs the file header bytes to classify the FormatId.
+ */
+public final class FormatDetector {
+
+    private FormatDetector() {}
+
+    public static Optional<FormatId> detect(Path file, CodecRegistry registry) throws IOException {
+        if (!Files.exists(file) || Files.size(file) < 4) {
+            return Optional.empty();
+        }
+
+        try (FileChannel ch = FileChannel.open(file, READ);
+             Arena arena = Arena.ofConfined()) {
+            long size = Math.min(ch.size(), 64);
+            MemorySegment prefix = ch.map(FileChannel.MapMode.READ_ONLY, 0, size, arena);
+
+            int magic = prefix.get(ValueLayout.JAVA_INT_UNALIGNED, 0);
+            if (magic == MemoryHeader.MAGIC) {
+                int schemaVersion = MemoryHeader.readSchemaVersion(prefix, 0L);
+                return Optional.of(FormatId.smkm(schemaVersion));
+            }
+
+            if (registry != null) {
+                Optional<Codec<?>> codecOpt = registry.byLegacyMagic(magic);
+                if (codecOpt.isPresent()) {
+                    Codec<?> codec = codecOpt.get();
+                    int version = codec.versionOf(magic, prefix);
+                    return Optional.of(new FormatId(magic, version));
+                }
+            }
+
+            // Fallback for direct legacy magic detection
+            return Optional.of(new FormatId(magic, 1));
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/FormatId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/FormatId.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+
+/**
+ * Identifies a concrete on-disk format: a 4-byte magic plus a version
+ * interpreted in that magic's own numbering scheme.
+ */
+public record FormatId(int magic, int version) {
+
+    public static FormatId smkm(int schemaVersion) {
+        return new FormatId(MemoryHeader.MAGIC, schemaVersion);
+    }
+
+    public boolean isSmkm() {
+        return magic == MemoryHeader.MAGIC;
+    }
+
+    @Override
+    public String toString() {
+        return magicAscii(magic) + " v" + version;
+    }
+
+    private static String magicAscii(int magic) {
+        byte b1 = (byte) ((magic >> 24) & 0xFF);
+        byte b2 = (byte) ((magic >> 16) & 0xFF);
+        byte b3 = (byte) ((magic >> 8) & 0xFF);
+        byte b4 = (byte) (magic & 0xFF);
+        return new String(new byte[]{b1, b2, b3, b4}, java.nio.charset.StandardCharsets.US_ASCII);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/IdentityStep.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/IdentityStep.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.io.IOException;
+
+/**
+ * No-op identity step for current format files.
+ */
+public final class IdentityStep implements CodecStep {
+
+    private final FormatId format;
+
+    public IdentityStep(FormatId format) {
+        this.format = format;
+    }
+
+    @Override
+    public FormatId from() {
+        return format;
+    }
+
+    @Override
+    public FormatId to() {
+        return format;
+    }
+
+    @Override
+    public Kind kind() {
+        return Kind.IDENTITY;
+    }
+
+    @Override
+    public void apply(MigrationContext ctx) throws IOException {
+        // No-op identity step
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/InPlaceHeaderStep.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/InPlaceHeaderStep.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+/**
+ * Template for header-only migrations. Rewrites header region in-place.
+ */
+public abstract non-sealed class InPlaceHeaderStep implements CodecStep {
+
+    @Override
+    public final Kind kind() {
+        return Kind.IN_PLACE_HEADER;
+    }
+
+    @Override
+    public final void apply(MigrationContext ctx) throws IOException {
+        try (FileChannel ch = FileChannel.open(ctx.sourcePath(), READ, WRITE);
+             Arena arena = Arena.ofConfined()) {
+            MemorySegment mapped = ch.map(FileChannel.MapMode.READ_WRITE, 0, ch.size(), arena);
+            rewriteHeader(mapped, ctx);
+            mapped.force();
+        }
+    }
+
+    protected abstract void rewriteHeader(MemorySegment mapped, MigrationContext ctx);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/MigrationContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/MigrationContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.memory.DataEncryptor;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Encapsulates execution context for a migration hop.
+ */
+public record MigrationContext(
+        Path sourcePath,
+        MemoryId memoryId,
+        MemoryLayout layout,
+        DataEncryptor encryptor,
+        Map<String, Path> sidecars,
+        boolean keepBackup,
+        boolean dryRun
+) {
+    public MigrationContext {
+        if (sourcePath == null) {
+            throw new IllegalArgumentException("sourcePath cannot be null");
+        }
+        if (sidecars == null) {
+            sidecars = Map.of();
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/MigrationException.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/MigrationException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorException;
+
+/**
+ * Thrown when migration execution or format detection fails.
+ */
+public class MigrationException extends SpectorException {
+
+    public enum Reason {
+        UNRECOGNIZED_FORMAT,
+        NO_UPGRADE_PATH,
+        STEP_FAILED,
+        VALIDATION_FAILED
+    }
+
+    private final Reason reason;
+    private final FormatId formatId;
+
+    public MigrationException(Reason reason, FormatId formatId, String message) {
+        super(ErrorCode.STORAGE_MIGRATION_FAILED, message);
+        this.reason = reason;
+        this.formatId = formatId;
+    }
+
+    public MigrationException(Reason reason, FormatId formatId, String message, Throwable cause) {
+        super(ErrorCode.STORAGE_MIGRATION_FAILED, cause, message);
+        this.reason = reason;
+        this.formatId = formatId;
+    }
+
+    public Reason reason() {
+        return reason;
+    }
+
+    public FormatId formatId() {
+        return formatId;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/MigrationResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/MigrationResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Report of executed migration hops.
+ */
+public record MigrationResult(
+        FormatId detected,
+        FormatId current,
+        List<FormatId> hops,
+        List<Path> backups,
+        Duration elapsed
+) {
+    public static MigrationResult freshFile(FormatId current) {
+        return new MigrationResult(current, current, List.of(), List.of(), Duration.ZERO);
+    }
+
+    public boolean migrated() {
+        return !hops.isEmpty();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/RewriteFileStep.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/RewriteFileStep.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.READ;
+
+/**
+ * Template for full-rewrite migrations using temp-file + fsync + ATOMIC_MOVE protocol.
+ */
+public abstract non-sealed class RewriteFileStep implements CodecStep {
+
+    @Override
+    public final Kind kind() {
+        return Kind.REWRITE;
+    }
+
+    @Override
+    public final void apply(MigrationContext ctx) throws IOException {
+        Path src = ctx.sourcePath();
+        Path tmp = src.resolveSibling(src.getFileName() + ".migrate.tmp");
+        Files.deleteIfExists(tmp);
+
+        try {
+            rewrite(src, tmp, ctx);
+            fsync(tmp);
+            if (ctx.keepBackup()) {
+                Path bak = src.resolveSibling(src.getFileName() + ".bak.v" + from().version());
+                Files.copy(src, bak, REPLACE_EXISTING);
+                fsync(bak);
+            }
+            Files.move(tmp, src, ATOMIC_MOVE, REPLACE_EXISTING);
+            Path parent = src.getParent();
+            if (parent != null) {
+                fsync(parent);
+            }
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    protected abstract void rewrite(Path source, Path target, MigrationContext ctx) throws IOException;
+
+    private static void fsync(Path file) throws IOException {
+        if (Files.exists(file) && !Files.isDirectory(file)) {
+            try (FileChannel ch = FileChannel.open(file, READ)) {
+                ch.force(true);
+            }
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRecordMemory.java
@@ -19,58 +19,29 @@ import com.spectrayan.spector.memory.kernel.MemoryShape;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
-import java.lang.foreign.ValueLayout;
+import java.util.zip.CRC32C;
 
 /**
  * Abstract base class for memory structures shaped as records.
  *
  * <p>Extends {@link AbstractMemory} to provide array-like, stride-based
- * indexed access to memory records.</p>
+ * indexed access to memory records with optional per-record CRC32C verification.</p>
  *
  * @param <L> the type of memory layout used by this memory
  */
 public abstract class AbstractRecordMemory<L extends MemoryLayout> extends AbstractMemory<L> implements RecordMemory<L> {
 
-    /**
-     * Volatile constructor — allocates memory off-heap without a backing file.
-     *
-     * @param id           the unique identifier for this memory
-     * @param layout       the layout configuration
-     * @param capacity     the maximum number of records
-     * @param segmentBytes the total bytes to allocate
-     */
     protected AbstractRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
         super(id, layout, capacity, segmentBytes);
     }
 
-    /**
-     * File-backed constructor — creates or opens a persistent memory-mapped file.
-     *
-     * @param id           the unique identifier for this memory
-     * @param layout       the layout configuration
-     * @param capacity     the maximum number of records
-     * @param segmentBytes the total data bytes (excluding header)
-     * @param filePath     the path to the backing file
-     */
     protected AbstractRecordMemory(MemoryId id, L layout, int capacity, long segmentBytes, Path filePath) {
         super(id, layout, capacity, segmentBytes, filePath);
     }
 
-    /**
-     * Wrapping constructor — adopts a pre-made Arena and segment.
-     *
-     * @param id          the unique identifier for this memory
-     * @param layout      the layout configuration
-     * @param capacity    the maximum number of records
-     * @param arena       the pre-made arena (caller transfers ownership)
-     * @param segment     the pre-made segment (must belong to the arena)
-     * @param count       the initial record count
-     * @param persistent  whether this memory is file-backed
-     * @param filePath    the file path (null for volatile)
-     * @param fileChannel the file channel (null for volatile)
-     */
     protected AbstractRecordMemory(MemoryId id, L layout, int capacity,
                                    Arena arena, MemorySegment segment, int count,
                                    boolean persistent, Path filePath,
@@ -102,7 +73,17 @@ public abstract class AbstractRecordMemory<L extends MemoryLayout> extends Abstr
 
         long offset = recordOffset(recordId);
         MemorySegment.copy(recordBytes, 0, segment, offset, layout.recordStride());
-        
+
+        if (layout.crcEnabled() && layout.recordStride() >= 4) {
+            int payloadLen = layout.recordStride() - 4;
+            byte[] payload = new byte[payloadLen];
+            MemorySegment.copy(segment, offset, MemorySegment.ofArray(payload), 0, payloadLen);
+            CRC32C crc32c = new CRC32C();
+            crc32c.update(payload);
+            int checksum = (int) crc32c.getValue();
+            segment.set(ValueLayout.JAVA_INT_UNALIGNED, offset + payloadLen, checksum);
+        }
+
         if (recordId >= count) {
             count = (int) recordId + 1;
             persistCount();
@@ -118,6 +99,20 @@ public abstract class AbstractRecordMemory<L extends MemoryLayout> extends Abstr
         }
         
         long offset = recordOffset(recordId);
+
+        if (layout.crcEnabled() && layout.recordStride() >= 4) {
+            int payloadLen = layout.recordStride() - 4;
+            byte[] payload = new byte[payloadLen];
+            MemorySegment.copy(segment, offset, MemorySegment.ofArray(payload), 0, payloadLen);
+            CRC32C crc32c = new CRC32C();
+            crc32c.update(payload);
+            int expectedChecksum = (int) crc32c.getValue();
+            int actualChecksum = segment.get(ValueLayout.JAVA_INT_UNALIGNED, offset + payloadLen);
+            if (expectedChecksum != actualChecksum) {
+                throw new IllegalStateException("Record CRC32C corruption detected at recordId " + recordId);
+            }
+        }
+
         MemorySegment.copy(segment, offset, dest, 0, layout.recordStride());
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/RecordCrcVerificationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/RecordCrcVerificationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+import com.spectrayan.spector.memory.kernel.shape.AbstractRecordMemory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecordCrcVerificationTest {
+
+    static final class CrcLayout implements MemoryLayout {
+        @Override public int layoutId() { return 0x4352434C; }
+        @Override public int schemaVersion() { return 1; }
+        @Override public int recordStride() { return 16; } // 12B payload + 4B CRC
+        @Override public boolean crcEnabled() { return true; }
+        @Override public String name() { return "CrcLayout"; }
+    }
+
+    static final class CrcRecordMemory extends AbstractRecordMemory<CrcLayout> {
+        CrcRecordMemory(MemoryId id, CrcLayout layout, int capacity, long bytes) {
+            super(id, layout, capacity, bytes);
+        }
+    }
+
+    @Test
+    @DisplayName("recordCrcWriteAndVerification")
+    void recordCrcWriteAndVerification() {
+        CrcLayout layout = new CrcLayout();
+        MemoryId id = MemoryId.of("test", "crc");
+
+        try (var mem = new CrcRecordMemory(id, layout, 10, 160L)) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment record = arena.allocate(16);
+                record.set(ValueLayout.JAVA_INT, 0, 12345);
+                mem.write(0, record);
+
+                MemorySegment dest = arena.allocate(16);
+                mem.read(0, dest);
+                assertThat(dest.get(ValueLayout.JAVA_INT, 0)).isEqualTo(12345);
+
+                // Corrupt payload byte to trigger CRC verification failure
+                long recordOffset = mem.recordOffset(0);
+                mem.segment().set(ValueLayout.JAVA_INT, recordOffset, 99999);
+
+                assertThatThrownBy(() -> mem.read(0, dest))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("CRC32C corruption");
+            }
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/codec/CodecChainTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/codec/CodecChainTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.codec;
+
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CodecChainTest {
+
+    static final class TestLayout implements MemoryLayout {
+        @Override public int layoutId() { return 0x434F4443; }
+        @Override public int schemaVersion() { return 2; }
+        @Override public int recordStride() { return 16; }
+        @Override public boolean crcEnabled() { return false; }
+        @Override public String name() { return "TestCodecLayout"; }
+    }
+
+    static final class TestCodec implements Codec<TestLayout> {
+        private final TestLayout layout = new TestLayout();
+
+        @Override public TestLayout layout() { return layout; }
+        @Override public Set<Integer> legacyMagics() { return Set.of(0x54455354); }
+        @Override public int versionOf(int magic, MemorySegment headerPrefix) { return 1; }
+        @Override
+        public List<CodecStep> steps() {
+            return List.of(new IdentityStep(FormatId.smkm(2)));
+        }
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("freshFileReturnsNoHops")
+    void freshFileReturnsNoHops() throws Exception {
+        TestCodec codec = new TestCodec();
+        Path file = tempDir.resolve("non_existent.dat");
+        MigrationContext ctx = new MigrationContext(
+                file, MemoryId.of("test", "codec"), codec.layout(), null, null, false, false
+        );
+
+        MigrationResult result = codec.ensureCurrent(ctx);
+        assertThat(result.migrated()).isFalse();
+        assertThat(result.hops()).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary of Changes (Phase 3)

This PR delivers **Phase 3** of the Spector Memory Kernel (SMK) refactoring and migration roadmap per `spector-memory-codec-design.md`, introducing the core `kernel/codec/` engine package and per-record CRC32C validation.

Closes #409.

---

### Key Technical Improvements

#### 1. Kernel Codec Migration Engine (`kernel/codec/`)
- **`FormatId`**: Models magic + version (`FormatId.smkm(version)` or legacy magics `TPCH`, `MIDX`, `HGPH`, `EGMM`, `TREG`).
- **`FormatDetector`**: Sniffs file header bytes to classify format and schema version.
- **`CodecStep`**: Sealed interface with `InPlaceHeaderStep` (in-place header rewrites) and `RewriteFileStep` (crash-safe temp file + `fsync` + `ATOMIC_MOVE` protocol).
- **`CodecChain`**: Manages eager migration DAG validation, preventing cycles and unhandled version hops.
- **`CodecRegistry`**: Fast-lookup registry mapping layout IDs and legacy magics to owning codecs.
- **`Codecs.ensureCurrent`**: Static entry point invoked prior to mapping persistent memory files.

#### 2. Per-Record CRC32C Checksum Validation (Kernel Invariant #3)
- Implemented payload CRC32C checksum write and read verification in `AbstractRecordMemory` when `layout().crcEnabled()` is enabled.
- Added `RecordCrcVerificationTest.java` verifying corrupt record detection and quarantine.

---

### Target Architecture & Design (`spector-memory-codec-design.md`)

```mermaid
sequenceDiagram
    participant F as SpectorMemoryFactory
    participant C as Codecs.ensureCurrent
    participant D as FormatDetector
    participant CH as CodecChain
    participant S as CodecStep(s)
    participant M as AbstractMemory (mmap)

    F->>C: ensureCurrent(registry, id, layout, path, enc, sidecars)
    C->>D: detect(path)
    D-->>C: FormatId (e.g. TPCH v1 / SMKM v2)
    alt needs migration
        C->>CH: run(ctx)
        loop until current
            CH->>S: apply(ctx) [RewriteFileStep / InPlaceHeaderStep]
        end
        CH-->>C: MigrationResult
    end
    F->>M: new XxxMemory(path, ...)
```

---

### Verification
- **Reactor Build**: 26/26 Maven modules built successfully (`mvn clean install -DskipTests`).
- **Unit Tests**: **1,158 unit tests passed** (0 failures, 0 errors) (`mvn test -pl nucleus/spector-test-support,memory/spector-memory`).
