### PR TITLE
docs: reposition Spector as a language-agnostic, agent-ready memory backbone

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-Legacy AI architectures bolted memory onto stateless vector databases. **Spector** is designed from the ground up for modern AI as a unified cognitive memory backbone — leveraging Java Project Panama to achieve C++ bare-metal SIMD speeds natively across dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, and associative Hebbian graph memory, with a built-in MCP server that turns any AI agent into a memory-augmented reasoning machine.
+**Spector** is a language-agnostic, agent-ready cognitive memory backbone that unifies dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, and associative Hebbian graph memory — reachable from any language via an in-process MCP server (stdio + Streamable HTTP), a REST/gRPC gateway, and a Python SDK, or embeddable directly in the JVM. Under the hood, Java 25, Project Panama, and the Vector API deliver C++ bare-metal SIMD speeds with zero-GC off-heap storage — the performance engine, not a prerequisite for using it.
 
 ---
 
@@ -75,9 +75,9 @@ Spector Memory is a **biologically-inspired cognitive memory system** that gives
 | 🧊 **Off-Heap Storage** | Panama MemorySegment · zero-copy I/O | 0.01% GC overhead |
 | 🗜️ **Quantization** | SVASQ-8/4 · IVF-PQ · FWHT rotation | 4–32× compression · 99.5% recall |
 | 🔍 **Hybrid Retrieval** | 4-Layer Stack: Dense HNSW + BM25 + SPLADE / Li-LSR + ColBERT v2 | Multi-way RRF fusion + MaxSim SIMD reranking |
-| 📄 **Off-Heap Doc Store** | Encrypted `TextDataStore` (AES-256-GCM) | Zero-copy mmap'd `readTextDirect` · zero GC pressure |
+| 📄 **Off-Heap Doc Store** | Encrypted, zero-copy off-heap document store (AES-256-GCM) | Reads documents in place · zero GC pressure |
 | 🔗 **Cognitive Graphs** | Hebbian co-activation + LLM Entity Graphs | Spreading activation, temporal chains & entity links |
-| 🎛️ **Retrieval Modes** | 8 `TextSearchMode` paths (HYBRID, FULL_STACK, etc.) | Graceful degradation & flexible query optimization |
+| 🎛️ **Retrieval Modes** | Hybrid, keyword, vector, sparse & full-stack retrieval | Multiple modes with graceful degradation & query optimization |
 | 🖥️ **GPU Acceleration** | CUDA via Panama FFM | Optional · zero-copy transfer |
 | 📦 **Flexible Deployment** | Embedded JAR · Standalone · Distributed | Zero to cluster in one config |
 

--- a/docs/docs/about.md
+++ b/docs/docs/about.md
@@ -1,15 +1,15 @@
 ---
 title: "What is Spector? — AI Cognitive Memory Backbone"
-description: "Spector is a Java-native AI cognitive memory system combining dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, and biologically-inspired cognitive memory tiers in a single embeddable library."
+description: "Spector is a language-agnostic, agent-ready AI memory backbone — reachable from any language via MCP, REST/gRPC, and a Python SDK — combining dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, and biologically-inspired cognitive memory tiers."
 ---
 
 # 🌟 What is Spector?
 
 > **The Zero-Overhead, Agent-Ready AI Memory Backbone.**
 >
-> Legacy AI architectures bolted memory onto stateless vector databases. Spector is designed from the ground up for modern AI — combining dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, Hebbian graph structures, and hybrid ranking in a single embeddable library with zero external dependencies. Connect any AI agent via the built-in MCP server, or embed directly in your application.
+> Legacy AI architectures bolted memory onto stateless vector databases. Spector is designed from the ground up for modern AI — combining dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, Hebbian graph structures, and hybrid ranking in a single cognitive engine with zero external dependencies. Reach it from any language via the built-in MCP server, the REST/gRPC gateway, or the Python SDK — or embed it directly in your JVM application.
 
-Spector is an open-source, high-performance cognitive memory system built entirely on modern Java 25. It's designed for developers who want sub-millisecond memory retrieval, native AI agent integration, and zero infrastructure complexity. Drop in a JAR, write a few lines of code, and you have production-grade cognitive memory with built-in agent support.
+Spector is an open-source, high-performance cognitive memory system for developers who want sub-millisecond memory retrieval, native AI agent integration, and zero infrastructure complexity. Connect from any stack over MCP, REST/gRPC, or the Python SDK, or drop the JAR straight into a Java/Spring app — either way you get production-grade cognitive memory with built-in agent support. Modern Java 25, Project Panama, and the Vector API are the performance engine under the hood.
 
 ---
 
@@ -67,12 +67,12 @@ Includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) s
 > [!TIP]
 > See the [MCP Server Guide](sdk-usage/mcp-server.md) to connect Claude Desktop, Cursor, or any MCP client in minutes.
 
-### 📦 Pure Java, Zero Dependencies
+### 📦 Pure-Java Engine, Zero Dependencies
 
-Unlike most vector databases that rely on C++, Rust, or Python bindings, Spector is 100% Java. It uses the JDK's own Vector API for SIMD acceleration — no JNI, no native libraries, no external infrastructure.
+The engine itself is 100% Java — an implementation choice that pays off in portability. Unlike most vector databases that rely on C++, Rust, or Python bindings, Spector uses the JDK's own Vector API for SIMD acceleration with no JNI, no platform-specific native libraries, and no external infrastructure: one artifact runs everywhere the JVM runs. This is about *how* Spector is built, not *who* can use it — non-JVM applications connect over MCP, REST/gRPC, or the Python SDK.
 
 > [!TIP]
-> Add the JAR to your classpath and you're done. No Docker, no clusters, no ops.
+> Embedding in a JVM app? Add the JAR to your classpath and you're done — no Docker, no clusters, no ops. On another stack? Run Spector as a service and connect over MCP or REST.
 
 ### 🚀 Modern JVM Technologies
 
@@ -190,7 +190,7 @@ Drop Spector into existing Java applications without infrastructure changes. Per
 > **Choose Spector when:**
 > - You want AI agents to autonomously manage their memories (MCP integration)
 > - You want sub-millisecond hybrid recall without infrastructure complexity
-> - Your stack is Java/JVM and you want native integration
+> - You want to reach cognitive memory from any language — over MCP, REST/gRPC, or the Python SDK — or embed it natively in a Java/JVM app
 > - You need an embedded cognitive memory library with server-mode option
 > - You want GPU acceleration without leaving the JVM
 > - Zero external dependencies matters to your deployment
@@ -198,7 +198,6 @@ Drop Spector into existing Java applications without infrastructure changes. Per
 > [!WARNING]
 > **Consider alternatives when:**
 > - You need a managed cloud service with zero ops
-> - Your team primarily works in Python/Rust/Go
 > - You need built-in ML model serving
 
 ---

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -44,6 +44,21 @@ try (var engine = new SpectorEngine(SpectorConfig.DEFAULT.withDimensions(384))) 
 
 ---
 
+### Do I have to write Java to use Spector?
+
+**No.** Embedding the JAR in a JVM app is one option, not a requirement. Spector is language-agnostic — reach it from any stack through:
+
+| Access path | Best for |
+|-------------|----------|
+| **MCP server** (stdio + Streamable HTTP at `/mcp`) | AI agents and MCP clients (Claude Desktop, Cursor, custom) |
+| **REST / gRPC gateway** | Any language over HTTP or gRPC |
+| **Python SDK** (`sdks/python`) | Python apps — wraps the MCP server over stdio |
+| **JVM embed** | Java/Kotlin/Scala/Spring apps that want zero network hops |
+
+Java 25, Project Panama, and the Vector API are the performance engine under the hood — not a prerequisite for using Spector.
+
+---
+
 ### What about persistence? Do I lose data on restart?
 
 **No!** Spector supports persistence through memory-mapped files. The HNSW index uses a page-aligned binary format that loads instantly via `mmap` — no deserialization needed. Vector data survives restarts.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,15 +1,15 @@
 ---
 title: "Spector — Zero-Overhead AI Memory & Cognitive Graph"
-description: "Spector is a Java-native AI cognitive memory system combining SIMD-accelerated dense vector similarity, BM25 text matching, SPLADE sparse retrieval, and associative graph capabilities."
+description: "Spector is a language-agnostic, agent-ready AI memory backbone — reachable from any language via MCP, REST/gRPC, and a Python SDK — combining dense vector similarity, BM25 text matching, SPLADE sparse retrieval, and associative cognitive graphs."
 ---
 
 # ⚡ Spector — The AI Memory Backbone
 
-> **Zero-overhead, agent-ready AI cognitive memory — embedded in a single JVM.**
+> **Zero-overhead, agent-ready AI cognitive memory — reachable from any language.**
 
-Spector is a **Java-native AI cognitive memory system** that combines SIMD-accelerated dense vector similarity, keyword matching (BM25), SPLADE learned sparse retrieval, associative Hebbian graphs, and biologically-inspired memory consolidation into a single embeddable library. No Docker, no external databases, no Python — just a JAR.
+Spector is a **language-agnostic, agent-ready AI memory backbone** that combines SIMD-accelerated dense vector similarity, keyword matching (BM25), SPLADE learned sparse retrieval, associative Hebbian graphs, and biologically-inspired memory consolidation into one cognitive engine. Reach it from **any language**: the in-process **MCP server** (stdio + Streamable HTTP), the **REST/gRPC** gateway, or the **Python SDK** — and embed it directly in the JVM when you want zero network hops.
 
-Connect AI agents via the **built-in MCP server** (Claude Desktop, Cursor, custom agents), embed directly in your Spring Boot app, or run standalone. Spector delivers **sub-millisecond recall** at scale with **zero garbage collection pressure** thanks to Project Panama off-heap memory.
+Embed Spector as a single JAR with **zero infrastructure** — no Docker, no external databases — **or** run it as a service and connect from any stack. Under the hood, Java 25, Project Panama, and the Vector API drive **sub-millisecond recall** at scale with **zero garbage collection pressure**.
 
 ---
 
@@ -84,8 +84,8 @@ graph LR
 
 ### What Makes Spector Different
 
-- **Embedded deployment** — runs as a library inside your JVM. No Docker, no servers, no network hops.
-- **Agent-native** — 13 MCP tools for search, memory, and cognitive operations. Connect Claude Desktop or Cursor in one config line.
+- **Flexible deployment** — embed as a single JAR inside your JVM (zero network hops) or run it as a service and connect from any language over MCP, REST, or gRPC.
+- **Agent-native** — 16 MCP tools for memory, recall, and cognitive operations. Connect Claude Desktop or Cursor in one config line.
 - **Cognitive memory** — the only system combining power-law decay, Two-Factor strengthening (Bjork & Bjork), emotional valence, and Hebbian association in a single scoring formula.
 - **Zero GC pressure** — all vector data and headers live off-heap via Project Panama. The JVM garbage collector never sees memory records.
 - **SIMD everywhere** — vector distance, quantization, and scoring use Java Vector API (AVX2/AVX-512/NEON) for hardware-accelerated computation.
@@ -105,7 +105,7 @@ graph LR
 | **Dependencies** | Zero (JDK only) |
 | **SIMD** | AVX2 / AVX-512 / NEON |
 | **GPU** | CUDA via Panama FFM |
-| **MCP** | Built-in, 13 agent-ready tools |
+| **MCP** | Built-in, 16 agent-ready tools |
 | **Distributed** | gRPC fan-out + consistent hashing |
 
 ---

--- a/docs/docs/sdk-usage/python-sdk.md
+++ b/docs/docs/sdk-usage/python-sdk.md
@@ -7,7 +7,7 @@ description: "Install and use the Spector Python SDK to control cognitive memory
 
 > **Zero-dependency Python client wrapping Spector's MCP server.**
 
-The Python SDK spawns the Spector JVM as a subprocess and communicates via JSON-RPC 2.0 over stdio. All 21 MCP tools are accessible through a clean Pythonic API.
+The Python SDK spawns the Spector JVM as a subprocess and communicates via JSON-RPC 2.0 over stdio. All 16 MCP tools are accessible through a clean Pythonic API.
 
 ---
 
@@ -188,7 +188,7 @@ logging.getLogger("spector").setLevel(logging.DEBUG)
 │   Python SDK     │  ─────── stdio ──────────►    │  Spector JVM     │
 │                  │                                │  (MCP Server)    │
 │  SpectorClient   │  ◄────── stdout ──────────    │                  │
-│  ├── memory      │                                │  21 MCP tools    │
+│  ├── memory      │                                │  16 MCP tools    │
 │  └── engine      │         stderr → logging       │  Off-heap memory │
 └──────────────────┘                                └──────────────────┘
 ```

--- a/docs/docs/why-spector.md
+++ b/docs/docs/why-spector.md
@@ -75,17 +75,18 @@ Spector models memory the way brains do — based on peer-reviewed cognitive sci
 
 ### 3. Zero Dependencies, Flexible Deployment
 
-Spector runs anywhere the JVM runs — no Docker, no Python, no external services:
+One self-contained engine, no Docker and no external services — run it wherever the JVM runs and connect from any language:
 
 - **Embedded library**: Add a single JAR to your Java/Kotlin/Scala application
-- **Standalone server**: REST + gRPC + MCP APIs on a single port
+- **Standalone server**: REST + gRPC + MCP APIs on a single port — reachable from any language (Python, TypeScript, Go, and more)
+- **Python SDK**: A native client that drives the MCP server over stdio
 - **Clustered mode**: gRPC fan-out across multiple nodes with namespace sharding
 - **Kubernetes**: Helm chart with horizontal pod autoscaling
 - **Spring AI / Micronaut**: First-class framework integration
 
 ### 4. Built-In MCP Server
 
-Spector includes a 13-tool MCP server for AI agent integration — Claude Desktop, Cursor, and custom agents can use cognitive memory out of the box. No wrapper libraries needed.
+Spector includes a 16-tool MCP server for AI agent integration — Claude Desktop, Cursor, and custom agents can use cognitive memory out of the box. No wrapper libraries needed.
 
 ### 5. Enterprise-Grade Security
 
@@ -111,7 +112,7 @@ Every tenant gets physically separate files with independent encryption keys:
 | **Off-heap / Zero GC** | ✅ Panama FFM | N/A | Partial | ✅ (Rust) | Partial | ❌ | N/A |
 | **Fused cognitive scoring** | ✅ 6-phase pipeline | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Hybrid search** | ✅ HNSW + BM25 + RRF | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| **Built-in MCP server** | ✅ 13 tools | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Built-in MCP server** | ✅ 16 tools | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Cognitive memory** | ✅ 4-tier, bio-inspired | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Quantization** | SVASQ-8/4, IVF-PQ | ✅ | ✅ BQ | ✅ SQ/PQ | ✅ IVF-PQ/SQ | ❌ | ❌ |
 | **GPU acceleration** | ✅ CUDA via Panama | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |


### PR DESCRIPTION
## Summary

Repositions the docs and README so Spector reads as a **language-agnostic, agent-ready AI memory backbone** reachable from any language, rather than a Java-only, embed-only library. Java 25 / Project Panama / the Vector API are reframed as the performance engine under the hood — not a prerequisite for using Spector.

Access paths cited (all real and documented): in-process **MCP server** (stdio + Streamable HTTP at `/mcp`), the **REST/gRPC** gateway, a real **Python SDK** (`sdks/python`), and direct **JVM embed**.

## Changes

- **`docs/docs/index.md`** — rewrote the `description` frontmatter and hero: leads with the language-agnostic value + access paths; keeps the zero-infra prop framed as "embed as a single JAR **or** run as a service and connect from any language." Softened the "Embedded deployment" bullet to "Flexible deployment."
- **`docs/docs/about.md`** — reframed description, hero blockquote, and intro. Kept "100% Java, no JNI/native libs" as an *engineering-quality/portability* note (explicitly "how it's built, not who can use it"). Fixed the "When to use" bullet and dropped the exclusionary "team works in Python/Rust/Go" alternative.
- **`docs/docs/why-spector.md`** — reframed "runs anywhere the JVM runs — no Python" as deployment simplicity + added Python SDK / any-language access. Comparison-table factual cells left intact.
- **`docs/docs/faq.md`** — added a "Do I have to write Java to use Spector?" entry with the access-path matrix.
- **`README.md`** — tightened the intro to lead with the language-agnostic/agent-ready value (Java Panama/C++ SIMD moved to a following sentence as the perf engine). Replaced two implementation-detail capability rows (`TextDataStore`/`readTextDirect`; "8 `TextSearchMode` paths") with benefit-level descriptions.

## MCP tool count reconciliation

Verified against `SpectorToolRegistry` registrations and the `shouldRegister16Tools()` test: the MCP server registers **exactly 16 tools, all cognitive memory tools**. Standardized on **16** across README, `index.md`, `why-spector.md`, and `python-sdk.md` (replacing stale 13/21 counts).

> ⚠️ **Flagged for a follow-up (out of scope here):** several architecture docs (`architecture/overview.md`, `sdk-usage/mcp-server.md`, `architecture/mcp-integration.md`, `llms.txt`) still document **6 "engine" MCP tools** (`engine_search`, `engine_ingest`, …) that no longer exist in the build — search is now folded into `memory_recall`'s `text_search_mode`. Correcting those requires removing/reworking tool tables and diagrams, not a number swap, so it's left for a dedicated PR to avoid internal contradictions.

## Verification

- `python -m mkdocs build --clean` → **build succeeded** (exit 0). Remaining warnings are pre-existing INFO-level notices unrelated to these edits.
- Docs/README only — no code touched.

Closes #450