### PR TITLE
feat(synapse): migrate cognitive soul storage to memory-mapped insula cortex

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/AgentSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/AgentSoul.java
@@ -5,64 +5,21 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Change Date: July 6, 2030
+ * Change Date: May 27, 2030
  * Change License: Apache License, Version 2.0
  */
-package com.spectrayan.spector.synapse.agent;
+package com.spectrayan.spector.memory.model;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * The agent's persistent identity — its "soul."
- *
- * <h3>Biological Analog: Default Mode Network (DMN) Self-Model</h3>
- * <p>Just as the human brain's DMN maintains a persistent self-model that shapes
- * perception, memory encoding, and social cognition, the AgentSoul defines WHO
- * the agent is. This identity persists across sessions and influences how the agent
- * processes, recalls, and responds to information.</p>
- *
- * <h3>Symmetry with PersonaContext</h3>
- * <p>The user has {@code PersonaContext} (their soul). The agent has {@code AgentSoul}
- * (its soul). Both are injected into the LLM system prompt and both influence
- * cognitive scoring — PersonaContext via self-relevance boost, AgentSoul via
- * expertise-relevance boost.</p>
- *
- * <h3>Persistence</h3>
- * <p>Stored in H2 via {@link AgentSoulRepository}. The agent can self-modify its
- * soul (except ethical guardrails) with user approval via conversational
- * interaction.</p>
- *
- * <h3>Mutability Rules</h3>
- * <ul>
- *   <li><b>Mutable (with user approval)</b>: name, purpose, personality, expertise,
- *       values, emotionalBaseline, communicationStyle</li>
- *   <li><b>Immutable (agent cannot modify)</b>: ethicalGuardrails</li>
- * </ul>
- *
- * @param id                   unique identifier (UUID)
- * @param name                 the agent's name (e.g., "Aria", "Atlas")
- * @param description          brief description of the agent's role
- * @param systemPrompt         system-level instructions for the LLM
- * @param purpose              the agent's core purpose (e.g., "ABA therapy companion")
- * @param personality          free-text personality description
- * @param expertiseDomains     domains the agent specializes in
- * @param coreValues           the agent's guiding values
- * @param ethicalGuardrails    immutable ethical constraints (agent CANNOT modify these)
- * @param emotionalBaseline    the agent's default emotional state
- * @param communicationStyle   how the agent communicates (e.g., "warm and encouraging")
- * @param model                preferred LLM model (e.g., "qwen3.5:latest")
- * @param tools                list of enabled tool names
- * @param expertiseEmbedding   pre-computed embedding of expertise domains (for scoring)
- * @param purposeEmbedding     pre-computed embedding of purpose text (for scoring)
- * @param createdAt            creation timestamp
- * @param updatedAt            last update timestamp
  */
 public record AgentSoul(
         // Identity
@@ -97,7 +54,7 @@ public record AgentSoul(
         // Timestamps
         Instant createdAt,
         Instant updatedAt
-) {
+) implements SoulContext {
 
     /**
      * Compact constructor — enforces immutability and safe defaults.
@@ -121,6 +78,11 @@ public record AgentSoul(
         if (purposeEmbedding != null) {
             purposeEmbedding = Arrays.copyOf(purposeEmbedding, purposeEmbedding.length);
         }
+    }
+
+    @Override
+    public float[] identityEmbedding() {
+        return purposeEmbedding;
     }
 
     /**
@@ -165,23 +127,10 @@ public record AgentSoul(
 
     /**
      * The agent's default emotional state — influences recall bias.
-     *
-     * <p>A "warm" agent with positive valence baseline will prefer recalling
-     * memories that led to positive outcomes for the user. A "clinical" agent
-     * with neutral baseline will recall objectively.</p>
-     *
-     * @param defaultValence  emotional baseline (-128 to +127, 0 = neutral)
-     * @param defaultArousal  activation baseline (0-255, 128 = moderate)
      */
     public record EmotionalBaseline(byte defaultValence, byte defaultArousal) {
-
-        /** Neutral baseline — no emotional bias in recall. */
         public static final EmotionalBaseline NEUTRAL = new EmotionalBaseline((byte) 0, (byte) 128);
-
-        /** Warm baseline — slight positive bias in recall (therapy/companion agents). */
         public static final EmotionalBaseline WARM = new EmotionalBaseline((byte) 30, (byte) 100);
-
-        /** Energetic baseline — high arousal, positive (coaching/motivational agents). */
         public static final EmotionalBaseline ENERGETIC = new EmotionalBaseline((byte) 40, (byte) 200);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/InsulaSelfModel.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/InsulaSelfModel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Container representation of the self-model JSON payload stored inside the INSULA region.
+ */
+public record InsulaSelfModel(
+        @JsonProperty("type") String type,
+        @JsonProperty("soul") SoulContext soul,
+        @JsonProperty("salience") SalienceProfile salience,
+        @JsonProperty("metadata") Map<String, Object> metadata
+) {
+    public InsulaSelfModel {
+        metadata = metadata != null ? Collections.unmodifiableMap(metadata) : Map.of();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/OrgUnitSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/OrgUnitSoul.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Organizational Unit-level soul/identity context.
+ */
+public record OrgUnitSoul(
+        String id,
+        String name,
+        String description,
+        List<String> expertise,
+        float[] identityEmbedding
+) implements SoulContext {
+    public OrgUnitSoul {
+        expertise = expertise != null ? Collections.unmodifiableList(expertise) : List.of();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/SoulContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/SoulContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Polymorphic soul context representing the self-model identity across different scopes.
+ */
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = TenantSoul.class, name = "TENANT"),
+    @JsonSubTypes.Type(value = OrgUnitSoul.class, name = "ORG_UNIT"),
+    @JsonSubTypes.Type(value = AgentSoul.class, name = "AGENT"),
+    @JsonSubTypes.Type(value = UserSoul.class, name = "USER")
+})
+public sealed interface SoulContext permits TenantSoul, OrgUnitSoul, AgentSoul, UserSoul {
+    String id();
+    String name();
+    String description();
+    float[] identityEmbedding();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TenantSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TenantSoul.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tenant-level soul/identity context.
+ */
+public record TenantSoul(
+        String id,
+        String name,
+        String description,
+        List<String> domainFocus,
+        List<String> complianceRules,
+        float[] identityEmbedding
+) implements SoulContext {
+    public TenantSoul {
+        domainFocus = domainFocus != null ? Collections.unmodifiableList(domainFocus) : List.of();
+        complianceRules = complianceRules != null ? Collections.unmodifiableList(complianceRules) : List.of();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/UserSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/UserSoul.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * User-level soul/identity context wrapping the PersonaContext.
+ */
+public record UserSoul(
+        String id,
+        String name,
+        String description,
+        PersonaContext persona,
+        float[] identityEmbedding
+) implements SoulContext {
+    @Override
+    public float[] identityEmbedding() {
+        if (identityEmbedding != null) {
+            return identityEmbedding;
+        }
+        return persona != null ? persona.aboutEmbedding() : null;
+    }
+}

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -170,7 +170,7 @@ public final class SpectorPropertyConstants {
     public static final long DEFAULT_MEMORY_TYPE_REGISTRY_SIZE = 1L * 1024 * 1024;
 
     public static final String MEMORY_INSULA_SIZE = "spector.memory.insula-size";
-    public static final long DEFAULT_MEMORY_INSULA_SIZE = 64L * 1024;
+    public static final long DEFAULT_MEMORY_INSULA_SIZE = 1024L * 1024;
 
     // Ingestion
     public static final String INGESTION_ROOT_DIRECTORY = "spector.ingestion.root-directory";

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/AgentCard.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/AgentCard.java
@@ -13,6 +13,7 @@
 package com.spectrayan.spector.synapse.agent;
 
 import java.util.List;
+import com.spectrayan.spector.memory.model.AgentSoul;
 
 /**
  * Agent capability discovery card manifest (A2A compatible).

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/AgentController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/AgentController.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.synapse.agent;
 
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
 import com.spectrayan.spector.synapse.agent.graph.AgenticChatGraph;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.config.FeatureGate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/api/ChatController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/api/ChatController.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.synapse.agent.chat.api;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
 import com.spectrayan.spector.synapse.agent.chat.dto.ChatDto.AgentChatRequest;
 import com.spectrayan.spector.synapse.agent.chat.dto.ChatDto.AgentChatResponse;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/service/ChatService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/service/ChatService.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.synapse.agent.chat.service;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.ToolRegistry;
 import com.spectrayan.spector.synapse.agent.chat.dto.ChatDto.AgentChatResponse;
 import com.spectrayan.spector.synapse.agent.chat.dto.ChatDto.ChatConfig;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/AgenticChatGraph.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/AgenticChatGraph.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.synapse.agent.graph;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.ToolRegistry;
 import com.spectrayan.spector.synapse.bridge.LlmBridge;
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.synapse.agent.graph.spec.FlowSpec;
 import com.spectrayan.spector.synapse.agent.graph.spec.NodeSpec;
 import com.spectrayan.spector.synapse.agent.graph.coordinator.AgentSelector;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 
 import com.spectrayan.spector.synapse.bridge.LlmBridge;
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/AgentDelegationNode.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/AgentDelegationNode.java
@@ -12,20 +12,21 @@
  */
 package com.spectrayan.spector.synapse.agent.graph.coordinator;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.graph.AgenticChatGraph;
 import com.spectrayan.spector.synapse.agent.graph.CognitiveState;
 import org.bsc.langgraph4j.action.NodeAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Node action that delegates task execution to a specialized child agent via AgenticChatGraph.
+ * Node that delegates execution to another agent.
  */
-public final class AgentDelegationNode implements NodeAction<CognitiveState> {
+public class AgentDelegationNode implements NodeAction<CognitiveState> {
 
     private static final Logger log = LoggerFactory.getLogger(AgentDelegationNode.class);
 
@@ -47,15 +48,17 @@ public final class AgentDelegationNode implements NodeAction<CognitiveState> {
         log.info("[AgentDelegationNode] Agent '{}' completed execution (result length={})",
                 soul.name(), result.length());
 
-        return Map.of(
-                "context", List.of("[" + soul.name() + "] " + result),
-                "answer", result,
-                "child_results", List.of(Map.of(
-                        "agent", soul.id(),
-                        "name", soul.name(),
-                        "task", subtask,
-                        "result", result
-                ))
-        );
+        Map<String, Object> response = new HashMap<>();
+        response.put("context", List.of("[" + (soul.name() != null ? soul.name() : "Agent") + "] " + result));
+        response.put("answer", result);
+
+        Map<String, String> child = new HashMap<>();
+        child.put("agent", soul.id() != null ? soul.id() : "");
+        child.put("name", soul.name() != null ? soul.name() : "");
+        child.put("task", subtask);
+        child.put("result", result);
+
+        response.put("child_results", List.of(child));
+        return response;
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/AgentSelector.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/AgentSelector.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.synapse.agent.graph.coordinator;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/nodes/PlannerNode.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/nodes/PlannerNode.java
@@ -62,7 +62,7 @@ public final class PlannerNode implements NodeAction<CoordinatorState> {
 
         String executionResult = state.executionResult().orElse("(no previous execution)");
 
-        List<com.spectrayan.spector.synapse.agent.AgentSoul> agents = soulService.listAllAgents();
+        List<com.spectrayan.spector.memory.model.AgentSoul> agents = soulService.listAllAgents();
         StringBuilder agentsList = new StringBuilder();
         if (agents.isEmpty()) {
             agentsList.append("- No specialized child agents available (use default system assistant)\n");

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/service/CognitiveSoulService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/service/CognitiveSoulService.java
@@ -13,40 +13,34 @@
 package com.spectrayan.spector.synapse.agent.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.InsulaSelfModel;
 import com.spectrayan.spector.memory.model.PersonaContext;
-import com.spectrayan.spector.synapse.agent.AgentSoul;
-import com.spectrayan.spector.synapse.memory.MemoryDto.RecallRequest;
-import com.spectrayan.spector.synapse.memory.MemoryDto.StoreRequest;
-import com.spectrayan.spector.synapse.memory.MemoryService;
+import com.spectrayan.spector.memory.model.UserSoul;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
 import com.spectrayan.spector.synapse.config.SynapseSalienceProvider;
-import com.spectrayan.spector.synapse.config.model.ConfigCategory;
-import com.spectrayan.spector.synapse.config.model.ScopedConfig;
-import com.spectrayan.spector.synapse.config.repository.ConfigRepository;
+import com.spectrayan.spector.synapse.memory.UserMemoryRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
- * Service for managing agent and user souls using Spector's cognitive memory.
- *
- * <p>Replaces H2-based storage with cognitive persistence. Souls are serialized
- * to JSON and stored as memories with specific identity tags.</p>
- *
- * <p>When the user persona is loaded or saved, this service automatically
- * updates the {@link SynapseSalienceProvider} so that the memory engine
- * applies user-salience-driven importance, valence, and arousal modulation
- * on all subsequent ingestion and recall operations.</p>
+ * Service for managing agent and user souls using Spector's INSULA cortex memory region.
  */
 @Service
 public class CognitiveSoulService {
 
     private static final Logger log = LoggerFactory.getLogger(CognitiveSoulService.class);
-    private static final String TAG_AGENT_SOUL = "identity:agent";
-    private static final String TAG_USER_SOUL = "identity:user";
 
     public static final AgentSoul DEFAULT_FALLBACK_SOUL = AgentSoul.builder()
             .id("default")
@@ -64,83 +58,87 @@ public class CognitiveSoulService {
             .tools(List.of())
             .build();
 
-    private final MemoryService memoryService;
+    private final UserMemoryRegistry userMemoryRegistry;
     private final ObjectMapper mapper;
     private final SynapseSalienceProvider salienceProvider;
-    private final ConfigRepository configRepository;
+    private final SynapseProperties synapseProps;
 
-    public CognitiveSoulService(MemoryService memoryService, ObjectMapper mapper,
+    public CognitiveSoulService(UserMemoryRegistry userMemoryRegistry,
+                                ObjectMapper mapper,
                                 SynapseSalienceProvider salienceProvider,
-                                ConfigRepository configRepository) {
-        this.memoryService = memoryService;
+                                SynapseProperties synapseProps) {
+        this.userMemoryRegistry = userMemoryRegistry;
         this.mapper = mapper;
         this.salienceProvider = salienceProvider;
-        this.configRepository = configRepository;
+        this.synapseProps = synapseProps;
     }
 
     /** Loads an agent soul by ID (or the default if ID is null). */
-    @SuppressWarnings("unchecked")
     public Optional<AgentSoul> loadAgentSoul(String id) {
-        String scope = id != null ? "agent:" + id : "agent:default";
-        return configRepository.get(scope, ConfigCategory.SOUL)
-                .map(sc -> {
-                    try {
-                        return mapper.convertValue(sc.values(), AgentSoul.class);
-                    } catch (Exception e) {
-                        log.warn("Failed to convert agent soul configuration: {}", e.getMessage());
-                        return null;
+        String namespaceId = "agent-" + (id != null ? id : "default");
+        SpectorMemory memory = userMemoryRegistry.resolveFor(namespaceId);
+        if (memory == null) {
+            return Optional.empty();
+        }
+
+        return memory.admin().insularCortex().get()
+                .flatMap(bytes -> fromJsonBytes(bytes, InsulaSelfModel.class))
+                .map(model -> {
+                    if (model.soul() instanceof AgentSoul agentSoul) {
+                        return agentSoul;
                     }
+                    return null;
                 });
     }
 
-    /** Lists all agent souls stored in H2 database. */
+    /** Lists all agent souls stored in sharded directories. */
     public List<AgentSoul> listAllAgents() {
-        return configRepository.findByCategory(ConfigCategory.SOUL).stream()
-                .filter(sc -> sc.scope().startsWith("agent:"))
-                .map(sc -> {
-                    try {
-                        return mapper.convertValue(sc.values(), AgentSoul.class);
-                    } catch (Exception e) {
-                        log.warn("Failed to convert agent soul configuration: {}", e.getMessage());
-                        return null;
-                    }
-                })
-                .filter(java.util.Objects::nonNull)
+        List<String> agentIds = discoverAgentIds();
+        if (agentIds.isEmpty()) {
+            return loadAgentSoul(null).map(List::of).orElse(List.of());
+        }
+        return agentIds.stream()
+                .map(this::loadAgentSoul)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    /** Saves an agent soul to the database. */
-    @SuppressWarnings("unchecked")
+    /** Saves an agent soul to the INSULA cortex. */
     public void saveAgentSoul(AgentSoul soul) {
-        String scope = "agent:" + soul.id();
-        Map<String, Object> values = mapper.convertValue(soul, Map.class);
-        ScopedConfig sc = new ScopedConfig(
-                scope,
-                ConfigCategory.SOUL,
-                values,
-                java.time.Instant.now(),
-                "default"
-        );
-        configRepository.save(sc);
-        log.info("[CognitiveSoul] Saved agent soul '{}' in database", soul.name());
+        String namespaceId = "agent-" + soul.id();
+        SpectorMemory memory = userMemoryRegistry.resolveFor(namespaceId);
+        if (memory == null) {
+            log.warn("[CognitiveSoul] Memory not resolved for agent namespace: {}", namespaceId);
+            return;
+        }
+
+        InsulaSelfModel selfModel = new InsulaSelfModel("AGENT", soul, null, Map.of());
+        byte[] bytes = toJsonBytes(selfModel);
+        var insula = memory.admin().insularCortex();
+        if (bytes != null && insula != null) {
+            insula.put(bytes);
+        }
+        log.info("[CognitiveSoul] Saved agent soul '{}' in INSULA", soul.name());
     }
 
     /**
      * Loads the user soul (PersonaContext).
-     *
-     * <p>When a user persona is found, it is automatically applied to the
-     * {@link SynapseSalienceProvider} so memory scoring reflects the user's
-     * personality and identity.</p>
      */
     public Optional<PersonaContext> loadUserSoul() {
-        Optional<PersonaContext> persona = configRepository.get("user:default:default", ConfigCategory.SOUL)
-                .map(sc -> {
-                    try {
-                        return mapper.convertValue(sc.values(), PersonaContext.class);
-                    } catch (Exception e) {
-                        log.warn("Failed to convert user soul configuration: {}", e.getMessage());
-                        return null;
+        String nsId = currentNamespaceId();
+        SpectorMemory memory = userMemoryRegistry.resolveFor(nsId);
+        if (memory == null) {
+            return Optional.empty();
+        }
+
+        var insula = memory.admin().insularCortex();
+        Optional<PersonaContext> persona = (insula == null) ? Optional.empty() : insula.get()
+                .flatMap(bytes -> fromJsonBytes(bytes, InsulaSelfModel.class))
+                .map(model -> {
+                    if (model.soul() instanceof UserSoul userSoul) {
+                        return userSoul.persona();
                     }
+                    return null;
                 });
 
         // Propagate to salience provider
@@ -154,33 +152,37 @@ public class CognitiveSoulService {
 
     /**
      * Saves the user soul (PersonaContext).
-     *
-     * <p>After persistence, the persona is immediately applied to the
-     * {@link SynapseSalienceProvider} so all subsequent memory operations
-     * use the updated user salience profile.</p>
      */
-    @SuppressWarnings("unchecked")
     public void saveUserSoul(PersonaContext persona) {
-        if (persona == null) {
-            configRepository.delete("user:default:default", ConfigCategory.SOUL);
-            salienceProvider.updateUserPersona(null);
-            log.info("[CognitiveSoul] Cleared user persona context");
+        String nsId = currentNamespaceId();
+        SpectorMemory memory = userMemoryRegistry.resolveFor(nsId);
+        if (memory == null) {
+            log.warn("[CognitiveSoul] Memory not resolved for namespace: {}", nsId);
             return;
         }
 
-        Map<String, Object> values = mapper.convertValue(persona, Map.class);
-        ScopedConfig sc = new ScopedConfig(
-                "user:default:default",
-                ConfigCategory.SOUL,
-                values,
-                java.time.Instant.now(),
-                "default"
-        );
-        configRepository.save(sc);
+        if (persona == null) {
+            var insula = memory.admin().insularCortex();
+            if (insula != null) {
+                insula.clear();
+            }
+            salienceProvider.updateUserPersona(null);
+            log.info("[CognitiveSoul] Cleared user persona context in INSULA for namespace: {}", nsId);
+            return;
+        }
+
+        UserSoul userSoul = new UserSoul(nsId, "User", "User Persona", persona, persona.aboutEmbedding());
+        InsulaSelfModel selfModel = new InsulaSelfModel("USER", userSoul, salienceProvider.effectiveProfile(), Map.of());
+        
+        byte[] bytes = toJsonBytes(selfModel);
+        var insula = memory.admin().insularCortex();
+        if (bytes != null && insula != null) {
+            insula.put(bytes);
+        }
 
         // Propagate to salience provider
         salienceProvider.updateUserPersona(persona);
-        log.info("[CognitiveSoul] Saved user persona context — salience profile updated");
+        log.info("[CognitiveSoul] Saved user persona context to INSULA — salience profile updated");
     }
 
     /** Get the current active agent soul, or a default fallback. */
@@ -267,25 +269,58 @@ public class CognitiveSoulService {
         return AgentSoul.EmotionalBaseline.NEUTRAL;
     }
 
-    private void forgetOldSouls(String tag) {
-        var results = memoryService.recall(new RecallRequest("identity", 10, null));
-        results.stream()
-                .filter(r -> r.tags() != null && r.tags().contains(tag))
-                .forEach(r -> memoryService.forget(r.id()));
+    private String currentNamespaceId() {
+        if (synapseProps.auth() != null && synapseProps.auth().enabled()) {
+            String userId = com.spectrayan.spector.synapse.security.SecurityUtils.getUserId();
+            if (userId != null && !userId.isBlank() && !"default".equals(userId)) {
+                return userId;
+            }
+        }
+        return "default";
     }
 
-    private String toJson(Object obj) {
-        try {
-            return mapper.writeValueAsString(obj);
-        } catch (Exception e) {
-            log.error("[CognitiveSoul] Failed to serialize soul: {}", e.getMessage());
-            return "{}";
+    private Path basePath() {
+        String path = synapseProps.getMemory().getPersistencePath();
+        if (path == null || path.isBlank()) {
+            path = synapseProps.dataDir();
+        }
+        return Path.of(path);
+    }
+
+    private List<String> discoverAgentIds() {
+        Path namespacesDir = basePath().resolve("namespaces");
+        if (!Files.exists(namespacesDir)) {
+            return List.of();
+        }
+        try (Stream<Path> stream = Files.walk(namespacesDir, 3)) {
+            return stream
+                    .filter(Files::isDirectory)
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .filter(name -> name.startsWith("agent-"))
+                    .map(name -> name.substring("agent-".length()))
+                    .toList();
+        } catch (IOException e) {
+            log.warn("Failed to walk namespaces directory: {}", e.getMessage());
+            return List.of();
         }
     }
 
-    private <T> Optional<T> fromJson(String json, Class<T> clazz) {
+    private byte[] toJsonBytes(Object obj) {
         try {
-            return Optional.of(mapper.readValue(json, clazz));
+            return mapper.writeValueAsBytes(obj);
+        } catch (Exception e) {
+            log.error("[CognitiveSoul] Failed to serialize soul: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private <T> Optional<T> fromJsonBytes(byte[] bytes, Class<T> clazz) {
+        if (bytes == null || bytes.length == 0) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(mapper.readValue(bytes, clazz));
         } catch (Exception e) {
             log.warn("[CognitiveSoul] Failed to deserialize {}: {}", clazz.getSimpleName(), e.getMessage());
             return Optional.empty();

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/service/IdentityPrimerService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/service/IdentityPrimerService.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.synapse.agent.service;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/ReadIdentityTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/ReadIdentityTool.java
@@ -16,7 +16,7 @@ import com.spectrayan.spector.runtime.SpectorRuntime;
 import io.modelcontextprotocol.spec.McpSchema;
 
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.mcp.tools.McpToolHandler.McpToolCategory;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/UpdateAgentSoulTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/UpdateAgentSoulTool.java
@@ -16,7 +16,7 @@ import com.spectrayan.spector.runtime.SpectorRuntime;
 import io.modelcontextprotocol.spec.McpSchema;
 
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
 
 import org.slf4j.Logger;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseSalienceProvider.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseSalienceProvider.java
@@ -63,17 +63,33 @@ public class SynapseSalienceProvider implements SalienceProfileProvider {
     private static final Logger log = LoggerFactory.getLogger(SynapseSalienceProvider.class);
 
     private final EmbeddingProvider embeddingProvider;
+    private final org.springframework.beans.factory.ObjectProvider<com.spectrayan.spector.synapse.memory.UserMemoryRegistry> registryProvider;
     private final ReentrantLock lock = new ReentrantLock();
 
     private volatile SalienceProfile currentProfile = SalienceProfile.NEUTRAL;
 
-    public SynapseSalienceProvider(EmbeddingProvider embeddingProvider) {
+    public SynapseSalienceProvider(EmbeddingProvider embeddingProvider,
+                                   org.springframework.beans.factory.ObjectProvider<com.spectrayan.spector.synapse.memory.UserMemoryRegistry> registryProvider) {
         this.embeddingProvider = embeddingProvider;
+        this.registryProvider = registryProvider;
         log.info("[SynapseSalience] Provider initialized (profile=NEUTRAL, awaiting user persona)");
     }
 
     @Override
     public SalienceProfile effectiveProfile() {
+        if (registryProvider != null) {
+            com.spectrayan.spector.synapse.memory.UserMemoryRegistry registry = registryProvider.getIfAvailable();
+            if (registry != null) {
+                try {
+                    com.spectrayan.spector.memory.SpectorMemory memory = registry.resolveForCurrentRequest();
+                    if (memory != null) {
+                        return memory.salienceProfile();
+                    }
+                } catch (Exception e) {
+                    log.warn("[SynapseSalience] Failed to resolve memory for current request: {}", e.getMessage());
+                }
+            }
+        }
         return currentProfile;
     }
 
@@ -274,6 +290,20 @@ public class SynapseSalienceProvider implements SalienceProfileProvider {
         if (betaOverride != null) builder.beta(betaOverride);
 
         currentProfile = builder.build();
+
+        if (registryProvider != null) {
+            com.spectrayan.spector.synapse.memory.UserMemoryRegistry registry = registryProvider.getIfAvailable();
+            if (registry != null) {
+                try {
+                    com.spectrayan.spector.memory.SpectorMemory memory = registry.resolveForCurrentRequest();
+                    if (memory != null) {
+                        memory.setSalienceProfile(currentProfile);
+                    }
+                } catch (Exception e) {
+                    log.warn("[SynapseSalience] Failed to apply salience profile to memory instance: {}", e.getMessage());
+                }
+            }
+        }
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/UserSalienceController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/UserSalienceController.java
@@ -38,9 +38,6 @@ import com.spectrayan.spector.memory.model.PersonaContext;
 import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
 import com.spectrayan.spector.synapse.config.SynapseSalienceProvider.InterestEntry;
-import com.spectrayan.spector.synapse.config.model.ConfigCategory;
-import com.spectrayan.spector.synapse.config.model.ScopedConfig;
-import com.spectrayan.spector.synapse.config.repository.ConfigRepository;
 import com.spectrayan.spector.synapse.memory.MemoryAccessObject;
 
 /**
@@ -55,7 +52,6 @@ public class UserSalienceController {
     private final SynapseSalienceProvider salienceProvider;
     private final CognitiveSoulService soulService;
     private final MemoryAccessObject mao;
-    private final ConfigRepository configRepository;
     private final ObjectMapper mapper;
 
     /**
@@ -69,13 +65,11 @@ public class UserSalienceController {
     public UserSalienceController(SynapseSalienceProvider salienceProvider,
                                   CognitiveSoulService soulService,
                                   MemoryAccessObject mao,
-                                  ConfigRepository configRepository,
                                   ObjectMapper mapper,
                                   ObjectProvider<SpectorMemory> memoryProvider) {
         this.salienceProvider = salienceProvider;
         this.soulService = soulService;
         this.mao = mao;
-        this.configRepository = configRepository;
         this.mapper = mapper;
         this.memoryProvider = memoryProvider;
     }
@@ -170,39 +164,12 @@ public class UserSalienceController {
 
         salienceProvider.updateScoringWeights(icnu, request.alpha(), request.beta());
 
-        // 3. Process persona if present
-        if (request.persona() != null) {
-            soulService.saveUserSoul(request.persona());
+        // 3. Process and save the unified self-model (persona + salience profile) to INSULA
+        PersonaContext persona = request.persona();
+        if (persona == null) {
+            persona = soulService.loadUserSoul().orElse(null);
         }
-
-        // 4. Save SALIENCE settings to H2 Database
-        try {
-            Map<String, Object> values = new HashMap<>();
-            values.put("interestsList", interestEntries.stream().map(e -> Map.of("topic", e.topic(), "level", e.level().name())).toList());
-            values.put("disinterestsList", disinterestEntries.stream().map(e -> Map.of("topic", e.topic(), "level", e.level().name())).toList());
-            if (icnu != null) {
-                values.put("icnuWeights", Map.of(
-                        "interest", icnu.interest(),
-                        "challenge", icnu.challenge(),
-                        "novelty", icnu.novelty(),
-                        "urgency", icnu.urgency()
-                ));
-            }
-            if (request.alpha() != null) values.put("alpha", request.alpha());
-            if (request.beta() != null) values.put("beta", request.beta());
-
-            ScopedConfig sc = new ScopedConfig(
-                    "user:default:default",
-                    ConfigCategory.SALIENCE,
-                    values,
-                    java.time.Instant.now(),
-                    "default"
-            );
-            configRepository.save(sc);
-            log.info("Persisted user salience profile to database under category SALIENCE");
-        } catch (Exception e) {
-            log.warn("Failed to persist user salience profile to database: {}", e.getMessage());
-        }
+        soulService.saveUserSoul(persona);
 
         return ResponseEntity.ok(Map.of(
                 "status", "success",
@@ -216,7 +183,6 @@ public class UserSalienceController {
         salienceProvider.updateInterests(List.of(), List.of());
         salienceProvider.updateScoringWeights(null, null, null);
         soulService.saveUserSoul(null);
-        configRepository.delete("user:default:default", ConfigCategory.SALIENCE);
 
         return ResponseEntity.ok(Map.of(
                 "status", "success",

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistry.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistry.java
@@ -38,6 +38,8 @@ import com.spectrayan.spector.config.properties.MemoryProperties;
 import com.spectrayan.spector.spring.autoconfigure.SpectorConfigProperties;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
 import com.spectrayan.spector.synapse.security.SecurityUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.model.InsulaSelfModel;
 
 /**
  * Resolves the {@link SpectorMemory} instance for the current request, isolating each authenticated
@@ -89,6 +91,7 @@ public final class UserMemoryRegistry implements AutoCloseable {
     private final ObjectProvider<EmbeddingProvider> embedderProvider;
     private final ObjectProvider<LlmProvider> textGenProvider;
     private final ObjectProvider<SalienceProfileProvider> salienceProvider;
+    private final ObjectProvider<ObjectMapper> objectMapperProvider;
 
     /** Maximum number of concurrently-cached per-user instances (LRU cap). */
     private final int maxInstances;
@@ -107,12 +110,14 @@ public final class UserMemoryRegistry implements AutoCloseable {
             ObjectProvider<EmbeddingProvider> embedderProvider,
             ObjectProvider<LlmProvider> textGenProvider,
             ObjectProvider<SalienceProfileProvider> salienceProvider,
+            ObjectProvider<ObjectMapper> objectMapperProvider,
             @Value("${spector.auth.memory.max-instances:512}") int maxInstances) {
         this.sharedProvider = sharedProvider;
         this.synapseProps = synapseProps;
         this.embedderProvider = embedderProvider;
         this.textGenProvider = textGenProvider;
         this.salienceProvider = salienceProvider;
+        this.objectMapperProvider = objectMapperProvider;
         this.maxInstances = Math.max(1, maxInstances);
         log.info("[UserMemoryRegistry] initialized: authEnabled={}, maxInstances={}",
                 synapseProps.auth().enabled(), this.maxInstances);
@@ -305,6 +310,24 @@ public final class UserMemoryRegistry implements AutoCloseable {
         SpectorMemory built = builder.build();
         log.info("[UserMemoryRegistry] built per-user memory instance (dims={}, persistenceMode={})",
                 memory.getDimensions(), memory.getPersistenceMode());
+
+        // Load saved salience profile from the INSULA region on startup
+        try {
+            java.util.Optional<byte[]> bytes = built.admin().insularCortex().get();
+            if (bytes.isPresent() && objectMapperProvider != null) {
+                ObjectMapper mapper = objectMapperProvider.getIfAvailable();
+                if (mapper != null) {
+                    InsulaSelfModel model = mapper.readValue(bytes.get(), InsulaSelfModel.class);
+                    if (model != null && model.salience() != null) {
+                        built.setSalienceProfile(model.salience());
+                        log.info("[UserMemoryRegistry] Restored salience profile from INSULA for user/agent {}", userId);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("[UserMemoryRegistry] Failed to restore salience profile from INSULA: {}", e.getMessage());
+        }
+
         return built;
     }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/AgentCardApiTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/AgentCardApiTest.java
@@ -15,6 +15,7 @@ package com.spectrayan.spector.synapse.agent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spectrayan.spector.synapse.agent.graph.AgenticChatGraph;
 import com.spectrayan.spector.synapse.agent.service.CognitiveSoulService;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/chat/ChatServiceLiveIT.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/chat/ChatServiceLiveIT.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.ToolRegistry;
 import com.spectrayan.spector.synapse.agent.chat.model.Conversation;
 import com.spectrayan.spector.synapse.agent.chat.service.ChatMemoryPort;

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/chat/DeepConversationLiveIT.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/chat/DeepConversationLiveIT.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.ToolRegistry;
 import com.spectrayan.spector.synapse.agent.chat.model.Conversation;
 import com.spectrayan.spector.synapse.agent.chat.service.ChatMemoryPort;

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraphTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraphTest.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.synapse.agent.graph.coordinator;
 
-import com.spectrayan.spector.synapse.agent.AgentSoul;
+import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.synapse.agent.ToolRegistry;
 import com.spectrayan.spector.synapse.agent.graph.AgenticChatGraph;
 import com.spectrayan.spector.synapse.agent.graph.CognitiveState;

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/config/EndToEndIsolationIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/config/EndToEndIsolationIntegrationTest.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -139,6 +140,7 @@ class EndToEndIsolationIntegrationTest {
         private ObjectProvider<EmbeddingProvider> embedderProvider;
         private ObjectProvider<LlmProvider> textGenProvider;
         private ObjectProvider<SalienceProfileProvider> salienceProvider;
+        private ObjectProvider<ObjectMapper> objectMapperProvider;
 
         @BeforeEach
         void setUp() {
@@ -150,6 +152,8 @@ class EndToEndIsolationIntegrationTest {
             when(textGenProvider.getIfAvailable()).thenReturn(null);
             salienceProvider = mockProvider();
             when(salienceProvider.getIfAvailable()).thenReturn(null);
+            objectMapperProvider = mockProvider();
+            when(objectMapperProvider.getIfAvailable()).thenReturn(new ObjectMapper());
         }
 
         @Test
@@ -207,6 +211,7 @@ class EndToEndIsolationIntegrationTest {
                     embedderProvider,
                     textGenProvider,
                     salienceProvider,
+                    objectMapperProvider,
                     maxInstances);
         }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpToolIsolationIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpToolIsolationIntegrationTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -277,6 +278,8 @@ class McpToolIsolationIntegrationTest {
         // No EmbeddingProvider available → per-user buildInstance fails closed (drives Req 11.4).
         ObjectProvider<LlmProvider> textGenProvider = mockProvider();
         ObjectProvider<SalienceProfileProvider> salienceProvider = mockProvider();
+        ObjectProvider<ObjectMapper> objectMapperProvider = mockProvider();
+        when(objectMapperProvider.getIfAvailable()).thenReturn(new ObjectMapper());
 
         return new UserMemoryRegistry(
                 sharedProvider,
@@ -284,6 +287,7 @@ class McpToolIsolationIntegrationTest {
                 embedderProvider,
                 textGenProvider,
                 salienceProvider,
+                objectMapperProvider,
                 512);
     }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/ConcurrentRequestThreadCaptureIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/ConcurrentRequestThreadCaptureIntegrationTest.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -219,6 +220,8 @@ class ConcurrentRequestThreadCaptureIntegrationTest {
         ObjectProvider<EmbeddingProvider> embedderProvider = mockProvider();
         ObjectProvider<LlmProvider> textGenProvider = mockProvider();
         ObjectProvider<SalienceProfileProvider> salienceProvider = mockProvider();
+        ObjectProvider<ObjectMapper> objectMapperProvider = mockProvider();
+        when(objectMapperProvider.getIfAvailable()).thenReturn(new ObjectMapper());
 
         return new UserMemoryRegistry(
                 sharedProvider,
@@ -226,6 +229,7 @@ class ConcurrentRequestThreadCaptureIntegrationTest {
                 embedderProvider,
                 textGenProvider,
                 salienceProvider,
+                objectMapperProvider,
                 512);
     }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistryRoutingPropertyTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistryRoutingPropertyTest.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -318,12 +319,15 @@ class UserMemoryRegistryRoutingPropertyTest {
         ObjectProvider<SalienceProfileProvider> salienceProvider = mockProvider();
         when(salienceProvider.getIfAvailable()).thenReturn(null);
 
+        ObjectProvider<ObjectMapper> objectMapperProvider = mockProvider();
+        when(objectMapperProvider.getIfAvailable()).thenReturn(new ObjectMapper());
+
         var auth = new com.spectrayan.spector.config.properties.AuthProperties(
                 true, null, null, null, null, null, null, null);
         var synapse = new SynapseProperties(0, null, base.toString(), null, null, auth);
 
         UserMemoryRegistry registry = new UserMemoryRegistry(
-                sharedProvider, synapse, embedderProvider, textGenProvider, salienceProvider, 512);
+                sharedProvider, synapse, embedderProvider, textGenProvider, salienceProvider, objectMapperProvider, 512);
         return new Fixture(registry, shared);
     }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistryTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistryTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -90,6 +91,7 @@ class UserMemoryRegistryTest {
     private ObjectProvider<EmbeddingProvider> embedderProvider;
     private ObjectProvider<LlmProvider> textGenProvider;
     private ObjectProvider<SalienceProfileProvider> salienceProvider;
+    private ObjectProvider<ObjectMapper> objectMapperProvider;
 
     @BeforeEach
     void setUp() {
@@ -101,6 +103,8 @@ class UserMemoryRegistryTest {
         when(textGenProvider.getIfAvailable()).thenReturn(null);
         salienceProvider = mockProvider();
         when(salienceProvider.getIfAvailable()).thenReturn(null);
+        objectMapperProvider = mockProvider();
+        when(objectMapperProvider.getIfAvailable()).thenReturn(new ObjectMapper());
     }
 
     @AfterEach
@@ -344,6 +348,7 @@ class UserMemoryRegistryTest {
                 embedderProvider,
                 textGenProvider,
                 salienceProvider,
+                objectMapperProvider,
                 maxInstances);
     }
 


### PR DESCRIPTION
## Summary
This PR implements **Phase 3** of the Insula SQL Migration: migrating all user and agent souls (cognitive identities) and active salience profiles from the legacy SQL relational H2 database to off-heap memory-mapped `INSULA` regions inside the `insularCortex` of `SpectorMemory`. 

## Key Changes
- **Configuration & Capacity Tuning**: Bumped the default memory-mapped `INSULA` region size to **1MB** (`SpectorPropertyConstants.java`) to support rich JSON profiles and embeddings.
- **Polymorphic Soul Models**: Implemented a sealed interface `SoulContext` (with `UserSoul`, `AgentSoul`, `OrgUnitSoul`, and `TenantSoul` subclasses) under the core `spector-memory` model package.
- **Unified Insula Model**: Implemented `InsulaSelfModel` as a unified off-heap container for serialization.
- **Service Rewrite**: Completely rewrote `CognitiveSoulService` to read/write/list directly from `insularCortex` of `SpectorMemory`, eliminating all H2 database repository dependencies.
- **Memory Context Restoration & Scoping**: Refactored `UserMemoryRegistry` to load the salience profile from `INSULA` on startup, and `SynapseSalienceProvider` to dynamically resolve thread-local/request-scoped active user memory.
- **Controller Cleanup**: Removed legacy `ConfigRepository` references from `UserSalienceController`.
- **Pure Constructor Injection**: Cleaned up constructor injection by removing the `@Autowired` annotations and secondary constructors across `UserMemoryRegistry` and `SynapseSalienceProvider` to enforce Spring's default constructor injection.

Closes #474

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
