### PR TITLE
spring boot starter improvements

### DIFF
--- a/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
+++ b/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
@@ -84,7 +84,7 @@ public class SpectorClient implements AutoCloseable {
     /**
      * Creates a new builder for SpectorClient.
      */
-    public static Builder builder() {
+    private static Builder builder() {
         return new Builder();
     }
 
@@ -422,7 +422,7 @@ public class SpectorClient implements AutoCloseable {
         private Duration connectTimeout = Duration.ofSeconds(5);
         private Duration requestTimeout = Duration.ofSeconds(30);
 
-        public Builder() {}
+        private Builder() {}
 
         /** Sets the server host (default: localhost). */
         public Builder host(String host) {

--- a/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
+++ b/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
@@ -84,7 +84,7 @@ public class SpectorClient implements AutoCloseable {
     /**
      * Creates a new builder for SpectorClient.
      */
-    private static Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 

--- a/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
+++ b/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
@@ -65,6 +65,26 @@ public class SpectorClient implements AutoCloseable {
     private final ObjectMapper objectMapper;
     private final Duration requestTimeout;
 
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public HttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+
     public SpectorClient(Builder builder) {
         this.baseUrl = "http://" + builder.host + ":" + builder.port;
         this.apiKey = builder.apiKey;

--- a/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
+++ b/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
@@ -65,7 +65,7 @@ public class SpectorClient implements AutoCloseable {
     private final ObjectMapper objectMapper;
     private final Duration requestTimeout;
 
-    private SpectorClient(Builder builder) {
+    public SpectorClient(Builder builder) {
         this.baseUrl = "http://" + builder.host + ":" + builder.port;
         this.apiKey = builder.apiKey;
         this.requestTimeout = builder.requestTimeout;
@@ -422,7 +422,7 @@ public class SpectorClient implements AutoCloseable {
         private Duration connectTimeout = Duration.ofSeconds(5);
         private Duration requestTimeout = Duration.ofSeconds(30);
 
-        private Builder() {}
+        public Builder() {}
 
         /** Sets the server host (default: localhost). */
         public Builder host(String host) {

--- a/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
+++ b/synapse/spector-client/src/main/java/com/spectrayan/spector/client/SpectorClient.java
@@ -69,23 +69,7 @@ public class SpectorClient implements AutoCloseable {
         return baseUrl;
     }
 
-    public String getApiKey() {
-        return apiKey;
-    }
-
-    public HttpClient getHttpClient() {
-        return httpClient;
-    }
-
-    public ObjectMapper getObjectMapper() {
-        return objectMapper;
-    }
-
-    public Duration getRequestTimeout() {
-        return requestTimeout;
-    }
-
-    public SpectorClient(Builder builder) {
+    private SpectorClient(Builder builder) {
         this.baseUrl = "http://" + builder.host + ":" + builder.port;
         this.apiKey = builder.apiKey;
         this.requestTimeout = builder.requestTimeout;

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
@@ -15,7 +15,14 @@
  */
 package com.spectrayan.spector.spring.autoconfigure;
 
+import com.spectrayan.spector.client.SpectorClient;
+import com.spectrayan.spector.provider.ProviderConfig;
+import com.spectrayan.spector.provider.anthropic.AnthropicProviderFactory;
+import com.spectrayan.spector.provider.azure.AzureOpenAiProviderFactory;
+import com.spectrayan.spector.provider.bedrock.BedrockProviderFactory;
+import com.spectrayan.spector.provider.embedding.EmbeddingConfig;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.EmbeddingResult;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.memory.DefaultSpectorMemory;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
@@ -25,15 +32,19 @@ import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.metrics.MeteredSpectorMemory;
 import com.spectrayan.spector.metrics.SpectorMetrics;
 
+import com.spectrayan.spector.provider.google.GoogleProviderFactory;
+import com.spectrayan.spector.provider.mistral.MistralProviderFactory;
+import com.spectrayan.spector.provider.ollama.OllamaEmbeddingProvider;
+import com.spectrayan.spector.provider.openai.OpenAiProviderFactory;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.vectorstore.spector.SpectorVectorStore;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -60,7 +71,7 @@ public class SpectorAutoConfiguration {
      * Creates the {@link SpectorMemory} bean when memory is enabled (default: true).
      */
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnBean(EmbeddingProvider.class)
     @ConditionalOnProperty(prefix = "spector.memory", name = "enabled", havingValue = "true", matchIfMissing = true)
     SpectorMemory spectorMemory(SpectorConfigProperties props,
                                  ObjectProvider<EmbeddingProvider> embedderProvider,
@@ -89,7 +100,7 @@ public class SpectorAutoConfiguration {
             builder.persistence(Path.of(memoryProps.getPersistencePath()));
         }
 
-        //  Entity extraction (LLM if LlmProvider is present) 
+        //  Entity extraction (LLM if LlmProvider is present)
         LlmProvider textGen = textGenProvider.getIfAvailable();
         if (textGen != null) {
             builder.entityExtractionMode(EntityExtractionMode.LLM);
@@ -98,14 +109,14 @@ public class SpectorAutoConfiguration {
             builder.entityExtractionMode(EntityExtractionMode.NONE);
         }
 
-        //  Salience profile provider (user-driven importance modulation) 
+        //  Salience profile provider (user-driven importance modulation)
         SalienceProfileProvider salience = salienceProvider.getIfAvailable();
         if (salience != null) {
             builder.salienceProfileProvider(salience);
             log.info("SpectorMemory: user salience profile provider wired");
         }
 
-        //  SPLADE + ColBERT providers (auto-created from embedding provider) 
+        //  SPLADE + ColBERT providers (auto-created from embedding provider)
         if (memoryProps.isSpladeEnabled()) {
             builder.SparseEmbeddingProvider(
                     new com.spectrayan.spector.provider.embedding.generic.DenseDerivedSparseProvider(embedder));
@@ -178,4 +189,244 @@ public class SpectorAutoConfiguration {
     public List<McpToolHandler> coreMemoryTools(SpectorMemory memory) {
         return SpectorToolRegistry.handlers("1.0.0", memory);
     }
+    /**
+     * Autoconfigures a dedicated {@link OpenAiProviderFactory} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "openAiEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "OpenAi", matchIfMissing = false)
+    EmbeddingProvider spectorOpenAIEmbeddingProvider(SpectorConfigProperties props) {
+        OpenAiProviderFactory openAiProviderFactory = new OpenAiProviderFactory();
+        return openAiProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+    /**
+     * Autoconfigures a dedicated {@link OllamaEmbeddingProvider} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link OllamaEmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "ollamaEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "Ollama", matchIfMissing = false)
+    EmbeddingProvider spectorOllamaEmbeddingProvider(SpectorConfigProperties props) {
+        return new OllamaEmbeddingProvider(generateEmbeddingConfig(props));
+    }
+    /**
+     * Autoconfigures a dedicated {@link AnthropicProviderFactory} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name' is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "anthropicEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "Anthropic", matchIfMissing = false)
+    EmbeddingProvider antrhopicEmbeddingProvider(SpectorConfigProperties props) {
+        AnthropicProviderFactory anthropicProviderFactory = new AnthropicProviderFactory();
+        return anthropicProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+    /**
+     * Autoconfigures a dedicated {@link AzureOpenAiProviderFactory} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "azureOpenAiEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "AzureOpenAi", matchIfMissing = false)
+    EmbeddingProvider spectorAzureOpenAiEmbeddingProvider(SpectorConfigProperties props) {
+        AzureOpenAiProviderFactory azureOpenAiProviderFactory = new AzureOpenAiProviderFactory();
+        return azureOpenAiProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+    /**
+     * Autoconfigures a dedicated {@link BedrockProviderFactory} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "bedrockEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "Bedrock", matchIfMissing = false)
+    EmbeddingProvider spectorBedrockEmbeddingProvider(SpectorConfigProperties props) {
+        BedrockProviderFactory bedrockProviderFactory = new BedrockProviderFactory();
+        return bedrockProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+    /**
+     * Autoconfigures a dedicated {@link GoogleProviderFactory} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "googleEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "Google", matchIfMissing = false)
+    EmbeddingProvider spectorGoogleEmbeddingProvider(SpectorConfigProperties props) {
+        GoogleProviderFactory googleProviderFactory = new GoogleProviderFactory();
+        return googleProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+    /**
+     * Autoconfigures a dedicated {@link MistralProviderFactory} when explicit
+     * Spector embedding properties are provided.
+     * <p>
+     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
+     *
+     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
+     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
+     */
+    @Bean(name = "mistralEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.embedding", name = "provider-name", havingValue = "Mistral", matchIfMissing = false)
+    EmbeddingProvider spectorMistralEmbeddingProvider(SpectorConfigProperties props) {
+        MistralProviderFactory mistralProviderFactory = new MistralProviderFactory();
+        return mistralProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+    /**
+     * Auto-configures an {@link EmbeddingProvider} by wrapping an existing Spring AI {@link EmbeddingModel} bean.
+     * <p>
+     * Serves as a fallback mechanism when no explicit Spector embedding configuration is provided,
+     * but an active Spring AI {@link EmbeddingModel} exists in the Spring application context.
+     *
+     * @param springEmbeddingModel the existing Spring AI {@link EmbeddingModel} bean
+     * @return an {@link EmbeddingProvider} delegating to the wrapped Spring AI model
+     */
+    @Bean
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnBean(EmbeddingModel.class)
+    EmbeddingProvider embeddingProvider(EmbeddingModel springEmbeddingModel) {
+
+        /**
+         * Inner adapter class wrapping Spring AI's {@link EmbeddingModel}
+         * to satisfy Spector's {@link EmbeddingProvider} contract.
+         */
+        class SpringAIEmbeddedProviderWrapper implements EmbeddingProvider {
+            private final EmbeddingModel springAIEmbeddedModel;
+
+            SpringAIEmbeddedProviderWrapper(EmbeddingModel springAIEmbeddedModel) {
+                this.springAIEmbeddedModel = springAIEmbeddedModel;
+            }
+            @Override
+            public EmbeddingResult embed(String text) {
+                float[] vector = this.springAIEmbeddedModel.embed(text).content().vector();
+                return EmbeddingResult.of(vector, this.springAIEmbeddedModel.modelName());
+            }
+            @Override
+            public int dimensions() {
+                return this.springAIEmbeddedModel.dimension();
+            }
+            @Override
+            public String modelName() {
+                return this.springAIEmbeddedModel.modelName();
+            }
+        }
+
+        return new SpringAIEmbeddedProviderWrapper(springEmbeddingModel);
+    }
+    /**
+     * Auto-configures {@link SpectorVectorStore} using local {@link SpectorMemory}.
+     *
+     * @param memory local embedded memory instance
+     * @return {@link SpectorVectorStore} backed by local memory
+     */
+    @Bean(name = "spectorVectorMemoryStore")
+    @ConditionalOnBean(SpectorMemory.class)
+    @ConditionalOnMissingBean(SpectorVectorStore.class)
+    SpectorVectorStore spectorVectorMemoryStore(SpectorMemory memory){
+        return new SpectorVectorStore(memory);
+    }
+    /**
+     * Auto-configures {@link SpectorVectorStore} using remote {@link SpectorClient}.
+     * <p>
+     * Evaluated only if no {@link SpectorVectorStore} bean (like the memory one above) was created.
+     *
+     * @param client remote client instance
+     * @return {@link SpectorVectorStore} backed by remote client
+     */
+    @Bean(name = "spectorVectorClientStore")
+    @ConditionalOnBean(SpectorClient.class)
+    @ConditionalOnMissingBean(SpectorVectorStore.class)
+    SpectorVectorStore spectorVectorClientStore(SpectorClient client){
+        return new SpectorVectorStore(client);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SpectorClient.class)
+    @ConditionalOnProperties(
+            {
+                    @ConditionalOnProperty(prefix = "spector.client",name = "host",matchIfMissing = true),
+                    @ConditionalOnProperty(prefix = "spector.client",name = "port",matchIfMissing = true),
+                    @ConditionalOnProperty(prefix = "spector.client",name = "api_key",matchIfMissing = true)
+            })
+    SpectorClient spectorClient(SpectorConfigProperties props){
+        if(props.getClient()!=null) return new SpectorClient( SpectorClient.builder());
+        return new SpectorClient(new SpectorClient.Builder()
+                .apiKey(props.getClient().getApi_key())
+                .host(props.getClient().getHost())
+                .port(props.getClient().getPort())
+                .requestTimeout(props.getClient().getRequestTimeout())
+                .maxConnections(props.getClient().getMaxConnexion())
+                .connectTimeout(props.getClient().getConnectTimeout())
+
+        );
+
+    }
+    /**
+     * Helper method to map {@link SpectorConfigProperties} to Spector's native {@link EmbeddingConfig}.
+     *
+     * @param props bound configuration properties
+     * @return an initialized {@link EmbeddingConfig} instance
+     */
+    EmbeddingConfig generateEmbeddingConfig(SpectorConfigProperties props) {
+        return new EmbeddingConfig(
+                props.getEmbedding().getModel(),
+                props.getEmbedding().getBaseUrl(),
+                props.getEmbedding().getTimeout(),
+                props.getEmbedding().getBatchSize(),
+                props.getEmbedding().getMaxConcurrent()
+        );
+    }
+    /**
+     * Helper method to map {@link SpectorConfigProperties} to Spector's native {@link ProviderConfig}.
+     *
+     * @param props bound configuration properties
+     * @return an initialized {@link ProviderConfig} instance
+     */
+    ProviderConfig generateProviderConfig(SpectorConfigProperties props){
+        SpectorConfigProperties.Embedding embedding = props.getEmbedding();
+        return new ProviderConfig(
+                embedding.getProviderName(),
+                embedding.getType(),
+                embedding.getModel(),
+                embedding.getApi_key(),
+                embedding.getBaseUrl(),
+                embedding.getDimensions(),
+                embedding.getProperties()
+        );
+    }
+
 }

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
@@ -23,6 +23,8 @@ import com.spectrayan.spector.provider.bedrock.BedrockProviderFactory;
 import com.spectrayan.spector.provider.embedding.EmbeddingConfig;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.provider.embedding.EmbeddingResult;
+import com.spectrayan.spector.provider.embedding.generic.DenseDerivedSparseProvider;
+import com.spectrayan.spector.provider.embedding.generic.DenseDerivedTokenProvider;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.memory.DefaultSpectorMemory;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
@@ -33,6 +35,7 @@ import com.spectrayan.spector.metrics.MeteredSpectorMemory;
 import com.spectrayan.spector.metrics.SpectorMetrics;
 
 import com.spectrayan.spector.provider.google.GoogleProviderFactory;
+import com.spectrayan.spector.provider.langchain4j.LangChain4jHelper;
 import com.spectrayan.spector.provider.mistral.MistralProviderFactory;
 import com.spectrayan.spector.provider.ollama.OllamaEmbeddingProvider;
 import com.spectrayan.spector.provider.openai.OpenAiProviderFactory;
@@ -46,13 +49,17 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import com.spectrayan.spector.commons.error.SpectorInternalException;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.mcp.tools.McpToolHandler;
 import com.spectrayan.spector.mcp.tools.SpectorToolRegistry;
+import org.springframework.context.annotation.Configuration;
+
 import java.util.List;
 
 /**
@@ -119,11 +126,11 @@ public class SpectorAutoConfiguration {
         //  SPLADE + ColBERT providers (auto-created from embedding provider)
         if (memoryProps.isSpladeEnabled()) {
             builder.SparseEmbeddingProvider(
-                    new com.spectrayan.spector.provider.embedding.generic.DenseDerivedSparseProvider(embedder));
+                    new DenseDerivedSparseProvider(embedder));
         }
         if (memoryProps.isColbertEnabled()) {
             builder.tokenEmbeddingProvider(
-                    new com.spectrayan.spector.provider.embedding.generic.DenseDerivedTokenProvider(embedder));
+                    new DenseDerivedTokenProvider(embedder));
         }
 
         SpectorMemory raw = builder.build();
@@ -143,18 +150,18 @@ public class SpectorAutoConfiguration {
         return raw;
     }
 
-    @org.springframework.context.annotation.Configuration
+    @Configuration
     static class SpringHttpClientAutoConfiguration {
-        SpringHttpClientAutoConfiguration(org.springframework.context.ApplicationContext context) {
+        SpringHttpClientAutoConfiguration(ApplicationContext context) {
             // 1. Try to find and register RestClient.Builder
             try {
                 Class<?> restClientBuilderClass = Class.forName("org.springframework.web.client.RestClient$Builder");
                 Object provider = context.getBeanProvider(restClientBuilderClass);
-                java.lang.reflect.Method getIfAvailable = provider.getClass().getMethod("getIfAvailable");
+                Method getIfAvailable = provider.getClass().getMethod("getIfAvailable");
                 Object builder = getIfAvailable.invoke(provider);
                 if (builder != null) {
                     log.info("[Spector] Auto-registering Spring RestClient.Builder in LangChain4jHelper");
-                    com.spectrayan.spector.provider.langchain4j.LangChain4jHelper.setSpringRestClientBuilder(builder);
+                    LangChain4jHelper.setSpringRestClientBuilder(builder);
                 }
             } catch (ClassNotFoundException e) {
                 // RestClient is not on the classpath
@@ -166,11 +173,11 @@ public class SpectorAutoConfiguration {
             try {
                 Class<?> webClientBuilderClass = Class.forName("org.springframework.web.reactive.function.client.WebClient$Builder");
                 Object provider = context.getBeanProvider(webClientBuilderClass);
-                java.lang.reflect.Method getIfAvailable = provider.getClass().getMethod("getIfAvailable");
+                Method getIfAvailable = provider.getClass().getMethod("getIfAvailable");
                 Object builder = getIfAvailable.invoke(provider);
                 if (builder != null) {
                     log.info("[Spector] Auto-registering Spring WebClient.Builder in LangChain4jHelper");
-                    com.spectrayan.spector.provider.langchain4j.LangChain4jHelper.setSpringWebClientBuilder(builder);
+                    LangChain4jHelper.setSpringWebClientBuilder(builder);
                 }
             } catch (ClassNotFoundException e) {
                 // WebClient is not on the classpath
@@ -184,7 +191,7 @@ public class SpectorAutoConfiguration {
      * Registers core MCP memory tools automatically when memory is available.
      */
     @Bean
-    @org.springframework.boot.autoconfigure.condition.ConditionalOnBean(SpectorMemory.class)
+    @ConditionalOnBean(SpectorMemory.class)
     @ConditionalOnMissingBean(name = "coreMemoryTools")
     public List<McpToolHandler> coreMemoryTools(SpectorMemory memory) {
         return SpectorToolRegistry.handlers("1.0.0", memory);
@@ -376,24 +383,31 @@ public class SpectorAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SpectorClient.class)
-    @ConditionalOnProperties(
-            {
-                    @ConditionalOnProperty(prefix = "spector.client",name = "host",matchIfMissing = true),
-                    @ConditionalOnProperty(prefix = "spector.client",name = "port",matchIfMissing = true),
-                    @ConditionalOnProperty(prefix = "spector.client",name = "api_key",matchIfMissing = true)
-            })
+    @ConditionalOnProperty(prefix = "spector.client",name = "host")
     SpectorClient spectorClient(SpectorConfigProperties props){
-        if(props.getClient()!=null) return new SpectorClient( SpectorClient.builder());
-        return new SpectorClient(new SpectorClient.Builder()
-                .apiKey(props.getClient().getApi_key())
-                .host(props.getClient().getHost())
-                .port(props.getClient().getPort())
-                .requestTimeout(props.getClient().getRequestTimeout())
-                .maxConnections(props.getClient().getMaxConnexion())
-                .connectTimeout(props.getClient().getConnectTimeout())
+        SpectorConfigProperties.Client clientProps = props.getClient();
+        SpectorClient.Builder builder = SpectorClient.builder();
 
-        );
+        if (clientProps.getHost() != null) {
+            builder.host(clientProps.getHost());
+            if (clientProps.getPort() > 0) {
+                builder.port(clientProps.getPort());
+            }
+            if (clientProps.getApiKey() != null) {
+                builder.apiKey(clientProps.getApiKey());
+            }
+            if (clientProps.getRequestTimeout() != null) {
+                builder.requestTimeout(clientProps.getRequestTimeout());
+            }
+            if (clientProps.getConnectTimeout() != null) {
+                builder.connectTimeout(clientProps.getConnectTimeout());
+            }
+            if (clientProps.getMaxConnections() > 0) {
+                builder.maxConnections(clientProps.getMaxConnections());
+            }
 
+        }
+        return builder.build();
     }
     /**
      * Helper method to map {@link SpectorConfigProperties} to Spector's native {@link EmbeddingConfig}.
@@ -422,7 +436,7 @@ public class SpectorAutoConfiguration {
                 embedding.getProviderName(),
                 embedding.getType(),
                 embedding.getModel(),
-                embedding.getApi_key(),
+                embedding.getApiKey(),
                 embedding.getBaseUrl(),
                 embedding.getDimensions(),
                 embedding.getProperties()

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorConfigProperties.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorConfigProperties.java
@@ -18,6 +18,8 @@ package com.spectrayan.spector.spring.autoconfigure;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
 
 /**
  * Spring Boot configuration properties for Spector.
@@ -48,6 +50,15 @@ public class SpectorConfigProperties {
     private Memory memory = new Memory();
     private Metrics metrics = new Metrics();
     private Embedding embedding = new Embedding();
+    private Client client = new Client();
+
+    public Client getClient() {
+        return client;
+    }
+
+    public void setClient(Client client) {
+        this.client = client;
+    }
 
     public Engine getEngine() { return engine; }
     public void setEngine(Engine engine) { this.engine = engine; }
@@ -126,6 +137,60 @@ public class SpectorConfigProperties {
         private String baseUrl = "http://localhost:11434";
         private int batchSize = 32;
         private int maxConcurrent = 0;
+        private Duration timeout;
+        private String api_key;
+        private String providerName;
+        private int dimensions;
+        private Map<String,String> properties;
+        private String type;
+
+        public Duration getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Duration timeout) {
+            this.timeout = timeout;
+        }
+
+        public String getApi_key() {
+            return api_key;
+        }
+
+        public void setApi_key(String api_key) {
+            this.api_key = api_key;
+        }
+
+        public String getProviderName() {
+            return providerName;
+        }
+
+        public void setProviderName(String providerName) {
+            this.providerName = providerName;
+        }
+
+        public int getDimensions() {
+            return dimensions;
+        }
+
+        public void setDimensions(int dimensions) {
+            this.dimensions = dimensions;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, String> properties) {
+            this.properties = properties;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
 
         public String getModel() { return model; }
         public void setModel(String model) { this.model = model; }
@@ -155,4 +220,61 @@ public class SpectorConfigProperties {
 
         return config;
     }
+    static class Client{
+        private String host;
+        private int port;
+        private String api_key;
+        private int maxConnexion;
+        private Duration requestTimeout;
+        private Duration connectTimeout;
+
+        public int getMaxConnexion() {
+            return maxConnexion;
+        }
+
+        public void setMaxConnexion(int maxConnexion) {
+            this.maxConnexion = maxConnexion;
+        }
+
+        public Duration getRequestTimeout() {
+            return requestTimeout;
+        }
+
+        public void setRequestTimeout(Duration requestTimeout) {
+            this.requestTimeout = requestTimeout;
+        }
+
+        public Duration getConnectTimeout() {
+            return connectTimeout;
+        }
+
+        public void setConnectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public String getApi_key() {
+            return api_key;
+        }
+
+        public void setApi_key(String api_key) {
+            this.api_key = api_key;
+        }
+    }
+
 }

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorConfigProperties.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorConfigProperties.java
@@ -152,11 +152,11 @@ public class SpectorConfigProperties {
             this.timeout = timeout;
         }
 
-        public String getapiKey() {
+        public String getApiKey() {
             return apiKey;
         }
 
-        public void setapiKey(String apiKey) {
+        public void setApiKey(String apiKey) {
             this.apiKey = apiKey;
         }
 

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorConfigProperties.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorConfigProperties.java
@@ -138,7 +138,7 @@ public class SpectorConfigProperties {
         private int batchSize = 32;
         private int maxConcurrent = 0;
         private Duration timeout;
-        private String api_key;
+        private String apiKey;
         private String providerName;
         private int dimensions;
         private Map<String,String> properties;
@@ -152,12 +152,12 @@ public class SpectorConfigProperties {
             this.timeout = timeout;
         }
 
-        public String getApi_key() {
-            return api_key;
+        public String getapiKey() {
+            return apiKey;
         }
 
-        public void setApi_key(String api_key) {
-            this.api_key = api_key;
+        public void setapiKey(String apiKey) {
+            this.apiKey = apiKey;
         }
 
         public String getProviderName() {
@@ -220,20 +220,20 @@ public class SpectorConfigProperties {
 
         return config;
     }
-    static class Client{
+    public static class Client{
         private String host;
         private int port;
-        private String api_key;
-        private int maxConnexion;
+        private String apiKey;
+        private int maxConnections;
         private Duration requestTimeout;
         private Duration connectTimeout;
 
-        public int getMaxConnexion() {
-            return maxConnexion;
+        public int getMaxConnections() {
+            return maxConnections;
         }
 
-        public void setMaxConnexion(int maxConnexion) {
-            this.maxConnexion = maxConnexion;
+        public void setMaxConnections(int maxConnections) {
+            this.maxConnections = maxConnections;
         }
 
         public Duration getRequestTimeout() {
@@ -268,12 +268,12 @@ public class SpectorConfigProperties {
             this.port = port;
         }
 
-        public String getApi_key() {
-            return api_key;
+        public String getApiKey() {
+            return apiKey;
         }
 
-        public void setApi_key(String api_key) {
-            this.api_key = api_key;
+        public void setApiKey(String apiKey) {
+            this.apiKey = apiKey;
         }
     }
 

--- a/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
+++ b/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
@@ -260,15 +260,17 @@ class SpectorAutoConfigurationTest {
         });
     }
     @Test
-    void shouldProvideSpectorClientBean(){
+    void shouldNotProvideSpectorClientBean(){
         contextRunner.run(context -> {
-            assertThat(context).hasSingleBean(SpectorClient.class);
+            assertThat(context).doesNotHaveBean(SpectorClient.class);
         });
     }
     @Test
     void shouldProvideSpectorClientWithClientPropertiesBean(){
-        contextRunner.withPropertyValues("spector.client.host=http://192.168.1.1","spector.client.port=36","spector.client.api_key=dgg").run(context -> {
+        contextRunner.withPropertyValues("spector.client.host=192.168.1.1","spector.client.port=36","spector.client.api_key=dgg").run(context -> {
             assertThat(context).hasSingleBean(SpectorClient.class);
+            SpectorClient client = context.getBean(SpectorClient.class);
+            assertThat(client.getBaseUrl()).isEqualTo("http://192.168.1.1:36");
         });
     }
 

--- a/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
+++ b/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
@@ -15,9 +15,11 @@
  */
 package com.spectrayan.spector.spring.autoconfigure;
 
+import com.spectrayan.spector.client.SpectorClient;
 import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.metrics.MeteredSpectorMemory;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -35,32 +37,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SpectorAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("spector.memory.enabled=true")
             .withConfiguration(AutoConfigurations.of(SpectorAutoConfiguration.class))
-            .withUserConfiguration(TestDependenciesConfiguration.class);
-
-    @Test
-    void defaultConfiguration_createsMemoryBean() {
-        this.contextRunner
-                .withPropertyValues("spector.memory.dimensions=384")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SpectorMemory.class);
-                    SpectorMemory memory = context.getBean(SpectorMemory.class);
-                    assertThat(memory).isNotNull();
-                });
-    }
-
-    @Test
-    void withMeterRegistry_wrapsMemoryWithMeteredDecorator() {
-        this.contextRunner
-                .withUserConfiguration(TestMeterRegistryConfiguration.class)
-                .withPropertyValues("spector.memory.dimensions=384", "spector.metrics.enabled=true")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SpectorMemory.class);
-                    SpectorMemory memory = context.getBean(SpectorMemory.class);
-                    assertThat(memory).isInstanceOf(MeteredSpectorMemory.class);
-                });
-    }
-
+            ;
     @Configuration(proxyBeanMethods = false)
     static class TestDependenciesConfiguration {
         @Bean
@@ -71,7 +50,6 @@ class SpectorAutoConfigurationTest {
             return mock;
         }
     }
-
     @Configuration(proxyBeanMethods = false)
     static class TestMeterRegistryConfiguration {
         @Bean
@@ -79,4 +57,220 @@ class SpectorAutoConfigurationTest {
             return new SimpleMeterRegistry();
         }
     }
+    @Configuration
+    static class TestWrapSpringAIAutoConfiguration{
+        @Bean
+        EmbeddingModel embeddingModel(){
+            return  Mockito.mock(EmbeddingModel.class);
+        }
+
+    }
+    @Test
+    void defaultConfiguration_createsMemoryBean() {
+        this.contextRunner
+                .withPropertyValues("spector.memory.dimensions=384")
+                .withUserConfiguration(TestDependenciesConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SpectorMemory.class);
+                    SpectorMemory memory = context.getBean(SpectorMemory.class);
+                    assertThat(memory).isNotNull();
+                });
+    }
+
+    @Test
+    void withMeterRegistry_wrapsMemoryWithMeteredDecorator() {
+        this.contextRunner
+                .withUserConfiguration(TestDependenciesConfiguration.class)
+                .withUserConfiguration(TestMeterRegistryConfiguration.class)
+                .withPropertyValues("spector.memory.dimensions=384", "spector.metrics.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SpectorMemory.class);
+                    SpectorMemory memory = context.getBean(SpectorMemory.class);
+                    assertThat(memory).isInstanceOf(MeteredSpectorMemory.class);
+                });
+    }
+
+    @Test
+    public void shouldCreateEmbeddingProviderBean(){
+        contextRunner.withUserConfiguration(TestWrapSpringAIAutoConfiguration.class).run(context -> {
+            assertThat(context).hasSingleBean(EmbeddingProvider.class);
+        });
+    }
+    @Test
+    void shouldNotCreateEmbeddingProviderBeanWithoutEmbeddingModelBean(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(EmbeddingProvider.class);
+        });
+    }
+    @Test
+    public void shouldCreateOllamaEmbeddingModelProvider(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=Ollama")
+                .run(context -> {
+                    assertThat(context).hasBean("ollamaEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateOllamaEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=Gpt")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("ollamaEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateOllamaEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("ollamaEmbeddingProvider");
+        });
+    }
+    @Test
+    public void shouldCreateOpenAIEmbeddingModelProvider(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=OpenAi","spector.embedding.model=Gpt4.5","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).hasBean("openAiEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateOpenAIEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=Mistral","spector.embedding.model=Gpt4.5","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("openAIEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateOpenAIEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("openAIEmbeddingProvider");
+        });
+    }
+    @Test
+    public void shouldCreateMistralEmbeddingModelProvider(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=Mistral","spector.embedding.model=Mistral Small 4","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).hasBean("mistralEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateAnthropicEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=As","spector.embedding.model=Claude","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("mistralEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateAnthropicEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("anthropicEmbeddingProvider");
+        });
+    }
+
+    @Test
+    void shouldNotCreateMistralEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=Mis","spector.embedding.model=Gpt4.5","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("mistralEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateMistralEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("mistralEmbeddingProvider");
+        });
+    }
+    @Test
+    public void shouldCreateAzureOpenAiEmbeddingModelProvider(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=AzureOpenAi","spector.embedding.model=gpt-4o","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).hasBean("azureOpenAiEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateAzureOpenAiEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=As","spector.embedding.model=Claude","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("azureOpenAiEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateAzureOpenAiEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("azureOpenAiEmbeddingProvider");
+        });
+    }
+    @Test
+    void shouldCreateVectorMemoryStoreBean(){
+        contextRunner.withUserConfiguration(TestSpectorVectorMemoryStoreBeanConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasBean("spectorVectorMemoryStore");
+                });
+    }
+    @Test
+    void shouldCreateVectorClientStoreBean(){
+        contextRunner.withUserConfiguration(TestSpectorVectorClientStoreBeanConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasBean("spectorVectorClientStore");
+                });
+    }
+    @Configuration
+    static class TestSpectorVectorMemoryStoreBeanConfiguration{
+        @Bean
+        SpectorMemory memory(){
+            return Mockito.mock(SpectorMemory.class);
+        }
+
+    }
+    @Configuration
+    static class TestSpectorVectorClientStoreBeanConfiguration{
+        @Bean
+        SpectorClient client(){
+            return Mockito.mock(SpectorClient.class);
+        }
+    }
+
+    @Test
+    void shouldNotCreateBedrockEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=bdrok","spector.embedding.model=Gpt4.5","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("bedrockEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateBedrockEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("openAIEmbeddingProvider");
+        });
+    }
+    @Test
+    public void shouldCreateGoogleEmbeddingModelProvider(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=Google","spector.embedding.model=Gemini 3.5","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).hasBean("googleEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateGoogleEmbeddingProviderWithFalsePropertiesValues(){
+        contextRunner.withPropertyValues("spector.embedding.provider-name=bdrok","spector.embedding.model=Gpt4.5","spector.embedding.type=LLM","spector.embedding.api_key=qdsf")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("googleEmbeddingProvider");
+                });
+    }
+    @Test
+    void shouldNotCreateGoogleEmbeddingProviderWithoutSettingPropertiesValues(){
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean("googleEmbeddingProvider");
+        });
+    }
+    @Test
+    void shouldProvideSpectorClientBean(){
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(SpectorClient.class);
+        });
+    }
+    @Test
+    void shouldProvideSpectorClientWithClientPropertiesBean(){
+        contextRunner.withPropertyValues("spector.client.host=http://192.168.1.1","spector.client.port=36","spector.client.api_key=dgg").run(context -> {
+            assertThat(context).hasSingleBean(SpectorClient.class);
+        });
+    }
+
+
 }


### PR DESCRIPTION
# feat(spring): auto-configure EmbeddingProvider, SpectorVectorStore and SpectorClient beans in starter

## 📋 Issue #57 - Progress
- [x] **1. Auto-configure the `EmbeddingProvider` bean** — no longer expects a pre-existing bean
- [x] **2. Auto-configure the `SpectorVectorStore` bean** — wired when `SpectorMemory` or `SpectorClient` is present
- [x] **3. Auto-configure `SpectorClient`** — wired when remote host properties are provided
- [ ] **4. Starter naming consistency** — intentionally left for a separate PR (out of scope)

## ✨ What's implemented

### Embedding providers (point 1)
- [x] Dedicated bean per provider, selected via `spector.embedding.provider-name`:
  - [x] `Ollama` → `OllamaEmbeddingProvider` (`EmbeddingConfig` from properties)
  - [x] `OpenAi` / `Anthropic` / `AzureOpenAi` / `Bedrock` / `Google` / `Mistral` → via their `*ProviderFactory` (`ProviderConfig` from properties)
- [x] Fallback: wraps an existing `EmbeddingModel` bean (LangChain4j) into an `EmbeddingProvider` adapter when no explicit Spector config is present
- [x] All beans back off on user-defined ones (`@ConditionalOnMissingBean`)
- [x] New properties in `SpectorConfigProperties.Embedding`: `providerName`, `type`, `model`, `apiKey`, `baseUrl`, `dimensions`, `timeout`, `batchSize`, `maxConcurrent`, `properties`

### Vector store (point 2)
- [x] `spectorVectorMemoryStore` → backed by local `SpectorMemory`
- [x] `spectorVectorClientStore` → backed by remote `SpectorClient` (only when no memory store exists)

### Remote client (point 3)
- [x] `SpectorClient` bean created only when `spector.client.host` is set
- [x] Built via `SpectorClient.builder()` with `host` / `port` / `apiKey` / timeouts
- [x] New properties in `SpectorConfigProperties.Client`: `host`, `port`, `apiKey`, `connectTimeout`, `requestTimeout`

### Safer memory wiring
- [x] `spectorMemory` is now gated by `@ConditionalOnBean(EmbeddingProvider.class)` instead of failing at runtime (declared **after** the provider beans so the condition works)

## ✅ Tests added (`ApplicationContextRunner`)

- [x] Embedding provider fallback wrapping an `EmbeddingModel` bean (+ negative case)
- [x] Conditional creation per `spector.embedding.provider-name` value (positive + negative cases)
- [x] `spectorVectorMemoryStore` creation when `SpectorMemory` is present
- [x] `spectorVectorClientStore` creation when `SpectorClient` is present
- [x] `SpectorClient` creation with and without `spector.client.*` properties
- [x] Existing tests preserved: default `SpectorMemory` bean + `MeteredSpectorMemory` decorator

## 🧪 Verification checklist

- [x] `mvn clean install -DskipTests` passes (Java 25)
- [x] `mvn test -pl synapse/spector-spring` passes
- [x] Diff contains only the starter module files (no unrelated changes)