### PR TITLE
refactor(memory): technical debt hardening and SystemMemoryId migration (#466)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
@@ -24,6 +24,8 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 
@@ -98,7 +100,7 @@ final class CognitiveGraphBuilder {
                 try {
                     com.spectrayan.spector.memory.kernel.codec.Codecs.ensureCurrent(
                             com.spectrayan.spector.memory.kernel.codec.Codecs.defaultRegistry(),
-                            com.spectrayan.spector.memory.kernel.MemoryId.of("graph", "hebbian-csr"),
+                            SystemMemoryId.HEBBIAN_CSR.id(),
                             new com.spectrayan.spector.memory.kernel.layout.HebbianLayout(),
                             loadFrom, null, null);
                 } catch (Exception e) {
@@ -126,7 +128,7 @@ final class CognitiveGraphBuilder {
             try {
                 com.spectrayan.spector.memory.kernel.codec.Codecs.ensureCurrent(
                         com.spectrayan.spector.memory.kernel.codec.Codecs.defaultRegistry(),
-                        com.spectrayan.spector.memory.kernel.MemoryId.of("temporal", "chain"),
+                        SystemMemoryId.TEMPORAL_CHAIN.id(),
                         new com.spectrayan.spector.memory.kernel.layout.TemporalLayout(),
                         loadFrom, null, null);
             } catch (Exception e) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
@@ -193,7 +193,7 @@ final class CognitiveGraphBuilder {
         EntityDirectory entityDirectory;
         if (entityEnabled) {
             int dirCap = builder.entityGraphCapacity;
-            TypeRegistryMemory entityTypeRegistry = TypeRegistryMemory.seeded("entity-type", com.spectrayan.spector.memory.graph.EntityType.SEED);
+            TypeRegistryMemory entityTypeRegistry = TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, com.spectrayan.spector.memory.graph.EntityType.SEED);
             if (isDisk && basePath != null) {
                 Path edir = StorageLayout.entityDirectoryRuntime(basePath);
                 if (java.nio.file.Files.exists(edir)) {
@@ -212,7 +212,7 @@ final class CognitiveGraphBuilder {
 
 
         TemporalKnowledgeGraph temporalKnowledgeGraph;
-        TypeRegistryMemory predRegistry = new TypeRegistryMemory("relation-type");
+        TypeRegistryMemory predRegistry = new TypeRegistryMemory(SystemMemoryId.RELATION_TYPE);
         if (isDisk && basePath != null) {
             Path runtimeTkg = StorageLayout.temporalFactsRuntime(basePath);
             long initialSize = 16L * 1024 * 1024; // 16MB

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
@@ -167,15 +167,16 @@ final class MemoryWalRecovery {
                         if (target instanceof com.spectrayan.spector.memory.kernel.shape.RecordMemory<?> rm) {
                             lastRecordOffset = rm.recordOffset(recordId);
                             String pathName = targetId.memoryName();
-                            if ("working".equals(pathName)) lastRecordType = MemoryType.WORKING;
-                            else if ("semantic".equals(pathName)) lastRecordType = MemoryType.SEMANTIC;
-                            else if ("procedural".equals(pathName)) lastRecordType = MemoryType.PROCEDURAL;
-                            else if ("episodic".equals(pathName)) lastRecordType = MemoryType.EPISODIC;
+                            try {
+                                lastRecordType = MemoryType.valueOf(pathName.toUpperCase(java.util.Locale.ROOT));
+                            } catch (IllegalArgumentException e) {
+                                // Unknown or legacy record memory name
+                            }
                         }
                     }
                     case APPEND -> {
                         MemoryId targetId = MemoryId.parse(event.memoryId());
-                        if ("cortex".equals(targetId.namespace()) && "text".equals(targetId.memoryName())) {
+                        if (SystemMemoryId.CORTEX_TEXT.id().equals(targetId)) {
                             lastTextOffset = currentTextCursor;
                             lastTextLength = event.payload().length;
                             currentTextCursor += 4 + lastTextLength;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
@@ -20,9 +20,11 @@ import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
+import com.spectrayan.spector.memory.error.SpectorWalCorruptionException;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.Memory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
@@ -122,14 +124,14 @@ final class MemoryWalRecovery {
             memories.put(hg.id(), hg);
         }
         if (temporalChain != null) {
-            memories.put(MemoryId.of("temporal", "chain"), temporalChain);
+            memories.put(SystemMemoryId.TEMPORAL_CHAIN.id(), temporalChain);
         }
         if (temporalKnowledgeGraph != null) {
             memories.put(temporalKnowledgeGraph.id(), temporalKnowledgeGraph.backing());
         }
 
         // Add textDataStore memory if available
-        MemoryId textId = MemoryId.of("cortex", "text");
+        MemoryId textId = SystemMemoryId.CORTEX_TEXT.id();
         if (index.textDataStore() != null) {
             memories.put(textId, index.textDataStore());
         }
@@ -183,7 +185,12 @@ final class MemoryWalRecovery {
                         if (lastRecordOffset != -1 && lastRecordType != null) {
                             // CognitiveRecordLayout has dynamic stride
                             int stride = 164; // default
-                            MemoryId targetId = MemoryId.of("tier", lastRecordType.name().toLowerCase());
+                            MemoryId targetId = switch (lastRecordType) {
+                                case WORKING -> SystemMemoryId.WORKING.id();
+                                case SEMANTIC -> SystemMemoryId.SEMANTIC.id();
+                                case PROCEDURAL -> SystemMemoryId.PROCEDURAL.id();
+                                case EPISODIC -> SystemMemoryId.EPISODIC.id();
+                            };
                             Memory<?> target = memories.get(targetId);
                             if (target != null) {
                                 stride = target.layout().recordStride();
@@ -199,7 +206,7 @@ final class MemoryWalRecovery {
                                 try {
                                     text = index.textDataStore().readTextDirect(lastTextOffset, lastTextLength);
                                 } catch (Exception e) {
-                                    log.warn("Operation failed: Failed to read text from DataStore", e);
+                                    throw new SpectorWalCorruptionException("Failed to read text from DataStore during WAL index recovery", e);
                                 }
                             }
 
@@ -212,8 +219,8 @@ final class MemoryWalRecovery {
                     default -> {}
                 }
             } catch (Exception e) {
-                log.warn("WAL recovery index sync failed for event seq={}, type={}: {}",
-                        event.sequence(), event.type(), e.getMessage());
+                throw new SpectorWalCorruptionException("WAL recovery index sync failed for event seq=" 
+                        + event.sequence() + ", type=" + event.type(), e);
             }
         }
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemory.java
@@ -22,6 +22,8 @@ import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.MemoryType;
 
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -188,7 +190,12 @@ public abstract class AbstractCognitiveRecordMemory
 
     /** Derives the stable, tier-scoped identity for this store (e.g. {@code tier/semantic}). */
     private static MemoryId tierId(MemoryType type) {
-        return MemoryId.of("tier", type.name().toLowerCase());
+        return switch (type) {
+            case WORKING -> SystemMemoryId.WORKING.id();
+            case SEMANTIC -> SystemMemoryId.SEMANTIC.id();
+            case PROCEDURAL -> SystemMemoryId.PROCEDURAL.id();
+            case EPISODIC -> SystemMemoryId.EPISODIC.id();
+        };
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TextAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/TextAppendMemory.java
@@ -18,6 +18,7 @@ import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.codec.XxHash64;
 import com.spectrayan.spector.memory.kernel.layout.TextBlobLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractAppendMemory;
@@ -40,6 +41,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Binary reader/writer for {@code text.dat} files within partition directories,
@@ -61,6 +63,7 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
     private final Map<String, TextPosition> textPositionMap = new LinkedHashMap<>();
     private final Map<Long, TextPosition> hashToPosition = new java.util.HashMap<>();
     private final AtomicInteger decryptFailCount = new AtomicInteger();
+    private final ReentrantLock writeLock = new ReentrantLock();
 
     /**
      * Creates a TextAppendMemory for the given file path (no encryption).
@@ -82,7 +85,7 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
     }
 
     private TextAppendMemory(Path file, DataEncryptor encryptor, Map<String, TextEntry> legacyEntries) {
-        super(MemoryId.of("cortex", "text"), new TextBlobLayout(), 0, calculateInitialSize(file, legacyEntries), file);
+        super(SystemMemoryId.CORTEX_TEXT.id(), new TextBlobLayout(), 0, calculateInitialSize(file, legacyEntries), file);
         this.file = file;
         this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
         this.entryCount = 0;
@@ -116,7 +119,7 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
 
     private TextAppendMemory(Arena arena, MemorySegment regionSlice, Path bundlePath,
                               boolean isNew, DataEncryptor encryptor) {
-        super(MemoryId.of("cortex", "text"), new TextBlobLayout(), 0,
+        super(SystemMemoryId.CORTEX_TEXT.id(), new TextBlobLayout(), 0,
               arena, regionSlice,
               isNew ? 0 : (int) MemoryHeader.readCount(regionSlice, 0),
               true, bundlePath, null, true);  // bundleManaged=true
@@ -255,36 +258,41 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
      * @param text the raw text content
      * @return the byte position of the text within text.dat for direct off-heap reads
      */
-    public synchronized TextPosition write(String id, MemoryType tier, String text) {
-        byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
-        byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+    public TextPosition write(String id, MemoryType tier, String text) {
+        writeLock.lock();
+        try {
+            byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
+            byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
 
-        long hash = XxHash64.hash(textBytes);
-        TextPosition existing = hashToPosition.get(hash);
-        if (existing != null && existing.textLength() == textBytes.length) {
-            textPositionMap.put(id, existing);
+            long hash = XxHash64.hash(textBytes);
+            TextPosition existing = hashToPosition.get(hash);
+            if (existing != null && existing.textLength() == textBytes.length) {
+                textPositionMap.put(id, existing);
+                entryCount++;
+                return existing;
+            }
+
+            int entrySize = 1 + 4 + idBytes.length + 4 + textBytes.length;
+
+            MemorySegment entrySeg = MemorySegment.ofArray(new byte[entrySize]);
+            entrySeg.set(ValueLayout.JAVA_BYTE, 0, (byte) tier.ordinal());
+            entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 1, idBytes.length);
+            MemorySegment.copy(MemorySegment.ofArray(idBytes), 0, entrySeg, 5, idBytes.length);
+            entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 5 + idBytes.length, textBytes.length);
+            MemorySegment.copy(MemorySegment.ofArray(textBytes), 0, entrySeg, 5 + idBytes.length + 4, textBytes.length);
+
+            long payloadOffset = append(entrySeg);
+            long textOffset = dataOffset() + payloadOffset + 9 + idBytes.length;
+
+            TextPosition pos = new TextPosition(textOffset, textBytes.length);
+            textPositionMap.put(id, pos);
+            hashToPosition.put(hash, pos);
             entryCount++;
-            return existing;
+
+            return pos;
+        } finally {
+            writeLock.unlock();
         }
-
-        int entrySize = 1 + 4 + idBytes.length + 4 + textBytes.length;
-
-        MemorySegment entrySeg = Arena.ofAuto().allocate(entrySize);
-        entrySeg.set(ValueLayout.JAVA_BYTE, 0, (byte) tier.ordinal());
-        entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 1, idBytes.length);
-        MemorySegment.copy(MemorySegment.ofArray(idBytes), 0, entrySeg, 5, idBytes.length);
-        entrySeg.set(ValueLayout.JAVA_INT_UNALIGNED, 5 + idBytes.length, textBytes.length);
-        MemorySegment.copy(MemorySegment.ofArray(textBytes), 0, entrySeg, 5 + idBytes.length + 4, textBytes.length);
-
-        long payloadOffset = append(entrySeg);
-        long textOffset = dataOffset() + payloadOffset + 9 + idBytes.length;
-
-        TextPosition pos = new TextPosition(textOffset, textBytes.length);
-        textPositionMap.put(id, pos);
-        hashToPosition.put(hash, pos);
-        entryCount++;
-
-        return pos;
     }
 
     /**
@@ -307,71 +315,76 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
      *
      * @return map of memory ID → TextEntry, empty map if file doesn't exist
      */
-    public synchronized Map<String, TextEntry> readAll() {
-        Map<String, TextEntry> entries = new LinkedHashMap<>();
-        textPositionMap.clear();
-        hashToPosition.clear();
+    public Map<String, TextEntry> readAll() {
+        writeLock.lock();
+        try {
+            Map<String, TextEntry> entries = new LinkedHashMap<>();
+            textPositionMap.clear();
+            hashToPosition.clear();
 
-        if (!Files.exists(file)) {
+            if (!Files.exists(file)) {
+                return entries;
+            }
+
+            java.util.Iterator<MemorySegment> it = replay(0);
+            long currentOffset = 0;
+            while (it.hasNext()) {
+                MemorySegment entrySeg = it.next();
+                int entryLen = (int) entrySeg.byteSize();
+                if (entryLen < 9) {
+                    currentOffset += 4 + entryLen;
+                    continue;
+                }
+
+                byte tierOrd = entrySeg.get(ValueLayout.JAVA_BYTE, 0);
+                if (tierOrd < 0 || tierOrd >= MemoryType.values().length) {
+                    currentOffset += 4 + entryLen;
+                    continue;
+                }
+
+                int idLen = entrySeg.get(ValueLayout.JAVA_INT_UNALIGNED, 1);
+                if (idLen < 0 || idLen > 10_000 || 5 + idLen + 4 > entryLen) {
+                    currentOffset += 4 + entryLen;
+                    continue;
+                }
+
+                String id = decodeUtf8FromSegment(entrySeg, 5, idLen);
+                int textLen = entrySeg.get(ValueLayout.JAVA_INT_UNALIGNED, 5 + idLen);
+                if (textLen < 0 || textLen > 10_000_000 || 5 + idLen + 4 + textLen > entryLen) {
+                    currentOffset += 4 + entryLen;
+                    continue;
+                }
+
+                String rawText = decodeUtf8FromSegment(entrySeg, 5 + idLen + 4, textLen);
+                String text = decryptIfNeeded(rawText);
+
+                MemoryType tier = MemoryType.values()[tierOrd];
+                entries.put(id, new TextEntry(id, tier, text));
+
+                long textOffset = dataOffset() + currentOffset + 4 + 9 + idLen;
+                TextPosition pos = new TextPosition(textOffset, textLen);
+                textPositionMap.put(id, pos);
+
+                byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+                long hash = XxHash64.hash(textBytes);
+                hashToPosition.put(hash, pos);
+
+                currentOffset += 4 + entryLen;
+            }
+
+            this.entryCount = entries.size();
+            log.debug("Loaded {} text entries from {} (mmap'd off-heap)", entries.size(), file);
+
+            int failures = decryptFailCount.getAndSet(0);
+            if (failures > 0) {
+                log.warn("text.dat: {} of {} entries failed decryption (wrong key or legacy data): {}",
+                        failures, entries.size(), file);
+            }
+
             return entries;
+        } finally {
+            writeLock.unlock();
         }
-
-        java.util.Iterator<MemorySegment> it = replay(0);
-        long currentOffset = 0;
-        while (it.hasNext()) {
-            MemorySegment entrySeg = it.next();
-            int entryLen = (int) entrySeg.byteSize();
-            if (entryLen < 9) {
-                currentOffset += 4 + entryLen;
-                continue;
-            }
-
-            byte tierOrd = entrySeg.get(ValueLayout.JAVA_BYTE, 0);
-            if (tierOrd < 0 || tierOrd >= MemoryType.values().length) {
-                currentOffset += 4 + entryLen;
-                continue;
-            }
-
-            int idLen = entrySeg.get(ValueLayout.JAVA_INT_UNALIGNED, 1);
-            if (idLen < 0 || idLen > 10_000 || 5 + idLen + 4 > entryLen) {
-                currentOffset += 4 + entryLen;
-                continue;
-            }
-
-            String id = decodeUtf8FromSegment(entrySeg, 5, idLen);
-            int textLen = entrySeg.get(ValueLayout.JAVA_INT_UNALIGNED, 5 + idLen);
-            if (textLen < 0 || textLen > 10_000_000 || 5 + idLen + 4 + textLen > entryLen) {
-                currentOffset += 4 + entryLen;
-                continue;
-            }
-
-            String rawText = decodeUtf8FromSegment(entrySeg, 5 + idLen + 4, textLen);
-            String text = decryptIfNeeded(rawText);
-
-            MemoryType tier = MemoryType.values()[tierOrd];
-            entries.put(id, new TextEntry(id, tier, text));
-
-            long textOffset = dataOffset() + currentOffset + 4 + 9 + idLen;
-            TextPosition pos = new TextPosition(textOffset, textLen);
-            textPositionMap.put(id, pos);
-
-            byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
-            long hash = XxHash64.hash(textBytes);
-            hashToPosition.put(hash, pos);
-
-            currentOffset += 4 + entryLen;
-        }
-
-        this.entryCount = entries.size();
-        log.debug("Loaded {} text entries from {} (mmap'd off-heap)", entries.size(), file);
-
-        int failures = decryptFailCount.getAndSet(0);
-        if (failures > 0) {
-            log.warn("text.dat: {} of {} entries failed decryption (wrong key or legacy data): {}",
-                    failures, entries.size(), file);
-        }
-
-        return entries;
     }
 
     /**
@@ -388,20 +401,25 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
      *
      * @param entries the surviving entries to write
      */
-    public synchronized void rebuild(Map<String, TextEntry> entries) {
-        textPositionMap.clear();
-        hashToPosition.clear();
+    public void rebuild(Map<String, TextEntry> entries) {
+        writeLock.lock();
+        try {
+            textPositionMap.clear();
+            hashToPosition.clear();
 
-        // Reset append cursor and count in-place
-        this.count = 0;
-        persistCount();
+            // Reset append cursor and count in-place
+            this.count = 0;
+            persistCount();
 
-        for (TextEntry entry : entries.values()) {
-            write(entry.id(), entry.tier(), entry.text());
+            for (TextEntry entry : entries.values()) {
+                write(entry.id(), entry.tier(), entry.text());
+            }
+            flush();
+            this.entryCount = entries.size();
+            log.debug("Rebuilt text.dat with {} entries (deduplicated): {}", entries.size(), file);
+        } finally {
+            writeLock.unlock();
         }
-        flush();
-        this.entryCount = entries.size();
-        log.debug("Rebuilt text.dat with {} entries (deduplicated): {}", entries.size(), file);
     }
 
     /** Returns the number of entries in this store. */
@@ -449,24 +467,30 @@ public final class TextAppendMemory extends AbstractAppendMemory<TextBlobLayout>
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    public synchronized boolean eraseEntry(String targetId) {
-        if (!Files.exists(file)) {
-            return false;
+    public boolean eraseEntry(String targetId) {
+        writeLock.lock();
+        try {
+            if (!Files.exists(file)) {
+                return false;
+            }
+
+            TextPosition pos = textPositionMap.get(targetId);
+            if (pos == null) return false;
+
+            MemorySegment seg = segment();
+            if (seg != null) {
+                seg.asSlice(pos.textOffset(), pos.textLength()).fill((byte) 0);
+                flush();
+            }
+
+            hashToPosition.entrySet().removeIf(entry -> entry.getValue().equals(pos));
+            textPositionMap.remove(targetId);
+            entryCount--;
+
+            log.debug("Securely erased {} bytes of text for memory '{}'", pos.textLength(), targetId);
+            return true;
+        } finally {
+            writeLock.unlock();
         }
-
-        TextPosition pos = textPositionMap.get(targetId);
-        if (pos == null) return false;
-
-        MemorySegment seg = segment();
-        if (seg != null) {
-            seg.asSlice(pos.textOffset(), pos.textLength()).fill((byte) 0);
-            flush();
-        }
-
-        hashToPosition.entrySet().removeIf(entry -> entry.getValue().equals(pos));
-        textPositionMap.remove(targetId);
-
-        log.debug("Securely erased {} bytes of text for memory '{}'", pos.textLength(), targetId);
-        return true;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityDirectory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityDirectory.java
@@ -22,6 +22,7 @@ import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.layout.EntityDirectoryLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractGraphMemory;
 
@@ -96,7 +97,7 @@ public final class EntityDirectory extends AbstractGraphMemory<EntityDirectoryLa
     private static final Logger log = LoggerFactory.getLogger(EntityDirectory.class);
 
     /** Kernel identity for the entity directory. */
-    private static final MemoryId MEMORY_ID = MemoryId.of("graph", "entity-directory");
+    private static final MemoryId MEMORY_ID = SystemMemoryId.ENTITY_DIRECTORY.id();
     /** Shared record layout — identifies directory records inside an SMKM container. */
     private static final EntityDirectoryLayout LAYOUT = new EntityDirectoryLayout();
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
@@ -342,8 +342,8 @@ final class EntityGraphMemory extends AbstractGraphMemory<EntityLayout> {
             return new Init(entityCapacity, edgeCapacity, 0, 0, arena,
                     entitySegment, edgeSegment, adjacencySegment, adjCap, 0,
                     false, null, null,
-                    TypeRegistryMemory.seeded("entity-type", EntityType.SEED),
-                    TypeRegistryMemory.seeded("relation-type", RelationType.SEED),
+                    TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, EntityType.SEED),
+                    TypeRegistryMemory.seeded(SystemMemoryId.RELATION_TYPE, RelationType.SEED),
                     null);
         }
 
@@ -437,12 +437,12 @@ final class EntityGraphMemory extends AbstractGraphMemory<EntityLayout> {
                 TypeRegistryMemory relationTypes;
                 if (parent != null) {
                     entityTypes = TypeRegistryMemory.load(
-                            StorageLayout.entityTypes(parent), "entity-type", EntityType.SEED);
+                            StorageLayout.entityTypes(parent), SystemMemoryId.ENTITY_TYPE, EntityType.SEED);
                     relationTypes = TypeRegistryMemory.load(
-                            StorageLayout.relationTypes(parent), "relation-type", RelationType.SEED);
+                            StorageLayout.relationTypes(parent), SystemMemoryId.RELATION_TYPE, RelationType.SEED);
                 } else {
-                    entityTypes = TypeRegistryMemory.seeded("entity-type", EntityType.SEED);
-                    relationTypes = TypeRegistryMemory.seeded("relation-type", RelationType.SEED);
+                    entityTypes = TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, EntityType.SEED);
+                    relationTypes = TypeRegistryMemory.seeded(SystemMemoryId.RELATION_TYPE, RelationType.SEED);
                 }
 
                 return new Init(entityCap, edgeCap, entityCount, edgeCount, arena,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
@@ -35,6 +35,7 @@ import java.nio.file.StandardOpenOption;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.layout.EntityLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractGraphMemory;
 import java.nio.charset.StandardCharsets;
@@ -126,7 +127,7 @@ final class EntityGraphMemory extends AbstractGraphMemory<EntityLayout> {
     private static final Logger log = LoggerFactory.getLogger(EntityGraphMemory.class);
 
     /** Kernel identity for the entity-relationship graph. */
-    private static final MemoryId MEMORY_ID = MemoryId.of("graph", "entity");
+    private static final MemoryId MEMORY_ID = SystemMemoryId.ENTITY.id();
     /** Shared record layout — identifies entity records inside an SMKM container. */
     private static final EntityLayout LAYOUT = new EntityLayout();
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphSerializer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphSerializer.java
@@ -16,6 +16,7 @@ import com.spectrayan.spector.memory.DataEncryptor;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.kernel.layout.EntityLayout;
 import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -291,10 +292,10 @@ final class EntityGraphSerializer {
             Path graphParent = filePath.getParent();
             TypeRegistryMemory entityTypes = TypeRegistryMemory.load(
                     StorageLayout.entityTypes(graphParent),
-                    "entity-type", EntityType.SEED);
+                    SystemMemoryId.ENTITY_TYPE, EntityType.SEED);
             TypeRegistryMemory relationTypes = TypeRegistryMemory.load(
                     StorageLayout.relationTypes(graphParent),
-                    "relation-type", RelationType.SEED);
+                    SystemMemoryId.RELATION_TYPE, RelationType.SEED);
 
             EntityGraphMemory graph = EntityGraphMemory.fromLoaded(entityCap, edgeCap, entCount, edgCount,
                     arena, entSeg, edgSeg, adjSeg, adjCap, adjHwm, names,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
@@ -37,6 +37,7 @@ import java.util.PrimitiveIterator;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.layout.HyperEntityLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractGraphMemory;
 
@@ -105,7 +106,7 @@ public final class HyperEntityGraphMemory extends AbstractGraphMemory<HyperEntit
     private static final Logger log = LoggerFactory.getLogger(HyperEntityGraphMemory.class);
 
     /** Kernel identity for the hyper-entity graph. */
-    private static final MemoryId MEMORY_ID = MemoryId.of("spector", "hyper-entity-graph");
+    private static final MemoryId MEMORY_ID = SystemMemoryId.HYPERGRAPH.id();
     /** Shared record layout — identifies hyperedge records inside an SMKM container. */
     private static final HyperEntityLayout LAYOUT = new HyperEntityLayout();
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistryMemory.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.shape.RegistryMemory;
 import com.spectrayan.spector.memory.kernel.layout.RegistryLayout;
 import com.spectrayan.spector.memory.kernel.shape.DefaultRegistryMemory;
@@ -57,7 +58,11 @@ public final class TypeRegistryMemory implements RegistryMemory {
      */
     public TypeRegistryMemory(String label) {
         this.label = label;
-        MemoryId registryId = MemoryId.of("graph", label);
+        MemoryId registryId = "entity-type".equals(label)
+                ? SystemMemoryId.ENTITY_TYPE.id()
+                : "relation-type".equals(label)
+                        ? SystemMemoryId.RELATION_TYPE.id()
+                        : MemoryId.of("graph", label);
         RegistryLayout layout = new RegistryLayout();
         // Create volatile DefaultRegistryMemory
         this.backing = new DefaultRegistryMemory(registryId, layout, 1024, 256 * 1024);
@@ -168,7 +173,11 @@ public final class TypeRegistryMemory implements RegistryMemory {
         Files.deleteIfExists(filePath);
         Files.createDirectories(filePath.getParent());
 
-        MemoryId registryId = MemoryId.of("graph", label);
+        MemoryId registryId = "entity-type".equals(label)
+                ? SystemMemoryId.ENTITY_TYPE.id()
+                : "relation-type".equals(label)
+                        ? SystemMemoryId.RELATION_TYPE.id()
+                        : MemoryId.of("graph", label);
         RegistryLayout layout = new RegistryLayout();
 
         // Calculate total size required for the new persistent registry memory segment
@@ -214,7 +223,11 @@ public final class TypeRegistryMemory implements RegistryMemory {
             TypeRegistryMemory registry = new TypeRegistryMemory(label);
 
             if (isStandard) {
-                MemoryId registryId = MemoryId.of("graph", label);
+                MemoryId registryId = "entity-type".equals(label)
+                        ? SystemMemoryId.ENTITY_TYPE.id()
+                        : "relation-type".equals(label)
+                                ? SystemMemoryId.RELATION_TYPE.id()
+                                : MemoryId.of("graph", label);
                 RegistryLayout layout = new RegistryLayout();
                 registry.backing.close();
                 registry.backing = new DefaultRegistryMemory(registryId, layout, 0, 0, filePath);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/TypeRegistryMemory.java
@@ -56,6 +56,13 @@ public final class TypeRegistryMemory implements RegistryMemory {
      *
      * @param label descriptive label for logging (e.g., "entity-type", "relation-type")
      */
+    public TypeRegistryMemory(SystemMemoryId systemMemoryId) {
+        this.label = systemMemoryId.id().memoryName();
+        RegistryLayout layout = new RegistryLayout();
+        this.backing = new DefaultRegistryMemory(systemMemoryId.id(), layout, 1024, 256 * 1024);
+    }
+
+    @Deprecated
     public TypeRegistryMemory(String label) {
         this.label = label;
         MemoryId registryId = "entity-type".equals(label)
@@ -64,13 +71,18 @@ public final class TypeRegistryMemory implements RegistryMemory {
                         ? SystemMemoryId.RELATION_TYPE.id()
                         : MemoryId.of("graph", label);
         RegistryLayout layout = new RegistryLayout();
-        // Create volatile DefaultRegistryMemory
         this.backing = new DefaultRegistryMemory(registryId, layout, 1024, 256 * 1024);
     }
 
-    /**
-     * Creates a registry pre-seeded with the given well-known types.
-     */
+    public static TypeRegistryMemory seeded(SystemMemoryId systemMemoryId, String... seedTypes) {
+        TypeRegistryMemory registry = new TypeRegistryMemory(systemMemoryId);
+        for (String type : seedTypes) {
+            registry.intern(type);
+        }
+        return registry;
+    }
+
+    @Deprecated
     public static TypeRegistryMemory seeded(String label, String... seedTypes) {
         TypeRegistryMemory registry = new TypeRegistryMemory(label);
         for (String type : seedTypes) {
@@ -173,11 +185,7 @@ public final class TypeRegistryMemory implements RegistryMemory {
         Files.deleteIfExists(filePath);
         Files.createDirectories(filePath.getParent());
 
-        MemoryId registryId = "entity-type".equals(label)
-                ? SystemMemoryId.ENTITY_TYPE.id()
-                : "relation-type".equals(label)
-                        ? SystemMemoryId.RELATION_TYPE.id()
-                        : MemoryId.of("graph", label);
+        MemoryId registryId = backing.id();
         RegistryLayout layout = new RegistryLayout();
 
         // Calculate total size required for the new persistent registry memory segment
@@ -201,6 +209,86 @@ public final class TypeRegistryMemory implements RegistryMemory {
         log.info("{} registry saved (SMKM V1): {} types → {}", label, currentEntries.size(), filePath);
     }
 
+    public static TypeRegistryMemory load(Path filePath, SystemMemoryId systemMemoryId, String... seedTypes) {
+        String label = systemMemoryId.id().memoryName();
+        if (!Files.exists(filePath)) {
+            log.info("{} registry file not found, creating seeded registry with {} types",
+                    label, seedTypes.length);
+            return seeded(systemMemoryId, seedTypes);
+        }
+
+        try {
+            int magic;
+            try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                ByteBuffer mb = ByteBuffer.allocate(4);
+                ch.read(mb);
+                mb.flip();
+                magic = mb.getInt();
+            }
+
+            boolean isStandard = (magic == MemoryHeader.MAGIC || magic == 0x4D4B4D53);
+            boolean isLegacy = (magic == LEGACY_FILE_MAGIC || magic == 0x47455254);
+
+            TypeRegistryMemory registry = new TypeRegistryMemory(systemMemoryId);
+
+            if (isStandard) {
+                RegistryLayout layout = new RegistryLayout();
+                registry.backing.close();
+                registry.backing = new DefaultRegistryMemory(systemMemoryId.id(), layout, 0, 0, filePath);
+
+                // Ensure all seed types are present (e.g. if new seed types were added)
+                for (String seed : seedTypes) {
+                    registry.intern(seed);
+                }
+                log.info("{} registry loaded (SMKM V1): {} types from {}", label, registry.size(), filePath.getFileName());
+                return registry;
+            } else if (isLegacy) {
+                // Read legacy file format
+                try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
+                    ByteBuffer header = ByteBuffer.allocate(12);
+                    ch.read(header);
+                    header.flip();
+                    header.getInt(); // magic
+                    header.getInt(); // version
+                    int count = header.getInt();
+
+                    for (int i = 0; i < count; i++) {
+                        ByteBuffer lenBuf = ByteBuffer.allocate(4);
+                        ch.read(lenBuf);
+                        lenBuf.flip();
+                        int nameLen = lenBuf.getInt();
+
+                        ByteBuffer nameBuf = ByteBuffer.allocate(nameLen);
+                        ch.read(nameBuf);
+                        nameBuf.flip();
+                        String name = StandardCharsets.UTF_8.decode(nameBuf).toString();
+
+                        ByteBuffer idBuf = ByteBuffer.allocate(4);
+                        ch.read(idBuf);
+                        idBuf.flip();
+                        int id = idBuf.getInt();
+
+                        registry.backing.putDirect(name, id);
+                    }
+                }
+
+                // Ensure all seed types are present
+                for (String seed : seedTypes) {
+                    registry.intern(seed);
+                }
+                log.info("{} registry loaded (legacy V1): {} types from {}", label, registry.size(), filePath.getFileName());
+                return registry;
+            } else {
+                log.warn("{} registry file has invalid magic: 0x{}, creating fresh", label, Integer.toHexString(magic));
+                return seeded(systemMemoryId, seedTypes);
+            }
+        } catch (Exception e) {
+            log.error("Failed to load {} registry, creating fresh: {}", label, e.getMessage());
+            return seeded(systemMemoryId, seedTypes);
+        }
+    }
+
+    @Deprecated
     public static TypeRegistryMemory load(Path filePath, String label, String... seedTypes) {
         if (!Files.exists(filePath)) {
             log.info("{} registry file not found, creating seeded registry with {} types",

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationRecordMemory.java
@@ -17,8 +17,10 @@ import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.layout.CoActivationLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractRecordMemory;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +73,7 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     private final ConcurrentHashMap<Long, String> hashToTag = new ConcurrentHashMap<>();
     private volatile Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats =
             new ConcurrentHashMap<>();
+    private final ReentrantLock saveLock = new ReentrantLock();
 
     public record DirectedEdge(String sourceTag, String targetTag) {
         @Override
@@ -99,7 +102,7 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     }
 
     public CoActivationRecordMemory(int maxPairs, int maxEdges) {
-        this(MemoryId.of("hebbian", "coactivation"), calculateTotalBytes(maxPairs, maxEdges), maxPairs, maxEdges);
+        this(SystemMemoryId.COACTIVATION.id(), calculateTotalBytes(maxPairs, maxEdges), maxPairs, maxEdges);
     }
 
     private CoActivationRecordMemory(MemoryId id, long totalBytes, int maxPairs, int maxEdges) {
@@ -122,7 +125,7 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     }
 
     private CoActivationRecordMemory(Path filePath, int pairCap, int edgeCap) {
-        super(MemoryId.of("hebbian", "coactivation"), new CoActivationLayout(),
+        super(SystemMemoryId.COACTIVATION.id(), new CoActivationLayout(),
                 (int) (8 + 32L * pairCap + 40L * edgeCap), 8 + 32L * pairCap + 40L * edgeCap, filePath);
 
         long totalBytes = 8 + 32L * pairCap + 40L * edgeCap;
@@ -133,7 +136,7 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
             segment.set(ValueLayout.JAVA_INT, dataOffset, pairCap);
             segment.set(ValueLayout.JAVA_INT, dataOffset + 4, edgeCap);
 
-            MemorySegment singleByte = Arena.ofAuto().allocate(1);
+            MemorySegment singleByte = MemorySegment.ofArray(new byte[1]);
             singleByte.set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
             write(totalBytes - 1, singleByte);
         }
@@ -334,60 +337,65 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     // PERSISTENCE: save / load
     // ══════════════════════════════════════════════════════════════
 
-    public synchronized void save(Path filePath) {
-        if (!isPersistent()) {
-            try {
-                Path parent = filePath.getParent();
-                if (parent != null) {
-                    Files.createDirectories(parent);
+    public void save(Path filePath) {
+        saveLock.lock();
+        try {
+            if (!isPersistent()) {
+                try {
+                    Path parent = filePath.getParent();
+                    if (parent != null) {
+                        Files.createDirectories(parent);
+                    }
+                    try (FileChannel ch = FileChannel.open(filePath,
+                            StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+
+                        long totalBytes = 8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity();
+                        ByteBuffer header = ByteBuffer.allocate(64);
+                        MemorySegment headerSeg = MemorySegment.ofBuffer(header);
+                        MemoryHeader.write(headerSeg, 0, layout().schemaVersion(), shape(),
+                                0x01, totalBytes, totalBytes, layout().recordStride(), layout().layoutId(),
+                                System.currentTimeMillis(), System.currentTimeMillis());
+                        header.limit(64).position(0);
+                        ch.write(header);
+
+                        ByteBuffer dataBuf = segment().asSlice(0, totalBytes).asByteBuffer().asReadOnlyBuffer();
+                        ch.write(dataBuf);
+
+                        ByteBuffer countsBuf = ByteBuffer.allocate(8);
+                        countsBuf.putInt(pairTable.count());
+                        countsBuf.putInt(edgeTable.count());
+                        countsBuf.flip();
+                        ch.write(countsBuf);
+
+                        writeTagIndex(ch);
+                        writeBanditStats(ch);
+                    }
+
+                } catch (IOException e) {
+                    throw new SpectorGraphPersistenceException("CoActivationRecordMemory", filePath, e);
                 }
-                try (FileChannel ch = FileChannel.open(filePath,
-                        StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            } else {
+                try {
+                    flush();
+                    Path path = filePath != null ? filePath : filePath();
+                    try (FileChannel ch = FileChannel.open(path, StandardOpenOption.WRITE)) {
+                        ch.position(MemoryHeader.HEADER_BYTES + 8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity());
 
-                    long totalBytes = 8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity();
-                    ByteBuffer header = ByteBuffer.allocate(64);
-                    MemorySegment headerSeg = MemorySegment.ofBuffer(header);
-                    MemoryHeader.write(headerSeg, 0, layout().schemaVersion(), shape(),
-                            0x01, totalBytes, totalBytes, layout().recordStride(), layout().layoutId(),
-                            System.currentTimeMillis(), System.currentTimeMillis());
-                    header.limit(64).position(0);
-                    ch.write(header);
+                        ByteBuffer countsBuf = ByteBuffer.allocate(8);
+                        countsBuf.putInt(pairTable.count());
+                        countsBuf.putInt(edgeTable.count());
+                        countsBuf.flip();
+                        ch.write(countsBuf);
 
-                    ByteBuffer dataBuf = segment().asSlice(0, totalBytes).asByteBuffer().asReadOnlyBuffer();
-                    ch.write(dataBuf);
-
-                    ByteBuffer countsBuf = ByteBuffer.allocate(8);
-                    countsBuf.putInt(pairTable.count());
-                    countsBuf.putInt(edgeTable.count());
-                    countsBuf.flip();
-                    ch.write(countsBuf);
-
-                    writeTagIndex(ch);
-                    writeBanditStats(ch);
+                        writeTagIndex(ch);
+                        writeBanditStats(ch);
+                    }
+                } catch (IOException e) {
+                    throw new SpectorGraphPersistenceException("CoActivationRecordMemory", filePath, e);
                 }
-
-            } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("CoActivationRecordMemory", filePath, e);
             }
-        } else {
-            try {
-                flush();
-                Path path = filePath != null ? filePath : filePath();
-                try (FileChannel ch = FileChannel.open(path, StandardOpenOption.WRITE)) {
-                    ch.position(MemoryHeader.HEADER_BYTES + 8 + 32L * pairTable.capacity() + 40L * edgeTable.capacity());
-
-                    ByteBuffer countsBuf = ByteBuffer.allocate(8);
-                    countsBuf.putInt(pairTable.count());
-                    countsBuf.putInt(edgeTable.count());
-                    countsBuf.flip();
-                    ch.write(countsBuf);
-
-                    writeTagIndex(ch);
-                    writeBanditStats(ch);
-                }
-            } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("CoActivationRecordMemory", filePath, e);
-            }
+        } finally {
+            saveLock.unlock();
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
@@ -20,6 +20,7 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.codec.Codecs;
 import com.spectrayan.spector.memory.kernel.layout.HebbianLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractGraphMemory;
@@ -66,7 +67,7 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
     private static final HebbianLayout LAYOUT = new HebbianLayout();
 
     /** Kernel identity for the Hebbian association graph. */
-    private static final MemoryId MEMORY_ID = MemoryId.of("graph", "hebbian-csr");
+    private static final MemoryId MEMORY_ID = SystemMemoryId.HEBBIAN_CSR.id();
 
     // ── On-disk container magics (logical values, as read big-endian) ──
     /** Legacy fixed-width container magic ('HGPH'), migrated via the codec. */

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -20,6 +20,7 @@ import com.spectrayan.spector.commons.error.SpectorStorageException;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.shape.DefaultRecordMemory;
 import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
 import com.spectrayan.spector.memory.kernel.layout.IndexEntryLayout;
@@ -130,7 +131,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     }
 
     public IndexRecordMemory() {
-        super(MemoryId.of("kernel", "index"), new IndexEntryLayout(), 100_000,
+        super(SystemMemoryId.INDEX.id(), new IndexEntryLayout(), 100_000,
               Arena.ofShared(), Arena.ofShared().allocate(100_000 * (long) INDEX_SLOT_STRIDE, 64),
               0, false, null, null);
     }
@@ -495,12 +496,12 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                 totalPoolBytes += 4 + b.length; // 4B length prefix + payload
             }
 
-            MemoryId poolId = MemoryId.of("index", "idpool");
+            MemoryId poolId = SystemMemoryId.INDEX_IDPOOL.id();
             IdBlobLayout poolLayout = new IdBlobLayout();
             try (DefaultAppendMemory<IdBlobLayout> poolMemory = new DefaultAppendMemory<>(
                     poolId, poolLayout, entryCount, MemoryHeader.HEADER_BYTES + totalPoolBytes, idPoolPath)) {
                 
-                MemoryId slotId = MemoryId.of("index", "slot");
+                MemoryId slotId = SystemMemoryId.INDEX_SLOT.id();
                 IndexEntryLayout slotLayout = new IndexEntryLayout();
                 // #443 Phase 2: stride flows from the layout (v6 = 48). The 64-byte header
                 // records recordStride + schemaVersion, so the loader can version-gate.
@@ -591,7 +592,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                 String poolName = fileName.endsWith(".midx") ? fileName.replace(".midx", ".idpl") : fileName + ".idpl";
                 Path idPoolPath = filePath.resolveSibling(poolName);
 
-                MemoryId slotId = MemoryId.of("index", "slot");
+                MemoryId slotId = SystemMemoryId.INDEX_SLOT.id();
                 IndexEntryLayout slotLayout = new IndexEntryLayout();
                 try (DefaultRecordMemory<IndexEntryLayout> slotMemory = new DefaultRecordMemory<>(
                         slotId, slotLayout, 0, 0, filePath)) {
@@ -618,7 +619,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                     }
 
                     int entryCount = slotMemory.size();
-                    MemoryId poolId = MemoryId.of("index", "idpool");
+                    MemoryId poolId = SystemMemoryId.INDEX_IDPOOL.id();
                     IdBlobLayout poolLayout = new IdBlobLayout();
                     try (DefaultAppendMemory<IdBlobLayout> poolMemory = new DefaultAppendMemory<>(
                             poolId, poolLayout, 0, 0, idPoolPath)) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryId.java
@@ -33,7 +33,9 @@ public record MemoryId(String namespace, String memoryName, int partitionSeq) im
      * @param namespace  The namespace.
      * @param memoryName The memory name.
      * @return A new MemoryId with partitionSeq set to 0.
+     * @deprecated Use {@link SystemMemoryId} constants instead of creating on-the-fly hardcoded instances.
      */
+    @Deprecated
     public static MemoryId of(String namespace, String memoryName) {
         return new MemoryId(namespace, memoryName, 0);
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/SystemMemoryId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/SystemMemoryId.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel;
+
+/**
+ * Centralized, strongly-typed registry of all system cognitive memory identities.
+ * Replaces hardcoded string instances of MemoryId.of.
+ */
+public enum SystemMemoryId {
+    HEBBIAN_CSR("graph", "hebbian-csr"),
+    TEMPORAL_CHAIN("temporal", "chain"),
+    COACTIVATION("hebbian", "coactivation"),
+    ENTITY_DIRECTORY("graph", "entity-directory"),
+    ENTITY("graph", "entity"),
+    CORTEX_TEXT("cortex", "text"),
+    TEMPORAL_FACTS("temporal", "facts"),
+    WORKING("tier", "working"),
+    SEMANTIC("tier", "semantic"),
+    PROCEDURAL("tier", "procedural"),
+    EPISODIC("tier", "episodic"),
+    HYPERGRAPH("spector", "hyper-entity-graph"),
+    ENTITY_TYPE("graph", "entity-type"),
+    RELATION_TYPE("graph", "relation-type"),
+    INDEX("kernel", "index"),
+    INDEX_IDPOOL("index", "idpool"),
+    INDEX_SLOT("index", "slot");
+
+    private final String namespace;
+    private final String memoryName;
+    private final MemoryId memoryId;
+
+    SystemMemoryId(String namespace, String memoryName) {
+        this.namespace = namespace;
+        this.memoryName = memoryName;
+        @SuppressWarnings("deprecation")
+        MemoryId id = MemoryId.of(namespace, memoryName);
+        this.memoryId = id;
+    }
+
+    public MemoryId id() {
+        return memoryId;
+    }
+
+    public MemoryId id(int partitionSeq) {
+        return new MemoryId(namespace, memoryName, partitionSeq);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractAppendMemory.java
@@ -19,6 +19,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.spectrayan.spector.memory.kernel.AbstractMemory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
@@ -30,6 +31,8 @@ import com.spectrayan.spector.memory.kernel.MemoryShape;
  */
 public abstract class AbstractAppendMemory<L extends MemoryLayout>
         extends AbstractMemory<L> implements AppendMemory<L> {
+
+    private final ReentrantLock appendLock = new ReentrantLock();
 
     protected AbstractAppendMemory(MemoryId id, L layout, int capacity, long segmentBytes) {
         super(id, layout, capacity, segmentBytes);
@@ -58,29 +61,34 @@ public abstract class AbstractAppendMemory<L extends MemoryLayout>
     }
 
     @Override
-    public synchronized long append(MemorySegment bytes) {
-        long len = bytes.byteSize();
-        // Check capacity bounds (here count stores the append cursor position in bytes)
-        if (dataOffset() + count + 4 + len > segment().byteSize()) {
-            throw new IndexOutOfBoundsException("Append memory full: cursor=" + count + ", request=" + (4 + len));
+    public long append(MemorySegment bytes) {
+        appendLock.lock();
+        try {
+            long len = bytes.byteSize();
+            // Check capacity bounds (here count stores the append cursor position in bytes)
+            if (dataOffset() + count + 4 + len > segment().byteSize()) {
+                throw new IndexOutOfBoundsException("Append memory full: cursor=" + count + ", request=" + (4 + len));
+            }
+
+            if (wal != null && !bypassWal) {
+                byte[] rawBytes = new byte[(int) len];
+                MemorySegment.copy(bytes, 0, MemorySegment.ofArray(rawBytes), 0, len);
+                wal.appendAppend(id.toString(), rawBytes);
+            }
+
+            long writeOffset = dataOffset() + count;
+            // Write 4B length prefix
+            segment().set(ValueLayout.JAVA_INT_UNALIGNED, writeOffset, (int) len);
+            // Copy payload
+            MemorySegment.copy(bytes, 0, segment(), writeOffset + 4, len);
+
+            long payloadOffset = count + 4;
+            count += (int) (4 + len);
+            persistCount();
+            return payloadOffset;
+        } finally {
+            appendLock.unlock();
         }
-
-        if (wal != null && !bypassWal) {
-            byte[] rawBytes = new byte[(int) len];
-            MemorySegment.copy(bytes, 0, MemorySegment.ofArray(rawBytes), 0, len);
-            wal.appendAppend(id.toString(), rawBytes);
-        }
-
-        long writeOffset = dataOffset() + count;
-        // Write 4B length prefix
-        segment().set(ValueLayout.JAVA_INT_UNALIGNED, writeOffset, (int) len);
-        // Copy payload
-        MemorySegment.copy(bytes, 0, segment(), writeOffset + 4, len);
-
-        long payloadOffset = count + 4;
-        count += (int) (4 + len);
-        persistCount();
-        return payloadOffset;
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcher.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import com.spectrayan.spector.memory.error.SpectorWalCorruptionException;
 import com.spectrayan.spector.memory.kernel.Memory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.shape.RecordMemory;
@@ -170,8 +171,8 @@ public final class WalRecoveryDispatcher {
                     }
                     replayCount++;
                 } catch (Exception e) {
-                    log.error("WAL recovery: failed to replay event seq={}, type={} on memory '{}': {}", 
-                            event.sequence(), event.type(), event.memoryId(), e.getMessage(), e);
+                    throw new SpectorWalCorruptionException("WAL recovery: failed to replay event seq=" 
+                            + event.sequence() + ", type=" + event.type() + " on memory '" + event.memoryId() + "'", e);
                 }
             }
         } finally {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChainMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalChainMemory.java
@@ -32,7 +32,9 @@ import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.AbstractMemory;
+import java.util.concurrent.locks.ReentrantLock;
 import com.spectrayan.spector.memory.kernel.shape.ChainMemory;
 import com.spectrayan.spector.memory.kernel.layout.TemporalLayout;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -58,6 +60,7 @@ public final class TemporalChainMemory implements ChainMemory<TemporalLayout>, A
     private static final long OFF_EPOCH_SEC = 12;
 
     private final TemporalChainBacking backing;
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * Creates a heap-allocated temporal chain (in-memory mode).
@@ -66,7 +69,7 @@ public final class TemporalChainMemory implements ChainMemory<TemporalLayout>, A
      */
     public TemporalChainMemory(int capacity) {
         TemporalLayout layout = new TemporalLayout();
-        MemoryId id = MemoryId.of("temporal", "chain");
+        MemoryId id = SystemMemoryId.TEMPORAL_CHAIN.id();
         long dataBytes = (long) NODE_BYTES * capacity;
         this.backing = new TemporalChainBacking(id, layout, capacity, dataBytes);
 
@@ -105,7 +108,7 @@ public final class TemporalChainMemory implements ChainMemory<TemporalLayout>, A
 
             // 2. Open using standard SMKM format
             TemporalLayout layout = new TemporalLayout();
-            MemoryId id = MemoryId.of("temporal", "chain");
+            MemoryId id = SystemMemoryId.TEMPORAL_CHAIN.id();
             long dataBytes = (long) NODE_BYTES * capacity;
             boolean isNew = !Files.exists(filePath) || Files.size(filePath) < MemoryHeader.HEADER_BYTES;
 
@@ -291,28 +294,33 @@ public final class TemporalChainMemory implements ChainMemory<TemporalLayout>, A
         return getPrevIndex(nodeIdx) != NO_LINK || getNextIndex(nodeIdx) != NO_LINK;
     }
 
-    public synchronized void linkNodes(int prevIdx, int nextIdx, int sessionId, int epochSec) {
-        boundsCheck(prevIdx);
-        boundsCheck(nextIdx);
+    public void linkNodes(int prevIdx, int nextIdx, int sessionId, int epochSec) {
+        lock.lock();
+        try {
+            boundsCheck(prevIdx);
+            boundsCheck(nextIdx);
 
-        long prevOff = backing.dataOffset() + (long) prevIdx * NODE_BYTES;
-        long nextOff = backing.dataOffset() + (long) nextIdx * NODE_BYTES;
+            long prevOff = backing.dataOffset() + (long) prevIdx * NODE_BYTES;
+            long nextOff = backing.dataOffset() + (long) nextIdx * NODE_BYTES;
 
-        MemorySegment seg = backing.segment();
-        seg.set(ValueLayout.JAVA_INT, prevOff + OFF_NEXT, nextIdx);
-        if (sessionId > 0) {
-            seg.set(ValueLayout.JAVA_INT, prevOff + OFF_SESSION, sessionId);
-        }
-        if (epochSec > 0) {
-            seg.set(ValueLayout.JAVA_INT, prevOff + OFF_EPOCH_SEC, epochSec);
-        }
+            MemorySegment seg = backing.segment();
+            seg.set(ValueLayout.JAVA_INT, prevOff + OFF_NEXT, nextIdx);
+            if (sessionId > 0) {
+                seg.set(ValueLayout.JAVA_INT, prevOff + OFF_SESSION, sessionId);
+            }
+            if (epochSec > 0) {
+                seg.set(ValueLayout.JAVA_INT, prevOff + OFF_EPOCH_SEC, epochSec);
+            }
 
-        seg.set(ValueLayout.JAVA_INT, nextOff + OFF_PREV, prevIdx);
-        if (sessionId > 0) {
-            seg.set(ValueLayout.JAVA_INT, nextOff + OFF_SESSION, sessionId);
-        }
-        if (epochSec > 0) {
-            seg.set(ValueLayout.JAVA_INT, nextOff + OFF_EPOCH_SEC, epochSec);
+            seg.set(ValueLayout.JAVA_INT, nextOff + OFF_PREV, prevIdx);
+            if (sessionId > 0) {
+                seg.set(ValueLayout.JAVA_INT, nextOff + OFF_SESSION, sessionId);
+            }
+            if (epochSec > 0) {
+                seg.set(ValueLayout.JAVA_INT, nextOff + OFF_EPOCH_SEC, epochSec);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -368,72 +376,92 @@ public final class TemporalChainMemory implements ChainMemory<TemporalLayout>, A
         return list.stream().mapToInt(Integer::intValue).toArray();
     }
 
-    public synchronized int pruneOlderThan(long epochSecCutoff) {
-        long cutoffSec = epochSecCutoff > 10_000_000_000L ? epochSecCutoff / 1000 : epochSecCutoff;
-        int count = 0;
-        for (int i = 0; i < backing.capacity(); i++) {
-            if (isLinked(i)) {
-                int epochSec = getEpochSec(i);
-                if (epochSec > 0 && epochSec < cutoffSec) {
-                    unlink(i);
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    public synchronized int pruneByImportance(long epochSecCutoff, float importanceThreshold, Function<Integer, Float> importanceLookup) {
-        if (importanceLookup == null) {
-            return 0;
-        }
-        long cutoffSec = epochSecCutoff > 10_000_000_000L ? epochSecCutoff / 1000 : epochSecCutoff;
-        int count = 0;
-        for (int i = 0; i < backing.capacity(); i++) {
-            if (isLinked(i)) {
-                int epochSec = getEpochSec(i);
-                if (epochSec > 0 && epochSec < cutoffSec) {
-                    float imp = importanceLookup.apply(i);
-                    if (imp < importanceThreshold) {
+    public int pruneOlderThan(long epochSecCutoff) {
+        lock.lock();
+        try {
+            long cutoffSec = epochSecCutoff > 10_000_000_000L ? epochSecCutoff / 1000 : epochSecCutoff;
+            int count = 0;
+            for (int i = 0; i < backing.capacity(); i++) {
+                if (isLinked(i)) {
+                    int epochSec = getEpochSec(i);
+                    if (epochSec > 0 && epochSec < cutoffSec) {
                         unlink(i);
                         count++;
                     }
                 }
             }
+            return count;
+        } finally {
+            lock.unlock();
         }
-        return count;
     }
 
-    public synchronized void unlink(int nodeIdx) {
-        boundsCheck(nodeIdx);
-        int p = getPrevIndex(nodeIdx);
-        int n = getNextIndex(nodeIdx);
-
-        if (p != NO_LINK) {
-            long pOff = backing.dataOffset() + (long) p * NODE_BYTES;
-            backing.segment().set(ValueLayout.JAVA_INT, pOff + OFF_NEXT, n);
-        }
-        if (n != NO_LINK) {
-            long nOff = backing.dataOffset() + (long) n * NODE_BYTES;
-            backing.segment().set(ValueLayout.JAVA_INT, nOff + OFF_PREV, p);
-        }
-
-        long selfOff = backing.dataOffset() + (long) nodeIdx * NODE_BYTES;
-        backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_PREV, NO_LINK);
-        backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_NEXT, NO_LINK);
-        backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_SESSION, 0);
-        backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_EPOCH_SEC, 0);
-    }
-
-    public synchronized void save(Path targetPath) {
-        flush();
-        if (backing.isPersistent() && backing.filePath() != null && !backing.filePath().equals(targetPath)) {
-            try {
-                Files.createDirectories(targetPath.getParent());
-                Files.copy(backing.filePath(), targetPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException e) {
-                throw new SpectorGraphPersistenceException("TemporalChainMemory", targetPath, e);
+    public int pruneByImportance(long epochSecCutoff, float importanceThreshold, Function<Integer, Float> importanceLookup) {
+        lock.lock();
+        try {
+            if (importanceLookup == null) {
+                return 0;
             }
+            long cutoffSec = epochSecCutoff > 10_000_000_000L ? epochSecCutoff / 1000 : epochSecCutoff;
+            int count = 0;
+            for (int i = 0; i < backing.capacity(); i++) {
+                if (isLinked(i)) {
+                    int epochSec = getEpochSec(i);
+                    if (epochSec > 0 && epochSec < cutoffSec) {
+                        float imp = importanceLookup.apply(i);
+                        if (imp < importanceThreshold) {
+                            unlink(i);
+                            count++;
+                        }
+                    }
+                }
+            }
+            return count;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void unlink(int nodeIdx) {
+        lock.lock();
+        try {
+            boundsCheck(nodeIdx);
+            int p = getPrevIndex(nodeIdx);
+            int n = getNextIndex(nodeIdx);
+
+            if (p != NO_LINK) {
+                long pOff = backing.dataOffset() + (long) p * NODE_BYTES;
+                backing.segment().set(ValueLayout.JAVA_INT, pOff + OFF_NEXT, n);
+            }
+            if (n != NO_LINK) {
+                long nOff = backing.dataOffset() + (long) n * NODE_BYTES;
+                backing.segment().set(ValueLayout.JAVA_INT, nOff + OFF_PREV, p);
+            }
+
+            long selfOff = backing.dataOffset() + (long) nodeIdx * NODE_BYTES;
+            backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_PREV, NO_LINK);
+            backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_NEXT, NO_LINK);
+            backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_SESSION, 0);
+            backing.segment().set(ValueLayout.JAVA_INT, selfOff + OFF_EPOCH_SEC, 0);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void save(Path targetPath) {
+        lock.lock();
+        try {
+            flush();
+            if (backing.isPersistent() && backing.filePath() != null && !backing.filePath().equals(targetPath)) {
+                try {
+                    Files.createDirectories(targetPath.getParent());
+                    Files.copy(backing.filePath(), targetPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    throw new SpectorGraphPersistenceException("TemporalChainMemory", targetPath, e);
+                }
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalFactsAppendMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalFactsAppendMemory.java
@@ -13,6 +13,7 @@
 package com.spectrayan.spector.memory.temporal;
 
 import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.layout.TemporalFactLayout;
 import com.spectrayan.spector.memory.kernel.shape.AbstractAppendMemory;
 
@@ -24,7 +25,7 @@ import java.nio.file.Path;
  */
 public final class TemporalFactsAppendMemory extends AbstractAppendMemory<TemporalFactLayout> {
 
-    private static final MemoryId MEMORY_ID = MemoryId.of("temporal", "facts");
+    private static final MemoryId MEMORY_ID = SystemMemoryId.TEMPORAL_FACTS.id();
 
     /**
      * Creates an in-memory (heap) TemporalFactsAppendMemory store with default capacity (64 KB).

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraph.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.spectrayan.spector.memory.graph.TypeRegistryMemory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.layout.TemporalFactLayout;
 import com.spectrayan.spector.memory.kernel.shape.DefaultAppendMemory;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -68,7 +69,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(TemporalKnowledgeGraph.class);
 
     /** Memory ID for WAL registration and recovery. */
-    private static final MemoryId MEMORY_ID = MemoryId.of("temporal", "facts");
+    private static final MemoryId MEMORY_ID = SystemMemoryId.TEMPORAL_FACTS.id();
 
     /** Default initial file size: 64 KB (room for ~1000 facts). */
     private static final long DEFAULT_INITIAL_SIZE = 64L * 1024;
@@ -453,7 +454,7 @@ public final class TemporalKnowledgeGraph implements AutoCloseable {
             long validFrom, long validTo, long txTime, float confidence,
             int retractsFactId) {
 
-        MemorySegment seg = Arena.ofAuto().allocate(64, 8);
+        MemorySegment seg = MemorySegment.ofArray(new byte[64]);
 
         seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_FACT_ID, factId);
         seg.set(ValueLayout.JAVA_INT_UNALIGNED, TemporalFactLayout.OFF_SUBJECT_ENTITY_ID, subjectEntityId);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/TypeRegistryMemoryPersistenceTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/graph/TypeRegistryMemoryPersistenceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -33,7 +34,7 @@ class TypeRegistryMemoryPersistenceTest {
     @Test
     @DisplayName("should save and load TypeRegistryMemory in standard SMKM registry format")
     void shouldSaveAndLoadRegistry() throws Exception {
-        TypeRegistryMemory original = TypeRegistryMemory.seeded("entity-type", "PERSON", "ORGANIZATION");
+        TypeRegistryMemory original = TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, "PERSON", "ORGANIZATION");
         
         // Intern dynamic ones
         int codeId = original.intern("CODE");
@@ -46,7 +47,7 @@ class TypeRegistryMemoryPersistenceTest {
         assertThat(Files.exists(filePath)).isTrue();
 
         // Load
-        TypeRegistryMemory loaded = TypeRegistryMemory.load(filePath, "entity-type", "PERSON", "ORGANIZATION");
+        TypeRegistryMemory loaded = TypeRegistryMemory.load(filePath, SystemMemoryId.ENTITY_TYPE, "PERSON", "ORGANIZATION");
         
         assertThat(loaded.size()).isEqualTo(4);
         assertThat(loaded.nameOf(codeId)).isEqualTo("CODE");
@@ -93,7 +94,7 @@ class TypeRegistryMemoryPersistenceTest {
         }
 
         // 2. Load the legacy registry file
-        TypeRegistryMemory registry = TypeRegistryMemory.load(legacyFile, "entity-type", "PERSON");
+        TypeRegistryMemory registry = TypeRegistryMemory.load(legacyFile, SystemMemoryId.ENTITY_TYPE, "PERSON");
         
         // size should be 3 (PERSON seed + 2 migrated entries)
         assertThat(registry.size()).isEqualTo(3);
@@ -105,7 +106,7 @@ class TypeRegistryMemoryPersistenceTest {
         registry.save(legacyFile);
 
         // Load again and verify standard SMKM loading
-        TypeRegistryMemory reloaded = TypeRegistryMemory.load(legacyFile, "entity-type", "PERSON");
+        TypeRegistryMemory reloaded = TypeRegistryMemory.load(legacyFile, SystemMemoryId.ENTITY_TYPE, "PERSON");
         assertThat(reloaded.size()).isEqualTo(3);
         assertThat(reloaded.idOf("SOFTWARE")).isEqualTo(10);
         assertThat(reloaded.idOf("HARDWARE")).isEqualTo(11);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraphTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/temporal/TemporalKnowledgeGraphTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 
 import com.spectrayan.spector.memory.graph.TypeRegistryMemory;
+import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,7 +39,7 @@ class TemporalKnowledgeGraphTest {
 
     @BeforeEach
     void setUp() {
-        predicateRegistry = new TypeRegistryMemory("relation-type");
+        predicateRegistry = new TypeRegistryMemory(SystemMemoryId.RELATION_TYPE);
         tkg = new TemporalKnowledgeGraph(predicateRegistry);
     }
 


### PR DESCRIPTION
Resolves #466

## Summary
This Pull Request addresses critical technical debt, correctness, and performance items identified during the deep review of the `spector-memory` module (recorded under ADR-0005).

## Key Changes
1. **Centralized strongly typed System Memory IDs & Enums**:
   - Introduced the `SystemMemoryId` enum to declare all core memory segment namespaces and keys centrally.
   - Deprecated the constructor `MemoryId.of(String, String)` to discourage dynamic string allocations.
   - Refactored `TypeRegistryMemory` constructors and static factories to accept `SystemMemoryId` directly, removing internal string comparisons (like `"entity-type".equals(label)`).
   - Replaced all hardcoded string invocations throughout the graph, recovery, and index layers.
2. **Eliminated hardcoded strings in WAL Recovery**:
   - Updated `MemoryWalRecovery` to match target logs directly via `SystemMemoryId.CORTEX_TEXT.id().equals(targetId)` and parse record memory folders using `MemoryType.valueOf()`.
3. **Virtual Thread Safety (Carrier Pinning Mitigation)**:
   - Replaced `synchronized` locks with explicit `ReentrantLock` instances across `AbstractAppendMemory`, `TextAppendMemory`, `CoActivationRecordMemory`, and `TemporalChainMemory` on hot I/O paths (e.g. WAL writes and segment forcing).
   - This prevents virtual threads from pinning underlying platform carrier threads during I/O blocking.
4. **Fail-Fast Recovery**:
   - Refactored `MemoryWalRecovery` and `WalRecoveryDispatcher` to abort boot and throw `SpectorWalCorruptionException` if sync or replay errors are encountered, preventing index drift.
5. **Hot-Path Allocator Optimization**:
   - Optimized `TemporalKnowledgeGraph` fact assertions and `TextAppendMemory` text writes to allocate heap-backed `MemorySegment.ofArray(new byte[size])` copies instead of instantiating native Panama `Arena.ofAuto()` per-fact, reducing GC pressure.

## Verification
- Built and verified locally using `mvn verify -pl memory/spector-memory -am`.
- All 1,196 tests (including integration, end-to-end, and property-based tests) passed successfully.
- Jacoco coverage checks and license audits passed without issues.
