### PR TITLE
fix(memory): single Hebbian migration authority — P0 data-loss hotfix (#432)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -310,15 +310,11 @@ public final class SpectorMemoryFactory {
             if (loadFrom == null) {
                 loadFrom = legacyGraph;
             }
-            try {
-                com.spectrayan.spector.memory.kernel.codec.Codecs.ensureCurrent(
-                        com.spectrayan.spector.memory.kernel.codec.Codecs.defaultRegistry(),
-                        com.spectrayan.spector.memory.kernel.MemoryId.of("hebbian", "graph"),
-                        new com.spectrayan.spector.memory.kernel.layout.HebbianLayout(),
-                        loadFrom, null, null);
-            } catch (Exception e) {
-                log.warn("Operation failed: Codec validation for HebbianLayout", e);
-            }
+            // NOTE(#432): No codec ensureCurrent() call here. HebbianGraphMemory.load()
+            // is the single migration authority — it detects legacy HGPH files and
+            // migrates them in-class to HCSR. Running the codec's HgphToCsrStep here
+            // rewrote HGPH -> SMKM, a format load() cannot read, silently dropping the
+            // graph. See Codecs.defaultRegistry() and #435.
             hebbianGraph = HebbianGraphMemory.load(loadFrom, graphCapacity,
                     builder.hebbianMaxDegree, builder.edgeImportance);
         } else {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
@@ -558,13 +558,21 @@ public final class HebbianGraphMemory implements HebbianGraphBase, GraphMemory<H
                 log.info("Detected legacy V2 HebbianGraph file, migrating to CSR: {}", filePath);
                 return migrateFromV2(filePath, maxDegree, edgeImportance);
             } else {
-                log.warn("Unknown HebbianGraph file magic: 0x{}, creating fresh", Integer.toHexString(magic));
-                return new HebbianGraphMemory(defaultCapacity, defaultCapacity * 2, maxDegree, edgeImportance);
+                // The file EXISTS (checked above) but carries an unrecognized magic.
+                // Returning a fresh empty graph here would silently discard the user's
+                // entire association graph (#432). Fail loud instead.
+                throw new IOException("Unrecognized HebbianGraph file magic: 0x"
+                        + Integer.toHexString(magic) + " (expected HCSR 0x"
+                        + Integer.toHexString(FILE_MAGIC) + " or legacy HGPH 0x"
+                        + Integer.toHexString(LEGACY_MAGIC) + "): " + filePath);
             }
         } catch (Exception e) {
-            log.error("Failed to load HebbianGraphMemory from {}, creating fresh: {}",
-                    filePath, e.getMessage());
-            return new HebbianGraphMemory(defaultCapacity, defaultCapacity * 2, maxDegree, edgeImportance);
+            // A file that is present but unreadable is a data-integrity problem, not a
+            // "start fresh" signal. Surface it so callers cannot silently lose data (#432).
+            // (File-absent was already handled above and returns a fresh graph.)
+            log.error("Failed to load HebbianGraphMemory from {} (file present but unreadable)",
+                    filePath, e);
+            throw new SpectorGraphPersistenceException("HebbianGraphMemory", filePath, e);
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codecs.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/codec/Codecs.java
@@ -15,7 +15,6 @@ package com.spectrayan.spector.memory.kernel.codec;
 import com.spectrayan.spector.memory.DataEncryptor;
 import com.spectrayan.spector.memory.cortex.TextAppendCodec;
 import com.spectrayan.spector.memory.cortex.TypeRegistryCodec;
-import com.spectrayan.spector.memory.hebbian.HebbianGraphCodec;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphCodec;
 import com.spectrayan.spector.memory.index.IndexRecordCodec;
 import com.spectrayan.spector.memory.kernel.MemoryId;
@@ -37,7 +36,13 @@ public final class Codecs {
             .register(new TextAppendCodec())
             .register(new TypeRegistryCodec())
             .register(new IndexRecordCodec())
-            .register(new HebbianGraphCodec())
+            // NOTE(#432): HebbianGraphCodec is deliberately NOT registered. Its
+            // HgphToCsrStep rewrites legacy HGPH files into an SMKM 64-byte header,
+            // but HebbianGraphMemory.save()/load() speak the HCSR 24-byte format and
+            // never recognize SMKM — so the codec produced a format nothing could read,
+            // silently discarding the user's association graph on upgrade. The in-class
+            // HebbianGraphMemory.migrateFromV2 (HGPH -> HCSR) is now the single migration
+            // authority. Full SMKM/kernel adoption for Hebbian is deferred to #435.
             .register(new HyperEntityGraphCodec())
             .build();
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemoryMigrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemoryMigrationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.hebbian;
+
+import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
+import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #432 — legacy Hebbian graph migration data loss.
+ *
+ * <p>Before the fix, {@code SpectorMemoryFactory} ran a codec ({@code HgphToCsrStep})
+ * that rewrote a legacy HGPH file into an SMKM 64-byte header on disk, but
+ * {@link HebbianGraphMemory#load} only recognizes the HCSR (0x48435352) and legacy
+ * HGPH (0x48475048) magics. An SMKM magic fell through to the "unknown magic" branch,
+ * which silently returned a fresh EMPTY graph — losing the user's entire association
+ * graph on upgrade.</p>
+ *
+ * <p>The fix makes the in-class {@code migrateFromV2} the single migration authority
+ * and turns the swallow-and-continue paths into hard failures for present-but-unreadable
+ * files.</p>
+ */
+class HebbianGraphMemoryMigrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("legacy HGPH file migrates to CSR preserving edges, weights and neighbors")
+    void legacyHgphMigratesPreservingEdges() {
+        // ── Build a populated legacy graph (writes the true HGPH v2 format) ──
+        Path graphFile = tempDir.resolve("hebbian.graph");
+        HebbianGraph legacy = new HebbianGraph(100);
+        legacy.strengthen(0, 1, 2.0f);  // 0<->1 weight 2.0
+        legacy.strengthen(0, 2, 5.0f);  // 0<->2 weight 5.0
+        legacy.strengthen(3, 4, 1.0f);  // 3<->4 weight 1.0
+        int legacyTotalEdges = legacy.totalEdges(); // 6 (bidirectional)
+        legacy.save(graphFile);
+        legacy.close();
+
+        // Sanity: the file was written in the legacy HGPH format (magic 0x48475048).
+        assertThat(readMagic(graphFile)).isEqualTo(0x48475048);
+
+        // ── Load through the CSR memory: must migrate, not silently drop ──
+        HebbianGraphMemory csr = HebbianGraphMemory.load(graphFile, 100);
+        try {
+            assertThat(csr.totalEdges())
+                    .as("migrated graph must not be empty")
+                    .isEqualTo(legacyTotalEdges)
+                    .isPositive();
+
+            // Node 0 has two neighbors, sorted by descending weight.
+            assertThat(csr.degree(0)).isEqualTo(2);
+            List<HebbianEdge> n0 = csr.neighbors(0);
+            assertThat(n0).hasSize(2);
+            assertThat(n0.get(0).neighborIndex()).isEqualTo(2);
+            assertThat(n0.get(0).weight()).isEqualTo(5.0f);
+            assertThat(n0.get(1).neighborIndex()).isEqualTo(1);
+            assertThat(n0.get(1).weight()).isEqualTo(2.0f);
+
+            // Reverse edges preserved.
+            assertThat(csr.degree(1)).isEqualTo(1);
+            assertThat(csr.neighbors(1).get(0).weight()).isEqualTo(2.0f);
+
+            assertThat(csr.degree(3)).isEqualTo(1);
+            assertThat(csr.neighbors(3).get(0).neighborIndex()).isEqualTo(4);
+            assertThat(csr.neighbors(3).get(0).weight()).isEqualTo(1.0f);
+
+            // After migration the file is rewritten in HCSR format (magic 0x48435352)
+            // and the legacy file is preserved as a .v2.bak backup.
+            assertThat(readMagic(graphFile)).isEqualTo(0x48435352);
+            assertThat(Files.exists(graphFile.resolveSibling(graphFile.getFileName() + ".v2.bak"))).isTrue();
+        } finally {
+            csr.close();
+        }
+    }
+
+    @Test
+    @DisplayName("present-but-unreadable file (unknown magic) throws instead of silently returning empty")
+    void unknownMagicThrowsInsteadOfSilentEmpty() throws Exception {
+        Path corrupt = tempDir.resolve("corrupt.graph");
+        // Unknown magic (not HCSR, not HGPH) — the exact case that used to be swallowed.
+        Files.write(corrupt, new byte[]{0x53, 0x4D, 0x4B, 0x4D, 1, 2, 3, 4}); // "SMKM" + junk
+
+        assertThatThrownBy(() -> HebbianGraphMemory.load(corrupt, 100))
+                .isInstanceOf(SpectorGraphPersistenceException.class);
+    }
+
+    @Test
+    @DisplayName("truncated HCSR file throws instead of silently returning empty")
+    void truncatedCsrFileThrows() throws Exception {
+        Path truncated = tempDir.resolve("truncated.graph");
+        // Valid HCSR magic but a bogus/short header — loadV3 must reject it.
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.putInt(0x48435352); // HCSR magic
+        buf.putInt(99);         // invalid version
+        Files.write(truncated, buf.array());
+
+        assertThatThrownBy(() -> HebbianGraphMemory.load(truncated, 100))
+                .isInstanceOf(SpectorGraphPersistenceException.class);
+    }
+
+    private static int readMagic(Path file) {
+        try {
+            byte[] head = new byte[4];
+            try (var in = Files.newInputStream(file)) {
+                int read = in.read(head);
+                assertThat(read).isEqualTo(4);
+            }
+            return ByteBuffer.wrap(head).getInt();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
P0 hotfix for silent, total data loss of the Hebbian association graph on legacy upgrade.

Two migration authorities disagreed on the on-disk format:
- `SpectorMemoryFactory` ran `Codecs.ensureCurrent(HebbianLayout)` whose registered `HebbianGraphCodec`/`HgphToCsrStep` rewrote a legacy **HGPH** file into an **SMKM** 64-byte `MemoryHeader` (`0x534D4B4D`).
- But `HebbianGraphMemory.save()`/`load()` speak the **HCSR** 24-byte format (`0x48435352`) and only recognize HCSR or legacy HGPH (`0x48475048`). An SMKM magic fell through to the "unknown magic" branch, which returned a **fresh empty graph** — discarding every association, no error surfaced.

## Fix (minimal scope)
- Deregister `HebbianGraphCodec` from `Codecs.defaultRegistry()` and remove the `ensureCurrent(HebbianLayout)` call in `SpectorMemoryFactory`. The in-class `HebbianGraphMemory.migrateFromV2` (HGPH → HCSR) is now the **single migration authority**.
- `HebbianGraphMemory.load()` now **fails loud** (`SpectorGraphPersistenceException`, logging the throwable) for a file that is present-but-unreadable, instead of swallowing and returning an empty graph. File-absent still returns a fresh graph.

Full SMKM/kernel adoption for Hebbian is intentionally deferred to #435.

## Tests
New `HebbianGraphMemoryMigrationTest` (3 tests):
- Populates a legacy `HebbianGraph`, saves the true HGPH format, loads via `HebbianGraphMemory` and asserts edge count/weights/neighbor ordering are preserved, HCSR rewrite happens, and a `.v2.bak` backup is created.
- Unknown-magic and truncated-HCSR files throw instead of silently returning empty.

`mvn test -pl memory/spector-memory` → **Tests run: 1167, Failures: 0, Errors: 0, Skipped: 18** (BUILD SUCCESS).

## Notes
- Scoped strictly to #432. Dead `kernel/Codec.java`, Temporal `ensureCurrent`, and other TDs are handled on the `refactor/issue-431-kernel-techdebt` integration branch.
- BSL-1.1 header on the new test file.

Closes #432
