### PR TITLE
fix(memory): multi-partition recall fan-out — P0 frozen-partition data loss (#443)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -964,7 +964,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 header.importance(), header.agentRecallCount(), spectorRecallCount,
                 header.centroidId(), header.valence(), header.arousal(),
                 header.storageStrength(), header.flags(), consolidationFlags,
-                quantizedVec, loc.partitionIndex(), loc.offset(),
+                quantizedVec, loc.graphSlot(), loc.offset(),
                 metadata, suppressed);
     }
 
@@ -1004,7 +1004,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                             header.centroidId(), header.valence(), header.arousal(),
                             header.storageStrength(), header.flags(), consolidationFlags,
                             null, // no vector for browse (use inspect for full detail)
-                            loc.partitionIndex(), loc.offset(),
+                            loc.graphSlot(), loc.offset(),
                             java.util.Map.of(), suppressionSet.isSuppressed(memId)));
                 }
             }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -699,9 +699,10 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 log.warn("Forget: memory '{}' not found in index", id);
                 return;
             }
-            MemorySegment segment = partitionManager.cognitiveRouter().segmentFor(loc.type());
+            CognitiveMemoryRouter router = partitionManager.routerFor(loc.colocatedPartition());
+            MemorySegment segment = router.segmentFor(loc.type());
             if (segment != null) {
-                CognitiveRecordLayout layout = partitionManager.cognitiveRouter().layoutFor(loc.type());
+                CognitiveRecordLayout layout = router.layoutFor(loc.type());
                 layout.tombstone(segment, loc.offset());
             }
             wal.appendForget(id);
@@ -759,7 +760,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         acquireLease();
         try {
             reinforcementHandler.reinforce(memoryId, valence,
-                    partitionManager.cognitiveRouter(), index);
+                    partitionManager, index);
         } finally {
             releaseLease();
         }
@@ -771,7 +772,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         acquireLease();
         try {
             reinforcementHandler.reinforceWithHints(memoryId, valence, updatedHints,
-                    partitionManager.cognitiveRouter(), index);
+                    partitionManager, index);
         } finally {
             releaseLease();
         }
@@ -814,8 +815,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         try {
             var loc = index.locate(memoryId);
             if (loc == null) return;
-            partitionManager.cognitiveRouter().layoutFor(loc.type())
-                    .markResolved(partitionManager.cognitiveRouter().segmentFor(loc.type()), loc.offset());
+            CognitiveMemoryRouter router = partitionManager.routerFor(loc.colocatedPartition());
+            router.layoutFor(loc.type())
+                    .markResolved(router.segmentFor(loc.type()), loc.offset());
             log.debug("Zeigarnik: marked '{}' as RESOLVED", memoryId);
         } finally {
             releaseLease();
@@ -828,8 +830,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         try {
             var loc = index.locate(memoryId);
             if (loc == null) return;
-            partitionManager.cognitiveRouter().layoutFor(loc.type())
-                    .markUnresolved(partitionManager.cognitiveRouter().segmentFor(loc.type()), loc.offset());
+            CognitiveMemoryRouter router = partitionManager.routerFor(loc.colocatedPartition());
+            router.layoutFor(loc.type())
+                    .markUnresolved(router.segmentFor(loc.type()), loc.offset());
             log.debug("Zeigarnik: marked '{}' as UNRESOLVED", memoryId);
         } finally {
             releaseLease();
@@ -858,8 +861,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                         "Memory '" + memoryId + "' does not exist in the index.");
             }
 
-            var layout = partitionManager.cognitiveRouter().layoutFor(loc.type());
-            var segment = partitionManager.cognitiveRouter().segmentFor(loc.type());
+            CognitiveMemoryRouter whyNotRouter = partitionManager.routerFor(loc.colocatedPartition());
+            var layout = whyNotRouter.layoutFor(loc.type());
+            var segment = whyNotRouter.segmentFor(loc.type());
             if (layout != null && segment != null) {
                 byte flags = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS,
                         loc.offset() + SynapticHeaderConstants.OFFSET_FLAGS);
@@ -928,8 +932,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         MemorySource source = index.source(id);
         String[] memTags = index.tags(id);
 
-        MemorySegment segment = partitionManager.cognitiveRouter().segmentFor(loc.type());
-        CognitiveRecordLayout layout = partitionManager.cognitiveRouter().layoutFor(loc.type());
+        CognitiveMemoryRouter inspectRouter = partitionManager.routerFor(loc.colocatedPartition());
+        MemorySegment segment = inspectRouter.segmentFor(loc.type());
+        CognitiveRecordLayout layout = inspectRouter.layoutFor(loc.type());
 
         if (segment == null || layout == null) return null;
 
@@ -981,8 +986,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             MemoryLocation loc = index.locate(memId);
             if (loc == null) continue;
 
-            MemorySegment segment = partitionManager.cognitiveRouter().segmentFor(loc.type());
-            CognitiveRecordLayout layout = partitionManager.cognitiveRouter().layoutFor(loc.type());
+            CognitiveMemoryRouter browseRouter = partitionManager.routerFor(loc.colocatedPartition());
+            MemorySegment segment = browseRouter.segmentFor(loc.type());
+            CognitiveRecordLayout layout = browseRouter.layoutFor(loc.type());
 
             if (segment != null && layout != null) {
                 var header = layout.readHeader(segment, loc.offset());
@@ -1048,10 +1054,30 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     }
 
     @Override
-    public int totalMemories() { return partitionManager.cognitiveRouter().totalCount(); }
+    public int totalMemories() {
+        // #443: aggregate across all live partitions. Working memory is global (shared by
+        // every router) so it is counted once; the other tiers are summed per partition.
+        int total = partitionManager.activeRouter().countFor(MemoryType.WORKING);
+        for (var handle : partitionManager.snapshot()) {
+            var router = handle.router();
+            total += router.countFor(MemoryType.EPISODIC)
+                    + router.countFor(MemoryType.SEMANTIC)
+                    + router.countFor(MemoryType.PROCEDURAL);
+        }
+        return total;
+    }
 
     @Override
-    public int memoryCount(MemoryType type) { return partitionManager.cognitiveRouter().countFor(type); }
+    public int memoryCount(MemoryType type) {
+        if (type == MemoryType.WORKING) {
+            return partitionManager.activeRouter().countFor(MemoryType.WORKING);
+        }
+        int total = 0;
+        for (var handle : partitionManager.snapshot()) {
+            total += handle.router().countFor(type);
+        }
+        return total;
+    }
 
     @Override
     public int decay(Duration olderThan, float factor) {
@@ -1334,6 +1360,10 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 partitionManager.activePartitionDir(),
                 index, hebbianGraph, temporalChain, entityGraph, hyperEntityGraph,
                 coActivationTracker, temporalKnowledgeGraph, partitionManager.cognitiveRouter(), wal);
+
+        // #443: release frozen partition handles (active router + working already closed
+        // by PersistenceManager). Closes the pre-#443 arena/mmap leak.
+        partitionManager.close();
     }
 
     // ==============================================================

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -13,9 +13,12 @@
 package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory;
+import com.spectrayan.spector.memory.cortex.PartitionHandle;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
 import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
 import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.TextAppendMemory;
 import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
@@ -31,25 +34,41 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import java.time.Instant;
 
 /**
- * Manages colocated partition directories for DISK persistence mode.
+ * Manages colocated partition directories for DISK persistence mode and owns the
+ * partition registry (issue #443, Phase 1).
  *
- * <p>Encapsulates partition discovery, creation, and rolling. Owns the volatile
- * {@code cognitiveRouter} and {@code activePartitionDir} fields, ensuring all
- * synchronization is centralized in one place.</p>
+ * <p>Encapsulates partition discovery, creation, and rolling. Holds a
+ * copy-on-write {@link #registry} — a {@code volatile} immutable
+ * {@code List<PartitionHandle>} whose last element is the single writable/active
+ * partition; all earlier handles are frozen, read-only, and remain OPEN so recall
+ * can fan out across them. Keeping frozen stores open is the fix for the pre-#443
+ * arena/mmap leak.</p>
+ *
+ * <h3>Roll handshake</h3>
+ * <p>On {@link #rollPartition()} the manager: (1) creates a new partition dir with
+ * fresh tier stores and a fresh {@code text.dat}; (2) freezes the current active
+ * handle (kept open); (3) publishes a new immutable snapshot with a single volatile
+ * store; (4) atomically points the ingestion target at the new router, the new text
+ * store and the new active sequence, and updates the index's active-partition seq.
+ * A missed field here would reintroduce split-brain, so all four updates happen
+ * together under {@link #partitionRollLock}.</p>
  *
  * <h3>Thread Safety</h3>
- * <p>Partition rolls are synchronized on an internal lock. The volatile
- * {@code cognitiveRouter} field ensures concurrent readers see the latest swap
- * without acquiring the lock. This provides safe publication for the
- * happens-before guarantee required by the ingestion pipeline.</p>
+ * <p>Frozen handles are immutable and read-only — no lock is required to read them.
+ * Readers take a single volatile {@link #snapshot()} read and iterate that fixed list.
+ * Rolls hold {@link #partitionRollLock} for the create-then-publish sequence. Never
+ * uses {@code synchronized}.</p>
  *
  * @see StorageLayout
+ * @see PartitionHandle
  */
-final class PartitionManager {
+final class PartitionManager implements PartitionRegistry, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(PartitionManager.class);
 
@@ -62,10 +81,14 @@ final class PartitionManager {
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
     private final CognitiveIngestionTarget cognitiveTarget;
+    private final DataEncryptor encryptor;
 
-    private volatile CognitiveMemoryRouter cognitiveRouter;
-    private volatile Path activePartitionDir;
-    private final java.util.concurrent.locks.ReentrantLock partitionRollLock = new java.util.concurrent.locks.ReentrantLock();
+    /** Copy-on-write registry: immutable list, last element = active. Never null. */
+    private volatile List<PartitionHandle> registry;
+    private final java.util.concurrent.locks.ReentrantLock partitionRollLock =
+            new java.util.concurrent.locks.ReentrantLock();
+    private final java.util.concurrent.atomic.AtomicBoolean closed =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
 
     PartitionManager(Path basePath,
                      int quantizedVecBytes,
@@ -74,31 +97,74 @@ final class PartitionManager {
                      int proceduralCapacity,
                      CognitiveMemoryRouter initialRouter,
                      Path initialPartitionDir,
+                     TextAppendMemory initialText,
+                     int initialSeq,
                      MemoryIndex index,
                      HebbianGraphBase hebbianGraph,
                      TemporalChainMemory temporalChain,
-                     CognitiveIngestionTarget cognitiveTarget) {
+                     CognitiveIngestionTarget cognitiveTarget,
+                     DataEncryptor encryptor) {
         this.basePath = basePath;
         this.quantizedVecBytes = quantizedVecBytes;
         this.semanticCapacity = semanticCapacity;
         this.episodicPartitionCapacity = episodicPartitionCapacity;
         this.proceduralCapacity = proceduralCapacity;
-        this.cognitiveRouter = initialRouter;
-        this.activePartitionDir = initialPartitionDir;
         this.index = index;
         this.hebbianGraph = hebbianGraph;
         this.temporalChain = temporalChain;
         this.cognitiveTarget = cognitiveTarget;
+        this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
+
+        PartitionHandle initial = new PartitionHandle(
+                initialSeq, initialPartitionDir, initialRouter, initialText, true);
+        this.registry = List.of(initial);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // PartitionRegistry (read side — used by recall + direct-resolve)
+    // ══════════════════════════════════════════════════════════════
+
+    @Override
+    public List<PartitionHandle> snapshot() {
+        return registry; // single volatile read of an immutable list
+    }
+
+    @Override
+    public PartitionHandle handleFor(int seq) {
+        List<PartitionHandle> snap = registry;
+        for (int i = snap.size() - 1; i >= 0; i--) {
+            PartitionHandle h = snap.get(i);
+            if (h.seq() == seq) return h;
+        }
+        return null;
+    }
+
+    @Override
+    public CognitiveMemoryRouter activeRouter() {
+        List<PartitionHandle> snap = registry;
+        return snap.get(snap.size() - 1).router();
+    }
+
+    /** Returns the active (writable) partition handle. */
+    PartitionHandle activeHandle() {
+        List<PartitionHandle> snap = registry;
+        return snap.get(snap.size() - 1);
     }
 
     /** Returns the current cognitive memory router (volatile read — safe for concurrent access). */
-    CognitiveMemoryRouter cognitiveRouter() { return cognitiveRouter; }
+    CognitiveMemoryRouter cognitiveRouter() { return activeRouter(); }
 
     /** Returns the active partition directory (volatile read). */
-    Path activePartitionDir() { return activePartitionDir; }
+    Path activePartitionDir() { return activeHandle().dir(); }
+
+    /** Returns the active partition sequence number. */
+    int activeSeq() { return activeHandle().seq(); }
 
     /**
      * Discovers existing partitions or creates partition 000 if none exist.
+     *
+     * <p>Phase 1 (issue #443) opens only the newest partition on load; open-all-on-load
+     * is deferred to Phase 2 (restart correctness).</p>
      *
      * @param basePath the memory persistence root
      * @return path to the active (latest) partition directory
@@ -140,11 +206,10 @@ final class PartitionManager {
      * Rolls to a new colocated partition directory.
      *
      * <p>Called automatically when a tier store reaches capacity during ingestion.
-     * Creates a new partition directory, fresh tier stores, and atomically swaps
-     * the CognitiveMemoryRouter so subsequent writes go to the new partition.</p>
-     *
-     * <p>Thread-safe: synchronized on internal lock so concurrent ingestion threads
-     * see a consistent swap.</p>
+     * Creates a new partition directory, fresh tier stores and a fresh {@code text.dat},
+     * freezes the current active handle (kept open), publishes a new immutable snapshot,
+     * then atomically repoints the ingestion target at the new router, text store and
+     * active sequence.</p>
      */
     void rollPartition() {
         partitionRollLock.lock();
@@ -187,22 +252,42 @@ final class PartitionManager {
                         quantizedVecBytes, semanticCapacity,
                         StorageLayout.semanticMem(newPartition));
 
+                // Fresh partition-scoped text.dat (D3b: text rolls with the partition)
+                TextAppendMemory newText = new TextAppendMemory(
+                        StorageLayout.textDat(newPartition), encryptor);
+
                 // Preserve working memory (global, not partitioned)
-                WorkingRecordMemory workingStore = cognitiveRouter.working();
+                WorkingRecordMemory workingStore = activeRouter().working();
 
                 // Flush index + graphs to runtime/ before rolling
                 flushGlobalState();
 
-                // Atomic swap
-                this.cognitiveRouter = new CognitiveMemoryRouter(workingStore, newEpisodic,
-                        newSemantic, newProcedural);
-                this.activePartitionDir = newPartition;
+                // Build the new active router (fully constructed before publication)
+                CognitiveMemoryRouter newRouter = new CognitiveMemoryRouter(
+                        workingStore, newEpisodic, newSemantic, newProcedural);
 
-                // Update ingestion target's router reference
-                cognitiveTarget.updateCognitiveRouter(this.cognitiveRouter);
+                // Freeze the current active handle (kept OPEN — leak fix) and publish
+                // a new immutable snapshot = frozen… + newlyFrozen + newActive.
+                List<PartitionHandle> current = registry;
+                List<PartitionHandle> next = new ArrayList<>(current.size() + 1);
+                for (int i = 0; i < current.size() - 1; i++) {
+                    next.add(current.get(i)); // already frozen
+                }
+                next.add(current.get(current.size() - 1).asFrozen()); // freeze prev active
+                PartitionHandle newActive = new PartitionHandle(
+                        nextSeq, newPartition, newRouter, newText, true);
+                next.add(newActive);
+                this.registry = List.copyOf(next); // single volatile publish
 
-                log.info("Rolled to new partition: {} (seq={}, semantic capacity={})",
-                        newPartition.getFileName(), nextSeq, semanticCapacity);
+                // Atomically repoint the ingestion target: router + text + active seq.
+                cognitiveTarget.updateCognitiveRouter(newRouter);
+                cognitiveTarget.updateTextDataStore(newText);
+                cognitiveTarget.updateActivePartitionSeq(nextSeq);
+                // Keep the index's active-partition seq in sync for reverse-key resolution.
+                index.setActivePartitionSeq(nextSeq);
+
+                log.info("Rolled to new partition: {} (seq={}, semantic capacity={}, live partitions={})",
+                        newPartition.getFileName(), nextSeq, semanticCapacity, this.registry.size());
 
             } catch (IOException e) {
                 throw new SpectorServerException(ErrorCode.INTERNAL_ERROR,
@@ -210,6 +295,40 @@ final class PartitionManager {
             }
         } finally {
             partitionRollLock.unlock();
+        }
+    }
+
+    /**
+     * Closes frozen partition handles at component shutdown (leak fix, issue #443).
+     *
+     * <p>Only frozen (non-active) handles' partition-scoped stores plus the active
+     * handle's {@code text.dat} are closed here. The active router (working + active
+     * tier stores) is closed by {@code PersistenceManager}. Working memory is global
+     * and is never closed by a handle. Idempotent.</p>
+     */
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        List<PartitionHandle> snap = registry;
+        for (int i = 0; i < snap.size(); i++) {
+            PartitionHandle h = snap.get(i);
+            boolean isActive = (i == snap.size() - 1);
+            if (isActive) {
+                // Active tier stores + working are closed by PersistenceManager; close
+                // only the active text.dat here (PersistenceManager does not own it).
+                closeQuietly(h.text());
+            } else {
+                h.close(); // frozen: episodic/semantic/procedural + text (never working)
+            }
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable c) {
+        if (c == null) return;
+        try {
+            c.close();
+        } catch (Exception e) {
+            log.debug("Failed to close active text store: {}", e.getMessage());
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -99,6 +99,7 @@ final class PartitionManager implements PartitionRegistry, AutoCloseable {
                      Path initialPartitionDir,
                      TextAppendMemory initialText,
                      int initialSeq,
+                     List<PartitionHandle> initialFrozen,
                      MemoryIndex index,
                      HebbianGraphBase hebbianGraph,
                      TemporalChainMemory temporalChain,
@@ -115,9 +116,21 @@ final class PartitionManager implements PartitionRegistry, AutoCloseable {
         this.cognitiveTarget = cognitiveTarget;
         this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
 
-        PartitionHandle initial = new PartitionHandle(
+        // #443 Phase 2 (open-all-on-load): the registry is seeded with every discovered
+        // partition — all older ones frozen/read-only, the newest active/writable.
+        PartitionHandle active = new PartitionHandle(
                 initialSeq, initialPartitionDir, initialRouter, initialText, true);
-        this.registry = List.of(initial);
+        List<PartitionHandle> initial = new ArrayList<>();
+        if (initialFrozen != null) {
+            for (PartitionHandle f : initialFrozen) {
+                if (f != null && f.seq() != initialSeq) {
+                    initial.add(f.asFrozen());
+                }
+            }
+            initial.sort(java.util.Comparator.comparingInt(PartitionHandle::seq));
+        }
+        initial.add(active); // active is last (highest seq)
+        this.registry = List.copyOf(initial);
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -161,45 +174,93 @@ final class PartitionManager implements PartitionRegistry, AutoCloseable {
     int activeSeq() { return activeHandle().seq(); }
 
     /**
-     * Discovers existing partitions or creates partition 000 if none exist.
-     *
-     * <p>Phase 1 (issue #443) opens only the newest partition on load; open-all-on-load
-     * is deferred to Phase 2 (restart correctness).</p>
+     * Discovers existing partitions or creates partition 000 if none exist, returning the
+     * newest (active) partition directory.
      *
      * @param basePath the memory persistence root
      * @return path to the active (latest) partition directory
      */
     static Path discoverOrCreatePartition(Path basePath) throws IOException {
+        List<Path> all = discoverAllPartitions(basePath);
+        return all.get(all.size() - 1); // newest = active
+    }
+
+    /**
+     * Enumerates <b>all</b> partition directories under {@code basePath}, ascending by
+     * sequence number, creating partition 000 if none exist (issue #443, Phase 2 —
+     * open-all-on-load). The last element is the newest (active) partition; all earlier
+     * elements are the frozen partitions the factory must open read-only.
+     *
+     * @param basePath the memory persistence root
+     * @return all partition dirs sorted by sequence (never empty; last = active)
+     */
+    static List<Path> discoverAllPartitions(Path basePath) throws IOException {
         Path partitionsDir = StorageLayout.partitionsDir(basePath);
         Files.createDirectories(partitionsDir);
 
-        // Scan for existing partition directories
-        Path latestPartition = null;
-        int maxSeq = -1;
+        java.util.TreeMap<Integer, Path> bySeq = new java.util.TreeMap<>();
         try (var stream = Files.newDirectoryStream(partitionsDir)) {
             for (Path dir : stream) {
                 if (!Files.isDirectory(dir)) continue;
                 String name = dir.getFileName().toString();
                 if (StorageLayout.isPartitionDir(name)) {
-                    int seq = StorageLayout.parsePartitionSeqNo(name);
-                    if (seq > maxSeq) {
-                        maxSeq = seq;
-                        latestPartition = dir;
-                    }
+                    bySeq.put(StorageLayout.parsePartitionSeqNo(name), dir);
                 }
             }
         }
 
-        if (latestPartition != null) {
-            return latestPartition;
+        if (bySeq.isEmpty()) {
+            // No partitions found → create partition 000
+            long epochSecs = Instant.now().getEpochSecond();
+            Path newPartition = StorageLayout.partitionDir(basePath, 0, epochSecs);
+            Files.createDirectories(newPartition);
+            log.info("Created initial partition: {}", newPartition.getFileName());
+            return List.of(newPartition);
         }
 
-        // No partitions found → create partition 000
-        long epochSecs = Instant.now().getEpochSecond();
-        Path newPartition = StorageLayout.partitionDir(basePath, 0, epochSecs);
-        Files.createDirectories(newPartition);
-        log.info("Created initial partition: {}", newPartition.getFileName());
-        return newPartition;
+        log.info("Discovered {} partition(s) on load: {}", bySeq.size(), bySeq.keySet());
+        return new ArrayList<>(bySeq.values()); // ascending by seq (last = newest/active)
+    }
+
+    /**
+     * Opens a single frozen (read-only) partition directory on load, building a
+     * {@link PartitionHandle} with its own tier stores and partition-scoped
+     * {@code text.dat} (issue #443, Phase 2). The handle shares the global
+     * {@code workingStore} (working memory is not partitioned and is never closed by a
+     * handle). The returned handle is marked non-writable/frozen.
+     *
+     * @param dir          the partition directory
+     * @param seq          the partition sequence number
+     * @param workingStore the global working-memory store (shared, never closed here)
+     * @param quantizedVecBytes quantized vector byte width
+     * @param semanticCapacity  semantic tier capacity
+     * @param episodicPartitionCapacity episodic tier capacity
+     * @param proceduralCapacity procedural tier capacity
+     * @param encryptor    the data encryptor (or NOOP)
+     * @return a frozen partition handle wrapping the opened stores
+     */
+    static PartitionHandle openFrozenPartition(Path dir, int seq,
+                                               WorkingRecordMemory workingStore,
+                                               int quantizedVecBytes,
+                                               int semanticCapacity,
+                                               int episodicPartitionCapacity,
+                                               int proceduralCapacity,
+                                               DataEncryptor encryptor) {
+        EpisodicRecordMemory episodic = new EpisodicRecordMemory(
+                StorageLayout.episodicMem(dir), quantizedVecBytes, episodicPartitionCapacity);
+        ProceduralRecordMemory procedural = new ProceduralRecordMemory(
+                quantizedVecBytes, proceduralCapacity, StorageLayout.proceduralMem(dir));
+        SemanticRecordMemory semantic = new SemanticRecordMemory(
+                quantizedVecBytes, semanticCapacity, StorageLayout.semanticMem(dir));
+
+        TextAppendMemory text = new TextAppendMemory(
+                StorageLayout.textDat(dir), encryptor != null ? encryptor : DataEncryptor.NOOP);
+        text.readAll();
+
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(
+                workingStore, episodic, semantic, procedural);
+        log.info("Opened frozen partition seq={} ({})", seq, dir.getFileName());
+        return new PartitionHandle(seq, dir, router, text, false);
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
@@ -215,7 +215,7 @@ final class ReinforcementHandler {
             newImportance = 0.5f * currentImportance + 0.5f * refusedImportance;
         } else {
             // Degree centrality boost from Hebbian graph
-            int graphIdx = loc.partitionIndex();
+            int graphIdx = loc.graphSlot();
             if (graphIdx >= 0 && hebbianGraph != null) {
                 var edges = hebbianGraph.neighbors(graphIdx);
                 int degree = edges.size();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
@@ -15,6 +15,7 @@ package com.spectrayan.spector.memory;
 import com.spectrayan.spector.memory.adaptor.ProfileAdaptor;
 import com.spectrayan.spector.memory.amygdala.ValenceTracker;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
@@ -89,11 +90,11 @@ final class ReinforcementHandler {
      *
      * @param memoryId   the memory ID to reinforce
      * @param valence    positive/negative outcome signal (-128 to +127)
-     * @param cognitiveRouter the current cognitive memory router
+     * @param partitionRegistry the live partition registry (#443)
      * @param index           the memory index
      */
     void reinforce(String memoryId, byte valence,
-                   CognitiveMemoryRouter cognitiveRouter, MemoryIndex index) {
+                   PartitionRegistry partitionRegistry, MemoryIndex index) {
         if (memoryId == null) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "memoryId");
         }
@@ -103,6 +104,8 @@ final class ReinforcementHandler {
             return;
         }
 
+        // #443: resolve the store by the memory's colocated partition.
+        CognitiveMemoryRouter cognitiveRouter = partitionRegistry.routerFor(loc.colocatedPartition());
         MemorySegment segment = cognitiveRouter.segmentFor(loc.type());
         if (segment != null) {
             CognitiveRecordLayout layout = cognitiveRouter.layoutFor(loc.type());
@@ -183,19 +186,20 @@ final class ReinforcementHandler {
      * @param memoryId     the memory ID to reinforce
      * @param valence      positive/negative outcome (-128 to +127)
      * @param updatedHints   optional ICNU hints for re-fusion (null = auto-compute)
-     * @param cognitiveRouter the current cognitive memory router
+     * @param partitionRegistry the live partition registry (#443)
      * @param index          the memory index
      */
     void reinforceWithHints(String memoryId, byte valence,
                             IngestionHints updatedHints,
-                            CognitiveMemoryRouter cognitiveRouter, MemoryIndex index) {
+                            PartitionRegistry partitionRegistry, MemoryIndex index) {
         // Delegate core reinforcement
-        reinforce(memoryId, valence, cognitiveRouter, index);
+        reinforce(memoryId, valence, partitionRegistry, index);
 
         // Importance re-fusion
         MemoryLocation loc = index.locate(memoryId);
         if (loc == null) return;
 
+        CognitiveMemoryRouter cognitiveRouter = partitionRegistry.routerFor(loc.colocatedPartition());
         MemorySegment segment = cognitiveRouter.segmentFor(loc.type());
         if (segment == null) return;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -208,6 +208,11 @@ public final class SpectorMemoryFactory {
             }
         }
 
+        // #443: sequence of the active (newest) partition — Phase 1 opens only this one.
+        final int initialPartitionSeq = resolvedPartitionDir != null
+                ? StorageLayout.parsePartitionSeqNo(resolvedPartitionDir.getFileName().toString())
+                : 0;
+
         //  Cognitive Memory stores 
         CognitiveMemoryRouter cognitiveRouter;
         WorkingRecordMemory workingStore;
@@ -258,6 +263,16 @@ public final class SpectorMemoryFactory {
             }
         } else {
             index = new MemoryIndex();
+        }
+
+        // #443: stamp loaded records with the active partition seq (Phase 1 opens only the
+        // newest partition, so all loaded records physically live there). Keeps the
+        // in-memory reverse key, text resolution and active-seq consistent. In-memory only —
+        // the .midx on-disk format is unchanged (persisting colocatedPartition is Phase 2).
+        if (isDisk && basePath != null && index.size() > 0) {
+            index.stampColocatedPartition(initialPartitionSeq);
+        } else {
+            index.setActivePartitionSeq(initialPartitionSeq);
         }
 
         //  WAL 
@@ -515,25 +530,35 @@ public final class SpectorMemoryFactory {
             }
         }
 
+        //  Seed the ingestion target's active partition seq (#443) 
+        cognitiveTarget.updateActivePartitionSeq(initialPartitionSeq);
+
         //  Partition Manager 
         PartitionManager partitionManager;
         if (isDisk) {
             partitionManager = new PartitionManager(
                     basePath, quantizedVecBytes, builder.semanticCapacity,
                     builder.episodicPartitionCapacity, builder.proceduralCapacity,
-                    cognitiveRouter, resolvedPartitionDir,
-                    index, hebbianGraph, temporalChain, cognitiveTarget);
+                    cognitiveRouter, resolvedPartitionDir, textDataStore, initialPartitionSeq,
+                    index, hebbianGraph, temporalChain, cognitiveTarget, builder.dataEncryptor);
             cognitiveTarget.setPartitionRollCallback(partitionManager::rollPartition);
         } else {
             partitionManager = new PartitionManager(
                     null, quantizedVecBytes, builder.semanticCapacity,
                     builder.episodicPartitionCapacity, builder.proceduralCapacity,
-                    cognitiveRouter, null,
-                    index, hebbianGraph, temporalChain, cognitiveTarget);
+                    cognitiveRouter, null, textDataStore, initialPartitionSeq,
+                    index, hebbianGraph, temporalChain, cognitiveTarget, builder.dataEncryptor);
         }
 
+        // #443 (D3b): resolve MemoryIndex.text(id) via the memory's colocated partition,
+        // backed by the live registry (replaces the single setTextDataStore for reads).
+        index.setTextResolver(seq -> {
+            var handle = partitionManager.handleFor(seq);
+            return handle != null ? handle.text() : null;
+        });
+
         //  WAL Recovery 
-        performWalRecovery(wal, cognitiveRouter, index, hebbianGraph, temporalChain, temporalKnowledgeGraph, entityGraph, coActivationTracker, cognitiveTarget, basePath);
+        performWalRecovery(wal, cognitiveRouter, index, hebbianGraph, temporalChain, temporalKnowledgeGraph, entityGraph, coActivationTracker, cognitiveTarget, basePath, initialPartitionSeq);
 
         if (wal != null) {
             if (entityGraph != null) {
@@ -570,7 +595,7 @@ public final class SpectorMemoryFactory {
 
         //  Recall Pipeline 
         RecallPipeline recallPipeline = new RecallPipeline(
-                embeddingProvider, cognitiveRouter, index,
+                embeddingProvider, partitionManager, index,
                 suppressionSet, habituationPenalty, prospectiveScheduler, wal,
                 quantizer.mins(), quantizer.scales(), semanticStrategy,
                 null, hebbianGraph, temporalChain, entityGraph, hyperEntityGraph, entityExtractor,
@@ -578,7 +603,7 @@ public final class SpectorMemoryFactory {
                 memorySpladeIndex, builder.SparseEmbeddingProvider, colbertReranker,
                 recallHistory);
 
-        recallPipeline.addListener(new LtpReconsolidationListener(index, cognitiveRouter, wal));
+        recallPipeline.addListener(new LtpReconsolidationListener(index, partitionManager, wal));
         recallPipeline.addListener(new HebbianCoActivationListener(coActivationTracker));
 
         //  Extracted Components 
@@ -768,7 +793,8 @@ public final class SpectorMemoryFactory {
             EntityGraphMemory entityGraph,
             CoActivationRecordMemory coActivationTracker,
             CognitiveIngestionTarget cognitiveTarget,
-            Path basePath) {
+            Path basePath,
+            int activePartitionSeq) {
         
         if (wal == null || !wal.isPersistent()) {
             return;
@@ -882,7 +908,8 @@ public final class SpectorMemoryFactory {
                             int storeIndex = (int) (lastRecordOffset / stride);
                             com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation loc =
                                     new com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation(
-                                            lastRecordType, lastRecordOffset, -1, lastTextOffset, lastTextLength);
+                                            lastRecordType, lastRecordOffset, -1, activePartitionSeq,
+                                            lastTextOffset, lastTextLength);
                             
                             String text = "";
                             if (index.textDataStore() != null && lastTextOffset != -1) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -197,18 +197,27 @@ public final class SpectorMemoryFactory {
         int quantizedVecBytes = builder.dimensions;
 
         Path resolvedPartitionDir = null;
+        // #443 Phase 2: open ALL partitions on load. The newest is active/writable; every
+        // older partition dir is opened read-only (frozen) so recall fan-out + direct-resolve
+        // work across partitions after restart.
+        List<Path> frozenPartitionDirs = List.of();
         if (isDisk && basePath != null) {
             try {
                 createDirectoriesSecure(StorageLayout.runtimeDir(basePath));
                 createDirectoriesSecure(StorageLayout.partitionsDir(basePath));
-                resolvedPartitionDir = PartitionManager.discoverOrCreatePartition(basePath);
-                log.info("Active partition: {}", resolvedPartitionDir.getFileName());
+                List<Path> allPartitions = PartitionManager.discoverAllPartitions(basePath);
+                resolvedPartitionDir = allPartitions.get(allPartitions.size() - 1); // newest = active
+                if (allPartitions.size() > 1) {
+                    frozenPartitionDirs = List.copyOf(allPartitions.subList(0, allPartitions.size() - 1));
+                }
+                log.info("Active partition: {} ({} frozen partition(s) to open)",
+                        resolvedPartitionDir.getFileName(), frozenPartitionDirs.size());
             } catch (java.io.IOException e) {
                 log.error("Failed to initialize partition layout: {}", e.getMessage(), e);
             }
         }
 
-        // #443: sequence of the active (newest) partition — Phase 1 opens only this one.
+        // #443: sequence of the active (newest) partition.
         final int initialPartitionSeq = resolvedPartitionDir != null
                 ? StorageLayout.parsePartitionSeqNo(resolvedPartitionDir.getFileName().toString())
                 : 0;
@@ -265,15 +274,18 @@ public final class SpectorMemoryFactory {
             index = new MemoryIndex();
         }
 
-        // #443: stamp loaded records with the active partition seq (Phase 1 opens only the
-        // newest partition, so all loaded records physically live there). Keeps the
-        // in-memory reverse key, text resolution and active-seq consistent. In-memory only —
-        // the .midx on-disk format is unchanged (persisting colocatedPartition is Phase 2).
-        if (isDisk && basePath != null && index.size() > 0) {
-            index.stampColocatedPartition(initialPartitionSeq);
-        } else {
-            index.setActivePartitionSeq(initialPartitionSeq);
+        // #443 Phase 2: colocated-partition provenance on load.
+        //  • v6 index → each record carries its persisted colocatedPartition (register()
+        //    already keyed the reverse index by it). Do NOT overwrite — just record the
+        //    active seq for the legacy partition-unaware reverse-lookup overload.
+        //  • v5/legacy index → no persisted partition; records default to partition 0
+        //    (ADR-0002: v5 loads with colocatedPartition=0; multi-partition v5 data is
+        //    unrecoverable and is not auto-healed). For the common single-partition store,
+        //    partition 0 IS the active partition, so this is correct.
+        if (index.size() > 0 && index.isColocatedPartitionPersisted()) {
+            log.info("Loaded a v6 index with persisted colocated partitions ({} records)", index.size());
         }
+        index.setActivePartitionSeq(initialPartitionSeq);
 
         //  WAL 
         MemoryWal wal;
@@ -533,6 +545,25 @@ public final class SpectorMemoryFactory {
         //  Seed the ingestion target's active partition seq (#443) 
         cognitiveTarget.updateActivePartitionSeq(initialPartitionSeq);
 
+        //  Frozen partition handles (#443 Phase 2 open-all-on-load) 
+        // Open every older partition dir read-only; each gets its own tier stores + text.dat
+        // and shares the global working store. These join the registry as frozen handles.
+        List<com.spectrayan.spector.memory.cortex.PartitionHandle> frozenHandles = new java.util.ArrayList<>();
+        if (isDisk && basePath != null && !frozenPartitionDirs.isEmpty()) {
+            for (Path frozenDir : frozenPartitionDirs) {
+                int frozenSeq = StorageLayout.parsePartitionSeqNo(frozenDir.getFileName().toString());
+                try {
+                    frozenHandles.add(PartitionManager.openFrozenPartition(
+                            frozenDir, frozenSeq, workingStore, quantizedVecBytes,
+                            builder.semanticCapacity, builder.episodicPartitionCapacity,
+                            builder.proceduralCapacity, builder.dataEncryptor));
+                } catch (RuntimeException e) {
+                    log.error("Failed to open frozen partition {} — records there will be unreadable: {}",
+                            frozenDir.getFileName(), e.getMessage(), e);
+                }
+            }
+        }
+
         //  Partition Manager 
         PartitionManager partitionManager;
         if (isDisk) {
@@ -540,6 +571,7 @@ public final class SpectorMemoryFactory {
                     basePath, quantizedVecBytes, builder.semanticCapacity,
                     builder.episodicPartitionCapacity, builder.proceduralCapacity,
                     cognitiveRouter, resolvedPartitionDir, textDataStore, initialPartitionSeq,
+                    frozenHandles,
                     index, hebbianGraph, temporalChain, cognitiveTarget, builder.dataEncryptor);
             cognitiveTarget.setPartitionRollCallback(partitionManager::rollPartition);
         } else {
@@ -547,6 +579,7 @@ public final class SpectorMemoryFactory {
                     null, quantizedVecBytes, builder.semanticCapacity,
                     builder.episodicPartitionCapacity, builder.proceduralCapacity,
                     cognitiveRouter, null, textDataStore, initialPartitionSeq,
+                    List.of(),
                     index, hebbianGraph, temporalChain, cognitiveTarget, builder.dataEncryptor);
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/PartitionHandle.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/PartitionHandle.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+
+/**
+ * Immutable handle to a single colocated partition (DISK mode).
+ *
+ * <p>Introduced for issue #443 (Phase 1). A handle bundles the per-partition
+ * tier stores (via a {@link CognitiveMemoryRouter}) and the partition-scoped
+ * {@code text.dat} store. Handles are held by {@code PartitionManager}'s
+ * copy-on-write registry: the last (writable) handle is the active partition;
+ * all earlier handles are frozen, read-only, and remain <em>open</em> so recall
+ * can fan out across them (this closes the pre-#443 arena/mmap leak).</p>
+ *
+ * <h3>Lifecycle</h3>
+ * <p>{@link #close()} releases the three partition-scoped tier stores (episodic,
+ * semantic, procedural) plus the partition {@code text.dat}. It deliberately does
+ * <b>not</b> close working memory — working memory is global (shared by every
+ * router) and is closed exactly once by the owning component.</p>
+ *
+ * @param seq      the partition sequence number (matches the {@code NNN_epoch} dir)
+ * @param dir      the partition directory (null in IN_MEMORY mode)
+ * @param router   the tier-store router for this partition
+ * @param text     the partition-scoped text store (null in IN_MEMORY mode)
+ * @param writable {@code true} for the single active partition, {@code false} for frozen
+ */
+public record PartitionHandle(int seq, Path dir, CognitiveMemoryRouter router,
+                              TextAppendMemory text, boolean writable)
+        implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(PartitionHandle.class);
+
+    /** Returns a frozen (read-only) copy of this handle wrapping the same open stores. */
+    public PartitionHandle asFrozen() {
+        return writable ? new PartitionHandle(seq, dir, router, text, false) : this;
+    }
+
+    /**
+     * Closes the partition-scoped stores (episodic, semantic, procedural) and the
+     * partition {@code text.dat}. Working memory is global and is never closed here.
+     */
+    @Override
+    public void close() {
+        if (router != null) {
+            closeQuietly(router.episodic());
+            closeQuietly(router.semantic());
+            closeQuietly(router.procedural());
+        }
+        closeQuietly(text);
+    }
+
+    private static void closeQuietly(AutoCloseable c) {
+        if (c == null) return;
+        try {
+            c.close();
+        } catch (Exception e) {
+            log.debug("Failed to close partition-scoped store: {}", e.getMessage());
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/PartitionRegistry.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/PartitionRegistry.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import java.util.List;
+
+/**
+ * Read-side view of the partition registry (issue #443, Phase 1).
+ *
+ * <p>Implemented by {@code PartitionManager}. Consumers (the recall pipeline,
+ * graph expansion, LTP listener, reinforcement handler) depend on this abstraction
+ * rather than a single {@link CognitiveMemoryRouter}, so recall fans out across all
+ * live partitions and point-lookups resolve to the partition a memory actually lives
+ * in.</p>
+ *
+ * <h3>Concurrency</h3>
+ * <p>{@link #snapshot()} performs a single volatile read of an immutable list. A reader
+ * takes the snapshot once at the start of an operation and iterates that fixed view —
+ * it can never observe a half-registered partition. Rolls publish a new immutable list
+ * by a single reference assignment under the manager's roll lock.</p>
+ */
+public interface PartitionRegistry {
+
+    /** Immutable snapshot of all live partitions, ordered by sequence (last = active). */
+    List<PartitionHandle> snapshot();
+
+    /** O(P) lookup of the handle for a given partition sequence, or {@code null} if unknown. */
+    PartitionHandle handleFor(int seq);
+
+    /** The router for the single active (writable) partition — used for all writes. */
+    CognitiveMemoryRouter activeRouter();
+
+    /**
+     * Resolves the router for the partition a memory lives in. Falls back to the active
+     * router when the sequence is unknown (defensive; keeps point-lookups total).
+     */
+    default CognitiveMemoryRouter routerFor(int seq) {
+        PartitionHandle h = handleFor(seq);
+        return h != null ? h.router() : activeRouter();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -55,6 +55,10 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     /** Legacy file magic: "MIDX" in ASCII. */
     private static final int LEGACY_INDEX_MAGIC = 0x4D494458;
 
+    /** Standard SMKM schema versions. v6 adds the persisted colocatedPartition (#443). */
+    private static final int INDEX_VERSION_V6 = 6;
+    private static final int INDEX_VERSION_V5 = 5;
+
     /** Legacy V1-V4 formats. */
     private static final int INDEX_VERSION_V4 = 4;
     private static final int INDEX_VERSION_V3 = 3;
@@ -96,23 +100,28 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     /**
      * Tracks where a memory is physically stored.
      *
-     * <p><b>issue #443 (Phase 1):</b> {@code colocatedPartition} identifies the DISK
-     * partition the record's tier store + {@code text.dat} live in. It is populated
-     * in-memory at ingest/load; it is <b>not</b> persisted to the {@code .midx} slot in
-     * Phase 1 (that on-disk change is Phase 2). {@code partitionIndex} remains the
-     * (misnamed) semantic HNSW / Hebbian graph node slot — its behaviour is unchanged.</p>
+     * <p><b>issue #443 (Phase 2):</b> {@code colocatedPartition} identifies the DISK
+     * partition the record's tier store + {@code text.dat} live in. As of Phase 2 it is
+     * <b>persisted</b> to the {@code .midx} v6 slot at {@code [40:4]}, so recall fan-out
+     * and direct-resolve work across partitions after restart.</p>
+     *
+     * <p>{@code graphSlot} is the semantic HNSW / Hebbian graph node slot (persisted at
+     * {@code [24:4]}). It was misnamed {@code partitionIndex} through v5 — the rename in
+     * Phase 2 ends the misnomer; its behaviour is unchanged (it never identified the
+     * colocated partition).</p>
      */
-    public record MemoryLocation(MemoryType type, long offset, int partitionIndex,
+    public record MemoryLocation(MemoryType type, long offset, int graphSlot,
                                   int colocatedPartition, long textOffset, int textLength) {
 
-        public MemoryLocation(MemoryType type, long offset, int partitionIndex) {
-            this(type, offset, partitionIndex, 0, -1L, -1);
+        /** Convenience ctor — colocatedPartition defaults to 0, no text position. */
+        public MemoryLocation(MemoryType type, long offset, int graphSlot) {
+            this(type, offset, graphSlot, 0, -1L, -1);
         }
 
-        /** Back-compat ctor — colocatedPartition defaults to 0. */
-        public MemoryLocation(MemoryType type, long offset, int partitionIndex,
+        /** Convenience ctor — colocatedPartition defaults to 0. */
+        public MemoryLocation(MemoryType type, long offset, int graphSlot,
                               long textOffset, int textLength) {
-            this(type, offset, partitionIndex, 0, textOffset, textLength);
+            this(type, offset, graphSlot, 0, textOffset, textLength);
         }
 
         public boolean hasTextPosition() {
@@ -122,7 +131,29 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
     public IndexRecordMemory() {
         super(MemoryId.of("kernel", "index"), new IndexEntryLayout(), 100_000,
-              Arena.ofShared(), Arena.ofShared().allocate(100_000 * 40L, 64), 0, false, null, null);
+              Arena.ofShared(), Arena.ofShared().allocate(100_000 * (long) INDEX_SLOT_STRIDE, 64),
+              0, false, null, null);
+    }
+
+    /** Slot stride of the current on-disk index layout (v6 = 48 bytes). */
+    private static final int INDEX_SLOT_STRIDE = new IndexEntryLayout().recordStride();
+
+    /**
+     * Whether the loaded {@code .midx} persisted a per-record {@code colocatedPartition}
+     * (v6+). When {@code false} (v5/legacy load or a fresh index), the colocated partition
+     * of every record defaults to 0 and callers must not assume a per-record partition map
+     * survived the round-trip.
+     */
+    private volatile boolean colocatedPartitionPersisted = false;
+
+    /** Returns {@code true} if load read a v6 {@code .midx} carrying colocatedPartition. */
+    public boolean isColocatedPartitionPersisted() {
+        return colocatedPartitionPersisted;
+    }
+
+    /** Marks that a per-record colocatedPartition was loaded from a v6 {@code .midx}. */
+    void markColocatedPartitionPersisted() {
+        this.colocatedPartitionPersisted = true;
     }
 
     @Override
@@ -331,19 +362,18 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     }
 
     /**
-     * Re-stamps every location's colocated partition and rebuilds the reverse index
-     * (issue #443). Called once after load: Phase 1 opens only the newest partition, so
-     * all loaded records physically live in {@code seq}. This keeps the in-memory reverse
-     * key, text resolution and active-seq consistent. NOTE: this is in-memory only and
-     * does not alter the {@code .midx} on-disk format (persisting colocatedPartition is
-     * Phase 2).
+     * Re-stamps every location's colocated partition to {@code seq} and rebuilds the reverse
+     * index (issue #443). In-memory only. As of Phase 2 the {@code .midx} v6 format persists
+     * {@code colocatedPartition} per record, so the factory no longer force-stamps loaded
+     * records — this helper is retained for callers that deliberately collapse a store into a
+     * single partition (e.g. compaction) and is a no-op for records already at {@code seq}.
      */
     public void stampColocatedPartition(int seq) {
         for (Map.Entry<String, MemoryLocation> e : locations.entrySet()) {
             MemoryLocation old = e.getValue();
             if (old.colocatedPartition() == seq) continue;
             MemoryLocation updated = new MemoryLocation(old.type(), old.offset(),
-                    old.partitionIndex(), seq, old.textOffset(), old.textLength());
+                    old.graphSlot(), seq, old.textOffset(), old.textLength());
             e.setValue(updated);
         }
         reverseIndex.clear();
@@ -384,10 +414,13 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         }
     }
 
-    public Map<String, String> textsByPartition(int partitionIndex) {
+    // NOTE (issue #443): this remains keyed on graphSlot (the former misnamed field), not
+    // the colocated partition. Re-pointing it at colocatedPartition is a consolidation
+    // follow-up (see ADR-0002 D5) and is intentionally out of scope for #443.
+    public Map<String, String> textsByPartition(int graphSlot) {
         Map<String, String> result = new java.util.HashMap<>();
         for (Map.Entry<String, MemoryLocation> entry : locations.entrySet()) {
-            if (entry.getValue().partitionIndex() == partitionIndex) {
+            if (entry.getValue().graphSlot() == graphSlot) {
                 String text = text(entry.getKey());
                 if (text != null && !text.isEmpty()) {
                     result.put(entry.getKey(), text);
@@ -407,7 +440,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
         reverseIndex.remove(reverseKey(oldLoc.colocatedPartition(), oldLoc.type(), oldLoc.offset()));
 
-        MemoryLocation newLoc = new MemoryLocation(oldLoc.type(), newOffset, oldLoc.partitionIndex(),
+        MemoryLocation newLoc = new MemoryLocation(oldLoc.type(), newOffset, oldLoc.graphSlot(),
                 oldLoc.colocatedPartition(), oldLoc.textOffset(), oldLoc.textLength());
         locations.put(id, newLoc);
 
@@ -469,7 +502,10 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                 
                 MemoryId slotId = MemoryId.of("index", "slot");
                 IndexEntryLayout slotLayout = new IndexEntryLayout();
-                long totalSlotBytes = (long) entryCount * 40;
+                // #443 Phase 2: stride flows from the layout (v6 = 48). The 64-byte header
+                // records recordStride + schemaVersion, so the loader can version-gate.
+                final int stride = slotLayout.recordStride();
+                long totalSlotBytes = (long) entryCount * stride;
                 try (DefaultRecordMemory<IndexEntryLayout> slotMemory = new DefaultRecordMemory<>(
                         slotId, slotLayout, entryCount, MemoryHeader.HEADER_BYTES + totalSlotBytes, filePath)) {
                     
@@ -483,18 +519,20 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                         long poolOffset = poolMemory.append(MemorySegment.ofArray(blobBytes));
                         int poolLen = blobBytes.length;
                         
-                        // Create a temporary 40-byte segment for the slot entry
-                        byte[] slotBytes = new byte[40];
+                        // Temporary slot segment sized to the current layout stride (v6 = 48B).
+                        byte[] slotBytes = new byte[stride];
                         ByteBuffer slotBuf = ByteBuffer.wrap(slotBytes);
                         slotBuf.order(java.nio.ByteOrder.nativeOrder());
                         
-                        slotBuf.putLong(poolOffset);
-                        slotBuf.putInt(poolLen);
-                        slotBuf.putInt(loc.type().ordinal());
-                        slotBuf.putLong(loc.offset());
-                        slotBuf.putInt(loc.partitionIndex());
-                        slotBuf.putLong(loc.textOffset());
-                        slotBuf.putInt(loc.textLength());
+                        slotBuf.putLong(poolOffset);            // [0:8]  idPoolOffset
+                        slotBuf.putInt(poolLen);                // [8:4]  idPoolLength
+                        slotBuf.putInt(loc.type().ordinal());   // [12:4] typeOrdinal
+                        slotBuf.putLong(loc.offset());          // [16:8] offset
+                        slotBuf.putInt(loc.graphSlot());        // [24:4] graphSlot
+                        slotBuf.putLong(loc.textOffset());      // [28:8] textOffset
+                        slotBuf.putInt(loc.textLength());       // [36:4] textLength
+                        slotBuf.putInt(loc.colocatedPartition());// [40:4] colocatedPartition (v6)
+                        slotBuf.putInt(0);                      // [44:4] reserved (v6)
                         
                         slotMemory.write(index, MemorySegment.ofArray(slotBytes));
                         
@@ -521,8 +559,9 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
         try {
             long fileSize = Files.size(filePath);
-            if (fileSize < 16) {
-                log.warn("MemoryIndex file too small ({}B), starting fresh", fileSize);
+            if (fileSize < 4) {
+                // Too small to even classify (no magic). Treat an empty placeholder as fresh.
+                log.warn("MemoryIndex file too small to classify ({}B), starting fresh", fileSize);
                 return index;
             }
 
@@ -539,7 +578,15 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
             boolean isLegacy = (magic == LEGACY_INDEX_MAGIC || magic == 0x5844494D);
 
             if (isStandard) {
-                // New standard format (V5+)
+                // Standard SMKM format (v5+) carries the full 64-byte MemoryHeader. A file
+                // that claims the SMKM magic but is shorter than the header is corrupt/truncated
+                // — throw rather than silently returning an empty index (#443 Phase 2 discipline).
+                if (fileSize < MemoryHeader.HEADER_BYTES) {
+                    throw new SpectorStorageException(ErrorCode.FILE_FORMAT_INVALID,
+                            "MemoryIndex truncated: " + filePath + " (" + fileSize + "B < "
+                                    + MemoryHeader.HEADER_BYTES + "B header)");
+                }
+
                 String fileName = filePath.getFileName().toString();
                 String poolName = fileName.endsWith(".midx") ? fileName.replace(".midx", ".idpl") : fileName + ".idpl";
                 Path idPoolPath = filePath.resolveSibling(poolName);
@@ -548,7 +595,28 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                 IndexEntryLayout slotLayout = new IndexEntryLayout();
                 try (DefaultRecordMemory<IndexEntryLayout> slotMemory = new DefaultRecordMemory<>(
                         slotId, slotLayout, 0, 0, filePath)) {
-                    
+
+                    // #443 Phase 2: version-gate on the persisted schemaVersion (throw-on-unreadable).
+                    int schemaVersion = MemoryHeader.readSchemaVersion(slotMemory.segment(), 0);
+                    final int slotStride;
+                    final boolean readColocated;
+                    switch (schemaVersion) {
+                        case INDEX_VERSION_V6 -> {
+                            slotStride = 48;      // v6 slot: 48 bytes incl. colocatedPartition + reserved
+                            readColocated = true;
+                        }
+                        case INDEX_VERSION_V5 -> {
+                            slotStride = 40;      // v5 slot: 40 bytes, no colocatedPartition
+                            readColocated = false;
+                            log.warn("v5 .midx: multi-partition data not recoverable, treating as partition 0 ({})",
+                                    filePath.getFileName());
+                        }
+                        default -> throw new SpectorStorageException(ErrorCode.FILE_FORMAT_INVALID,
+                                "MemoryIndex unsupported schema version v" + schemaVersion
+                                        + (schemaVersion > INDEX_VERSION_V6 ? " (newer than supported v6)" : "")
+                                        + ": " + filePath);
+                    }
+
                     int entryCount = slotMemory.size();
                     MemoryId poolId = MemoryId.of("index", "idpool");
                     IdBlobLayout poolLayout = new IdBlobLayout();
@@ -559,17 +627,21 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                         long slotBase = slotMemory.dataOffset();
                         
                         for (int i = 0; i < entryCount; i++) {
-                            long slotOffset = slotBase + (long) i * 40;
+                            long slotOffset = slotBase + (long) i * slotStride;
                             long poolOffset = slotSeg.get(ValueLayout.JAVA_LONG_UNALIGNED, slotOffset);
                             int poolLen = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 8);
                             int typeOrd = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 12);
                             long offset = slotSeg.get(ValueLayout.JAVA_LONG_UNALIGNED, slotOffset + 16);
-                            int partitionIndex = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 24);
+                            int graphSlot = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 24);
                             long textOffset = slotSeg.get(ValueLayout.JAVA_LONG_UNALIGNED, slotOffset + 28);
                             int textLength = slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 36);
+                            // v6: colocatedPartition at [40:4]; v5: absent → default 0.
+                            int colocatedPartition = readColocated
+                                    ? slotSeg.get(ValueLayout.JAVA_INT_UNALIGNED, slotOffset + 40) : 0;
                             
                             MemoryType type = MemoryType.values()[typeOrd];
-                            MemoryLocation loc = new MemoryLocation(type, offset, partitionIndex, textOffset, textLength);
+                            MemoryLocation loc = new MemoryLocation(type, offset, graphSlot,
+                                    colocatedPartition, textOffset, textLength);
                             
                             MemorySegment blobSeg = poolMemory.read(poolOffset, poolLen);
                             DeserializedEntry target = new DeserializedEntry();
@@ -578,8 +650,14 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                             index.register(target.id, loc, target.textFallback, target.source, target.tags, target.metadata);
                         }
                     }
+
+                    // Only a v6 file carries a persisted per-record colocated partition.
+                    if (readColocated) {
+                        index.markColocatedPartitionPersisted();
+                    }
+                    log.info("MemoryIndex loaded (SMKM v{}): {} entries from {}",
+                            schemaVersion, index.size(), filePath.getFileName());
                 }
-                log.info("MemoryIndex loaded (SMKM V5): {} entries from {}", index.size(), filePath.getFileName());
             } else if (isLegacy) {
                 // Legacy index loading (V1-V4)
                 try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
@@ -603,6 +681,10 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
             } else {
                 log.warn("Invalid MemoryIndex magic: 0x{}, starting fresh", Integer.toHexString(magic));
             }
+        } catch (SpectorStorageException sse) {
+            // Format errors (unknown/newer schema, truncation) must NOT be silently swallowed
+            // into an empty index — that would erase durable data (#443 Phase 2; #432/#433).
+            throw sse;
         } catch (Exception e) {
             log.error("Failed to load MemoryIndex from {}, starting fresh: {}", filePath, e.getMessage());
         }
@@ -732,7 +814,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         locBuf.flip();
         int typeOrd = locBuf.getInt();
         long offset = locBuf.getLong();
-        int partitionIndex = locBuf.getInt();
+        int graphSlot = locBuf.getInt();
         MemoryType type = MemoryType.values()[typeOrd];
 
         String text = readString(ch);
@@ -778,7 +860,8 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
             textLength = tpBuf.getInt();
         }
 
-        MemoryLocation loc = new MemoryLocation(type, offset, partitionIndex, textOffset, textLength);
+        // Legacy (v1–v4) has no colocated partition → default 0 (partition 0).
+        MemoryLocation loc = new MemoryLocation(type, offset, graphSlot, textOffset, textLength);
         index.register(id, loc, text, source, tagArray, metadata);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -76,8 +76,16 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     // ── Reverse index: (type, offset) → id ──
     private final ConcurrentHashMap<Long, String> reverseIndex = new ConcurrentHashMap<>();
 
-    // ── Off-heap text data store ──
+    // ── Off-heap text data store (active partition; back-compat / fallback) ──
     private volatile TextAppendMemory textDataStore;
+
+    // ── Registry-backed per-partition text resolver (issue #443, D3b) ──
+    // Resolves a colocated-partition seq → that partition's TextAppendMemory.
+    private volatile java.util.function.IntFunction<TextAppendMemory> textResolver;
+
+    // ── Active partition sequence (issue #443) — used by the legacy, partition-
+    //    unaware findIdByOffset(type, offset) overload to resolve the reverse key. ──
+    private volatile int activePartitionSeq = 0;
 
     // ── Inverted tag index ──
     private final ConcurrentHashMap<String, java.util.Set<String>> tagToIds = new ConcurrentHashMap<>();
@@ -87,12 +95,24 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
     /**
      * Tracks where a memory is physically stored.
+     *
+     * <p><b>issue #443 (Phase 1):</b> {@code colocatedPartition} identifies the DISK
+     * partition the record's tier store + {@code text.dat} live in. It is populated
+     * in-memory at ingest/load; it is <b>not</b> persisted to the {@code .midx} slot in
+     * Phase 1 (that on-disk change is Phase 2). {@code partitionIndex} remains the
+     * (misnamed) semantic HNSW / Hebbian graph node slot — its behaviour is unchanged.</p>
      */
     public record MemoryLocation(MemoryType type, long offset, int partitionIndex,
-                                  long textOffset, int textLength) {
+                                  int colocatedPartition, long textOffset, int textLength) {
 
         public MemoryLocation(MemoryType type, long offset, int partitionIndex) {
-            this(type, offset, partitionIndex, -1L, -1);
+            this(type, offset, partitionIndex, 0, -1L, -1);
+        }
+
+        /** Back-compat ctor — colocatedPartition defaults to 0. */
+        public MemoryLocation(MemoryType type, long offset, int partitionIndex,
+                              long textOffset, int textLength) {
+            this(type, offset, partitionIndex, 0, textOffset, textLength);
         }
 
         public boolean hasTextPosition() {
@@ -110,8 +130,17 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         return MemoryHeader.HEADER_BYTES + index * layout.recordStride();
     }
 
-    private static long reverseKey(MemoryType type, long offset) {
-        return ((long) type.ordinal() << 48) | (offset & 0x0000_FFFF_FFFF_FFFFL);
+    // Reverse-index key (issue #443): partition-aware IN MEMORY only.
+    //   bits [52:64) partition (up to 4096), [48:52) type ordinal, [0:48) offset.
+    // WORKING memory is a single GLOBAL store that never rolls, so its (type, offset)
+    // pairs are globally unique — its key is partition-independent (fixed 0). This keeps
+    // working-record reverse lookups consistent regardless of which partition seq was
+    // active at ingest time.
+    private static long reverseKey(int partition, MemoryType type, long offset) {
+        int p = (type == MemoryType.WORKING) ? 0 : partition;
+        return (((long) p & 0xFFFL) << 52)
+                | (((long) type.ordinal() & 0xFL) << 48)
+                | (offset & 0x0000_FFFF_FFFF_FFFFL);
     }
 
     public void register(String id, MemoryLocation location, String text,
@@ -133,7 +162,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
             metadataMap.put(id, Map.copyOf(metadata));
         }
 
-        reverseIndex.put(reverseKey(location.type(), location.offset()), id);
+        reverseIndex.put(reverseKey(location.colocatedPartition(), location.type(), location.offset()), id);
 
         synchronized (orderedIds) {
             orderedIds.add(id);
@@ -159,7 +188,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         metadataMap.remove(id);
 
         if (loc != null) {
-            reverseIndex.remove(reverseKey(loc.type(), loc.offset()));
+            reverseIndex.remove(reverseKey(loc.colocatedPartition(), loc.type(), loc.offset()));
         }
 
         if (removedTags != null) {
@@ -182,11 +211,29 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
     public String text(String id) {
         MemoryLocation loc = locations.get(id);
-        if (loc != null && loc.hasTextPosition() && textDataStore != null) {
-            String offHeapText = textDataStore.readTextDirect(loc.textOffset(), loc.textLength());
-            if (offHeapText != null) return offHeapText;
+        if (loc != null && loc.hasTextPosition()) {
+            // issue #443 (D3b): resolve the text store by the memory's colocated
+            // partition; fall back to the active store, then the on-heap map.
+            TextAppendMemory store = resolveTextStore(loc.colocatedPartition());
+            if (store != null) {
+                String offHeapText = store.readTextDirect(loc.textOffset(), loc.textLength());
+                if (offHeapText != null) return offHeapText;
+            }
+            if (textDataStore != null && store != textDataStore) {
+                String offHeapText = textDataStore.readTextDirect(loc.textOffset(), loc.textLength());
+                if (offHeapText != null) return offHeapText;
+            }
         }
         return texts.getOrDefault(id, "");
+    }
+
+    private TextAppendMemory resolveTextStore(int partition) {
+        var resolver = this.textResolver;
+        if (resolver != null) {
+            TextAppendMemory store = resolver.apply(partition);
+            if (store != null) return store;
+        }
+        return textDataStore;
     }
 
     public MemorySource source(String id) {
@@ -242,8 +289,17 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         });
     }
 
+    /** Partition-aware reverse lookup (issue #443). */
+    public String findIdByOffset(int partition, MemoryType type, long offset) {
+        return reverseIndex.get(reverseKey(partition, type, offset));
+    }
+
+    /**
+     * Legacy, partition-unaware reverse lookup. Resolves against the active partition
+     * seq — correct for active-partition operations (graph expansion, HNSW rebuild).
+     */
     public String findIdByOffset(MemoryType type, long offset) {
-        return reverseIndex.get(reverseKey(type, offset));
+        return reverseIndex.get(reverseKey(activePartitionSeq, type, offset));
     }
 
     public String findTextByOffset(MemoryType type, long offset) {
@@ -257,6 +313,45 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
     public TextAppendMemory textDataStore() {
         return this.textDataStore;
+    }
+
+    /** Injects the registry-backed per-partition text resolver (issue #443, D3b). */
+    public void setTextResolver(java.util.function.IntFunction<TextAppendMemory> resolver) {
+        this.textResolver = resolver;
+    }
+
+    /** Sets the active partition sequence used by the legacy reverse-lookup overload. */
+    public void setActivePartitionSeq(int seq) {
+        this.activePartitionSeq = seq;
+    }
+
+    /** Returns the active partition sequence. */
+    public int activePartitionSeq() {
+        return this.activePartitionSeq;
+    }
+
+    /**
+     * Re-stamps every location's colocated partition and rebuilds the reverse index
+     * (issue #443). Called once after load: Phase 1 opens only the newest partition, so
+     * all loaded records physically live in {@code seq}. This keeps the in-memory reverse
+     * key, text resolution and active-seq consistent. NOTE: this is in-memory only and
+     * does not alter the {@code .midx} on-disk format (persisting colocatedPartition is
+     * Phase 2).
+     */
+    public void stampColocatedPartition(int seq) {
+        for (Map.Entry<String, MemoryLocation> e : locations.entrySet()) {
+            MemoryLocation old = e.getValue();
+            if (old.colocatedPartition() == seq) continue;
+            MemoryLocation updated = new MemoryLocation(old.type(), old.offset(),
+                    old.partitionIndex(), seq, old.textOffset(), old.textLength());
+            e.setValue(updated);
+        }
+        reverseIndex.clear();
+        for (Map.Entry<String, MemoryLocation> e : locations.entrySet()) {
+            MemoryLocation loc = e.getValue();
+            reverseIndex.put(reverseKey(loc.colocatedPartition(), loc.type(), loc.offset()), e.getKey());
+        }
+        this.activePartitionSeq = seq;
     }
 
     public int size() {
@@ -310,13 +405,13 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         MemoryLocation oldLoc = locations.get(id);
         if (oldLoc == null) return;
 
-        reverseIndex.remove(reverseKey(oldLoc.type(), oldLoc.offset()));
+        reverseIndex.remove(reverseKey(oldLoc.colocatedPartition(), oldLoc.type(), oldLoc.offset()));
 
         MemoryLocation newLoc = new MemoryLocation(oldLoc.type(), newOffset, oldLoc.partitionIndex(),
-                oldLoc.textOffset(), oldLoc.textLength());
+                oldLoc.colocatedPartition(), oldLoc.textOffset(), oldLoc.textLength());
         locations.put(id, newLoc);
 
-        reverseIndex.put(reverseKey(newLoc.type(), newOffset), id);
+        reverseIndex.put(reverseKey(newLoc.colocatedPartition(), newLoc.type(), newOffset), id);
     }
 
     public void relocateBatch(Map<String, Long> relocations) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IndexEntryLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IndexEntryLayout.java
@@ -15,23 +15,33 @@ package com.spectrayan.spector.memory.kernel.layout;
 import com.spectrayan.spector.memory.kernel.MemoryLayout;
 
 /**
- * Memory layout for the index entry slot table (40 bytes fixed size).
+ * Memory layout for the index entry slot table (48 bytes fixed size, v6).
  *
- * <p>Format:
+ * <p>Format (v6 — issue #443 Phase 2):
  * - [0:8]   idPoolOffset (long)
  * - [8:4]   idPoolLength (int)
  * - [12:4]  typeOrdinal (int)
  * - [16:8]  offset (long)
- * - [24:4]  partitionIndex (int)
+ * - [24:4]  graphSlot (int)            — semantic-HNSW / Hebbian node slot (was misnamed
+ *                                        {@code partitionIndex} in v5; behaviour unchanged)
  * - [28:8]  textOffset (long)
  * - [36:4]  textLength (int)
+ * - [40:4]  colocatedPartition (int)   — NEW in v6: the DISK partition the record lives in
+ * - [44:4]  reserved (int)             — NEW in v6: must be 0 (8-byte alignment)
  * </p>
+ *
+ * <p><b>Format history:</b> v5 slots were 40 bytes with {@code partitionIndex} at
+ * {@code [24:4]} and no colocated-partition dimension. v6 appends
+ * {@code colocatedPartition} + {@code reserved} (stride 40 → 48, 8-byte aligned) so
+ * restart-correct multi-partition recall can resolve each record to its partition.
+ * The loader gates on {@link com.spectrayan.spector.memory.kernel.MemoryHeader#readSchemaVersion}:
+ * v6 reads the 48-byte slot, v5 reads the 40-byte slot with {@code colocatedPartition = 0}.</p>
  */
 public final class IndexEntryLayout implements MemoryLayout {
 
-    private static final int STRIDE = 40;
+    private static final int STRIDE = 48;
     private static final int LAYOUT_ID = 0x4D494458; // 'MIDX'
-    private static final int VERSION = 5;
+    private static final int VERSION = 6;
 
     @Override
     public int layoutId() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -232,6 +232,23 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         this.postIngestSync.updateCognitiveRouter(newRouter);
     }
 
+    /**
+     * Updates the partition-scoped {@code text.dat} store after a roll (#443, D3b).
+     * Called by {@code PartitionManager.rollPartition()} under the roll lock.
+     */
+    public void updateTextDataStore(TextAppendMemory newText) {
+        this.postIngestSync.updateTextDataStore(newText);
+    }
+
+    /**
+     * Updates the active colocated-partition sequence after a roll (#443).
+     * Called by {@code PartitionManager.rollPartition()} under the roll lock, and once
+     * at wiring time to seed the initial partition seq.
+     */
+    public void updateActivePartitionSeq(int seq) {
+        this.postIngestSync.updateActivePartitionSeq(seq);
+    }
+
 
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -31,6 +31,7 @@ import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
 import com.spectrayan.spector.memory.cortex.CognitiveRecordMemory;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 import com.spectrayan.spector.core.similarity.SimilarityFunction;
@@ -77,7 +78,7 @@ final class GraphExpansionStage {
     private final EntityExtractor entityExtractor;
     private final GraphScoringPolicy graphScoringPolicy;
     private final MemoryIndex index;
-    private final CognitiveMemoryRouter cognitiveRouter;
+    private final PartitionRegistry partitionRegistry;   // #443: live registry (nullable in tests)
     private final float[] calibrationMins;
     private final float[] calibrationScales;
 
@@ -88,7 +89,7 @@ final class GraphExpansionStage {
                         EntityExtractor entityExtractor,
                         GraphScoringPolicy graphScoringPolicy,
                         MemoryIndex index,
-                        CognitiveMemoryRouter cognitiveRouter,
+                        PartitionRegistry partitionRegistry,
                         float[] calibrationMins,
                         float[] calibrationScales) {
         this.hebbianGraph = hebbianGraph;
@@ -98,9 +99,17 @@ final class GraphExpansionStage {
         this.entityExtractor = entityExtractor;
         this.graphScoringPolicy = graphScoringPolicy != null ? graphScoringPolicy : GraphScoringPolicy.DEFAULT;
         this.index = index;
-        this.cognitiveRouter = cognitiveRouter;
+        this.partitionRegistry = partitionRegistry;
         this.calibrationMins = calibrationMins;
         this.calibrationScales = calibrationScales;
+    }
+
+    /**
+     * Active router for graph-slot resolution. Graph expansion operates on the active
+     * partition for #443 (spanning frozen partitions for graphs is a deferred follow-up).
+     */
+    private CognitiveMemoryRouter activeRouter() {
+        return partitionRegistry != null ? partitionRegistry.activeRouter() : null;
     }
 
     /**
@@ -378,8 +387,9 @@ final class GraphExpansionStage {
      * Converts a MemoryLocation's byte offset to a record index.
      */
     int offsetToRecordIndex(MemoryIndex.MemoryLocation loc) {
-        int stride = cognitiveRouter.layoutFor(loc.type()).stride();
-        com.spectrayan.spector.memory.cortex.CognitiveRecordMemory store = cognitiveRouter.get(loc.type());
+        CognitiveMemoryRouter router = activeRouter();
+        int stride = router.layoutFor(loc.type()).stride();
+        com.spectrayan.spector.memory.cortex.CognitiveRecordMemory store = router.get(loc.type());
         long dataOffset = (store != null && store.isPersistent())
                 ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
         return (int) ((loc.offset() - dataOffset) / stride);
@@ -389,17 +399,19 @@ final class GraphExpansionStage {
      * Finds a memory ID by approximate index across all tiers.
      */
     String findMemoryByApproximateIndex(int approxIdx) {
+        CognitiveMemoryRouter router = activeRouter();
+        if (router == null) return null;
         for (MemoryType type : MemoryType.values()) {
-            if (cognitiveRouter != null) {
-                var layout = cognitiveRouter.layoutFor(type);
-                if (layout == null) continue;
-                com.spectrayan.spector.memory.cortex.CognitiveRecordMemory store = cognitiveRouter.get(type);
-                long dataOffset = AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES;
-                long baseOffset = (store != null && store.isPersistent()) ? dataOffset : 0;
-                long offset = baseOffset + (long) approxIdx * layout.stride();
-                String id = index.findIdByOffset(type, offset);
-                if (id != null) return id;
-            }
+            var layout = router.layoutFor(type);
+            if (layout == null) continue;
+            com.spectrayan.spector.memory.cortex.CognitiveRecordMemory store = router.get(type);
+            long dataOffset = AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES;
+            long baseOffset = (store != null && store.isPersistent()) ? dataOffset : 0;
+            long offset = baseOffset + (long) approxIdx * layout.stride();
+            // Legacy overload resolves against the active partition seq (graph expansion
+            // is active-partition-focused for #443).
+            String id = index.findIdByOffset(type, offset);
+            if (id != null) return id;
         }
         return null;
     }
@@ -412,10 +424,14 @@ final class GraphExpansionStage {
             MemoryIndex.MemoryLocation loc = index.locate(memoryId);
             if (loc == null) return 0f;
 
-            MemorySegment seg = cognitiveRouter.segmentFor(loc.type());
+            // #443: resolve the neighbor's segment by the partition it actually lives in.
+            CognitiveMemoryRouter router = partitionRegistry != null
+                    ? partitionRegistry.routerFor(loc.colocatedPartition()) : null;
+            if (router == null) return 0f;
+            MemorySegment seg = router.segmentFor(loc.type());
             if (seg == null) return 0f;
 
-            CognitiveRecordLayout layout = cognitiveRouter.layoutFor(loc.type());
+            CognitiveRecordLayout layout = router.layoutFor(loc.type());
             float l2dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
                     queryVector, seg, layout.vectorOffset(loc.offset()),
                     calibrationMins, calibrationScales, layout.quantizedVecBytes());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/LtpReconsolidationListener.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/LtpReconsolidationListener.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory.pipeline;
 
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -52,12 +53,12 @@ public final class LtpReconsolidationListener implements RecallListener {
     private static final long AUTO_LTP_COOLDOWN_MS = 300_000L; // 5 minutes
 
     private final MemoryIndex index;
-    private final CognitiveMemoryRouter cognitiveRouter;
+    private final PartitionRegistry partitionRegistry;
     private final MemoryWal wal;
 
-    public LtpReconsolidationListener(MemoryIndex index, CognitiveMemoryRouter cognitiveRouter, MemoryWal wal) {
+    public LtpReconsolidationListener(MemoryIndex index, PartitionRegistry partitionRegistry, MemoryWal wal) {
         this.index = index;
-        this.cognitiveRouter = cognitiveRouter;
+        this.partitionRegistry = partitionRegistry;
         this.wal = wal;
     }
 
@@ -67,9 +68,11 @@ public final class LtpReconsolidationListener implements RecallListener {
         for (CognitiveResult r : results) {
             MemoryLocation loc = index.locate(r.id());
             if (loc != null) {
-                MemorySegment segment = cognitiveRouter.segmentFor(loc.type());
+                // #443: resolve the header segment by the memory's colocated partition.
+                CognitiveMemoryRouter router = partitionRegistry.routerFor(loc.colocatedPartition());
+                MemorySegment segment = router.segmentFor(loc.type());
                 if (segment != null) {
-                    CognitiveRecordLayout layout = cognitiveRouter.layoutFor(loc.type());
+                    CognitiveRecordLayout layout = router.layoutFor(loc.type());
 
                     if (layout.headerLayout().version() >= 3) {
                         long creationMs = layout.readTimestamp(segment, loc.offset());
@@ -101,7 +104,7 @@ public final class LtpReconsolidationListener implements RecallListener {
 
                 // Log recall hit for analytics
                 wal.append(WalEvent.EventType.RECALL_HIT,
-                        index.findIdByOffset(loc.type(), loc.offset()), null);
+                        index.findIdByOffset(loc.colocatedPartition(), loc.type(), loc.offset()), null);
             }
         }
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -181,7 +181,7 @@ final class PostIngestSync {
         int textLength = (textPos != null) ? textPos.textLength() : -1;
         // #443: stamp the colocated partition (activePartitionSeq) so recall, text
         // resolution and direct-resolve can locate this record's partition. storeIndex
-        // remains the semantic/graph node slot (partitionIndex — behaviour unchanged).
+        // remains the semantic/graph node slot (graphSlot — behaviour unchanged).
         var location = new MemoryLocation(params.type(), params.offset(), storeIndex,
                 activePartitionSeq, textOffset, textLength);
 
@@ -282,8 +282,8 @@ final class PostIngestSync {
             try {
                 MemoryLocation targetLoc = index.locate(edgeHint.targetMemoryId());
                 if (targetLoc != null) {
-                    int targetIdx = targetLoc.partitionIndex() >= 0
-                            ? targetLoc.partitionIndex()
+                    int targetIdx = targetLoc.graphSlot() >= 0
+                            ? targetLoc.graphSlot()
                             : (int) (targetLoc.offset() / 164);
                     hebbianGraph.strengthen(memoryIdx, targetIdx, edgeHint.weight());
                 }
@@ -304,8 +304,8 @@ final class PostIngestSync {
             try {
                 MemoryLocation predLoc = index.locate(linkHint.predecessorMemoryId());
                 if (predLoc != null) {
-                    int predIdx = predLoc.partitionIndex() >= 0
-                            ? predLoc.partitionIndex()
+                    int predIdx = predLoc.graphSlot() >= 0
+                            ? predLoc.graphSlot()
                             : (int) (predLoc.offset() / 164);
                     temporalChain.linkNodes(predIdx, memoryIdx, linkHint.sessionId(), (int) (System.currentTimeMillis() / 1000));
                 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -82,8 +82,9 @@ final class PostIngestSync {
     private final EntityExtractor entityExtractor;
     private final EntityGraphMemory entityGraph;
     private final MemoryBM25Index bm25Index;
-    private final TextAppendMemory textDataStore;
-    private final int activePartitionIndex;
+    private volatile TextAppendMemory textDataStore;  // volatile: rolled with the partition (#443)
+    private final int activePartitionIndex;           // BM25/SPLADE slot (always 0 — one partition slot)
+    private volatile int activePartitionSeq;          // colocated-partition seq stamped on MemoryLocation (#443)
     private final MemorySpladeIndex spladeIndex;
     private final SparseEmbeddingProvider spladeProvider;
     private final DataEncryptor encryptor;
@@ -113,11 +114,22 @@ final class PostIngestSync {
         this.spladeProvider = spladeProvider;
         this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
         this.hyperEntityGraph = hyperEntityGraph;
+        this.activePartitionSeq = 0;
     }
 
     /** Called when the cognitive memory router is swapped after a partition roll. */
     void updateCognitiveRouter(CognitiveMemoryRouter newRouter) {
         this.cognitiveRouter = newRouter;
+    }
+
+    /** Called when the partition-scoped {@code text.dat} is rolled (#443, D3b). */
+    void updateTextDataStore(TextAppendMemory newText) {
+        this.textDataStore = newText;
+    }
+
+    /** Called when the active partition sequence changes on roll (#443). */
+    void updateActivePartitionSeq(int seq) {
+        this.activePartitionSeq = seq;
     }
 
     /**
@@ -167,8 +179,11 @@ final class PostIngestSync {
         // Step 8: Register in ID index (with text.dat byte offsets for off-heap reads)
         long textOffset = (textPos != null) ? textPos.textOffset() : -1L;
         int textLength = (textPos != null) ? textPos.textLength() : -1;
+        // #443: stamp the colocated partition (activePartitionSeq) so recall, text
+        // resolution and direct-resolve can locate this record's partition. storeIndex
+        // remains the semantic/graph node slot (partitionIndex — behaviour unchanged).
         var location = new MemoryLocation(params.type(), params.offset(), storeIndex,
-                textOffset, textLength);
+                activePartitionSeq, textOffset, textLength);
 
         if (params.metadata() != null) {
             index.register(params.id(), location,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -31,7 +31,6 @@ import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.memory.model.TextSearchMode;
-import com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory;
 import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory.EpisodicPartition;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index.BM25Candidate;
@@ -41,6 +40,8 @@ import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
 import com.spectrayan.spector.memory.cortex.CognitiveRecordMemory;
+import com.spectrayan.spector.memory.cortex.PartitionHandle;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
@@ -129,7 +130,7 @@ public final class RecallPipeline {
     private static final Logger log = LoggerFactory.getLogger(RecallPipeline.class);
 
     private final EmbeddingProvider embeddingProvider;
-    private final CognitiveMemoryRouter cognitiveRouter;
+    private final PartitionRegistry partitionRegistry;
     private final MemoryIndex index;
     private final SuppressionSet suppressionSet;
     private final HabituationPenalty habituationPenalty;
@@ -188,7 +189,7 @@ public final class RecallPipeline {
      * Creates a recall pipeline with all required subsystems.
      */
     public RecallPipeline(EmbeddingProvider embeddingProvider,
-                           CognitiveMemoryRouter cognitiveRouter,
+                           PartitionRegistry partitionRegistry,
                            MemoryIndex index,
                            SuppressionSet suppressionSet,
                            HabituationPenalty habituationPenalty,
@@ -196,7 +197,7 @@ public final class RecallPipeline {
                            MemoryWal wal,
                            float[] calibrationMins,
                            float[] calibrationScales) {
-        this(embeddingProvider, cognitiveRouter, index, suppressionSet, habituationPenalty,
+        this(embeddingProvider, partitionRegistry, index, suppressionSet, habituationPenalty,
                 prospectiveScheduler, wal, calibrationMins, calibrationScales, null, null,
                 null, null, null, null, null, GraphScoringPolicy.DEFAULT, null,
                 null, null, null);
@@ -209,7 +210,7 @@ public final class RecallPipeline {
      *                                HNSW vector search fused with cognitive scoring
      */
     public RecallPipeline(EmbeddingProvider embeddingProvider,
-                           CognitiveMemoryRouter cognitiveRouter,
+                           PartitionRegistry partitionRegistry,
                            MemoryIndex index,
                            SuppressionSet suppressionSet,
                            HabituationPenalty habituationPenalty,
@@ -218,7 +219,7 @@ public final class RecallPipeline {
                            float[] calibrationMins,
                            float[] calibrationScales,
                             SemanticRecallStrategy semanticRecallStrategy) {
-        this(embeddingProvider, cognitiveRouter, index, suppressionSet, habituationPenalty,
+        this(embeddingProvider, partitionRegistry, index, suppressionSet, habituationPenalty,
                 prospectiveScheduler, wal, calibrationMins, calibrationScales,
                 semanticRecallStrategy, null,
                 null, null, null, null, null, GraphScoringPolicy.DEFAULT, null,
@@ -233,7 +234,7 @@ public final class RecallPipeline {
      * @param coActivationTracker    nullable  --  when provided, STDP causal boost is applied
      */
     public RecallPipeline(EmbeddingProvider embeddingProvider,
-                           CognitiveMemoryRouter cognitiveRouter,
+                           PartitionRegistry partitionRegistry,
                            MemoryIndex index,
                            SuppressionSet suppressionSet,
                            HabituationPenalty habituationPenalty,
@@ -243,7 +244,7 @@ public final class RecallPipeline {
                            float[] calibrationScales,
                            SemanticRecallStrategy semanticRecallStrategy,
                            CoActivationRecordMemory coActivationTracker) {
-        this(embeddingProvider, cognitiveRouter, index, suppressionSet, habituationPenalty,
+        this(embeddingProvider, partitionRegistry, index, suppressionSet, habituationPenalty,
                 prospectiveScheduler, wal, calibrationMins, calibrationScales,
                 semanticRecallStrategy, coActivationTracker,
                 null, null, null, null, null, GraphScoringPolicy.DEFAULT, null,
@@ -254,7 +255,7 @@ public final class RecallPipeline {
      * Creates a recall pipeline with optional fused semantic recall, STDP, and 3-Layer Cognitive Graph.
      */
     public RecallPipeline(EmbeddingProvider embeddingProvider,
-                           CognitiveMemoryRouter cognitiveRouter,
+                           PartitionRegistry partitionRegistry,
                            MemoryIndex index,
                            SuppressionSet suppressionSet,
                            HabituationPenalty habituationPenalty,
@@ -275,7 +276,7 @@ public final class RecallPipeline {
                            SparseEmbeddingProvider spladeProvider,
                            ColBERTReranker colbertReranker) {
         this.embeddingProvider = embeddingProvider;
-        this.cognitiveRouter = cognitiveRouter;
+        this.partitionRegistry = partitionRegistry;
         this.index = index;
         this.suppressionSet = suppressionSet;
         this.habituationPenalty = habituationPenalty;
@@ -300,7 +301,7 @@ public final class RecallPipeline {
         //  Delegate graph expansion to focused stage class 
         this.graphExpansionStage = new GraphExpansionStage(
                 hebbianGraph, temporalChain, entityGraph, hyperEntityGraph, entityExtractor,
-                this.graphScoringPolicy, index, cognitiveRouter,
+                this.graphScoringPolicy, index, partitionRegistry,
                 calibrationMins, calibrationScales);
     }
 
@@ -308,7 +309,7 @@ public final class RecallPipeline {
      * Creates a recall pipeline with all subsystems plus RecallHistory for associative recall.
      */
     public RecallPipeline(EmbeddingProvider embeddingProvider,
-                           CognitiveMemoryRouter cognitiveRouter,
+                           PartitionRegistry partitionRegistry,
                            MemoryIndex index,
                            SuppressionSet suppressionSet,
                            HabituationPenalty habituationPenalty,
@@ -330,7 +331,7 @@ public final class RecallPipeline {
                            ColBERTReranker colbertReranker,
                            RecallHistory recallHistory) {
         this.embeddingProvider = embeddingProvider;
-        this.cognitiveRouter = cognitiveRouter;
+        this.partitionRegistry = partitionRegistry;
         this.index = index;
         this.suppressionSet = suppressionSet;
         this.habituationPenalty = habituationPenalty;
@@ -355,7 +356,7 @@ public final class RecallPipeline {
         //  Delegate graph expansion to focused stage class 
         this.graphExpansionStage = new GraphExpansionStage(
                 hebbianGraph, temporalChain, entityGraph, hyperEntityGraph, entityExtractor,
-                this.graphScoringPolicy, index, cognitiveRouter,
+                this.graphScoringPolicy, index, partitionRegistry,
                 calibrationMins, calibrationScales);
     }
 
@@ -1007,9 +1008,10 @@ public final class RecallPipeline {
                 if (!options.includeContradictions()) {
                     MemoryIndex.MemoryLocation loc = index.locate(id);
                     if (loc != null) {
-                        MemorySegment segment = cognitiveRouter.segmentFor(loc.type());
+                        CognitiveMemoryRouter router = partitionRegistry.routerFor(loc.colocatedPartition());
+                        MemorySegment segment = router.segmentFor(loc.type());
                         if (segment != null) {
-                            CognitiveRecordLayout layout = cognitiveRouter.layoutFor(loc.type());
+                            CognitiveRecordLayout layout = router.layoutFor(loc.type());
                             byte cFlags = layout.readConsolidationFlags(segment, loc.offset());
                             if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
                         }
@@ -1052,85 +1054,112 @@ public final class RecallPipeline {
             float[] queryVector, RecallOptions options, long nowMs, MemoryType[] targetTypes) {
         List<Callable<List<CognitiveResult>>> tasks = new ArrayList<>();
 
-        // Working Memory scan  --  use visibleCount() for SWMR safety
+        // #443 (D4b): consult the LIVE partition registry snapshot at recall start —
+        // one volatile read of an immutable list. Recall fans out across every live
+        // partition; frozen semantic partitions are scored via the SIMD slab scan.
+        List<PartitionHandle> snapshot = partitionRegistry.snapshot();
+        CognitiveMemoryRouter active = partitionRegistry.activeRouter();
+        boolean singlePartition = snapshot.size() == 1;
+        final int activeSeq = snapshot.get(snapshot.size() - 1).seq();
+
+        // Working Memory scan (GLOBAL — scanned once via the active router)
         if (CognitiveMemoryRouter.shouldScan(MemoryType.WORKING, targetTypes)
-                && cognitiveRouter.working().visibleCount() > 0) {
+                && active.working().visibleCount() > 0) {
             tasks.add(() -> {
-                MemorySegment seg = cognitiveRouter.working().segment();
+                MemorySegment seg = active.working().segment();
                 NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
                 try {
                     return scoreStoreToList(
-                            seg, cognitiveRouter.working().visibleCount(),
-                            cognitiveRouter.working().cognitiveLayout(), queryVector, options, nowMs,
-                            MemoryType.WORKING, 0L);
+                            seg, active.working().visibleCount(),
+                            active.working().cognitiveLayout(), queryVector, options, nowMs,
+                            MemoryType.WORKING, 0L, activeSeq);
                 } finally {
                     NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
                 }
             });
         }
 
-        // Episodic Memory  --  one task per partition (disjoint segments  ->  zero contention)
-        if (CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, targetTypes)) {
-            for (EpisodicPartition partition : cognitiveRouter.episodic().partitions()) {
-                if (partition.visibleCount() > 0) {
-                    tasks.add(() -> {
-                        MemorySegment seg = partition.segment();
-                        NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
-                        try {
-                            return scoreStoreToList(
-                                    seg, partition.visibleCount(),
-                                    partition.layout(), queryVector, options, nowMs,
-                                    MemoryType.EPISODIC, partition.dataOffset());
-                        } finally {
-                            NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
-                        }
-                    });
+        // #443 (D2): one scan task per partition segment per tier. Disjoint segments
+        // → zero contention, matching the existing per-partition task model.
+        for (PartitionHandle handle : snapshot) {
+            CognitiveMemoryRouter router = handle.router();
+
+            // Episodic — one task per episodic partition of this handle
+            if (CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, targetTypes)) {
+                for (EpisodicPartition partition : router.episodic().partitions()) {
+                    if (partition.visibleCount() > 0) {
+                        tasks.add(() -> {
+                            MemorySegment seg = partition.segment();
+                            NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
+                            try {
+                                return scoreStoreToList(
+                                        seg, partition.visibleCount(),
+                                        partition.layout(), queryVector, options, nowMs,
+                                        MemoryType.EPISODIC, partition.dataOffset(), handle.seq());
+                            } finally {
+                                NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
+                            }
+                        });
+                    }
                 }
             }
-        }
 
-        // Semantic Memory  --  fused HNSW+cognitive if strategy available, else header slab
-        if (CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, targetTypes)) {
-            if (cognitiveRouter.semantic() != null && cognitiveRouter.semantic().visibleCount() > 0) {
-                if (semanticRecallStrategy != null && semanticRecallStrategy.isAvailable()) {
-                    // Fused pipeline: HNSW search  ->  cognitive re-ranking
-                    tasks.add(() -> semanticRecallStrategy.recall(queryVector, options, nowMs));
-                } else {
-                    // Fallback: full-record slab scan (with tag/valence filters)
-                    tasks.add(() -> {
-                        MemorySegment seg = cognitiveRouter.semantic().headerSlab();
-                        NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
-                        try {
-                            return scoreHeaderSlabToList(
-                                    seg, cognitiveRouter.semantic().visibleCount(),
-                                    cognitiveRouter.semantic().cognitiveLayout(), queryVector, options, nowMs,
-                                    cognitiveRouter.semantic().isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0);
-                        } finally {
-                            NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
-                        }
-                    });
+            // Semantic — active partition uses the HNSW fast path ONLY while there is a
+            // single partition (the global HNSW's per-store slot indices collide across
+            // partitions after a roll). Once rolled, every semantic partition (including
+            // the active one) is scored on its full-record slab via CognitiveScorer,
+            // which computes similarity (SemanticRecordMemory stores header + vector).
+            if (CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, targetTypes)) {
+                SemanticRecordMemoryRef sem = new SemanticRecordMemoryRef(router.semantic());
+                if (sem.store != null && sem.store.visibleCount() > 0) {
+                    boolean useHnsw = handle.writable() && singlePartition
+                            && semanticRecallStrategy != null && semanticRecallStrategy.isAvailable();
+                    if (useHnsw) {
+                        tasks.add(() -> semanticRecallStrategy.recall(queryVector, options, nowMs));
+                    } else {
+                        tasks.add(() -> {
+                            MemorySegment seg = sem.store.segment();
+                            NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
+                            try {
+                                return scoreStoreToList(
+                                        seg, sem.store.visibleCount(),
+                                        sem.store.cognitiveLayout(), queryVector, options, nowMs,
+                                        MemoryType.SEMANTIC, sem.store.dataOffset(), handle.seq());
+                            } finally {
+                                NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
+                            }
+                        });
+                    }
                 }
             }
-        }
 
-        // Procedural Memory scan
-        if (CognitiveMemoryRouter.shouldScan(MemoryType.PROCEDURAL, targetTypes)
-                && cognitiveRouter.procedural().visibleCount() > 0) {
-            tasks.add(() -> {
-                MemorySegment seg = cognitiveRouter.procedural().segment();
-                NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
-                try {
-                    return scoreStoreToList(
-                            seg, cognitiveRouter.procedural().visibleCount(),
-                            cognitiveRouter.procedural().cognitiveLayout(), queryVector, options, nowMs,
-                            MemoryType.PROCEDURAL, cognitiveRouter.procedural().dataOffset());
-                } finally {
-                    NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
-                }
-            });
+            // Procedural
+            if (CognitiveMemoryRouter.shouldScan(MemoryType.PROCEDURAL, targetTypes)
+                    && router.procedural().visibleCount() > 0) {
+                tasks.add(() -> {
+                    MemorySegment seg = router.procedural().segment();
+                    NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
+                    try {
+                        return scoreStoreToList(
+                                seg, router.procedural().visibleCount(),
+                                router.procedural().cognitiveLayout(), queryVector, options, nowMs,
+                                MemoryType.PROCEDURAL, router.procedural().dataOffset(), handle.seq());
+                    } finally {
+                        NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
+                    }
+                });
+            }
         }
 
         return tasks;
+    }
+
+    /** Tiny holder so lambdas can capture a stable semantic-store reference per handle. */
+    private static final class SemanticRecordMemoryRef {
+        final com.spectrayan.spector.memory.cortex.SemanticRecordMemory store;
+        SemanticRecordMemoryRef(com.spectrayan.spector.memory.cortex.SemanticRecordMemory store) {
+            this.store = store;
+        }
     }
 
     /**
@@ -1139,37 +1168,47 @@ public final class RecallPipeline {
     private List<CognitiveResult> sequentialScan(float[] queryVector, RecallOptions options,
                                                    long nowMs, MemoryType[] targetTypes) {
         List<CognitiveResult> results = new ArrayList<>();
+        List<PartitionHandle> snapshot = partitionRegistry.snapshot();
+        CognitiveMemoryRouter active = partitionRegistry.activeRouter();
+        boolean singlePartition = snapshot.size() == 1;
+        final int activeSeq = snapshot.get(snapshot.size() - 1).seq();
+
+        // Working (global — once)
         if (CognitiveMemoryRouter.shouldScan(MemoryType.WORKING, targetTypes)
-                && cognitiveRouter.working().visibleCount() > 0) {
-            results.addAll(scoreStoreToList(cognitiveRouter.working().segment(),
-                    cognitiveRouter.working().visibleCount(), cognitiveRouter.working().cognitiveLayout(),
-                    queryVector, options, nowMs, MemoryType.WORKING, 0L));
+                && active.working().visibleCount() > 0) {
+            results.addAll(scoreStoreToList(active.working().segment(),
+                    active.working().visibleCount(), active.working().cognitiveLayout(),
+                    queryVector, options, nowMs, MemoryType.WORKING, 0L, activeSeq));
         }
-        if (CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, targetTypes)) {
-            for (EpisodicPartition p : cognitiveRouter.episodic().partitions()) {
-                if (p.visibleCount() > 0) {
-                    results.addAll(scoreStoreToList(p.segment(), p.visibleCount(), p.layout(),
-                            queryVector, options, nowMs, MemoryType.EPISODIC, p.dataOffset()));
+
+        for (PartitionHandle handle : snapshot) {
+            CognitiveMemoryRouter router = handle.router();
+            if (CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, targetTypes)) {
+                for (EpisodicPartition p : router.episodic().partitions()) {
+                    if (p.visibleCount() > 0) {
+                        results.addAll(scoreStoreToList(p.segment(), p.visibleCount(), p.layout(),
+                                queryVector, options, nowMs, MemoryType.EPISODIC, p.dataOffset(), handle.seq()));
+                    }
                 }
             }
-        }
-        if (CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, targetTypes)) {
-            if (cognitiveRouter.semantic() != null && cognitiveRouter.semantic().visibleCount() > 0) {
-                if (semanticRecallStrategy != null && semanticRecallStrategy.isAvailable()) {
+            if (CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, targetTypes)
+                    && router.semantic() != null && router.semantic().visibleCount() > 0) {
+                boolean useHnsw = handle.writable() && singlePartition
+                        && semanticRecallStrategy != null && semanticRecallStrategy.isAvailable();
+                if (useHnsw) {
                     results.addAll(semanticRecallStrategy.recall(queryVector, options, nowMs));
                 } else {
-                    results.addAll(scoreHeaderSlabToList(cognitiveRouter.semantic().headerSlab(),
-                            cognitiveRouter.semantic().visibleCount(), cognitiveRouter.semantic().cognitiveLayout(),
-                            queryVector, options, nowMs,
-                            cognitiveRouter.semantic().isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0));
+                    results.addAll(scoreStoreToList(router.semantic().segment(),
+                            router.semantic().visibleCount(), router.semantic().cognitiveLayout(),
+                            queryVector, options, nowMs, MemoryType.SEMANTIC, router.semantic().dataOffset(), handle.seq()));
                 }
             }
-        }
-        if (CognitiveMemoryRouter.shouldScan(MemoryType.PROCEDURAL, targetTypes)
-                && cognitiveRouter.procedural().visibleCount() > 0) {
-            results.addAll(scoreStoreToList(cognitiveRouter.procedural().segment(),
-                    cognitiveRouter.procedural().visibleCount(), cognitiveRouter.procedural().cognitiveLayout(),
-                    queryVector, options, nowMs, MemoryType.PROCEDURAL, cognitiveRouter.procedural().dataOffset()));
+            if (CognitiveMemoryRouter.shouldScan(MemoryType.PROCEDURAL, targetTypes)
+                    && router.procedural().visibleCount() > 0) {
+                results.addAll(scoreStoreToList(router.procedural().segment(),
+                        router.procedural().visibleCount(), router.procedural().cognitiveLayout(),
+                        queryVector, options, nowMs, MemoryType.PROCEDURAL, router.procedural().dataOffset(), handle.seq()));
+            }
         }
         return results;
     }
@@ -1181,7 +1220,7 @@ public final class RecallPipeline {
     private List<CognitiveResult> scoreStoreToList(MemorySegment segment, int recordCount,
                                                      CognitiveRecordLayout layout, float[] queryVector,
                                                      RecallOptions options, long nowMs, MemoryType type,
-                                                     long baseOffset) {
+                                                     long baseOffset, int partitionSeq) {
         List<ScoredRecord> scored = CognitiveScorer.score(
                 segment, recordCount, layout, queryVector, options, nowMs, baseOffset,
                 calibrationMins, calibrationScales);
@@ -1189,63 +1228,15 @@ public final class RecallPipeline {
         List<CognitiveResult> results = new ArrayList<>(scored.size());
         for (ScoredRecord sr : scored) {
             // P8: Header already captured during scoring  --  no off-heap re-read
-            results.add(headerToResult(sr, sr.header(), type));
+            results.add(headerToResult(sr, sr.header(), type, partitionSeq));
         }
         return results;
     }
 
-    private List<CognitiveResult> scoreHeaderSlabToList(MemorySegment headerSlab, int recordCount,
-                                                          CognitiveRecordLayout layout, float[] queryVector,
-                                                          RecallOptions options, long nowMs,
-                                                          long dataOffset) {
-        long queryTagMask = options.synapticTagMask();
-        byte minValence = options.minValence();
-        byte maxValence = options.maxValence();
-        float tagRelevanceBoost = options.tagRelevanceBoost();
-
-        List<CognitiveResult> results = new ArrayList<>();
-        for (int i = 0; i < recordCount; i++) {
-            long offset = dataOffset + (long) i * layout.stride();
-            CognitiveHeader header = layout.readHeader(headerSlab, offset);
-
-            byte flags = header.flags();
-            if (SynapticHeaderConstants.isTombstoned(flags)) continue;
-
-            if (!options.includeContradictions()) {
-                byte cFlags = layout.readConsolidationFlags(headerSlab, offset);
-                if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
-            }
-
-            // Phase 2: Synaptic tag gating (was missing for semantic tier)
-            if (queryTagMask != 0) {
-                if ((header.synapticTags() & queryTagMask) == 0) continue; // zero overlap  ->  skip
-            }
-
-            // Phase 3: Valence filter (was missing for semantic tier)
-            byte valence = header.valence();
-            if (valence < minValence || valence > maxValence) continue;
-
-            float importance = header.importance();
-            if (importance < options.minImportance()) continue;
-
-            long timestamp = header.timestampMs();
-            int agentRecallCount = header.agentRecallCount();
-            int rawBucket = DecayStrategy.ageToBucket(timestamp, nowMs);
-            int adjusted = DecayStrategy.adjustForReconsolidation(rawBucket, agentRecallCount);
-            float decay = DecayStrategy.decay(adjusted);
-
-            // Score with weighted tag relevance boost (consistent with CognitiveScorer)
-            float baseScore = options.beta() * importance * decay;
-            float tagOverlap = SynapticTagEncoder.overlapRatio(header.synapticTags(), queryTagMask);
-            float score = baseScore * (1.0f + tagOverlap * tagRelevanceBoost);
-
-            results.add(headerToResult(new ScoredRecord(offset, score, i, header), header, MemoryType.SEMANTIC));
-        }
-        return results;
-    }
-
-    private CognitiveResult headerToResult(ScoredRecord sr, CognitiveHeader header, MemoryType type) {
-        String id = index.findIdByOffset(type, sr.offset());  // O(1) via reverse index
+    private CognitiveResult headerToResult(ScoredRecord sr, CognitiveHeader header, MemoryType type,
+                                            int partitionSeq) {
+        // #443: resolve id via the partition being scanned (partition-aware reverse key).
+        String id = index.findIdByOffset(partitionSeq, type, sr.offset());  // O(1) via reverse index
         String text = id != null ? index.text(id) : "";
         MemorySource source = id != null ? index.source(id) : MemorySource.OBSERVED;
         String[] tags = id != null ? index.tags(id) : new String[0];
@@ -1454,7 +1445,8 @@ public final class RecallPipeline {
             try {
                 var loc = index.locate(result.id());
                 if (loc == null) continue;
-                MemorySegment segment = cognitiveRouter.segmentFor(loc.type());
+                MemorySegment segment = partitionRegistry.routerFor(loc.colocatedPartition())
+                        .segmentFor(loc.type());
                 if (segment != null) {
                     segment.set(java.lang.foreign.ValueLayout.JAVA_BYTE,
                             loc.offset() + SynapticHeaderConstants.OFFSET_LAST_RECALL_PROFILE,

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
@@ -123,6 +123,7 @@ class PartitionManagerTest {
         return new PartitionManager(
                 basePath, VEC_BYTES, SEMANTIC_CAP, EPISODIC_CAP, PROCEDURAL_CAP,
                 router, activeDir, /* initialText */ null, seq,
+                /* initialFrozen */ java.util.List.of(),
                 index, hebbian, temporal, cognitiveTarget, DataEncryptor.NOOP);
     }
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
 import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory;
+import com.spectrayan.spector.memory.cortex.PartitionHandle;
 import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
 import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
@@ -118,9 +119,11 @@ class PartitionManagerTest {
     }
 
     private PartitionManager newManager(CognitiveMemoryRouter router, Path activeDir) {
+        int seq = StorageLayout.parsePartitionSeqNo(activeDir.getFileName().toString());
         return new PartitionManager(
                 basePath, VEC_BYTES, SEMANTIC_CAP, EPISODIC_CAP, PROCEDURAL_CAP,
-                router, activeDir, index, hebbian, temporal, cognitiveTarget);
+                router, activeDir, /* initialText */ null, seq,
+                index, hebbian, temporal, cognitiveTarget, DataEncryptor.NOOP);
     }
 
     private static CognitiveHeader episodicHeader(long timestampMs) {
@@ -301,5 +304,54 @@ class PartitionManagerTest {
                 .as("Hebbian graph flushed to runtime/").isTrue();
         assertThat(Files.exists(StorageLayout.temporalChainRuntime(basePath)))
                 .as("Temporal chain flushed to runtime/").isTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // (e) Leak / lifecycle (issue #443, D6 test 6)
+    // ──────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("leak: after N rolls frozen handles stay OPEN/readable, then close exactly once at close()")
+    void frozenHandlesStayOpenThenCloseOnce() throws Exception {
+        Path p0 = PartitionManager.discoverOrCreatePartition(basePath);
+        CognitiveMemoryRouter router0 = newRouter(p0);
+        PartitionManager pm = newManager(router0, p0);
+
+        // Seed the initial (soon-to-be-frozen) partition with readable records.
+        EpisodicRecordMemory episodic0 = router0.episodic();
+        for (int i = 0; i < EPISODIC_CAP; i++) {
+            episodic0.append(episodicHeader(1_000L + i), vec());
+        }
+
+        final int rolls = 5;
+        for (int i = 0; i < rolls; i++) {
+            pm.rollPartition();
+        }
+
+        // Registry now holds the initial partition + one handle per roll; last = active.
+        List<PartitionHandle> snapshot = pm.snapshot();
+        assertThat(snapshot).hasSize(rolls + 1);
+        assertThat(snapshot.get(snapshot.size() - 1).writable()).isTrue();
+        for (int i = 0; i < snapshot.size() - 1; i++) {
+            assertThat(snapshot.get(i).writable()).as("earlier handles are frozen").isFalse();
+        }
+
+        // FROZEN handles remain OPEN and readable (this is the leak fix — old Arenas kept mapped).
+        assertThat(episodic0.totalRecords()).isEqualTo(EPISODIC_CAP);
+        assertThat(episodic0.readHeader(0).timestampMs()).isEqualTo(1_000L);
+        assertThat(episodic0.readHeader(EPISODIC_CAP - 1).timestampMs())
+                .isEqualTo(1_000L + (EPISODIC_CAP - 1));
+
+        // Ensure the active roll-created router is closed by tearDown.
+        routersToClose.add(pm.cognitiveRouter());
+
+        // Close once: frozen handles' stores are released (reads now throw on closed Arena).
+        pm.close();
+        assertThatThrownBy(() -> episodic0.readHeader(0))
+                .as("frozen store's arena is closed after component close()")
+                .isInstanceOf(RuntimeException.class);
+
+        // Idempotent: a second close() is a no-op (each handle closed exactly once).
+        pm.close();
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionRecallFanoutTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionRecallFanoutTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.kernel.StorageLayout;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.test.FakeEmbeddingProvider;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #443 (Phase 1): in-process multi-partition recall
+ * fan-out and partition-keyed direct-resolve.
+ *
+ * <p>DISK mode with tiny tier capacities forces {@code PartitionManager.rollPartition()}
+ * mid-test, so records straddle a frozen partition (000) and the active partition (001).
+ * Before the fix, recall stayed pinned to the active partition and never returned
+ * pre-roll records; direct-resolve resolved against the active store only.</p>
+ */
+@DisplayName("issue #443 — multi-partition recall fan-out + direct-resolve (Phase 1)")
+class PartitionRecallFanoutTest {
+
+    private SpectorMemory memory;
+
+    private SpectorMemory build(Path dir, int episodicCap, int semanticCap) {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        return DefaultSpectorMemory.builder()
+                .dimensions(embed.dimensions())
+                .embeddingProvider(embed)
+                .persistenceMode(MemoryPersistenceMode.DISK)
+                .persistence(dir)
+                .workingCapacity(32)
+                .episodicPartitionCapacity(episodicCap)
+                .semanticCapacity(semanticCap)
+                .proceduralCapacity(32)
+                .surpriseWarmup(1)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (memory != null) {
+            memory.close();
+            memory = null;
+        }
+    }
+
+    private static Set<String> ids(List<CognitiveResult> results) {
+        return results.stream().map(CognitiveResult::id).collect(Collectors.toSet());
+    }
+
+    private static long partitionDirCount(Path base) throws Exception {
+        try (var stream = Files.newDirectoryStream(StorageLayout.partitionsDir(base))) {
+            long n = 0;
+            for (Path p : stream) {
+                if (Files.isDirectory(p) && StorageLayout.isPartitionDir(p.getFileName().toString())) n++;
+            }
+            return n;
+        }
+    }
+
+    // ── D6 test 1: in-process episodic roll ───────────────────────
+
+    @Test
+    @DisplayName("episodic roll: a PRE-roll record is still returned by recall (fails pre-#443)")
+    void recallSpansFrozenEpisodicPartition(@TempDir Path dir) throws Exception {
+        memory = build(dir, /*episodicCap*/ 2, /*semanticCap*/ 64);
+
+        // Fill partition 000 (cap 2), then overflow → roll to partition 001.
+        memory.remember("epi-0", "the database migration failed on shard seven",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("epi-1", "cache warmup completed for the payments service",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("epi-2", "kafka consumer lag spiked during the deploy",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+
+        assertThat(partitionDirCount(dir)).as("a roll must have occurred").isGreaterThanOrEqualTo(2);
+        assertThat(memory.memoryCount(MemoryType.EPISODIC)).isEqualTo(3);
+
+        // Recall the PRE-roll record (lives in the now-frozen partition 000).
+        List<CognitiveResult> results = memory.recall("the database migration failed on shard seven",
+                RecallOptions.builder().topK(10).build());
+        assertThat(ids(results)).as("pre-roll frozen-partition record must be recalled").contains("epi-0");
+    }
+
+    // ── D6 test 2: in-process semantic roll (similarity-bearing) ──
+
+    @Test
+    @DisplayName("semantic roll: a PRE-roll semantic record returns with a similarity-bearing score")
+    void recallSpansFrozenSemanticPartitionWithSimilarity(@TempDir Path dir) throws Exception {
+        memory = build(dir, /*episodicCap*/ 64, /*semanticCap*/ 2);
+
+        memory.remember("sem-0", "postgres uses MVCC for concurrency control",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("sem-1", "redis is an in-memory key value store",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("sem-2", "kubernetes schedules pods onto worker nodes",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "grp").join();
+
+        assertThat(partitionDirCount(dir)).as("a roll must have occurred").isGreaterThanOrEqualTo(2);
+
+        List<CognitiveResult> results = memory.recall("postgres uses MVCC for concurrency control",
+                RecallOptions.builder().topK(10).build());
+
+        CognitiveResult preRoll = results.stream()
+                .filter(r -> "sem-0".equals(r.id())).findFirst().orElse(null);
+        assertThat(preRoll).as("pre-roll frozen-semantic record must be recalled").isNotNull();
+        // Frozen-semantic slab scan computes similarity (SemanticRecordMemory stores the
+        // quantized vector), so the score is similarity-bearing, not importance-only.
+        assertThat(preRoll.breakdown()).isNotNull();
+        assertThat(preRoll.breakdown().similarity())
+                .as("frozen-semantic slab scan yields a similarity component").isGreaterThan(0f);
+    }
+
+    // ── D6 test 5: direct-resolve across partitions ──────────────
+
+    @Test
+    @DisplayName("direct-resolve: inspect/forget/reinforce/markResolved/browse hit the correct frozen store")
+    void directResolveAcrossPartitions(@TempDir Path dir) throws Exception {
+        memory = build(dir, /*episodicCap*/ 2, /*semanticCap*/ 64);
+
+        memory.remember("d-0", "the incident postmortem is due friday",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("d-1", "rotate the tls certificate before it expires",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("d-2", "the on-call rotation changes next week",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+
+        assertThat(partitionDirCount(dir)).as("a roll must have occurred").isGreaterThanOrEqualTo(2);
+
+        // inspect a FROZEN-partition record → returns its OWN text/header (no collision
+        // with the active partition, whose first record shares the same physical offset).
+        var recD0 = memory.inspect("d-0");
+        assertThat(recD0).isNotNull();
+        assertThat(recD0.text()).isEqualTo("the incident postmortem is due friday");
+        assertThat(recD0.memoryType()).isEqualTo(MemoryType.EPISODIC);
+
+        var recD1 = memory.inspect("d-1");
+        assertThat(recD1).isNotNull();
+        assertThat(recD1.text()).isEqualTo("rotate the tls certificate before it expires");
+
+        // reinforce + markResolved on a frozen-partition record must not fail.
+        memory.reinforce("d-0", (byte) 50);
+        memory.markResolved("d-0");
+
+        // browse by tag surfaces frozen-partition records too.
+        var browsed = memory.browse("grp").stream()
+                .map(r -> r.id()).collect(Collectors.toSet());
+        assertThat(browsed).contains("d-0", "d-1", "d-2");
+
+        // forget the frozen-partition record → tombstones the RIGHT record; recall excludes it,
+        // while its partition sibling (d-1) remains recallable.
+        memory.forget("d-0");
+        assertThat(memory.inspect("d-0")).as("forgotten record removed from index").isNull();
+
+        List<CognitiveResult> after = memory.recall("the incident postmortem is due friday",
+                RecallOptions.builder().topK(10).build());
+        assertThat(ids(after)).as("forgotten frozen-partition record excluded from recall").doesNotContain("d-0");
+
+        var recD1After = memory.inspect("d-1");
+        assertThat(recD1After).as("sibling in same frozen partition is untouched").isNotNull();
+        assertThat(recD1After.text()).isEqualTo("rotate the tls certificate before it expires");
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionRestartRecallTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionRestartRecallTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.kernel.StorageLayout;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.test.FakeEmbeddingProvider;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Restart-correctness regression tests for issue #443 (Phase 2, ADR-0002 D6.3 &amp; D6.4).
+ *
+ * <p>These exercise the on-disk v6 {@code .midx} + open-all-on-load path: a DISK store is
+ * forced to roll across ≥2 partitions, closed, and reopened from scratch via the factory.
+ * Recall and direct-resolve must then span every persisted partition with correct text —
+ * behaviour that was impossible before Phase 2 because the colocated partition was never
+ * persisted and only the newest partition dir was opened on load.</p>
+ */
+@DisplayName("issue #443 — restart-correct multi-partition recall (Phase 2)")
+class PartitionRestartRecallTest {
+
+    private SpectorMemory memory;
+
+    private SpectorMemory build(Path dir, int episodicCap, int semanticCap) {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        return DefaultSpectorMemory.builder()
+                .dimensions(embed.dimensions())
+                .embeddingProvider(embed)
+                .persistenceMode(MemoryPersistenceMode.DISK)
+                .persistence(dir)
+                .workingCapacity(32)
+                .episodicPartitionCapacity(episodicCap)
+                .semanticCapacity(semanticCap)
+                .proceduralCapacity(32)
+                .surpriseWarmup(1)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (memory != null) {
+            memory.close();
+            memory = null;
+        }
+    }
+
+    private static Set<String> ids(List<CognitiveResult> results) {
+        return results.stream().map(CognitiveResult::id).collect(Collectors.toSet());
+    }
+
+    private static long partitionDirCount(Path base) throws Exception {
+        try (var stream = Files.newDirectoryStream(StorageLayout.partitionsDir(base))) {
+            long n = 0;
+            for (Path p : stream) {
+                if (Files.isDirectory(p) && StorageLayout.isPartitionDir(p.getFileName().toString())) n++;
+            }
+            return n;
+        }
+    }
+
+    // ── D6 test 3: restart across ≥2 partitions ───────────────────
+
+    @Test
+    @DisplayName("restart: recall returns records from BOTH the oldest and newest partition, with text")
+    void recallSpansPartitionsAfterRestart(@TempDir Path dir) throws Exception {
+        // Phase A: build a store, force a roll so records straddle partition 000 and 001.
+        memory = build(dir, /*episodicCap*/ 2, /*semanticCap*/ 64);
+        memory.remember("r-0", "the database migration failed on shard seven",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("r-1", "cache warmup completed for the payments service",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+        memory.remember("r-2", "kafka consumer lag spiked during the deploy",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "grp").join();
+
+        assertThat(partitionDirCount(dir)).as("a roll must have occurred").isGreaterThanOrEqualTo(2);
+        memory.close();
+        memory = null;
+
+        // Phase B: reopen from disk — v6 .midx + open-all-on-load must rehydrate BOTH partitions.
+        memory = build(dir, /*episodicCap*/ 2, /*semanticCap*/ 64);
+        assertThat(memory.memoryCount(MemoryType.EPISODIC))
+                .as("all persisted episodic records must reload").isEqualTo(3);
+
+        // Recall a record from the OLDEST (now-frozen) partition 000.
+        List<CognitiveResult> oldest = memory.recall(
+                "the database migration failed on shard seven",
+                RecallOptions.builder().topK(10).build());
+        assertThat(ids(oldest)).as("oldest-partition record recalled after restart").contains("r-0");
+        CognitiveResult r0 = oldest.stream().filter(r -> "r-0".equals(r.id())).findFirst().orElseThrow();
+        assertThat(r0.text()).as("oldest-partition text resolves via its own text.dat")
+                .isEqualTo("the database migration failed on shard seven");
+
+        // Recall a record from the NEWEST (active) partition.
+        List<CognitiveResult> newest = memory.recall(
+                "kafka consumer lag spiked during the deploy",
+                RecallOptions.builder().topK(10).build());
+        assertThat(ids(newest)).as("newest-partition record recalled after restart").contains("r-2");
+        CognitiveResult r2 = newest.stream().filter(r -> "r-2".equals(r.id())).findFirst().orElseThrow();
+        assertThat(r2.text()).isEqualTo("kafka consumer lag spiked during the deploy");
+    }
+
+    // ── D6 test 4: reverse-key collision across partitions ────────
+
+    @Test
+    @DisplayName("reverse-key collision: same physical offset in different partitions resolve independently after reload")
+    void reverseKeyCollisionResolvesPerPartitionAfterReload(@TempDir Path dir) throws Exception {
+        // episodicCap=1 forces a roll after every record → each partition's first (only)
+        // record lands at the SAME physical offset. Pre-#443 these collided on the reverse key.
+        memory = build(dir, /*episodicCap*/ 1, /*semanticCap*/ 64);
+        memory.remember("c-0", "first record lives in partition zero",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "col").join();
+        memory.remember("c-1", "second record lives in partition one",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "col").join();
+        memory.remember("c-2", "third record lives in partition two",
+                MemoryType.EPISODIC, MemorySource.OBSERVED, "col").join();
+
+        assertThat(partitionDirCount(dir)).as("multiple rolls must have occurred").isGreaterThanOrEqualTo(3);
+        memory.close();
+        memory = null;
+
+        // Reopen and inspect each id — each must return ITS OWN text/header, proving the
+        // persisted colocatedPartition disambiguates the shared physical offset.
+        memory = build(dir, /*episodicCap*/ 1, /*semanticCap*/ 64);
+
+        var c0 = memory.inspect("c-0");
+        var c1 = memory.inspect("c-1");
+        var c2 = memory.inspect("c-2");
+        assertThat(c0).isNotNull();
+        assertThat(c1).isNotNull();
+        assertThat(c2).isNotNull();
+
+        assertThat(c0.text()).isEqualTo("first record lives in partition zero");
+        assertThat(c1.text()).isEqualTo("second record lives in partition one");
+        assertThat(c2.text()).isEqualTo("third record lives in partition two");
+
+        assertThat(c0.memoryType()).isEqualTo(MemoryType.EPISODIC);
+        assertThat(c1.memoryType()).isEqualTo(MemoryType.EPISODIC);
+        assertThat(c2.memoryType()).isEqualTo(MemoryType.EPISODIC);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/MemoryPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/MemoryPersistenceTest.java
@@ -183,7 +183,7 @@ class MemoryPersistenceTest {
         assertThat(loaded.locate("mem-1")).isNotNull();
         assertThat(loaded.locate("mem-1").type()).isEqualTo(MemoryType.EPISODIC);
         assertThat(loaded.locate("mem-1").offset()).isEqualTo(64L);
-        assertThat(loaded.locate("mem-1").partitionIndex()).isEqualTo(0);
+        assertThat(loaded.locate("mem-1").graphSlot()).isEqualTo(0);
         assertThat(loaded.text("mem-1")).isEqualTo("The cat sat on the mat");
         assertThat(loaded.source("mem-1")).isEqualTo(MemorySource.OBSERVED);
         assertThat(loaded.tags("mem-1")).containsExactly("animal", "location");

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexPersistenceTest.java
@@ -70,7 +70,7 @@ class MemoryIndexPersistenceTest {
         assertThat(loc2).isNotNull();
         assertThat(loc2.type()).isEqualTo(MemoryType.EPISODIC);
         assertThat(loc2.offset()).isEqualTo(1024L);
-        assertThat(loc2.partitionIndex()).isEqualTo(5);
+        assertThat(loc2.graphSlot()).isEqualTo(5);
         assertThat(loc2.textOffset()).isEqualTo(200L);
         assertThat(loc2.textLength()).isEqualTo(11);
         assertThat(loaded.source("mem-2")).isEqualTo(MemorySource.INFERRED);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexV6FormatTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexV6FormatTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.index;
+
+import com.spectrayan.spector.commons.error.SpectorStorageException;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.model.MemoryType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Golden-file + throw-on-unreadable tests for the {@code .midx} v6 on-disk format
+ * (issue #443, ADR-0002 D6.7 / Phase 2).
+ *
+ * <p>Highest-risk part of the epic (on-disk format change), so this test locks down:</p>
+ * <ol>
+ *   <li><b>v6 round-trip</b> — save/load preserves the per-record {@code colocatedPartition}.</li>
+ *   <li><b>v5 back-compat</b> — a synthesized v5 file (64-byte header schemaVersion=5 +
+ *       40-byte slots, reusing the real id-pool) loads with {@code colocatedPartition = 0}
+ *       and does not crash.</li>
+ *   <li><b>throw-on-unreadable</b> — a newer-than-v6 schema and a truncated standard file
+ *       both throw {@link SpectorStorageException} rather than silently returning empty.</li>
+ * </ol>
+ */
+@DisplayName("issue #443 — .midx v6 format golden-file + throw-on-unreadable (Phase 2)")
+class MemoryIndexV6FormatTest {
+
+    private static final int LAYOUT_ID = 0x4D494458; // 'MIDX'
+    private static final int HEADER = MemoryHeader.HEADER_BYTES; // 64
+    private static final int V6_STRIDE = 48;
+    private static final int V5_STRIDE = 40;
+
+    @TempDir
+    Path dir;
+
+    // ── 1. v6 round-trip preserves colocatedPartition ─────────────
+
+    @Test
+    @DisplayName("v6 round-trip: save/load preserves colocatedPartition per record")
+    void v6RoundTripPreservesColocatedPartition() {
+        MemoryIndex original = new MemoryIndex();
+        // No text position → text lives inline in the id-pool blob (keeps this test
+        // independent of text.dat; it exercises the .midx slot format only).
+        original.register("m-a",
+                new MemoryLocation(MemoryType.EPISODIC, /*offset*/ 64L, /*graphSlot*/ 3,
+                        /*colocatedPartition*/ 0, /*textOffset*/ -1L, /*textLength*/ -1),
+                "alpha in partition zero", MemorySource.OBSERVED, new String[]{"p0"});
+        original.register("m-b",
+                new MemoryLocation(MemoryType.EPISODIC, /*offset*/ 64L, /*graphSlot*/ 7,
+                        /*colocatedPartition*/ 2, /*textOffset*/ -1L, /*textLength*/ -1),
+                "bravo in partition two", MemorySource.INFERRED, new String[]{"p2"});
+
+        Path midx = dir.resolve("gold_v6.midx");
+        original.save(midx);
+
+        MemoryIndex loaded = MemoryIndex.load(midx);
+        assertThat(loaded.size()).isEqualTo(2);
+        assertThat(loaded.isColocatedPartitionPersisted())
+                .as("a v6 file must report colocatedPartition as persisted").isTrue();
+
+        MemoryLocation a = loaded.locate("m-a");
+        assertThat(a.colocatedPartition()).isEqualTo(0);
+        assertThat(a.graphSlot()).isEqualTo(3);
+        assertThat(a.offset()).isEqualTo(64L);
+        assertThat(loaded.text("m-a")).isEqualTo("alpha in partition zero");
+
+        MemoryLocation b = loaded.locate("m-b");
+        assertThat(b.colocatedPartition()).as("colocatedPartition survives the v6 round-trip").isEqualTo(2);
+        assertThat(b.graphSlot()).isEqualTo(7);
+        assertThat(loaded.text("m-b")).isEqualTo("bravo in partition two");
+
+        // Reverse key is partition-aware: two records at the SAME offset in different
+        // partitions resolve to their own ids (no collision).
+        assertThat(loaded.findIdByOffset(0, MemoryType.EPISODIC, 64L)).isEqualTo("m-a");
+        assertThat(loaded.findIdByOffset(2, MemoryType.EPISODIC, 64L)).isEqualTo("m-b");
+    }
+
+    // ── 2. v5 golden file loads with colocatedPartition = 0 ───────
+
+    @Test
+    @DisplayName("v5 golden file: loads clean with colocatedPartition=0 (WARN, no crash)")
+    void v5FileLoadsWithZeroColocatedPartition() throws Exception {
+        // Build a v6 file first so we can reuse its byte-identical id-pool (.idpl),
+        // then synthesize a v5 .midx (40-byte slots, schemaVersion=5) from its slots.
+        MemoryIndex src = new MemoryIndex();
+        src.register("v5-a",
+                new MemoryLocation(MemoryType.SEMANTIC, 128L, 1, 5, -1L, -1),
+                "semantic fact one", MemorySource.USER_STATED, new String[]{"k"});
+        src.register("v5-b",
+                new MemoryLocation(MemoryType.PROCEDURAL, 256L, -1, 9, -1L, -1),
+                "procedural step two", MemorySource.PROCEDURAL, new String[]{});
+        Path v6midx = dir.resolve("src_v6.midx");
+        src.save(v6midx);
+        Path v6idpl = dir.resolve("src_v6.idpl");
+
+        // Synthesize the v5 pair.
+        Path v5midx = dir.resolve("gold_v5.midx");
+        Path v5idpl = dir.resolve("gold_v5.idpl");
+        Files.copy(v6idpl, v5idpl);      // id-pool format is identical between v5 and v6
+        writeV5MidxFromV6(v6midx, v5midx);
+
+        MemoryIndex loaded = MemoryIndex.load(v5midx);
+        assertThat(loaded.size()).isEqualTo(2);
+        assertThat(loaded.isColocatedPartitionPersisted())
+                .as("a v5 file has no persisted colocated partition").isFalse();
+
+        // v5 has no colocatedPartition dimension → every record defaults to partition 0.
+        assertThat(loaded.locate("v5-a").colocatedPartition()).isEqualTo(0);
+        assertThat(loaded.locate("v5-b").colocatedPartition()).isEqualTo(0);
+        // graphSlot (the former misnamed field at [24:4]) is preserved.
+        assertThat(loaded.locate("v5-a").graphSlot()).isEqualTo(1);
+        assertThat(loaded.text("v5-a")).isEqualTo("semantic fact one");
+        assertThat(loaded.text("v5-b")).isEqualTo("procedural step two");
+    }
+
+    // ── 3. throw-on-unreadable: newer version + truncation ────────
+
+    @Test
+    @DisplayName("newer-than-v6 schema throws SpectorStorageException")
+    void newerSchemaVersionThrows() throws Exception {
+        Path midx = dir.resolve("future.midx");
+        byte[] file = new byte[HEADER]; // header only, count=0
+        MemorySegment seg = MemorySegment.ofArray(file);
+        MemoryHeader.write(seg, 0, /*schemaVersion*/ 7, MemoryShape.RECORD, 0x01,
+                /*capacity*/ 0, /*count*/ 0, V6_STRIDE, LAYOUT_ID,
+                System.currentTimeMillis(), System.currentTimeMillis());
+        Files.write(midx, file);
+
+        assertThatThrownBy(() -> MemoryIndex.load(midx))
+                .isInstanceOf(SpectorStorageException.class)
+                .hasMessageContaining("v7");
+    }
+
+    @Test
+    @DisplayName("truncated standard file (< 64B header) throws SpectorStorageException")
+    void truncatedStandardFileThrows() throws Exception {
+        Path midx = dir.resolve("truncated.midx");
+        byte[] file = new byte[32]; // shorter than the 64-byte header
+        MemorySegment seg = MemorySegment.ofArray(file);
+        seg.set(ValueLayout.JAVA_INT_UNALIGNED, 0, MemoryHeader.MAGIC); // claims SMKM
+        Files.write(midx, file);
+
+        assertThatThrownBy(() -> MemoryIndex.load(midx))
+                .isInstanceOf(SpectorStorageException.class)
+                .hasMessageContaining("truncated");
+    }
+
+    @Test
+    @DisplayName("missing file starts fresh (no throw)")
+    void missingFileStartsFresh() {
+        MemoryIndex loaded = MemoryIndex.load(dir.resolve("does-not-exist.midx"));
+        assertThat(loaded.size()).isZero();
+    }
+
+    // ── helper: transcode a v6 .midx to a v5 .midx (drop colocatedPartition) ──
+
+    private static void writeV5MidxFromV6(Path v6midx, Path v5midx) throws Exception {
+        byte[] v6 = Files.readAllBytes(v6midx);
+        MemorySegment v6seg = MemorySegment.ofArray(v6);
+        int count = (int) MemoryHeader.readCount(v6seg, 0);
+
+        long dataBytes = (long) count * V5_STRIDE;
+        byte[] v5 = new byte[(int) (HEADER + dataBytes)];
+        MemorySegment v5seg = MemorySegment.ofArray(v5);
+        MemoryHeader.write(v5seg, 0, /*schemaVersion*/ 5, MemoryShape.RECORD, 0x01,
+                /*capacity*/ count, /*count*/ count, V5_STRIDE, LAYOUT_ID,
+                System.currentTimeMillis(), System.currentTimeMillis());
+
+        ByteBuffer in = ByteBuffer.wrap(v6).order(ByteOrder.nativeOrder());
+        ByteBuffer out = ByteBuffer.wrap(v5).order(ByteOrder.nativeOrder());
+        for (int i = 0; i < count; i++) {
+            int base = HEADER + i * V6_STRIDE;
+            long poolOffset = in.getLong(base);
+            int poolLen = in.getInt(base + 8);
+            int typeOrd = in.getInt(base + 12);
+            long offset = in.getLong(base + 16);
+            int graphSlot = in.getInt(base + 24);
+            long textOffset = in.getLong(base + 28);
+            int textLength = in.getInt(base + 36);
+            // [40:8] colocatedPartition + reserved are intentionally dropped for v5.
+
+            int outBase = HEADER + i * V5_STRIDE;
+            out.putLong(outBase, poolOffset);
+            out.putInt(outBase + 8, poolLen);
+            out.putInt(outBase + 12, typeOrd);
+            out.putLong(outBase + 16, offset);
+            out.putInt(outBase + 24, graphSlot);
+            out.putLong(outBase + 28, textOffset);
+            out.putInt(outBase + 36, textLength);
+        }
+        Files.write(v5midx, v5);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
@@ -90,8 +90,9 @@ class WalRecoveryDispatcherTest {
             entityGraph.bindWal(wal);
             temporalChain.bindWal(wal);
 
-            // Write checkpoint mutations
-            byte[] bytes = new byte[40];
+            // Write checkpoint mutations (source must be a full record stride wide; the
+            // IndexEntryLayout slot is 48 bytes as of the v6 .midx format — issue #443).
+            byte[] bytes = new byte[new IndexEntryLayout().recordStride()];
             bytes[0] = 11;
             recordMem.write(0, MemorySegment.ofArray(bytes));
             registryMem.intern("CHECKPOINT_KEY");
@@ -133,7 +134,7 @@ class WalRecoveryDispatcherTest {
             hebbianGraph.bindWal(wal);
 
             // Mutate RecordMemory
-            byte[] bytes = new byte[40];
+            byte[] bytes = new byte[new IndexEntryLayout().recordStride()];
             bytes[0] = 42;
             recordMem.write(1, MemorySegment.ofArray(bytes));
 


### PR DESCRIPTION
## P0 fix: multi-partition recall (frozen-partition data loss)

Fixes the silent correctness bug where recall never spanned more than one colocated partition — after a roll (in-process) or restart with ≥2 partition dirs, frozen-partition records were silently omitted, direct-resolve mis-resolved against the active partition, and the reverse index collided on cross-partition offsets. DISK mode only; IN_MEMORY was never affected.

Design: [`spectrayan/RnD/adr-0002-issue-443-partition-recall-fanout.md`](https://github.com/spectrayan/spectrayan/blob/main/RnD/adr-0002-issue-443-partition-recall-fanout.md) (Titan, CEO-approved).

### Phase 1 (`ef44cdd`) — in-process correctness + mmap leak
- `PartitionManager` keeps frozen partitions **open** in a volatile copy-on-write registry (`PartitionHandle`/`PartitionRegistry`) — fixes the arena/mmap leak.
- `RecallPipeline` consults the live snapshot per recall and **fans out scan tasks across every partition**; direct-resolve (`inspect`/`forget`/`browse`/`reinforce`/`markResolved`) is partition-keyed via `routerFor(seq)`.
- `text.dat` rolls with the partition; per-partition text resolution.
- Global HNSW is used only for the single-partition case (its slot index collides across partitions after a roll); frozen-semantic falls back to the SIMD slab scan. Per-partition HNSW is a deferred perf follow-up.

### Phase 2 (`be08ebe`) — restart correctness + `.midx` v6
- `.midx` slot **40 → 48 bytes** (8-byte aligned): adds `colocatedPartition` `[40:4]` + `reserved` `[44:4]`; renames the misnamed `[24:4] partitionIndex` → `graphSlot`. File keeps the standard 64-byte `MemoryHeader`.
- `IndexEntryLayout` schemaVersion **5 → 6**; loader branches on the header's `schemaVersion`: **v6** reads the new slot; **v5** loads with `colocatedPartition=0` + one WARN (single-partition data stays correct; pre-existing multi-partition data was already corrupt and is not auto-healed); legacy v1–v4 preserved; unknown/newer or truncated → **throws** `SpectorStorageException` (no silent empty).
- `PartitionManager.discoverAllPartitions` opens **all** partition dirs on load (newest = writable, rest frozen read-only); index entries resolve to their partition via the persisted `colocatedPartition`.
- De-hardcoded the `40` literals in `IndexRecordMemory.save` to `layout.recordStride()`.

### Backward compatibility
Existing v5 `.midx` files load cleanly (treated as partition 0). This is fully correct for any store that never rolled; stores that had already rolled under the bug had unrecoverable partition mapping regardless.

### Tests
`mvn test -pl memory/spector-memory -am` → **1188 pass, 0 fail, 18 skipped**. New: in-process episodic/semantic roll recall, cross-partition direct-resolve, frozen-handle leak/lifecycle, restart recall across ≥2 partitions with correct text, reverse-key collision at identical offsets, `.midx` v6 golden-file + v5-loads-clean + throw-on-unreadable.

### Deferred follow-ups (not required for correctness)
Per-partition/native multi-partition HNSW; `ConsolidationService`/`ReflectDaemon`/`ReflectionOrchestrator` spanning frozen partitions; query-time partition pruning to bound fan-out latency.

Closes #443
