### PR TITLE
feat(synapse): wire RecallOptions and browse() into chat adapter (#479)

### DIFF
--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/infrastructure/SpectorMemoryChatAdapter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/infrastructure/SpectorMemoryChatAdapter.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.synapse.agent.chat.infrastructure;
 
 import com.spectrayan.spector.synapse.agent.chat.model.Conversation;
 import com.spectrayan.spector.synapse.agent.chat.service.ChatMemoryPort;
+import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.StoreRequest;
 import com.spectrayan.spector.synapse.memory.MemoryService;
@@ -31,6 +32,17 @@ import java.util.Map;
  *
  * <p>All chat sessions and messages are stored as cognitive memories,
  * eliminating the need for a relational database.</p>
+ *
+ * <h3>Retrieval Strategy</h3>
+ * <ul>
+ *   <li><strong>Session replay</strong> ({@link #loadSessionHistory}, {@link #listSessions}):
+ *       Uses {@link com.spectrayan.spector.memory.SpectorMemory#browse(String...)} via
+ *       {@link MemoryService#browse} — an inverted tag index lookup (O(1) exact matching),
+ *       not vector search. Guarantees completeness for session replay.</li>
+ *   <li><strong>Cross-session recall</strong> ({@link #recallRelevantMemories}):
+ *       Uses cognitive recall with {@code RecallMode.OBSERVE} to find semantically
+ *       related memories without triggering LTP/habituation side effects.</li>
+ * </ul>
  */
 @Component
 public class SpectorMemoryChatAdapter implements ChatMemoryPort {
@@ -47,13 +59,12 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
     public List<Map<String, Object>> loadSessionHistory(String sessionId) {
         if (sessionId == null || !memoryService.isEngineAvailable()) return List.of();
 
-        // Recall memories for this session, sorted by temporal chain (ideally)
-        // For now, we query specifically for session tags
-        var results = memoryService.recall(new RecallRequest("session:" + sessionId, 100, null));
+        // browse() uses inverted tag index — O(1) exact tag match, no vector search.
+        // Guarantees complete session replay regardless of memory store size.
+        var results = memoryService.browse(
+                new BrowseRequest(List.of("session:" + sessionId, "type:turn"), 500));
 
         return results.stream()
-                .filter(r -> r.tags() != null && r.tags().contains("session:" + sessionId))
-                .sorted((a, b) -> a.id().compareTo(b.id())) // Rough temporal order by ID if they are sequential
                 .map(r -> {
                     String role = r.tags().stream()
                             .filter(t -> t.startsWith("role:"))
@@ -63,7 +74,7 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
                     return Map.<String, Object>of(
                             "role", role,
                             "content", r.text(),
-                            "timestamp", System.currentTimeMillis() // Metadata not fully preserved in recall currently
+                            "timestamp", r.timestampMs()
                     );
                 })
                 .toList();
@@ -87,13 +98,13 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
                     List.of("chat", "session:" + sessionId, "role:assistant", "model:" + model, "type:turn"),
                     null, Map.of()));
 
-            // Delete any existing session summaries for this session to avoid duplicates
+            // Delete any existing session summaries for this session to avoid duplicates.
+            // browse() uses inverted tag index — exact match, no false positives.
             try {
-                var existing = memoryService.recall(new RecallRequest("id:" + sessionId, 10, null));
+                var existing = memoryService.browse(
+                        new BrowseRequest(List.of("session_summary", "id:" + sessionId), 10));
                 for (var r : existing) {
-                    if (r.tags() != null && r.tags().contains("session_summary") && r.tags().contains("id:" + sessionId)) {
-                        memoryService.forget(r.id());
-                    }
+                    memoryService.forget(r.id());
                 }
             } catch (Exception e) {
                 log.debug("[ChatAdapter] Failed to delete old session summary: {}", e.getMessage());
@@ -117,11 +128,11 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
     public List<Conversation> listSessions(int limit) {
         if (!memoryService.isEngineAvailable()) return List.of();
 
-        // Query for session summaries
-        var results = memoryService.recall(new RecallRequest("session_summary", limit, null));
+        // browse() uses inverted tag index — returns all session summaries.
+        var results = memoryService.browse(
+                new BrowseRequest(List.of("session_summary"), limit));
 
         return results.stream()
-                .filter(r -> r.tags() != null && r.tags().contains("session_summary"))
                 .map(r -> {
                     String sid = r.tags().stream()
                             .filter(t -> t.startsWith("id:"))
@@ -132,8 +143,8 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
                             sid,
                             0, // Message count not easily available without another query
                             r.text().replace("Session Preview: ", ""),
-                            Instant.now(), // Real timestamps not available in recall DTO
-                            Instant.now()
+                            Instant.ofEpochMilli(r.timestampMs()),
+                            Instant.ofEpochMilli(r.timestampMs())
                     );
                 })
                 .toList();
@@ -148,7 +159,10 @@ public class SpectorMemoryChatAdapter implements ChatMemoryPort {
         }
 
         try {
-            var results = memoryService.recall(new RecallRequest(query, limit, null));
+            // Use OBSERVE mode — reading for context priming should NOT strengthen memories
+            // (no LTP reconsolidation, no habituation, no ACT-R timestamp updates)
+            var results = memoryService.recall(new RecallRequest(
+                    query, limit, null, null, null, "OBSERVE"));
 
             return results.stream()
                     // Exclude memories from the current session and raw turn noise

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/memory/SpectorChatMemoryRepository.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/memory/SpectorChatMemoryRepository.java
@@ -64,7 +64,7 @@ public class SpectorChatMemoryRepository implements ChatMemoryRepository {
         if (!memoryService.isEngineAvailable()) return List.of();
         
         // Recall session summaries and extract IDs from tags
-        var results = memoryService.recall(new RecallRequest("session_summary", 100, null));
+        var results = memoryService.recall(new RecallRequest("session_summary", 100, null, null, null, null));
         return results.stream()
                 .filter(r -> r.tags() != null && r.tags().contains("session_summary"))
                 .map(r -> r.tags().stream()
@@ -81,7 +81,7 @@ public class SpectorChatMemoryRepository implements ChatMemoryRepository {
     public List<Message> findByConversationId(String conversationId) {
         if (conversationId == null || !memoryService.isEngineAvailable()) return List.of();
 
-        var results = memoryService.recall(new RecallRequest("session:" + conversationId, 100, null));
+        var results = memoryService.recall(new RecallRequest("session:" + conversationId, 100, null, null, null, null));
 
         return results.stream()
                 .filter(r -> r.tags() != null && r.tags().contains("session:" + conversationId))
@@ -128,7 +128,7 @@ public class SpectorChatMemoryRepository implements ChatMemoryRepository {
         // Implement "forget" logic for all memories with session tag
         if (!memoryService.isEngineAvailable()) return;
         
-        var results = memoryService.recall(new RecallRequest("session:" + conversationId, 100, null));
+        var results = memoryService.recall(new RecallRequest("session:" + conversationId, 100, null, null, null, null));
         results.stream()
                 .filter(r -> r.tags() != null && r.tags().contains("session:" + conversationId))
                 .forEach(r -> memoryService.forget(r.id()));

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
@@ -28,6 +28,7 @@ import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.id.TsidGenerator;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.GraphNeighborhood;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
@@ -203,6 +204,41 @@ public class MemoryAccessObject {
             return memory.recall(query);
         } catch (Exception e) {
             log.error("[MemoryAccessObject] Recall failed: {}", e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    /**
+     * Call cognitive recall with explicit {@link RecallOptions}.
+     *
+     * <p>Enables tag-filtered recall via
+     * {@link RecallOptions.Builder#synapticFilter(String...)}, scoring mode
+     * selection, and side-effect-free observation via
+     * {@link com.spectrayan.spector.memory.model.RecallMode#OBSERVE}.</p>
+     */
+    public List<CognitiveResult> recall(SpectorMemory memory, String query, RecallOptions options) {
+        if (!isAvailable(memory)) return List.of();
+        try {
+            return memory.recall(query, options);
+        } catch (Exception e) {
+            log.error("[MemoryAccessObject] Recall with options failed: {}", e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    /**
+     * Tag-based metadata browsing — no vector search.
+     *
+     * <p>Delegates to {@link SpectorMemory#browse(String...)} which uses
+     * the inverted tag index ({@code IndexRecordMemory.tagToIds}) for
+     * O(1) exact tag matching with AND semantics.</p>
+     */
+    public List<CognitiveRecord> browse(SpectorMemory memory, String... tags) {
+        if (!isAvailable(memory)) return List.of();
+        try {
+            return memory.browse(tags);
+        } catch (Exception e) {
+            log.error("[MemoryAccessObject] Browse failed: {}", e.getMessage(), e);
             return List.of();
         }
     }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
@@ -19,6 +19,8 @@ import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryStatusResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryTableResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallResult;
+import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseRequest;
+import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseResult;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ReflectResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ReinforceByIdRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RememberRequest;
@@ -174,6 +176,19 @@ public class MemoryController {
     @PostMapping("/recall")
     public ResponseEntity<List<RecallResult>> recall(@RequestBody RecallRequest request) {
         return ResponseEntity.ok(memoryService.recall(request));
+    }
+
+    /**
+     * Tag-based memory browsing (no vector search).
+     *
+     * <p>Uses the engine's inverted tag index for O(1) exact tag matching.
+     * Useful for session history replay, auditing, and bulk operations.</p>
+     *
+     * <p>{@code POST /api/v1/memory/browse}</p>
+     */
+    @PostMapping("/browse")
+    public ResponseEntity<List<BrowseResult>> browse(@RequestBody BrowseRequest request) {
+        return ResponseEntity.ok(memoryService.browse(request));
     }
 
     // ══════════════════════════════════════════════════════════════

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryDto.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryDto.java
@@ -123,14 +123,25 @@ public final class MemoryDto {
     /**
      * Request for cognitive recall.
      *
-     * @param query  recall query
-     * @param topK   max results
-     * @param depth  recall depth (how many association hops)
+     * <p>Supports tag-based filtering via the engine's
+     * {@link com.spectrayan.spector.memory.model.RecallOptions#synapticTagMask()}
+     * Bloom filter. When {@code tags} are provided, only memories whose
+     * synaptic tags overlap the query mask are returned.</p>
+     *
+     * @param query       recall query text (will be embedded)
+     * @param topK        max results
+     * @param depth       recall depth (how many association hops)
+     * @param tags        synaptic tag filter — AND semantics (nullable)
+     * @param scoringMode "COGNITIVE", "SIMILARITY", or "ASSOCIATIVE" (nullable = COGNITIVE)
+     * @param recallMode  "LEARN", "OBSERVE", or "REPLAY" (nullable = LEARN)
      */
     public record RecallRequest(
             String query,
             Integer topK,
-            Integer depth
+            Integer depth,
+            List<String> tags,
+            String scoringMode,
+            String recallMode
     ) {
         public RecallRequest {
             if (topK == null || topK <= 0) topK = 10;
@@ -370,6 +381,42 @@ public final class MemoryDto {
             double cognitiveScore,
             String memoryType,
             String ageDescription,
+            List<String> tags
+    ) {}
+
+    /**
+     * Request for tag-based memory browsing (no vector search).
+     *
+     * <p>Delegates to {@link com.spectrayan.spector.memory.SpectorMemory#browse(String...)}
+     * which uses an inverted tag index ({@code IndexRecordMemory.tagToIds}) for
+     * O(1) exact tag matching with AND semantics.</p>
+     *
+     * @param tags  tag strings to filter by — all must match (AND semantics)
+     * @param limit maximum number of results to return
+     */
+    public record BrowseRequest(
+            List<String> tags,
+            Integer limit
+    ) {
+        public BrowseRequest {
+            if (limit == null || limit <= 0) limit = 100;
+        }
+    }
+
+    /**
+     * Result from tag-based memory browsing.
+     *
+     * @param id          memory ID
+     * @param text        memory text content
+     * @param memoryType  tier name (SEMANTIC, EPISODIC, etc.)
+     * @param timestampMs creation timestamp in epoch milliseconds
+     * @param tags        decoded synaptic tag labels
+     */
+    public record BrowseResult(
+            String id,
+            String text,
+            String memoryType,
+            long timestampMs,
             List<String> tags
     ) {}
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -45,7 +45,10 @@ import com.spectrayan.spector.memory.id.TsidGenerator;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallMode;
+import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.model.ScoringMode;
 import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
 import com.spectrayan.spector.synapse.memory.MemoryDto.AcceptedResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.CompactionResult;
@@ -59,6 +62,8 @@ import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryTableRow;
 import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryVectorResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallResult;
+import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseRequest;
+import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseResult;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ReflectResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RememberRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ResolveRequest;
@@ -350,9 +355,39 @@ public class MemoryService {
         if (request.query() == null || request.query().isBlank()) {
             throw new IllegalArgumentException("Recall query cannot be blank");
         }
-        log.debug("[MemoryService] recall: query='{}', topK={}", request.query(), request.topK());
+        log.debug("[MemoryService] recall: query='{}', topK={}, tags={}",
+                request.query(), request.topK(), request.tags());
         long start = System.nanoTime();
-        List<CognitiveResult> results = mao.recall(resolveMemory(), request.query());
+
+        // Build RecallOptions from DTO when tag/mode fields are present
+        List<CognitiveResult> results;
+        boolean hasOptions = (request.tags() != null && !request.tags().isEmpty())
+                || request.scoringMode() != null
+                || request.recallMode() != null;
+
+        if (hasOptions) {
+            var optionsBuilder = RecallOptions.builder().topK(request.topK());
+            if (request.tags() != null && !request.tags().isEmpty()) {
+                optionsBuilder.synapticFilter(request.tags().toArray(String[]::new));
+            }
+            if (request.scoringMode() != null) {
+                try {
+                    optionsBuilder.scoringMode(ScoringMode.valueOf(request.scoringMode()));
+                } catch (IllegalArgumentException e) {
+                    log.warn("[MemoryService] Unknown scoringMode '{}', using COGNITIVE", request.scoringMode());
+                }
+            }
+            if (request.recallMode() != null) {
+                try {
+                    optionsBuilder.recallMode(RecallMode.valueOf(request.recallMode()));
+                } catch (IllegalArgumentException e) {
+                    log.warn("[MemoryService] Unknown recallMode '{}', using LEARN", request.recallMode());
+                }
+            }
+            results = mao.recall(resolveMemory(), request.query(), optionsBuilder.build());
+        } else {
+            results = mao.recall(resolveMemory(), request.query());
+        }
         long elapsedMicros = (System.nanoTime() - start) / 1000;
         recallCount.incrementAndGet();
         totalLatencyMs.addAndGet(elapsedMicros / 1000);
@@ -406,11 +441,36 @@ public class MemoryService {
             throw new IllegalArgumentException("Search query cannot be blank");
         }
         log.debug("[MemoryService] search: query='{}', topK={}", request.query(), request.topK());
-        List<RecallResult> results = recall(new RecallRequest(request.query(), request.topK(), 1));
+        List<RecallResult> results = recall(new RecallRequest(request.query(), request.topK(), 1, null, null, null));
         return results.stream()
                 .map(r -> new SearchResult(
                         r.id(), r.text(), r.tier(), r.cognitiveScore(), r.cognitiveScore(),
                         r.tags(), Instant.now()))
+                .toList();
+    }
+
+    /**
+     * Tag-based memory browsing — no vector search.
+     *
+     * <p>Delegates to {@link com.spectrayan.spector.memory.SpectorMemory#browse(String...)}
+     * which uses the inverted tag index ({@code IndexRecordMemory.tagToIds}) for
+     * O(1) exact tag matching with AND semantics. Results are sorted by timestamp
+     * (oldest first) for chronological session replay.</p>
+     */
+    public List<BrowseResult> browse(BrowseRequest request) {
+        if (request.tags() == null || request.tags().isEmpty()) {
+            throw new IllegalArgumentException("Browse requires at least one tag");
+        }
+        log.debug("[MemoryService] browse: tags={}, limit={}", request.tags(), request.limit());
+        List<CognitiveRecord> records = mao.browse(
+                resolveMemory(),
+                request.tags().toArray(String[]::new));
+
+        return records.stream()
+                .sorted(java.util.Comparator.comparingLong(CognitiveRecord::timestampMs))
+                .limit(request.limit())
+                .map(r -> new BrowseResult(r.id(), r.text(), r.memoryType().name(),
+                        r.timestampMs(), Arrays.asList(r.tags())))
                 .toList();
     }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryServiceTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryServiceTest.java
@@ -106,7 +106,7 @@ class MemoryServiceTest {
     @Test
     @DisplayName("recall — returns mapped results from DAO")
     void recall_returnsMappedResults() {
-        var request = new RecallRequest("Java concurrency", 5, null);
+        var request = new RecallRequest("Java concurrency", 5, null, null, null, null);
         var results = List.of(
                 new CognitiveResult("id1", "Virtual threads in Java 25", 0.9f, 2.0f, 0.0f, 0, (byte)0, MemoryType.SEMANTIC, MemorySource.OBSERVED, new String[]{"java"}, 1.0f, 1.0f),
                 new CognitiveResult("id2", "Platform thread limitations", 0.7f, 5.0f, 0.0f, 0, (byte)0, MemoryType.EPISODIC, MemorySource.OBSERVED, new String[0], 1.0f, 1.0f)
@@ -125,7 +125,7 @@ class MemoryServiceTest {
     @Test
     @DisplayName("recall — blank query throws IllegalArgumentException")
     void recall_blankQuery_throws() {
-        var request = new RecallRequest("", 5, null);
+        var request = new RecallRequest("", 5, null, null, null, null);
 
         assertThatThrownBy(() -> service.recall(request))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/SynapseMemoryIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/SynapseMemoryIntegrationTest.java
@@ -166,7 +166,7 @@ class SynapseMemoryIntegrationTest {
     @Order(10)
     @DisplayName("recall: returns semantically relevant results for Panama FFM query")
     void recall_panama_ffm_query() {
-        var request = new RecallRequest("Panama foreign memory off-heap", 10, null);
+        var request = new RecallRequest("Panama foreign memory off-heap", 10, null, null, null, null);
         var results = memoryService.recall(request);
 
         assertThat(results).isNotEmpty();
@@ -189,7 +189,7 @@ class SynapseMemoryIntegrationTest {
     @Order(11)
     @DisplayName("recall: Cortex UI query retrieves pagination-related memory")
     void recall_cortex_ui_query() {
-        var request = new RecallRequest("Cortex UI memory table pagination", 5, null);
+        var request = new RecallRequest("Cortex UI memory table pagination", 5, null, null, null, null);
         var results = memoryService.recall(request);
 
         assertThat(results).isNotEmpty();
@@ -214,7 +214,7 @@ class SynapseMemoryIntegrationTest {
 
         try { TimeUnit.SECONDS.sleep(2); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 
-        var request = new RecallRequest("Java concurrency virtual threads", 2, null);
+        var request = new RecallRequest("Java concurrency virtual threads", 2, null, null, null, null);
         var results = memoryService.recall(request);
 
         assertThat(results).hasSizeLessThanOrEqualTo(2);
@@ -381,7 +381,7 @@ class SynapseMemoryIntegrationTest {
 
         // Verify it can be recalled
         var beforeForget = memoryService.recall(
-                new RecallRequest("Zyxwvutsrqponmlkjihgfedcba unique marker", 10, null));
+                new RecallRequest("Zyxwvutsrqponmlkjihgfedcba unique marker", 10, null, null, null, null));
         assertThat(beforeForget.stream().anyMatch(r -> r.id().equals(targetId))).isTrue();
 
         // Forget it


### PR DESCRIPTION
## Summary

Wire Spector Memory's existing `RecallOptions` and `browse()` API into Synapse's chat adapter layer, replacing the broken semantic-search-with-stream-filter pattern.

### The Problem

`SpectorMemoryChatAdapter` uses semantic vector search (`recall("session:abc123")`) to retrieve chat session history, then post-filters results with Java Streams. This is:

1. **Semantically wrong** — `"session:abc123"` has no meaningful vector embedding
2. **Incomplete** — HNSW is approximate; it can miss messages
3. **Expensive** — O(k log N) vector search when O(1) tag lookup exists
4. **Side-effectful** — `recall()` with default options triggers LTP reconsolidation

### The Fix

**Zero engine changes.** All capabilities already exist in `spector-memory`:

| Chat Operation | Before | After |
|:---|:---|:---|
| Session replay | `recall("session:abc")` + Stream filter | `browse("session:abc", "type:turn")` — inverted index |
| List sessions | `recall("session_summary")` + Stream filter | `browse("session_summary")` — inverted index |
| Cross-session recall | `recall(query)` (mutating) | `recall(query, RecallOptions{OBSERVE})` — no mutations |
| Delete old summaries | `recall("id:sessionId")` (unreliable) | `browse("session_summary", "id:sessionId")` — exact |

### Changes

**Commit 1: DTO Layer** — `MemoryDto.java`
- Expand `RecallRequest` with `tags`, `scoringMode`, `recallMode` fields
- Add `BrowseRequest`/`BrowseResult` records
- Fix all 3-arg callers in `SpectorChatMemoryRepository`

**Commit 2: Service Layer** — `MemoryAccessObject.java`, `MemoryService.java`
- Add `recall(SpectorMemory, String, RecallOptions)` overload to MAO
- Add `browse(SpectorMemory, String...)` to MAO
- Wire `MemoryService.recall()` to build `RecallOptions` from DTO
- Add `MemoryService.browse()` method

**Commit 3: Controller** — `MemoryController.java`
- Add `POST /api/v1/memory/browse` endpoint

**Commit 4: Chat Adapter** — `SpectorMemoryChatAdapter.java`
- Rewrite `loadSessionHistory()` to use `browse()`
- Rewrite `listSessions()` to use `browse()`
- Rewrite `saveToSession()` summary cleanup to use `browse()`
- Use `RecallMode.OBSERVE` for `recallRelevantMemories()`

### Build Verification

```
mvn compile -pl synapse/spector-synapse -am -q  # ✅ PASS
```

Closes #479
