### PR TITLE
chore(deps): centralize and unify dependency and plugin version management (#421)

### DIFF
--- a/bench/spector-bench/pom.xml
+++ b/bench/spector-bench/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
-            <version>1.9.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -100,7 +99,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.5.0</version>
                 <configuration>
                     <!-- exec:exec launches a child JVM with enable-preview flag -->
                     <executable>java</executable>

--- a/memory/spector-ingestion/pom.xml
+++ b/memory/spector-ingestion/pom.xml
@@ -47,12 +47,10 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
-            <version>3.2.2</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/memory/spector-memory/pom.xml
+++ b/memory/spector-memory/pom.xml
@@ -111,7 +111,6 @@
         <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
-            <version>1.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nucleus/spector-bom/pom.xml
+++ b/nucleus/spector-bom/pom.xml
@@ -34,6 +34,11 @@
             </dependency>
             <dependency>
                 <groupId>com.spectrayan</groupId>
+                <artifactId>spector-hdc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.spectrayan</groupId>
                 <artifactId>spector-config</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -53,6 +58,12 @@
                 <groupId>com.spectrayan</groupId>
                 <artifactId>spector-providers</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.spectrayan</groupId>
+                <artifactId>spector-test-support</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- ── Search Layer ── -->

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,14 @@
         <flyway.version>12.4.0</flyway.version>
         <spring-ai.version>2.0.0</spring-ai.version>
         <langgraph4j.version>1.8.20</langgraph4j.version>
+        <jsqlparser.version>4.9</jsqlparser.version>
+        <tika.version>3.2.2</tika.version>
+        <jqwik.version>1.9.2</jqwik.version>
+        <sse-server.version>2.0.0</sse-server.version>
+        <tabula.version>1.0.5</tabula.version>
+        <pdfbox.version>3.0.8</pdfbox.version>
+        <netty.version>4.2.13.Final</netty.version>
+        <picocli.version>4.7.6</picocli.version>
 
         <!-- Test dependency versions -->
         <junit.version>6.1.2</junit.version>
@@ -152,6 +160,15 @@
         <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
         <license-maven-plugin.version>5.1.1</license-maven-plugin.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+        <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
+        <git-commit-id-plugin.version>10.0.0</git-commit-id-plugin.version>
+        <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 
         <!-- JaCoCo coverage threshold — default 0, modules raise as tests are added (target: 0.80) -->
         <jacoco.minimum.coverage>0</jacoco.minimum.coverage>
@@ -440,7 +457,71 @@
             <dependency>
                 <groupId>com.github.jsqlparser</groupId>
                 <artifactId>jsqlparser</artifactId>
-                <version>4.9</version>
+                <version>${jsqlparser.version}</version>
+            </dependency>
+
+            <!-- Netty BOM -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Apache Tika (PDF, DOCX, HTML text extraction) -->
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-core</artifactId>
+                <version>${tika.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-parsers-standard-package</artifactId>
+                <version>${tika.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+
+            <!-- jqwik — property-based testing -->
+            <dependency>
+                <groupId>net.jqwik</groupId>
+                <artifactId>jqwik</artifactId>
+                <version>${jqwik.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Spectrayan SSE Server -->
+            <dependency>
+                <groupId>com.spectrayan.sse</groupId>
+                <artifactId>sse-server</artifactId>
+                <version>${sse-server.version}</version>
+            </dependency>
+
+            <!-- Tabula (structured table extraction from PDFs) -->
+            <dependency>
+                <groupId>technology.tabula</groupId>
+                <artifactId>tabula</artifactId>
+                <version>${tabula.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- PDFBox -->
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox</artifactId>
+                <version>${pdfbox.version}</version>
+            </dependency>
+
+            <!-- Picocli -->
+            <dependency>
+                <groupId>info.picocli</groupId>
+                <artifactId>picocli</artifactId>
+                <version>${picocli.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -625,11 +706,32 @@
                     </executions>
                 </plugin>
 
+                <!-- Resources plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                </plugin>
+
+                <!-- Exec plugin -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin.version}</version>
+                </plugin>
+
+                <!-- Git commit ID plugin -->
+                <plugin>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
+                    <version>${git-commit-id-plugin.version}</version>
+                </plugin>
+
                 <!-- Release process and publishing -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <updateWorkingCopyVersions>true</updateWorkingCopyVersions>
@@ -644,7 +746,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.4</version>
+                    <version>${maven-deploy-plugin.version}</version>
                     <configuration>
                         <altDeploymentRepository>${mavenAltDeploymentRepository}</altDeploymentRepository>
                         <altSnapshotDeploymentRepository>${mavenAltSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
@@ -653,7 +755,7 @@
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.9.0</version>
+                    <version>${central-publishing-maven-plugin.version}</version>
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>central</publishingServerId>
@@ -663,7 +765,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.8</version>
+                    <version>${maven-gpg-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>sign-artifacts</id>
@@ -682,7 +784,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>${maven-source-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -695,7 +797,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.12.0</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <additionalOptions>--add-modules ${vector.api.module} --enable-preview</additionalOptions>
                         <source>${java.version}</source>

--- a/synapse/spector-cli/pom.xml
+++ b/synapse/spector-cli/pom.xml
@@ -17,8 +17,6 @@
 
     <properties>
         <spector.module.name>com.spectrayan.spector.cli</spector.module.name>
-        <picocli.version>4.7.6</picocli.version>
-        <git-commit-id-plugin.version>10.0.0</git-commit-id-plugin.version>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
         <!-- CLI is main-method heavy with picocli wiring — lower coverage target -->
         <jacoco.minimum.coverage>0.60</jacoco.minimum.coverage>
@@ -29,7 +27,6 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>${picocli.version}</version>
         </dependency>
 
         <!-- Spector Client SDK (remote mode) -->
@@ -95,7 +92,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.5.0</version>
                 <configuration>
                     <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
                 </configuration>
@@ -104,7 +100,6 @@
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
-                <version>${git-commit-id-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>get-git-info</id>

--- a/synapse/spector-spring/pom.xml
+++ b/synapse/spector-spring/pom.xml
@@ -159,7 +159,6 @@
         <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
-            <version>1.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/synapse/spector-synapse/pom.xml
+++ b/synapse/spector-synapse/pom.xml
@@ -28,14 +28,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM — MUST be first (Armeria needs 4.2.x) -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.2.13.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <!-- Spring Boot 4 BOM -->
             <dependency>
@@ -190,7 +182,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.22</version>
         </dependency>
         <!-- ── Jackson 2.x (needed by LangChain4j, Tika, JacksonConfig ObjectMapper) ── -->
         <dependency>
@@ -206,7 +197,6 @@
         <dependency>
             <groupId>com.spectrayan.sse</groupId>
             <artifactId>sse-server</artifactId>
-            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -217,12 +207,10 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
-            <version>3.2.2</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -230,7 +218,6 @@
         <dependency>
             <groupId>technology.tabula</groupId>
             <artifactId>tabula</artifactId>
-            <version>1.0.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -242,7 +229,6 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>3.0.8</version>
         </dependency>
 
         <!-- ── Logging runtime ── -->
@@ -297,7 +283,6 @@
         <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
-            <version>1.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Description
Centralizes and unifies all third-party dependencies and plugin versions inside the root parent POM properties and dependency/plugin management blocks. This aligns version definitions, removes hardcoded versions from submodule dependency/plugin tags (in ingestion, memory, spring, synapse, cli, and bench modules), and includes `spector-hdc` and `spector-test-support` in `spector-bom` for external consumers.

## Related Issue
Closes #421

## Type of Change
- [x] Dependency / Build update (centralized dependency and plugin management)

## Module(s) Affected
- [x] Parent POM (`pom.xml`) & `spector-bom`
- [x] `spector-ingestion` & `spector-memory`
- [x] `spector-synapse`, `spector-spring`, `spector-cli`
- [x] `spector-bench` (benchmarks)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added Javadoc for all public classes/methods (N/A — build/dependency changes only)
- [x] I have added tests to cover my changes (N/A — build/dependency changes only)
- [x] All new and existing tests passed (`mvn test`)
- [x] No hardcoded secrets or credentials are included
