### PR TITLE
feat(memory): graduate hypergraph to primary graph structure (#424)

### DIFF
--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/BenchmarkSetup.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/BenchmarkSetup.java
@@ -190,8 +190,7 @@ public final class BenchmarkSetup implements AutoCloseable {
                 .entityExtractionMode(EntityExtractionMode.CUSTOM)
                 .entityExtractor(customExtractor);
 
-        boolean useHypergraph = Boolean.getBoolean("spector.benchmark.useHypergraphRecall");
-        log.info("System property 'spector.benchmark.useHypergraphRecall' is: '{}'", System.getProperty("spector.benchmark.useHypergraphRecall"));
+
         float threshold = 0.40f;
         String thresholdStr = System.getProperty("spector.benchmark.graphExpansionThreshold");
         if (thresholdStr != null && !thresholdStr.isBlank()) {
@@ -200,7 +199,7 @@ public final class BenchmarkSetup implements AutoCloseable {
             } catch (NumberFormatException ignored) {}
         }
         com.spectrayan.spector.memory.pipeline.GraphExpansionMode expansionMode = com.spectrayan.spector.memory.pipeline.GraphExpansionMode.resolve();
-        log.info("Instantiating GraphScoringPolicy with useHypergraphRecall={}, threshold={}, mode={}", useHypergraph, threshold, expansionMode);
+        log.info("Instantiating GraphScoringPolicy with threshold={}, mode={}", threshold, expansionMode);
         com.spectrayan.spector.memory.pipeline.GraphScoringPolicy scoringPolicy = new com.spectrayan.spector.memory.pipeline.GraphScoringPolicy(
                 0.3f,   // causalBoostWeight
                 0.3f,   // hebbianBoostFactor
@@ -211,7 +210,6 @@ public final class BenchmarkSetup implements AutoCloseable {
                 3,      // temporalMaxHops
                 2,      // entityMaxHops
                 threshold,
-                useHypergraph,
                 expansionMode
         );
         builder.graphScoringPolicy(scoringPolicy);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -252,6 +252,10 @@ public final class SpectorMemoryBuilder {
     public SpectorMemoryBuilder entityGraphCapacity(int c) { this.entityGraphCapacity = c; return this; }
 
     /** Enable/disable the HyperEntityGraph layer (default: true). */
+    /**
+     * @deprecated Hypergraph is now standard. This configuration option has no effect and will be removed in a future release.
+     */
+    @Deprecated(since = "1.2.0", forRemoval = true)
     public SpectorMemoryBuilder hyperEntityGraphEnabled(boolean enabled) { this.hyperEntityGraphEnabled = enabled; return this; }
 
     /** Max entities to extract per memory (default: 10). */

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -391,9 +391,23 @@ public final class SpectorMemoryFactory {
             int hyperCap = builder.entityGraphCapacity;
             int hyperEdgeCap = hyperCap * 2;
             if (isDisk && basePath != null) {
-                Path hyperPath = StorageLayout.hyperEntityGraphRuntime(basePath);
-                if (java.nio.file.Files.exists(hyperPath)) {
-                    hyperEntityGraph = HyperEntityGraphMemory.load(hyperPath, hyperCap, hyperEdgeCap);
+                Path runtimeHyper = StorageLayout.hyperEntityGraphRuntime(basePath);
+                Path v2Hyper = resolvedPartitionDir != null
+                        ? StorageLayout.hyperEntityGraph(resolvedPartitionDir) : null;
+                Path loadFrom = getNewerPath(runtimeHyper, v2Hyper, null);
+                if (loadFrom == null) {
+                    loadFrom = runtimeHyper;
+                }
+                try {
+                    com.spectrayan.spector.memory.kernel.codec.Codecs.ensureCurrent(
+                            com.spectrayan.spector.memory.kernel.codec.Codecs.defaultRegistry(),
+                            com.spectrayan.spector.memory.kernel.MemoryId.of("spector", "hyper-entity-graph"),
+                            new com.spectrayan.spector.memory.kernel.layout.HyperEntityLayout(),
+                            loadFrom, null, null);
+                } catch (Exception ignored) {}
+
+                if (java.nio.file.Files.exists(loadFrom)) {
+                    hyperEntityGraph = HyperEntityGraphMemory.load(loadFrom, hyperCap, hyperEdgeCap);
                 } else {
                     hyperEntityGraph = new HyperEntityGraphMemory(hyperCap, hyperEdgeCap);
                 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/StorageLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/StorageLayout.java
@@ -667,6 +667,15 @@ public final class StorageLayout {
         return partitionDir.resolve(FILE_RELATION_TYPES);
     }
 
+    /**
+     * Resolves the hypergraph.hyeg file within a partition.
+     * @deprecated V3: use {@link #hyperEntityGraphRuntime(Path)} with basePath instead.
+     */
+    @Deprecated(forRemoval = true)
+    public static Path hyperEntityGraph(Path partitionDir) {
+        return partitionDir.resolve(FILE_HYPERGRAPH);
+    }
+
 
 
     // ── WAL resolvers ──

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacade.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacade.java
@@ -239,7 +239,7 @@ public final class CognitiveGraphFacade {
      * @return topology stats, or empty if entity graph is not configured
      */
     public TopologyStats topologyStats() {
-        if (entityGraph == null) return TopologyStats.empty();
+        if (hyperEntityGraph == null || entityGraph == null) return TopologyStats.empty();
         try {
             var nameIndex = entityGraph.nameIndex();
 
@@ -252,23 +252,17 @@ public final class CognitiveGraphFacade {
 
                 var eStats = entityTypeAgg.computeIfAbsent(entityType, _ -> new int[3]);
                 eStats[0]++; // node count
-                int memCount = 0;
-                try { memCount = entityGraph.memoryRefCount(entityId); } catch (Exception ignored) {}
-                eStats[2] += memCount; // memory refs
+                var hEdges = hyperEntityGraph.findHyperedgesForEntity(entityId);
+                eStats[2] += hEdges.size(); // memory refs
 
-                try {
-                    var edgeList = entityGraph.edges(entityId);
-                    eStats[1] += edgeList.size();
-                    for (var ee : edgeList) {
-                        String relType = ee.relationType() != null ? ee.relationType() : "UNKNOWN";
-                        var rStats = relationTypeAgg.computeIfAbsent(relType, _ -> new int[3]);
-                        rStats[0]++; // edge count
-                        rStats[1] += 2; // from + to node
-                        try {
-                            rStats[2] += entityGraph.memoryRefCount(ee.targetEntityId());
-                        } catch (Exception ignored) {}
-                    }
-                } catch (Exception ignored) {}
+                eStats[1] += hEdges.size();
+                for (var he : hEdges) {
+                    String relType = "HYPEREDGE";
+                    var rStats = relationTypeAgg.computeIfAbsent(relType, _ -> new int[3]);
+                    rStats[0]++; // edge count
+                    rStats[1] += he.vertices().size(); // from + to node
+                    rStats[2]++; // memory refs
+                }
             }
 
             List<EntityTypeStats> entityTypes = entityTypeAgg.entrySet().stream()
@@ -345,27 +339,24 @@ public final class CognitiveGraphFacade {
 
     private void collectEntityEdges(Map<Integer, String> slotToId,
                                     HashSet<String> validIds, List<GraphEdge> edges) {
-        if (entityGraph == null) return;
+        if (hyperEntityGraph == null || entityGraph == null) return;
         try {
             var nameIndex = entityGraph.nameIndex();
             for (var entry : nameIndex.entrySet()) {
                 int entityId = entry.getValue();
                 String entityType = safeEntityType(entityId);
-                var entityEdgeList = entityGraph.edges(entityId);
-                for (var ee : entityEdgeList) {
-                    int[] fromMems = entityGraph.memoriesForEntity(entityId);
-                    int[] toMems = entityGraph.memoriesForEntity(ee.targetEntityId());
-                    String toEntityType = safeEntityType(ee.targetEntityId());
-                    for (int fm : fromMems) {
+                var hEdges = hyperEntityGraph.findHyperedgesForEntity(entityId);
+                for (int i = 0; i < hEdges.size(); i++) {
+                    for (int j = i + 1; j < hEdges.size(); j++) {
+                        int fm = hEdges.get(i).memoryIdx();
+                        int tm = hEdges.get(j).memoryIdx();
                         String fromMemId = slotToId.get(fm);
+                        String toMemId = slotToId.get(tm);
                         if (fromMemId == null || !validIds.contains(fromMemId)) continue;
-                        for (int tm : toMems) {
-                            String toMemId = slotToId.get(tm);
-                            if (toMemId == null || !validIds.contains(toMemId)) continue;
-                            edges.add(new GraphEdge(
-                                    fromMemId, toMemId, "ENTITY", ee.relationType(),
-                                    (double) ee.weight(), entityType, toEntityType));
-                        }
+                        if (toMemId == null || !validIds.contains(toMemId)) continue;
+                        edges.add(new GraphEdge(
+                                fromMemId, toMemId, "ENTITY", "SHARED_ENTITY",
+                                0.5, entityType, entityType));
                     }
                 }
             }
@@ -431,17 +422,16 @@ public final class CognitiveGraphFacade {
                                     Map<Integer, List<Integer>> slotToEntities,
                                     List<String> visitedIds, HashSet<String> visitedIdsSet,
                                     List<Integer> nextLevel, List<GraphEdge> edges) {
-        if (entityGraph == null) return;
+        if (hyperEntityGraph == null) return;
         List<Integer> entities = slotToEntities.get(slot);
         if (entities == null) return;
         try {
             for (int entityId : entities) {
                 String entityType = safeEntityType(entityId);
-                int[] mems = entityGraph.memoriesForEntity(entityId);
-
-                // 1. Shared entity links
-                for (int targetSlot : mems) {
-                    if (targetSlot == slot) continue;
+                var hEdges = hyperEntityGraph.findHyperedgesForEntity(entityId);
+                for (var he : hEdges) {
+                    int targetSlot = he.memoryIdx();
+                    if (targetSlot == slot || targetSlot < 0) continue;
                     String targetId = slotToId.get(targetSlot);
                     if (targetId != null) {
                         edges.add(new GraphEdge(
@@ -451,27 +441,6 @@ public final class CognitiveGraphFacade {
                             visitedIds.add(targetId);
                             visitedIdsSet.add(targetId);
                             nextLevel.add(targetSlot);
-                        }
-                    }
-                }
-
-                // 2. Connected entities
-                var entityEdgeList = entityGraph.edges(entityId);
-                for (var ee : entityEdgeList) {
-                    int targetEntityId = ee.targetEntityId();
-                    String targetEntityType = safeEntityType(targetEntityId);
-                    int[] targetMems = entityGraph.memoriesForEntity(targetEntityId);
-                    for (int targetSlot : targetMems) {
-                        String targetId = slotToId.get(targetSlot);
-                        if (targetId != null) {
-                            edges.add(new GraphEdge(
-                                    currentId, targetId, "ENTITY", ee.relationType(),
-                                    (double) ee.weight(), entityType, targetEntityType));
-                            if (!visitedIdsSet.contains(targetId)) {
-                                visitedIds.add(targetId);
-                                visitedIdsSet.add(targetId);
-                                nextLevel.add(targetSlot);
-                            }
                         }
                     }
                 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphCodec.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphCodec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.graph;
+
+import com.spectrayan.spector.memory.kernel.codec.Codec;
+import com.spectrayan.spector.memory.kernel.codec.CodecStep;
+import com.spectrayan.spector.memory.kernel.layout.HyperEntityLayout;
+
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Codec binding for HyperEntityGraphMemory format.
+ */
+public final class HyperEntityGraphCodec implements Codec<HyperEntityLayout> {
+
+    private final HyperEntityLayout layout = new HyperEntityLayout();
+
+    @Override
+    public HyperEntityLayout layout() {
+        return layout;
+    }
+
+    @Override
+    public Set<Integer> legacyMagics() {
+        return Set.of(0x48594547);
+    }
+
+    @Override
+    public int versionOf(int magic, MemorySegment headerPrefix) {
+        return 1;
+    }
+
+    @Override
+    public List<CodecStep> steps() {
+        return List.of();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
@@ -31,6 +31,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.PrimitiveIterator;
+
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.layout.HyperEntityLayout;
+import com.spectrayan.spector.memory.sync.MemoryWal;
 
 /**
  * Hyperedge-based entity layer for graph compression.
@@ -66,7 +73,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @see EntityGraph
  */
-public final class HyperEntityGraphMemory implements AutoCloseable {
+public final class HyperEntityGraphMemory implements AutoCloseable, com.spectrayan.spector.memory.kernel.shape.GraphMemory<HyperEntityLayout> {
 
     private static final Logger log = LoggerFactory.getLogger(HyperEntityGraphMemory.class);
 
@@ -145,6 +152,33 @@ public final class HyperEntityGraphMemory implements AutoCloseable {
     private List<List<Integer>> incidenceHeap;
 
     private final ReentrantLock graphLock = new ReentrantLock();
+
+    private final MemoryId memoryId = MemoryId.of("spector", "hyper-entity-graph");
+    private final HyperEntityLayout layout = new HyperEntityLayout();
+    private MemoryWal wal;
+    private boolean bypassWal = false;
+
+    @Override public MemoryId id() { return memoryId; }
+    @Override public HyperEntityLayout layout() { return layout; }
+    @Override public Arena arena() { return arena; }
+    @Override public MemorySegment segment() { return hedges; }
+    @Override public int size() { return totalHyperedges; }
+    @Override public int capacity() { return hyperedgeCapacity; }
+    @Override public int schemaVersion() { return FILE_VERSION; }
+    @Override public MemoryShape shape() { return MemoryShape.GRAPH; }
+    @Override public void flush() { /* heap allocated, flush no-op */ }
+    @Override public void bindWal(MemoryWal wal) { this.wal = wal; }
+    @Override public void setBypassWal(boolean bypass) { this.bypassWal = bypass; }
+    @Override public boolean isBypassWal() { return bypassWal; }
+    @Override public MemoryWal getWal() { return wal; }
+
+    @Override public int addEdge(int fromNode, int toNode, MemorySegment edgeBytes) { return -1; }
+    @Override public void removeEdge(int edgeId) { deleteHyperedge(edgeId); }
+    @Override public PrimitiveIterator.OfInt neighbours(int nodeId) {
+        return findCoOccurringEntities(nodeId).stream().mapToInt(Integer::intValue).iterator();
+    }
+    @Override public int edgeCount() { return totalHyperedges; }
+    @Override public int nodeCount() { return entityCapacity; }
 
     // ══════════════════════════════════════════════════════════════
     // CONSTRUCTORS
@@ -261,6 +295,12 @@ public final class HyperEntityGraphMemory implements AutoCloseable {
 
             int edgeId = nextHyperedgeId++;
             totalHyperedges++;
+
+            if (wal != null && !bypassWal) {
+                ByteBuffer buf = ByteBuffer.allocate(HEDGE_BYTES);
+                buf.putInt(type).putFloat(weight).putInt(vertexCount).putInt(memoryIdx).putLong(timestamp);
+                wal.appendRecordWrite(memoryId.toString(), edgeId, buf.array());
+            }
 
             // Write hyperedge header
             long hedgeOff = (long) edgeId * HEDGE_BYTES;
@@ -498,17 +538,24 @@ public final class HyperEntityGraphMemory implements AutoCloseable {
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE,
                 StandardOpenOption.TRUNCATE_EXISTING)) {
 
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            header.putInt(FILE_MAGIC);
-            header.putInt(FILE_VERSION);
-            header.putInt(entityCapacity);
-            header.putInt(hyperedgeCapacity);
-            header.putInt(nextHyperedgeId);
-            header.putInt(nextVertexOffset);
-            header.putInt(totalHyperedges);
-            header.putInt(0); // reserved
-            header.flip();
-            ch.write(header);
+            MemorySegment stdHeaderSeg = Arena.ofAuto().allocate(MemoryHeader.HEADER_BYTES);
+            MemoryHeader.write(stdHeaderSeg, 0, FILE_VERSION, MemoryShape.GRAPH, 0,
+                    hyperedgeCapacity, totalHyperedges, HEDGE_BYTES, layout.layoutId(),
+                    System.currentTimeMillis(), System.currentTimeMillis());
+            ch.write(stdHeaderSeg.asByteBuffer());
+
+            ByteBuffer customHeader = ByteBuffer.allocate(FILE_HEADER_BYTES);
+            customHeader.order(java.nio.ByteOrder.nativeOrder());
+            customHeader.putInt(FILE_MAGIC);
+            customHeader.putInt(FILE_VERSION);
+            customHeader.putInt(entityCapacity);
+            customHeader.putInt(hyperedgeCapacity);
+            customHeader.putInt(nextHyperedgeId);
+            customHeader.putInt(nextVertexOffset);
+            customHeader.putInt(totalHyperedges);
+            customHeader.putInt(0); // reserved
+            customHeader.flip();
+            ch.write(customHeader);
 
             // Write hyperedge segment
             writeSegment(ch, hedges, (long) nextHyperedgeId * HEDGE_BYTES);
@@ -534,24 +581,58 @@ public final class HyperEntityGraphMemory implements AutoCloseable {
         }
 
         try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
-            ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
-            ch.read(header);
-            header.flip();
+            ByteBuffer firstIntBuf = ByteBuffer.allocate(4);
+            firstIntBuf.order(java.nio.ByteOrder.nativeOrder());
+            ch.read(firstIntBuf);
+            firstIntBuf.flip();
+            int firstInt = firstIntBuf.getInt();
+            ch.position(0);
 
-            int magic = header.getInt();
-            int version = header.getInt();
-            if (magic != FILE_MAGIC || version != FILE_VERSION) {
-                log.warn("Invalid HyperEntityGraphMemory file: magic=0x{}, version={}", 
-                         Integer.toHexString(magic), version);
+            int loadedEntityCap, loadedHedgeCap, loadedNextId, loadedNextVertexOff, loadedTotal;
+            long dataOffset;
+
+            if (firstInt == MemoryHeader.MAGIC) {
+                // Read standard 64B header
+                ByteBuffer stdBuf = ByteBuffer.allocate(MemoryHeader.HEADER_BYTES);
+                stdBuf.order(java.nio.ByteOrder.nativeOrder());
+                ch.read(stdBuf);
+
+                // Read custom 32B header
+                ByteBuffer customBuf = ByteBuffer.allocate(FILE_HEADER_BYTES);
+                customBuf.order(java.nio.ByteOrder.nativeOrder());
+                ch.read(customBuf);
+                customBuf.flip();
+
+                int magic = customBuf.getInt();
+                int version = customBuf.getInt();
+                loadedEntityCap = customBuf.getInt();
+                loadedHedgeCap = customBuf.getInt();
+                loadedNextId = customBuf.getInt();
+                loadedNextVertexOff = customBuf.getInt();
+                loadedTotal = customBuf.getInt();
+
+                dataOffset = MemoryHeader.HEADER_BYTES + FILE_HEADER_BYTES;
+            } else if (firstInt == FILE_MAGIC) {
+                ByteBuffer header = ByteBuffer.allocate(FILE_HEADER_BYTES);
+                header.order(java.nio.ByteOrder.nativeOrder());
+                ch.read(header);
+                header.flip();
+
+                int magic = header.getInt();
+                int version = header.getInt();
+                loadedEntityCap = header.getInt();
+                loadedHedgeCap = header.getInt();
+                loadedNextId = header.getInt();
+                loadedNextVertexOff = header.getInt();
+                loadedTotal = header.getInt();
+
+                dataOffset = FILE_HEADER_BYTES;
+            } else {
+                log.warn("Invalid HyperEntityGraphMemory file: magic=0x{}", Integer.toHexString(firstInt));
                 return new HyperEntityGraphMemory(entityCapacity, hyperedgeCapacity);
             }
-
-            int loadedEntityCap = header.getInt();
-            int loadedHedgeCap = header.getInt();
-            int loadedNextId = header.getInt();
-            int loadedNextVertexOff = header.getInt();
-            int loadedTotal = header.getInt();
-            header.getInt(); // reserved
+            
+            ch.position(dataOffset);
 
             // Create graph with loaded capacities
             HyperEntityGraphMemory graph = new HyperEntityGraphMemory(

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codecs.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codecs.java
@@ -16,6 +16,7 @@ import com.spectrayan.spector.memory.DataEncryptor;
 import com.spectrayan.spector.memory.cortex.TextAppendCodec;
 import com.spectrayan.spector.memory.cortex.TypeRegistryCodec;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphCodec;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphCodec;
 import com.spectrayan.spector.memory.index.IndexRecordCodec;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryLayout;
@@ -37,6 +38,7 @@ public final class Codecs {
             .register(new TypeRegistryCodec())
             .register(new IndexRecordCodec())
             .register(new HebbianGraphCodec())
+            .register(new HyperEntityGraphCodec())
             .build();
 
     private Codecs() {}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HyperEntityLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HyperEntityLayout.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.MemoryLayout;
+
+/**
+ * Memory layout for nodes/relations in the Hyper Entity Graph.
+ */
+public final class HyperEntityLayout implements MemoryLayout {
+
+    private static final int STRIDE = 32;
+    private static final int LAYOUT_ID = 0x48594547; // 'HYEG'
+    private static final int VERSION = 1;
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return "HyperEntityGraph";
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -306,7 +306,7 @@ final class GraphExpansionStage {
                 if (entityId < 0) continue;
  
                 Set<Integer> reachableMemories;
-                if (graphScoringPolicy.useHypergraphRecall() && hyperEntityGraph != null) {
+                if (hyperEntityGraph != null) {
                     reachableMemories = hyperEntityGraph.collectMemories(entityId, graphScoringPolicy.entityMaxHops());
                 } else {
                     reachableMemories = entityGraph.collectMemories(

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphScoringPolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphScoringPolicy.java
@@ -58,7 +58,6 @@ public record GraphScoringPolicy(
         int temporalMaxHops,
         int entityMaxHops,
         float graphExpansionThreshold,
-        boolean useHypergraphRecall,
         GraphExpansionMode graphExpansionMode
 ) {
 
@@ -66,7 +65,7 @@ public record GraphScoringPolicy(
     public static final String THRESHOLD_SYSTEM_PROPERTY = "spector.benchmark.graphExpansionThreshold";
 
     /**
-     * Backward-compatible constructor — uses default graph expansion threshold, no hypergraph recall, GATED mode.
+     * Backward-compatible constructor — uses default graph expansion threshold, GATED mode.
      */
     public GraphScoringPolicy(float causalBoostWeight, float hebbianBoostFactor,
                                float temporalForwardFactor, float temporalBackwardFactor,
@@ -74,11 +73,11 @@ public record GraphScoringPolicy(
                                int temporalMaxHops, int entityMaxHops) {
         this(causalBoostWeight, hebbianBoostFactor, temporalForwardFactor,
                 temporalBackwardFactor, entityHopAttenuation, hebbianMaxDepth,
-                temporalMaxHops, entityMaxHops, 0.40f, false, GraphExpansionMode.GATED);
+                temporalMaxHops, entityMaxHops, 0.40f, GraphExpansionMode.GATED);
     }
 
     /**
-     * Backward-compatible constructor — uses custom graph expansion threshold and no hypergraph recall.
+     * Backward-compatible constructor — uses custom graph expansion threshold.
      */
     public GraphScoringPolicy(float causalBoostWeight, float hebbianBoostFactor,
                                float temporalForwardFactor, float temporalBackwardFactor,
@@ -87,28 +86,13 @@ public record GraphScoringPolicy(
                                float graphExpansionThreshold) {
         this(causalBoostWeight, hebbianBoostFactor, temporalForwardFactor,
                 temporalBackwardFactor, entityHopAttenuation, hebbianMaxDepth,
-                temporalMaxHops, entityMaxHops, graphExpansionThreshold, false, GraphExpansionMode.GATED);
-    }
-
-    /**
-     * Constructor with all fields except expansion mode — defaults to GATED.
-     */
-    public GraphScoringPolicy(float causalBoostWeight, float hebbianBoostFactor,
-                               float temporalForwardFactor, float temporalBackwardFactor,
-                               float entityHopAttenuation, int hebbianMaxDepth,
-                               int temporalMaxHops, int entityMaxHops,
-                               float graphExpansionThreshold, boolean useHypergraphRecall) {
-        this(causalBoostWeight, hebbianBoostFactor, temporalForwardFactor,
-                temporalBackwardFactor, entityHopAttenuation, hebbianMaxDepth,
-                temporalMaxHops, entityMaxHops, graphExpansionThreshold, useHypergraphRecall,
-                GraphExpansionMode.GATED);
+                temporalMaxHops, entityMaxHops, graphExpansionThreshold, GraphExpansionMode.GATED);
     }
 
     /**
      * Default policy — reads runtime overrides from system properties.
      *
      * <ul>
-     *   <li>{@code spector.benchmark.useHypergraphRecall} — boolean (default: false)</li>
      *   <li>{@code spector.benchmark.graphExpansionThreshold} — float (default: 0.40)</li>
      *   <li>{@code spector.memory.graphExpansionMode} — GATED/ALWAYS/ENTITY_ONLY (default: GATED)</li>
      * </ul>
@@ -123,7 +107,6 @@ public record GraphScoringPolicy(
                 threshold = Float.parseFloat(thresholdStr);
             } catch (NumberFormatException ignored) { /* use default */ }
         }
-        boolean useHypergraph = Boolean.getBoolean("spector.benchmark.useHypergraphRecall");
         GraphExpansionMode mode = GraphExpansionMode.resolve();
 
         return new GraphScoringPolicy(
@@ -136,7 +119,6 @@ public record GraphScoringPolicy(
                 3,      // temporalMaxHops
                 2,      // entityMaxHops
                 threshold,
-                useHypergraph,
                 mode
         );
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -350,16 +350,6 @@ final class PostIngestSync {
                 entityGraph.linkEntityToMemory(eid, memoryIdx);
                 entityIds.add(eid);
                 entitiesAdded++;
-                for (EntityRelation rel : entity.relations()) {
-                    int targetEid = entityGraph.findEntity(rel.targetEntityName());
-                    if (targetEid < 0) {
-                        targetEid = entityGraph.addEntity(rel.targetEntityName(), "OTHER");
-                    }
-                    if (targetEid >= 0) {
-                        entityGraph.addRelation(eid, targetEid, rel.relationTypeName());
-                        relationsAdded++;
-                    }
-                }
             }
         }
         if (entitiesAdded > 0) {

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacadeTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/CognitiveGraphFacadeTest.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory.graph;
 
 import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory.HyperEdge;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.GraphNeighborhood;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
@@ -65,6 +66,10 @@ class CognitiveGraphFacadeTest {
         when(entityGraph.nameIndex()).thenReturn(nameIndex);
         when(entityGraph.memoriesForEntity(10)).thenReturn(new int[]{0, 1});
         when(entityGraph.entityType(10)).thenReturn("CONCEPT");
+
+        var mockEdge = mock(HyperEdge.class);
+        when(mockEdge.memoryIdx()).thenReturn(1);
+        when(hyperEntityGraph.findHyperedgesForEntity(10)).thenReturn(List.of(mockEdge));
 
         // Set up inspector to return records for mem-1 and mem-2
         var rec1 = mock(CognitiveRecord.class);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/HypergraphRecallSpikeTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/HypergraphRecallSpikeTest.java
@@ -119,9 +119,9 @@ class HypergraphRecallSpikeTest {
         hyperGraph.addHyperedge(new int[]{0, 2}, new int[]{1, 1}, 1, 1.0f, 99, System.currentTimeMillis());
 
         GraphScoringPolicy policy = new GraphScoringPolicy(
-                0.3f, 0.3f, 0.8f, 0.7f, 0.25f, 2, 3, 2, 0.40f, true // useHypergraphRecall = true
+                0.3f, 0.3f, 0.8f, 0.7f, 0.25f, 2, 3, 2, 0.40f,
+                GraphExpansionMode.GATED
         );
-
         GraphExpansionStage stage = new GraphExpansionStage(
                 null, null, entityGraph, hyperGraph, null, policy, null, null, null, null
         );

--- a/scripts/cognitive-benchmark.ps1
+++ b/scripts/cognitive-benchmark.ps1
@@ -16,7 +16,7 @@ param(
     [int]$HeapMb        = 8192,
     [switch]$SkipBuild,
     [switch]$MiniDataset,          # Use the built-in 50-memory mini-dataset for quick tests
-    [switch]$UseHypergraph,        # Use hypergraph recall path instead of binary entity graph
+
     [switch]$NoPersistence,        # Disable disk persistence for ephemeral memory setup
     [double]$GraphExpansionThreshold = 0.40,  # Similarity threshold below which graph expansion fires
     [string]$GraphExpansionMode = ""          # GATED (default), ALWAYS, or ENTITY_ONLY
@@ -117,7 +117,7 @@ $jvmArgs = @(
     "-Xmx${HeapMb}m"
     "-Dlogback.configurationFile=logback-bench.xml"
     "-Dspector.embedding.cache-dir=$(Join-Path $resolvedDataset '../../.spector-bench')"
-    "-Dspector.benchmark.useHypergraphRecall=$($UseHypergraph.IsPresent.ToString().ToLower())"
+
     "-Dspector.benchmark.persistence=$((!$NoPersistence).ToString().ToLower())"
     "-Dspector.benchmark.graphExpansionThreshold=$GraphExpansionThreshold"
     "-Dspector.memory.text-segment-size=33554432"


### PR DESCRIPTION
## Summary

Graduates HyperEntityGraphMemory as the sole entity graph implementation in Spector Memory, replacing the binary EntityGraphMemory. This involves kernel architecture integration, pipeline graduation, and configuration cleanup.

Closes #424

---

## ADR

See [adr-hypergraph-graduation.md](https://github.com/spectrayan/spectrayan/blob/main/RnD/adr-hypergraph-graduation.md) (Status: **Accepted**)

---

## Benchmark Evidence

| Metric | Value |
|:---|:---|
| **Cognitive nDCG@10** | 0.244 (no regression) |
| **Cohen's d** | +0.353 (medium effect) |
| **Wilcoxon p-value** | 0.001 (significant) |
| **Bootstrap 95% CI** | [0.005, 0.056] excludes 0 |
| **Candidates under expansion** | Hypergraph: 30-90 vs Binary: 2,900-4,000+ (50x reduction) |
| **Latency under expansion** | 16.8ms vs 28.5ms |

---

## Changes by Group

### Group 1: Kernel Integration
- **[NEW]** `HyperEntityLayout.java` — kernel `MemoryLayout` (layoutId=0x48594547, schema v1, stride=32)
- **[NEW]** `HyperEntityGraphCodec.java` — codec chain step registered with `CodecRegistry`
- **[MODIFY]** `HyperEntityGraphMemory.java` — integrated with kernel architecture, `GraphMemory` contract, WAL binding, 64B header migration

### Group 2: Configuration Cleanup
- **[MODIFY]** `GraphScoringPolicy.java` — removed `useHypergraphRecall` field and system property
- **[MODIFY]** `SpectorMemoryBuilder.java` — deprecated `hyperEntityGraphEnabled()`

### Group 3: Pipeline Integration
- **[MODIFY]** `GraphExpansionStage.java` — removed binary graph branching; hypergraph-only path
- **[MODIFY]** `CognitiveIngestionTarget.java` — removed dual-write to binary graph
- **[MODIFY]** `CognitiveGraphFacade.java` — topology methods now source exclusively from hypergraph

### Group 4: Benchmark Harness
- **[MODIFY]** `BenchmarkSetup.java` — removed `useHypergraph` variable and system property
- **[MODIFY]** `cognitive-benchmark.ps1` — removed `-UseHypergraph` parameter

---

## Testing

| Check | Result |
|:---|:---|
| `mvn install -DskipTests` | ✅ BUILD SUCCESS |
| `mvn test -pl memory/spector-memory` | ✅ 1,164 tests, 0 failures, 18 skipped |
| Benchmark regression (nDCG >= 0.244) | ✅ PASS (nDCG=0.244, d=0.353) |
| `useHypergraphRecall` cleanup | ✅ No production code references |

---

## Migration Plan (Post-Merge)

Binary `EntityGraphMemory` code is **not deleted** in this PR — it is unwired from the pipeline. Deletion follows a phased plan:

1. **Phase 2**: §5 robustness validation on second dataset seed (in progress)
2. **Phase 3**: CLI migration tool for existing Docker persisted data
3. **Phase 4**: Binary graph code excision (gated on Phase 3 completion)