### PR TITLE
docs: reposition Spector as agent-ready cognitive memory (#450)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-Legacy AI architectures bolted memory onto stateless vector databases. **Spector** is designed from the ground up for modern AI as a unified cognitive memory backbone — leveraging Java Project Panama to achieve C++ bare-metal SIMD speeds natively across dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, and associative Hebbian graph memory, with a built-in MCP server that turns any AI agent into a memory-augmented reasoning machine.
+Legacy AI stacks bolt memory onto stateless vector databases — storage without cognition. **Spector** is a cognitive memory backbone for modern AI agents: it remembers, forgets, consolidates, and **forms associations** across a biologically-inspired memory graph — Hebbian co-activation, temporal chains, and entity links — then retrieves with fused semantic and hybrid scoring at sub-millisecond latency. Connect any AI agent through the built-in **MCP server**, call it over **REST/gRPC**, drive it from the **Python SDK**, or embed it directly in the JVM. Every user, agent, or tenant is physically isolated in its own on-disk namespace — true data separation, not a shared-store filter. Under the hood, Java Project Panama and the Vector API deliver C++-class SIMD speed with zero garbage-collection pressure.
 
 ---
 
@@ -68,18 +68,18 @@ Spector Memory is a **biologically-inspired cognitive memory system** that gives
 
 ## ✨ Key Capabilities
 
-| Capability | Technology | Performance / Specifications |
-|:---|:---|:---|
-| 🤖 **Agent-Native (MCP)** | Model Context Protocol · 16 tools · stdio + Streamable HTTP | Claude · Cursor · autonomous agents |
-| ⚡ **SIMD Scoring** | Java Vector API (AVX2/AVX-512/NEON) | 0.13ms p50 recall |
-| 🧊 **Off-Heap Storage** | Panama MemorySegment · zero-copy I/O | 0.01% GC overhead |
-| 🗜️ **Quantization** | SVASQ-8/4 · IVF-PQ · FWHT rotation | 4–32× compression · 99.5% recall |
-| 🔍 **Hybrid Retrieval** | 4-Layer Stack: Dense HNSW + BM25 + SPLADE / Li-LSR + ColBERT v2 | Multi-way RRF fusion + MaxSim SIMD reranking |
-| 📄 **Off-Heap Doc Store** | Encrypted `TextDataStore` (AES-256-GCM) | Zero-copy mmap'd `readTextDirect` · zero GC pressure |
-| 🔗 **Cognitive Graphs** | Hebbian co-activation + LLM Entity Graphs | Spreading activation, temporal chains & entity links |
-| 🎛️ **Retrieval Modes** | 8 `TextSearchMode` paths (HYBRID, FULL_STACK, etc.) | Graceful degradation & flexible query optimization |
-| 🖥️ **GPU Acceleration** | CUDA via Panama FFM | Optional · zero-copy transfer |
-| 📦 **Flexible Deployment** | Embedded JAR · Standalone · Distributed | Zero to cluster in one config |
+| Capability | What makes it different |
+|:---|:---|
+| 🧠 **Cognitive memory tiers** | Working → Episodic → Semantic → Procedural, with decay, consolidation, and emotional valence — memory that behaves like memory, not a key-value store |
+| 🔗 **Associative memory graphs** | Hebbian co-activation, temporal chains, and entity links with spreading activation — recall surfaces what's *related*, not just what matches |
+| 🤖 **In-process MCP server** | Cognitive tools over stdio + Streamable HTTP — agents call memory directly, zero network hops |
+| ⚡ **Fused SIMD scoring** | Similarity × importance × decay in one pass — 0.13ms p50 recall at 1M memories |
+| 🔍 **Hybrid retrieval** | Dense + sparse + late-interaction reranking, fused with RRF, with graceful degradation |
+| 🔒 **Physical namespace isolation** | Every user, agent, or tenant's memory lives in its own on-disk directory tree — true data separation, not a logical filter — hash-sharded to millions of namespaces, encrypted at rest (AES-256-GCM) |
+| 🧊 **Zero-GC off-heap storage** | 100% off-heap via Panama — ~0.01% GC overhead measured |
+| 🗜️ **Quantization** | SVASQ-8/4 + IVF-PQ — 4–32× compression at ~99.5% recall |
+| 🖥️ **GPU acceleration** | Optional CUDA via Panama FFM, zero-copy transfer |
+| 📦 **Flexible deployment** | Embedded JAR, standalone, or distributed |
 
 ---
 

--- a/docs/docs/about.md
+++ b/docs/docs/about.md
@@ -1,15 +1,15 @@
 ---
 title: "What is Spector? — AI Cognitive Memory Backbone"
-description: "Spector is a Java-native AI cognitive memory system combining dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, and biologically-inspired cognitive memory tiers in a single embeddable library."
+description: "Spector is a cognitive memory backbone for AI agents, combining biologically-inspired memory tiers, associative Hebbian graphs, and fused semantic and hybrid retrieval in a single embeddable library with a built-in MCP server."
 ---
 
 # 🌟 What is Spector?
 
 > **The Zero-Overhead, Agent-Ready AI Memory Backbone.**
 >
-> Legacy AI architectures bolted memory onto stateless vector databases. Spector is designed from the ground up for modern AI — combining dense vector similarity, BM25 keyword matching, SPLADE learned sparse retrieval, Hebbian graph structures, and hybrid ranking in a single embeddable library with zero external dependencies. Connect any AI agent via the built-in MCP server, or embed directly in your application.
+> Legacy AI stacks bolt memory onto stateless vector databases — storage without cognition. Spector is built from the ground up for modern AI agents: it remembers, forgets, consolidates, and **forms associations** across a biologically-inspired memory graph — Hebbian co-activation, temporal chains, and entity links — then retrieves with fused semantic and hybrid scoring. Connect any AI agent through the built-in MCP server, call it over REST/gRPC, drive it from the Python SDK, or embed it directly in the JVM.
 
-Spector is an open-source, high-performance cognitive memory system built entirely on modern Java 25. It's designed for developers who want sub-millisecond memory retrieval, native AI agent integration, and zero infrastructure complexity. Drop in a JAR, write a few lines of code, and you have production-grade cognitive memory with built-in agent support.
+Spector is an open-source, high-performance cognitive memory system. It delivers sub-millisecond memory retrieval, native AI agent integration, and zero infrastructure complexity — reach it from any language over MCP or REST/gRPC, use the Python SDK, or embed it as a single JAR. Every user, agent, or tenant is physically isolated in its own on-disk namespace. Under the hood, modern Java 25, Project Panama, and the Vector API deliver the performance.
 
 ---
 
@@ -53,7 +53,7 @@ graph LR
 
 ### 🤖 Agent-Native (MCP Protocol)
 
-Includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server with 16 tools. AI agents connect directly via JSON-RPC — no Python frameworks, no network round-trips.
+Includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server with 16 cognitive memory tools. AI agents connect directly via JSON-RPC — no adapter layer, no network round-trips.
 
 | Feature | Python Vector DB MCP | **Spector MCP** |
 |:---|:---|:---|
@@ -67,9 +67,17 @@ Includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) s
 > [!TIP]
 > See the [MCP Server Guide](sdk-usage/mcp-server.md) to connect Claude Desktop, Cursor, or any MCP client in minutes.
 
-### 📦 Pure Java, Zero Dependencies
+### � Associative Cognitive Graphs
 
-Unlike most vector databases that rely on C++, Rust, or Python bindings, Spector is 100% Java. It uses the JDK's own Vector API for SIMD acceleration — no JNI, no native libraries, no external infrastructure.
+Spector doesn't just store vectors — it links memories. Hebbian co-activation, temporal chains, and an LLM-powered entity graph connect related memories, and spreading activation means recall surfaces what's *related*, not just what matches. It's memory that forms associations, the way a brain does.
+
+### 🔒 Physical Namespace Isolation
+
+Every user, agent, or tenant's memory lives in its own on-disk directory tree — true data separation, not a `WHERE tenant_id = ?` filter over a shared store. Namespaces are hash-sharded to scale to millions and encrypted at rest (AES-256-GCM).
+
+### �📦 Pure-Java Engine, Zero Dependencies
+
+Unlike most vector databases that rely on C++, Rust, or Python bindings, Spector's engine is pure Java — no JNI, no native libraries, no external infrastructure to install. It uses the JDK's own Vector API for SIMD acceleration.
 
 > [!TIP]
 > Add the JAR to your classpath and you're done. No Docker, no clusters, no ops.
@@ -164,7 +172,7 @@ Spector offers two quantization paths:
 
 ### 🤖 Agentic AI Memory
 
-Connect AI agents (Claude, Cursor, custom) directly to Spector via the built-in MCP server. The agent autonomously ingests documents, searches for relevant context, and retrieves information — all with zero Python glue-code. *"Point your LLM at Spector's MCP port, and it instantly has mathematically-perfect long-term memory."*
+Connect AI agents (Claude, Cursor, custom) directly to Spector via the built-in MCP server. The agent autonomously ingests documents, searches for relevant context, and retrieves information — all with zero glue-code. *"Point your LLM at Spector's MCP port, and it instantly has mathematically-perfect long-term memory."*
 
 ### 🔍 Semantic Search & Recall Applications
 
@@ -190,15 +198,15 @@ Drop Spector into existing Java applications without infrastructure changes. Per
 > **Choose Spector when:**
 > - You want AI agents to autonomously manage their memories (MCP integration)
 > - You want sub-millisecond hybrid recall without infrastructure complexity
-> - Your stack is Java/JVM and you want native integration
-> - You need an embedded cognitive memory library with server-mode option
+> - You work in any language — connect over MCP or REST/gRPC, drive it from the Python SDK, or embed it natively in the JVM
+> - You need cognitive memory that forms associations, not just a vector store
 > - You want GPU acceleration without leaving the JVM
 > - Zero external dependencies matters to your deployment
 
 > [!WARNING]
 > **Consider alternatives when:**
 > - You need a managed cloud service with zero ops
-> - Your team primarily works in Python/Rust/Go
+> - You need multi-modal retrieval across images, audio, and video out of the box
 > - You need built-in ML model serving
 
 ---

--- a/docs/docs/architecture/mcp-integration.md
+++ b/docs/docs/architecture/mcp-integration.md
@@ -1,19 +1,19 @@
 ---
 title: "MCP Integration — Model Context Protocol Server"
-description: "Connect AI agents to Spector via the built-in MCP server. 13 tools for search, memory, and cognitive operations. Works with Claude Desktop, Cursor, and custom agents."
+description: "Connect AI agents to Spector via the built-in MCP server — 16 cognitive memory tools for storing, recalling, and introspecting memory. Works with Claude Desktop, Cursor, and custom agents."
 ---
 
 # 🤖 MCP Integration Architecture
 
-> **Spector's built-in Model Context Protocol (MCP) server gives any AI agent instant, in-process access to SIMD-accelerated vector search — with zero network overhead.**
+> **Spector's built-in Model Context Protocol (MCP) server gives any AI agent instant, in-process access to SIMD-accelerated cognitive memory — with zero network overhead.**
 
 ---
 
 ## Overview
 
-The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is Anthropic's open standard for connecting AI agents to external data sources. Instead of writing custom Python glue-code with orchestration frameworks, agents connect directly to an MCP server via JSON-RPC and autonomously invoke tools.
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is Anthropic's open standard for connecting AI agents to external data sources. Instead of writing custom glue-code with orchestration frameworks, agents connect directly to an MCP server via JSON-RPC and autonomously invoke tools.
 
-**Spector's MCP server runs in-process.** When Claude Desktop or Cursor calls `engine_search`, the request goes from JSON-RPC → Java method call → SIMD kernel — never touching a network socket. This makes Spector **23–113× faster than Python-based MCP servers** that route through HTTP/gRPC.
+**Spector's MCP server runs in-process.** When Claude Desktop or Cursor calls `memory_recall`, the request goes from JSON-RPC → Java method call → SIMD kernel — never touching a network socket. This makes Spector **23–113× faster than Python-based MCP servers** that route through HTTP/gRPC.
 
 Spector supports **two MCP transports**:
 
@@ -41,21 +41,12 @@ graph LR
             PP["\ud83d\udcac SpectorPromptProvider"]
         end
 
-        subgraph "Engine Tools"
-            T1["EngineSearchTool"]
-            T2["EngineHybridSearchTool"]
-            T3["EngineRagTool"]
-            T4["EngineIngestTool"]
-            T5["EngineDeleteTool"]
-            T6["EngineStatusTool"]
-        end
-
-        subgraph "Memory Tools"
+        subgraph "Cognitive Memory Tools — 16"
             M1["MemoryRememberTool"]
             M2["MemoryRecallTool"]
             M3["MemoryForgetTool"]
             M4["MemoryIntrospectTool"]
-            M5["... 11 more"]
+            M5["... 12 more"]
         end
 
         subgraph Foundation
@@ -69,8 +60,8 @@ graph LR
         Runtime["\u26a1 SpectorRuntime<br/><i>Composition Root</i>"]
     end
 
-    subgraph "spector-engine"
-        Engine["\ud83d\udd27 SpectorEngine"]
+    subgraph "spector-memory"
+        Memory["\ud83e\udde0 SpectorMemory"]
     end
 
     subgraph "spector-core"
@@ -82,14 +73,13 @@ graph LR
     StdioTransport --> Server
     HttpTransport --> Server
     Server --> TR & RP & PP
-    TR --> T1 & T2 & T3 & T4 & T5 & T6
-    T1 & T2 & T3 & T4 & T5 & T6 --> TH
-    T1 & T2 & T3 & T4 & T5 & T6 --> SB
-    T1 & T2 & T3 --> RF
-    T6 --> RF
-    T1 & T2 & T3 & T4 & T5 & T6 --> Runtime
-    Runtime --> Engine
-    Engine --> SIMD
+    TR --> M1 & M2 & M3 & M4 & M5
+    M1 & M2 & M3 & M4 & M5 --> TH
+    M1 & M2 & M3 & M4 & M5 --> SB
+    M1 & M2 & M3 & M4 & M5 --> RF
+    M1 & M2 & M3 & M4 & M5 --> Runtime
+    Runtime --> Memory
+    Memory --> SIMD
 ```
 
 ### Data Flow
@@ -100,25 +90,25 @@ sequenceDiagram
     participant MCP as \ud83d\udce1 MCP Transport (stdio / Streamable HTTP)
     participant Handler as \ud83d\udd27 McpToolHandler
     participant Runtime as \u26a1 SpectorRuntime
-    participant Engine as \ud83d\udd27 SpectorEngine
+    participant Memory as \ud83e\udde0 SpectorMemory
     participant SIMD as \ud83d\udd2c SIMD Kernel
 
-    Agent->>MCP: tools/call {"name": "engine_search", "arguments": {"query": "..."}}
-    MCP->>Handler: EngineSearchTool.execute(runtime, args)
+    Agent->>MCP: tools/call {"name": "memory_recall", "arguments": {"query": "..."}}
+    MCP->>Handler: MemoryRecallTool.execute(runtime, args)
     
     Note over Handler: requireString(args, "query")<br/>optionalInt(args, "top_k", 5)
     
-    Handler->>Runtime: runtime.search().query(query, topK)
-    Runtime->>Engine: engine.search(query, topK)
-    Engine->>SIMD: HNSW traversal (off-heap MemorySegment)
-    SIMD-->>Engine: ScoredResult[] (~100µs)
-    Engine-->>Runtime: SearchResponse
+    Handler->>Runtime: runtime.memory().recall(query, topK)
+    Runtime->>Memory: memory.recall(query, topK)
+    Memory->>SIMD: Fused scoring: sim × importance × decay (off-heap MemorySegment)
+    SIMD-->>Memory: ScoredMemory[] (~0.13ms)
+    Memory-->>Runtime: RecallResult
     Runtime-->>Handler: SpectorResult[]
     
-    Note over Handler: ResultFormatter.formatSearchResults()<br/>McpToolHandler.textResult()
+    Note over Handler: ResultFormatter.formatRecallResults()<br/>McpToolHandler.textResult()
     
     Handler-->>MCP: CallToolResult (text content)
-    MCP-->>Agent: {"content": [{"type": "text", "text": "Found 5 results..."}]}
+    MCP-->>Agent: {"content": [{"type": "text", "text": "Recalled 5 memories..."}]}
 ```
 
 ---
@@ -133,26 +123,25 @@ spector-mcp/src/main/java/com/spectrayan/spector/mcp/
 │   └── ToolSchemaBuilder.java     ← Type-safe fluent builder for JSON schemas
 ├── tools/
 │   ├── McpToolHandler.java        ← Abstract base with timing, error handling
-│   ├── SpectorToolRegistry.java   ← Mode-aware tool discovery & registration
-│   ├── engine/                    ← Engine tools (available in SEARCH/HYBRID mode)
-│   │   ├── EngineSearchTool.java
-│   │   ├── EngineHybridSearchTool.java
-│   │   ├── EngineRagTool.java
-│   │   ├── EngineIngestTool.java
-│   │   ├── EngineDeleteTool.java
-│   │   └── EngineStatusTool.java
-│   └── memory/                    ← Memory tools (available in MEMORY/HYBRID mode)
+│   ├── SpectorToolRegistry.java   ← Tool discovery & registration
+│   └── memory/                    ← 16 cognitive memory tools
+│       ├── MemoryToolHandler.java     ← Memory-aware base handler
 │       ├── MemoryRememberTool.java
 │       ├── MemoryRecallTool.java
-│       ├── MemoryForgetTool.java
+│       ├── MemoryScratchpadTool.java
 │       ├── MemoryReinforceTool.java
+│       ├── MemoryForgetTool.java
+│       ├── MemoryStatusTool.java
+│       ├── MemoryIntrospectTool.java
 │       ├── MemorySuppressTool.java
 │       ├── MemoryResolveTool.java
-│       ├── MemoryIntrospectTool.java
-│       ├── MemoryScratchpadTool.java
 │       ├── MemoryReminderTool.java
 │       ├── MemoryWhyNotTool.java
-│       └── MemoryStatusTool.java
+│       ├── MemoryComputeImportanceTool.java
+│       ├── MemoryInspectTool.java
+│       ├── MemoryExportTool.java
+│       ├── MemoryBrowseTool.java
+│       └── MemorySalienceTool.java
 ├── resources/
 │   └── SpectorResourceProvider.java   ← Resource definitions & handlers
 ├── prompts/
@@ -165,75 +154,26 @@ spector-mcp/src/main/java/com/spectrayan/spector/mcp/
 
 ## Tool Reference
 
-### `engine_search`
+The MCP server exposes **16 cognitive memory tools**. All are registered when cognitive memory is enabled (`spector.memory.enabled: true`). Memory tools embed text to store and recall memories, so an embedding provider (e.g., Ollama) must be configured.
 
-Performs semantic similarity search using vector embeddings. Requires an embedding provider (e.g., Ollama) to be configured.
-
-| Parameter | Type | Required | Default | Description |
-|:---|:---|:---|:---|:---|
-| `query` | string | ✅ | — | Natural language search query |
-| `top_k` | integer | ❌ | 5 | Number of results to return (1–100) |
-
-### `engine_hybrid_search`
-
-Combined keyword (BM25) + semantic (vector) search with reciprocal rank fusion. Falls back to keyword-only if no embedding provider is configured.
-
-| Parameter | Type | Required | Default | Description |
-|:---|:---|:---|:---|:---|
-| `query` | string | ✅ | — | Search query for both keyword and semantic matching |
-| `top_k` | integer | ❌ | 5 | Number of results to return |
-| `mode` | enum | ❌ | `hybrid` | Search mode: `hybrid`, `keyword`, or `vector` |
-
-### `engine_rag`
-
-Retrieval-Augmented Generation — retrieves relevant context with source citations formatted for LLM consumption.
-
-| Parameter | Type | Required | Default | Description |
-|:---|:---|:---|:---|:---|
-| `query` | string | ✅ | — | The question or topic to retrieve context for |
-| `top_k` | integer | ❌ | 5 | Number of context passages to retrieve |
-
-### `engine_ingest`
-
-Ingests a document into the search index with automatic embedding and optional chunking.
-
-| Parameter | Type | Required | Default | Description |
-|:---|:---|:---|:---|:---|
-| `id` | string | ✅ | — | Unique document identifier |
-| `content` | string | ✅ | — | Document text content |
-| `title` | string | ❌ | — | Optional document title |
-
-### `engine_delete`
-
-Removes a document from the search index by ID.
-
-| Parameter | Type | Required | Default | Description |
-|:---|:---|:---|:---|:---|
-| `id` | string | ✅ | — | Document ID to delete |
-
-### `engine_status`
-
-Returns engine metadata including document count, dimensions, SIMD capabilities, embedding provider status, and GPU availability.
-
-| Parameter | Type | Required | Default | Description |
-|:---|:---|:---|:---|:---|
-| *(none)* | — | — | — | No input parameters required |
-
-### Memory Tools
-
-| Tool | Parameters | Description |
+| Tool | Key parameters | Description |
 |:---|:---|:---|
-| `memory_remember` | `id`, `text`, `type`, `source`, `tags` | Store a cognitive memory |
-| `memory_recall` | `query`, `top_k`, `tags`, `types` | Cognitive recall across all tiers |
-| `memory_forget` | `id` | Tombstone a memory |
-| `memory_reinforce` | `id`, `valence` | Positive/negative feedback |
-| `memory_suppress` | `id`, `reason` | Suppress from recall |
-| `memory_resolve` | `id` | Mark as resolved |
-| `memory_introspect` | `topic` | Topic knowledge analysis |
-| `memory_scratchpad` | `text` | Quick-write to working memory |
-| `memory_reminder` | `text`, `delay_seconds`, `tags` | Schedule future reminder |
-| `memory_why_not` | `memory_id`, `query`, `top_k` | Explain why not recalled |
-| `memory_status` | *(none)* | Tier counts and partition info |
+| `memory_remember` | `text` (req), `tier`, `tags`, `source`, `interest`/`challenge`/`urgency`, `valence`, `arousal` | Store a memory with cognitive metadata (ID auto-generated) |
+| `memory_recall` | `query` (req), `top_k`, `profile`, `synaptic_filter`, `min_importance`, `point_in_time` | Fused cognitive recall across all tiers |
+| `memory_scratchpad` | `text` (req) | Quick-write a short-lived note to working memory |
+| `memory_reinforce` | `memory_id` (req), `valence` (req) | Report a positive/negative outcome for a memory |
+| `memory_forget` | `memory_id` (req) | Tombstone a memory by ID |
+| `memory_status` | *(none)* | Memory tier counts and persistence info |
+| `memory_introspect` | `topic` (req) | Metamemory self-analysis on a topic |
+| `memory_suppress` | `memory_id` (req), `action` (req), `reason` | Suppress or unsuppress a memory from recall |
+| `memory_resolve` | `memory_id` (req), `resolved` (req) | Mark a memory resolved/unresolved (Zeigarnik) |
+| `memory_reminder` | `text` (req), `delay_seconds` (req), `tags` | Schedule a time-triggered reminder |
+| `memory_why_not` | `memory_id` (req), `query` (req), `top_k` | Explain why a memory was not recalled |
+| `memory_compute_importance` | `text` (req), `interest`/`challenge`/`urgency`, `valence`, `arousal` | Preview importance without storing |
+| `memory_inspect` | `id` (req) | Full cognitive X-ray of a memory |
+| `memory_export` | `format` | Bulk export of all live memories |
+| `memory_browse` | `tags` (req) | Browse memories by tag (AND semantics, no vector search) |
+| `memory_salience` | `operation` (req), profile fields | Inspect and tune the active salience profile |
 
 ---
 
@@ -248,7 +188,7 @@ public abstract class McpToolHandler {
     abstract String name();
     abstract String description();
     abstract Map<String, Object> inputSchema();
-    abstract CallToolResult execute(SpectorEngine engine, Map<String, Object> args);
+    abstract CallToolResult execute(SpectorRuntime runtime, Map<String, Object> args);
 
     // Base class automatically provides:
     // - Timing wrapper (nanoTime → milliseconds)
@@ -262,24 +202,19 @@ Define the tool schema with `ToolSchemaBuilder`:
 
 ```java
 var schema = ToolSchemaBuilder.object()
-    .requiredString("query", "Natural language search query.")
+    .requiredString("query", "Natural language query for memory recall.")
     .optionalInt("top_k", "Number of results to return.", 5)
-    .optionalEnum("mode", "Search mode.", "hybrid", "hybrid", "keyword", "vector")
+    .optionalString("profile", "Cognitive scoring profile preset.", "")
     .build();
 ```
 
-Register the tool in `SpectorToolRegistry.handlers()`:
+Register the tool in `SpectorToolRegistry.handlers()` — one line per tool:
 
 ```java
-List.of(
-    new EngineSearchTool(),
-    new EngineHybridSearchTool(),
-    new EngineRagTool(),
-    new EngineIngestTool(),
-    new EngineDeleteTool(),
-    new EngineStatusTool(serverVersion)
-    // new YourNewTool()  ← just add here
-);
+handlers.add(new MemoryRememberTool(memory));
+handlers.add(new MemoryRecallTool(memory));
+// ... 14 more cognitive memory tools
+// handlers.add(new YourNewTool(memory));  ← just add here
 ```
 
 ---
@@ -313,7 +248,7 @@ graph LR
 graph LR
     A2["🤖 Agent"] --> B2["JSON-RPC"]
     B2 --> C2["☕ Virtual Thread"]
-    C2 --> D2["SpectorEngine.search()"]
+    C2 --> D2["SpectorMemory.recall()"]
     D2 --> E2["Off-heap MemorySegment"]
     E2 --> F2["SIMD registers"]
     F2 --> G2["✅ Results"]
@@ -339,11 +274,10 @@ graph LR
 ## Security Considerations
 
 > [!WARNING]
-> The `engine_ingest` and `engine_delete` tools allow agents to modify the search index. In production environments, consider:
-> - Running the MCP server in read-only mode (expose only search tools)
-> - Using `SEARCH` mode to disable memory write tools
-> - Implementing document-level access control
-> - Rate limiting ingestion operations
+> Several tools mutate memory state — `memory_remember`, `memory_forget`, `memory_suppress`, `memory_reinforce`, `memory_resolve`, and `memory_scratchpad`. In production environments, consider:
+> - Restricting write tools via OAuth 2.1 scopes (`memory:write`) — Spector Enterprise filters tools at `list_tools` time and enforces them per request
+> - Implementing namespace/tenant-level access control
+> - Rate limiting write operations
 > - Auditing all write operations
 
 ---

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -24,7 +24,7 @@ graph TB
     end
 
     subgraph Transport["Transport Layer"]
-        mcp["MCP Server<br/><i>stdio · Streamable HTTP · 21 tools (6 search + 15 memory)</i>"]
+        mcp["MCP Server<br/><i>stdio · Streamable HTTP · 16 cognitive memory tools</i>"]
         armeria["Armeria Server :7070<br/><i>REST + gRPC + SSE streaming</i>"]
     end
 
@@ -172,34 +172,26 @@ graph TB
 
     subgraph MCP["MCP Server — Dual Transport · JSON-RPC 2.0"]
         transport["Transport Layer<br/><i>stdio (stdin/stdout) for CLI agents<br/>Streamable HTTP (/mcp) for remote agents</i>"]
-        registry["SpectorToolRegistry<br/><i>21 tools · auto-registration</i>"]
+        registry["SpectorToolRegistry<br/><i>16 tools · auto-registration</i>"]
         handler["McpToolHandler<br/><i>Base class · thread-safe · virtual threads</i>"]
 
-        subgraph Engine["Engine Tools — 6"]
-            e1["engine_search — Semantic vector search"]
-            e2["engine_hybrid_search — Vector + BM25 + RRF"]
-            e3["engine_rag — RAG with context assembly"]
-            e4["engine_ingest — File/text ingestion"]
-            e5["engine_delete — Document removal"]
-            e6["engine_status — Index stats & health"]
-        end
-
-        subgraph Mem["Cognitive Memory Tools — 15"]
+        subgraph Mem["Cognitive Memory Tools — 16"]
             m1["memory_remember — Store with importance & tags"]
             m2["memory_recall — Fused SIMD scoring recall"]
-            m3["working_memory_scratchpad — Reasoning scratch space"]
+            m3["memory_scratchpad — Working-memory scratch space"]
             m4["memory_reinforce — Outcome feedback +/-"]
             m5["memory_forget — Intentional forgetting"]
             m6["memory_status — Per-tier statistics"]
             m7["memory_introspect — Self-reflection"]
             m8["memory_suppress — Temporary suppression"]
-            m9["memory_resolve — Conflict resolution"]
+            m9["memory_resolve — Mark resolved/unresolved"]
             m10["memory_reminder — Proactive reminders"]
             m11["memory_why_not — Explain recall misses"]
             m12["memory_compute_importance — Pre-ingestion scoring"]
             m13["memory_inspect — Full cognitive X-ray"]
             m14["memory_export — Bulk memory export"]
             m15["memory_browse — Browse by tag/tier"]
+            m16["memory_salience — Tune salience profile"]
         end
     end
 
@@ -210,12 +202,11 @@ graph TB
     end
 
     Agents -->|stdio / HTTP| transport --> registry --> handler
-    handler --> Engine & Mem
-    Engine & Mem --> runtime --> simd --> panama
+    handler --> Mem
+    Mem --> runtime --> simd --> panama
 
     style Agents fill:#5b6abf,stroke:#e94560,color:#fff
     style MCP fill:#4a6fa5,stroke:#3b82f6,color:#fff
-    style Engine fill:#3b82f6,stroke:#7c3aed,color:#fff
     style Mem fill:#7c3aed,stroke:#e94560,color:#fff
     style Core fill:#5b6abf,stroke:#e94560,color:#fff
 ```
@@ -244,11 +235,11 @@ sequenceDiagram
     Runtime->>SIMD: Fused scoring: sim × importance × decay
     SIMD-->>Agent: 📋 Ranked memories (~0.13ms)
 
-    Agent->>MCP: tools/call {"name": "engine_hybrid_search", ...}
-    MCP->>Tools: Route → EngineHybridSearchTool
-    Tools->>Runtime: search().hybridSearch(text, topK)
-    Runtime->>SIMD: Parallel HNSW + BM25 → RRF
-    SIMD-->>Agent: 🔍 Ranked results (~88µs)
+    Agent->>MCP: tools/call {"name": "memory_introspect", ...}
+    MCP->>Tools: Route → MemoryIntrospectTool
+    Tools->>Runtime: memory().introspect(topic)
+    Runtime->>SIMD: Confidence + knowledge-gap analysis over tiers
+    SIMD-->>Agent: 🔍 Knowledge report (~0.2ms)
 ```
 
 ### Performance: MCP-Native vs. Adapter Pattern
@@ -258,7 +249,7 @@ sequenceDiagram
 | **Architecture** | Engine + MCP in one JVM | Python → HTTP → DB → HTTP → agent |
 | **Search latency** | **88µs** (SIMD) | 5–50ms (network round-trip) |
 | **Memory recall** | **0.13ms** (fused scoring) | 50–200ms (Mem0/Letta/Zep) |
-| **Tools** | **21** (6 engine + 15 cognitive) | 3–5 basic CRUD |
+| **Tools** | **16** (cognitive memory tools) | 3–5 basic CRUD |
 | **GC pressure** | **Zero** (Panama off-heap) | Full GC overhead |
 | **Deployment** | `java -jar spector.jar` | Python + pip + DB + config |
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,15 +1,15 @@
 ---
 title: "Spector — Zero-Overhead AI Memory & Cognitive Graph"
-description: "Spector is a Java-native AI cognitive memory system combining SIMD-accelerated dense vector similarity, BM25 text matching, SPLADE sparse retrieval, and associative graph capabilities."
+description: "Spector is a cognitive memory backbone for AI agents — biologically-inspired memory tiers and associative graphs with fused semantic and hybrid retrieval, a built-in MCP server, and sub-millisecond recall."
 ---
 
 # ⚡ Spector — The AI Memory Backbone
 
-> **Zero-overhead, agent-ready AI cognitive memory — embedded in a single JVM.**
+> **Agent-ready cognitive memory that forms associations — sub-millisecond recall, zero infrastructure.**
 
-Spector is a **Java-native AI cognitive memory system** that combines SIMD-accelerated dense vector similarity, keyword matching (BM25), SPLADE learned sparse retrieval, associative Hebbian graphs, and biologically-inspired memory consolidation into a single embeddable library. No Docker, no external databases, no Python — just a JAR.
+Spector gives AI agents real memory: it **remembers, forgets, consolidates, and forms associations** across working, episodic, semantic, and procedural tiers, linked by Hebbian, temporal, and entity graphs. Retrieval fuses dense semantic search with hybrid signals and cognitive scoring for sub-millisecond recall.
 
-Connect AI agents via the **built-in MCP server** (Claude Desktop, Cursor, custom agents), embed directly in your Spring Boot app, or run standalone. Spector delivers **sub-millisecond recall** at scale with **zero garbage collection pressure** thanks to Project Panama off-heap memory.
+Connect your agents through the **built-in MCP server** (Claude Desktop, Cursor, custom agents), call it over **REST/gRPC**, use the **Python SDK**, or embed it as a single JAR — no external database, no infrastructure to run. Every user, agent, or tenant is physically isolated in its own on-disk namespace. Java Project Panama keeps it all off-heap with zero GC pressure.
 
 ---
 
@@ -66,7 +66,7 @@ Connect AI agents via the **built-in MCP server** (Claude Desktop, Cursor, custo
 
 ## 💡 How It Works
 
-Spector combines **three search modalities** — semantic vectors, keyword matching, and cognitive scoring — into a single fused pipeline:
+Spector fuses **semantic vector search, hybrid retrieval, and cognitive scoring** into a single pipeline:
 
 ```mermaid
 graph LR
@@ -84,8 +84,9 @@ graph LR
 
 ### What Makes Spector Different
 
-- **Embedded deployment** — runs as a library inside your JVM. No Docker, no servers, no network hops.
-- **Agent-native** — 13 MCP tools for search, memory, and cognitive operations. Connect Claude Desktop or Cursor in one config line.
+- **Flexible deployment** — connect over MCP or REST/gRPC, drive it from the Python SDK, or embed it as a library inside your JVM. No Docker, no external database, no network hops when embedded.
+- **Agent-native** — 16 MCP tools for memory, recall, and cognitive operations. Connect Claude Desktop or Cursor in one config line.
+- **Associative memory** — Hebbian co-activation, temporal chains, and entity graphs with spreading activation, so recall surfaces what's *related*, not just what matches.
 - **Cognitive memory** — the only system combining power-law decay, Two-Factor strengthening (Bjork & Bjork), emotional valence, and Hebbian association in a single scoring formula.
 - **Zero GC pressure** — all vector data and headers live off-heap via Project Panama. The JVM garbage collector never sees memory records.
 - **SIMD everywhere** — vector distance, quantization, and scoring use Java Vector API (AVX2/AVX-512/NEON) for hardware-accelerated computation.
@@ -105,7 +106,7 @@ graph LR
 | **Dependencies** | Zero (JDK only) |
 | **SIMD** | AVX2 / AVX-512 / NEON |
 | **GPU** | CUDA via Panama FFM |
-| **MCP** | Built-in, 13 agent-ready tools |
+| **MCP** | Built-in, 16 agent-ready tools |
 | **Distributed** | gRPC fan-out + consistent hashing |
 
 ---

--- a/docs/docs/llms.txt
+++ b/docs/docs/llms.txt
@@ -2,13 +2,13 @@
 
 > The Zero-Overhead, Agent-Ready AI Memory Backbone.
 
-Spector is a Java-native AI search engine and cognitive memory system. It uses Project Panama for off-heap memory (zero GC), Java Vector API for SIMD-accelerated search (AVX2/AVX-512/NEON), and includes a built-in MCP server for AI agent integration.
+Spector is an agent-ready AI cognitive memory backbone. It gives AI agents memory that remembers, forgets, consolidates, and forms associations across biologically-inspired tiers linked by Hebbian, temporal, and entity graphs, with fused semantic and hybrid retrieval. Connect agents through the built-in MCP server, call it over REST/gRPC, drive it from the Python SDK, or embed it in the JVM. Under the hood, Project Panama (off-heap, zero GC) and the Java Vector API (AVX2/AVX-512/NEON) deliver the performance.
 
 ## Key Features
 
 - SIMD-accelerated vector search: 88µs p50, 61K QPS
 - Cognitive Memory: biologically-inspired 4-tier memory engine with 0.13ms recall at 1M memories
-- Built-in MCP Server with 13 tools (6 search + 7 cognitive memory)
+- Built-in MCP Server with 16 cognitive memory tools
 - 100% off-heap Panama storage — zero garbage collection pressure
 - SVASQ quantization: Float32 recall at INT8 memory sizes (99.5%+ recall)
 - Hybrid search: semantic (HNSW) + keyword (BM25) with RRF fusion

--- a/docs/docs/memory/getting-started.md
+++ b/docs/docs/memory/getting-started.md
@@ -215,7 +215,7 @@ Then configure your agent:
 }
 ```
 
-With `memory.enabled: true`, the MCP server registers all 13 tools (6 search + 7 cognitive memory).
+With `memory.enabled: true`, the MCP server registers all 16 cognitive memory tools.
 
 ---
 

--- a/docs/docs/sdk-usage/mcp-server.md
+++ b/docs/docs/sdk-usage/mcp-server.md
@@ -40,14 +40,14 @@ Add the following to your agent's MCP configuration (see per-agent sections belo
 
 ### 3. Start Using
 
-Your AI agent now has access to up to 21 tools. With cognitive memory enabled (`spector.memory.enabled: true`), all tools are registered. In `SEARCH` mode, only the 6 engine tools are available:
+With cognitive memory enabled (`spector.memory.enabled: true`), your AI agent now has access to all 16 cognitive memory tools:
 
-- *"Search for documents about SIMD acceleration"* → `engine_search`
-- *"Find articles mentioning 'Panama' and related to memory management"* → `engine_hybrid_search`
-- *"What does the codebase say about quantization?"* → `engine_rag`
-- *"Add this document to the index: ..."* → `engine_ingest`
 - *"Remember that the user prefers dark mode"* → `memory_remember`
 - *"What do you remember about the user's preferences?"* → `memory_recall`
+- *"That answer was wrong — downgrade it"* → `memory_reinforce`
+- *"Jot this down while I think it through"* → `memory_scratchpad`
+- *"What do you actually know about this project?"* → `memory_introspect`
+- *"Forget what I told you about the old API key"* → `memory_forget`
 
 ---
 
@@ -227,7 +227,7 @@ curl -X POST http://localhost:7070/mcp \
 # Step 3: Call a tool
 curl -X POST http://localhost:7070/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"engine_status","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"memory_status","arguments":{}}}'
 ```
 
 > [!TIP]
@@ -237,20 +237,7 @@ curl -X POST http://localhost:7070/mcp \
 
 ## MCP Tools Overview
 
-Once connected, your agent has access to these tools:
-
-### Engine Tools (available in SEARCH and HYBRID mode)
-
-| Tool | Description | Requires Embedding |
-|:---|:---|:---|
-| `engine_search` | Vector similarity search | ✅ |
-| `engine_hybrid_search` | Keyword + vector with RRF fusion | Partial (keyword mode works without) |
-| `engine_rag` | Retrieval-Augmented Generation context | ✅ |
-| `engine_ingest` | Add documents to the index | ✅ (for auto-embedding) |
-| `engine_delete` | Remove documents by ID | ❌ |
-| `engine_status` | Engine capabilities and stats | ❌ |
-
-### Memory Tools (available in MEMORY and HYBRID mode)
+Once connected, your agent has access to Spector's 16 cognitive memory tools:
 
 | Tool | Description |
 |:---|:---|
@@ -262,13 +249,14 @@ Once connected, your agent has access to these tools:
 | `memory_forget` | Tombstone a memory by ID |
 | `memory_reinforce` | Report positive/negative outcome for a memory |
 | `memory_suppress` | Suppress a memory from recall results |
-| `memory_resolve` | Mark a memory as resolved |
+| `memory_resolve` | Mark a memory as resolved or unresolved |
 | `memory_introspect` | Metamemory self-analysis on a topic |
 | `memory_compute_importance` | Read-only importance estimation for text |
 | `memory_scratchpad` | Quick-write to working memory |
 | `memory_reminder` | Schedule a time-triggered reminder |
 | `memory_why_not` | Explain why a memory was not recalled |
 | `memory_status` | Memory tier counts and persistence info |
+| `memory_salience` | Inspect and tune the active salience profile |
 
 > [!NOTE]
 > For full tool schemas and parameter details, see the [MCP Integration Architecture](../architecture/mcp-integration.md#tool-reference) page.
@@ -285,7 +273,7 @@ Once connected, your agent has access to these tools:
 
 ### "Embedding provider not configured" errors
 
-The `engine_search` and `engine_rag` tools require an embedding provider. Ensure:
+The cognitive memory tools embed text to store and recall memories, so they require an embedding provider. Ensure:
 
 1. Ollama is running: `ollama serve`
 2. The model is pulled: `ollama pull nomic-embed-text`

--- a/docs/docs/sdk-usage/python-sdk.md
+++ b/docs/docs/sdk-usage/python-sdk.md
@@ -7,7 +7,7 @@ description: "Install and use the Spector Python SDK to control cognitive memory
 
 > **Zero-dependency Python client wrapping Spector's MCP server.**
 
-The Python SDK spawns the Spector JVM as a subprocess and communicates via JSON-RPC 2.0 over stdio. All 21 MCP tools are accessible through a clean Pythonic API.
+The Python SDK spawns the Spector JVM as a subprocess and communicates via JSON-RPC 2.0 over stdio. All 16 MCP tools are accessible through a clean Pythonic API.
 
 ---
 
@@ -188,7 +188,7 @@ logging.getLogger("spector").setLevel(logging.DEBUG)
 │   Python SDK     │  ─────── stdio ──────────►    │  Spector JVM     │
 │                  │                                │  (MCP Server)    │
 │  SpectorClient   │  ◄────── stdout ──────────    │                  │
-│  ├── memory      │                                │  21 MCP tools    │
+│  ├── memory      │                                │  16 MCP tools    │
 │  └── engine      │         stderr → logging       │  Off-heap memory │
 └──────────────────┘                                └──────────────────┘
 ```

--- a/docs/docs/why-spector.md
+++ b/docs/docs/why-spector.md
@@ -5,7 +5,7 @@ description: "Why existing databases can't solve AI memory — and how Spector's
 
 # Why Spector?
 
-> **The short answer**: AI memory requires fusing semantic similarity, temporal decay, emotional valence, and adaptive importance into a single sub-millisecond ranking decision. No existing database — SQL, NoSQL, or vector — can do this. Spector was built from scratch to solve exactly this problem.
+> **The short answer**: AI memory requires fusing semantic similarity, temporal decay, emotional valence, adaptive importance, and the associations *between* memories into a single sub-millisecond ranking decision. No existing database — SQL, NoSQL, or vector — can do this. Spector was built from scratch to solve exactly this problem.
 
 ---
 
@@ -75,7 +75,7 @@ Spector models memory the way brains do — based on peer-reviewed cognitive sci
 
 ### 3. Zero Dependencies, Flexible Deployment
 
-Spector runs anywhere the JVM runs — no Docker, no Python, no external services:
+Spector needs no Docker, no external database, and no extra services. Reach it from any language over MCP or REST/gRPC, drive it from the Python SDK, or embed it directly:
 
 - **Embedded library**: Add a single JAR to your Java/Kotlin/Scala application
 - **Standalone server**: REST + gRPC + MCP APIs on a single port
@@ -85,7 +85,7 @@ Spector runs anywhere the JVM runs — no Docker, no Python, no external service
 
 ### 4. Built-In MCP Server
 
-Spector includes a 13-tool MCP server for AI agent integration — Claude Desktop, Cursor, and custom agents can use cognitive memory out of the box. No wrapper libraries needed.
+Spector includes a 16-tool MCP server for AI agent integration — Claude Desktop, Cursor, and custom agents can use cognitive memory out of the box. No wrapper libraries needed.
 
 ### 5. Enterprise-Grade Security
 
@@ -111,7 +111,7 @@ Every tenant gets physically separate files with independent encryption keys:
 | **Off-heap / Zero GC** | ✅ Panama FFM | N/A | Partial | ✅ (Rust) | Partial | ❌ | N/A |
 | **Fused cognitive scoring** | ✅ 6-phase pipeline | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Hybrid search** | ✅ HNSW + BM25 + RRF | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| **Built-in MCP server** | ✅ 13 tools | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Built-in MCP server** | ✅ 16 tools | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Cognitive memory** | ✅ 4-tier, bio-inspired | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Quantization** | SVASQ-8/4, IVF-PQ | ✅ | ✅ BQ | ✅ SQ/PQ | ✅ IVF-PQ/SQ | ❌ | ❌ |
 | **GPU acceleration** | ✅ CUDA via Panama | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
@@ -139,7 +139,7 @@ Every tenant gets physically separate files with independent encryption keys:
 ## When to Choose Something Else
 
 - You need a **managed cloud service** with zero ops → Pinecone
-- You're building in **Python** and want the simplest path → ChromaDB
+- You want a **pure-Python** library with no JVM in the process at all → ChromaDB
 - You already have **PostgreSQL** and just want to add basic vector search → pgvector
 - You need **multi-modal** search (images, video, audio) → Weaviate, Milvus
 


### PR DESCRIPTION
## Summary

Repositions the top-of-funnel docs/README per the CEO-approved copy in #450 and its three refinement comments. **Docs/README only — no code changes.**

- **Lead with agent-ready cognitive memory that forms associations** (Hebbian co-activation, temporal chains, entity links, spreading activation). Access paths — MCP server (stdio + Streamable HTTP), REST/gRPC, Python SDK, JVM-embed — are presented as natural capabilities, not a defensive "language-agnostic/polyglot" label.
- **Removed exclusionary framing** ("no Python", "Java-only", "100% Java" as who-can-use-it). Kept "pure-Java, no JNI/native deps" as an engineering-quality note; reframed Java/Panama/Vector API as the performance engine under the hood.
- **De-emphasized BM25** in hero/positioning copy (README intro, index/about/why-spector heros, headline enumerations). BM25 is preserved in the technical retrieval/architecture deep-dive pages for accuracy.
- **Elevated associative memory graphs** and **physical namespace isolation** (per-namespace on-disk directory trees, hash-sharded, encrypted at rest — framed as true data separation, not access control) as headline differentiators.
- **Reconciled the MCP tool count to 16** (verified — see below) and removed a large body of stale/fictional `engine_*` tool documentation.

## Files changed
`README.md`, `docs/docs/index.md`, `docs/docs/about.md`, `docs/docs/why-spector.md`, `docs/docs/llms.txt`, `docs/docs/sdk-usage/python-sdk.md`, `docs/docs/sdk-usage/mcp-server.md`, `docs/docs/architecture/overview.md`, `docs/docs/architecture/mcp-integration.md`, `docs/docs/memory/getting-started.md`.

## MCP tool count — verified
`SpectorToolRegistry` registers **exactly 16 tools, all `memory_*`** (remember, recall, scratchpad, reinforce, forget, status, introspect, suppress, resolve, reminder, why_not, compute_importance, inspect, export, browse, salience). There are **no `engine_*` MCP tools** anywhere in the codebase. The README's "16" was correct; python-sdk.md ("21"), overview.md ("21 / 6 engine + 15 memory"), mcp-server.md, getting-started.md and llms.txt ("13 / 6 search + 7 memory") were stale. All are now consistently **16 cognitive memory tools**, and the fictional `engine_*` tool catalog in `mcp-integration.md`/`mcp-server.md`/`overview.md` was replaced with the real memory tools.

## Verification
`python -m mkdocs build --clean` (from `docs/`) — **build succeeded, exit 0**. Remaining INFO warnings are pre-existing (nav entries, footnotes, an `index.md#-benchmarks` link that predates this PR).

## Notes / flagged
- `docs/docs/roadmap.md` still lists the historical "6 tools" MCP milestone with old tool names — left as-is (point-in-time roadmap history, out of scope).
- `modules/index.md` / `ingestion-pipeline.md` "SEARCH/MEMORY mode" refer to the **ingestion pipeline** target modes, not MCP tools — intentionally unchanged.

Closes #450