### PR TITLE
feat(memory): ImportanceProvider SPI — pluggable importance scoring (#481)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveIngestionTargetBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveIngestionTargetBuilder.java
@@ -47,7 +47,8 @@ final class CognitiveIngestionTargetBuilder {
             RetrievalIndexBuilder.RetrievalIndices retrieval,
             MemoryIndex index,
             MemoryWal wal,
-            int activePartitionIndex) {
+            int activePartitionIndex,
+            ImportanceProvider importanceProvider) {
 
         //  Ingestion Target 
         CognitiveIngestionTarget cognitiveTarget = new CognitiveIngestionTarget(
@@ -58,7 +59,7 @@ final class CognitiveIngestionTargetBuilder {
                 graphs.entityDirectory(), graphs.hyperEntityGraph(),
                 retrieval.bm25Index(), retrieval.textDataStore(), activePartitionIndex,
                 retrieval.memorySpladeIndex(), builder.SparseEmbeddingProvider,
-                builder.dataEncryptor);
+                builder.dataEncryptor, importanceProvider);
 
         //  Wire Salience Profile Provider 
         if (builder.salienceProfileProvider != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -66,7 +66,8 @@ import com.spectrayan.spector.memory.metamemory.MemoryInsight;
 import com.spectrayan.spector.memory.metamemory.MemoryIntrospector;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.CognitiveResult;
-import com.spectrayan.spector.memory.model.ImportanceEstimate;
+import com.spectrayan.spector.memory.model.ImportanceContext;
+import com.spectrayan.spector.memory.model.ImportanceResult;
 import com.spectrayan.spector.memory.model.IngestionContext;
 import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
 import com.spectrayan.spector.memory.model.MemoryType;
@@ -168,7 +169,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     //  Extracted Strategy/Handler Components 
     private final PartitionManager partitionManager;     // owns volatile cognitiveRouter
-    private final ImportanceEstimator importanceEstimator;
+    private final ImportanceProvider importanceProvider;
     private final ReflectionOrchestrator reflectionOrchestrator;
     private final ReinforcementHandler reinforcementHandler;
     private final ConsolidationService consolidationService;
@@ -248,7 +249,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.index = bundle.index();
         this.quantizer = bundle.quantizer();
         this.partitionManager = bundle.partitionManager();
-        this.importanceEstimator = bundle.importanceEstimator();
+        this.importanceProvider = bundle.importanceProvider();
         this.reflectionOrchestrator = bundle.reflectionOrchestrator();
         this.reinforcementHandler = bundle.reinforcementHandler();
         this.consolidationService = new ConsolidationService(builder.LlmProvider, this.embeddingProvider);
@@ -641,10 +642,44 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     }
 
     @Override
-    public ImportanceEstimate estimateImportance(String text,
-                                                  com.spectrayan.spector.memory.neurodivergent.IngestionHints hints) {
-        return importanceEstimator.estimate(text, hints, embeddingProvider,
-                partitionManager.cognitiveRouter(), index);
+    public ImportanceResult estimateImportance(String text,
+                                                com.spectrayan.spector.memory.neurodivergent.IngestionHints hints) {
+        try {
+            // Step 1: Embed text
+            float[] vector = embeddingProvider.embed(text).vector();
+
+            // Step 1b: L2-normalize
+            float norm = com.spectrayan.spector.core.similarity.VectorOps.magnitude(vector);
+            if (norm > 0f && Math.abs(norm - 1.0f) > 1e-6f) {
+                vector = com.spectrayan.spector.core.similarity.VectorOps.normalize(vector);
+            }
+
+            // Step 2: Compute nearest distance (read-only)
+            float nearestDist;
+            var workingStore = partitionManager.cognitiveRouter().working();
+            if (workingStore != null && workingStore.visibleCount() > 0) {
+                nearestDist = workingStore.nearestDistance(
+                        vector, quantizer.mins(), quantizer.scales());
+            } else {
+                nearestDist = com.spectrayan.spector.core.similarity.VectorOps.magnitude(vector);
+            }
+
+            // Step 3: Resolve effective salience profile
+            com.spectrayan.spector.memory.model.SalienceProfile profile = cognitiveTarget.salienceProfile();
+
+            // Step 4: Build context and delegate to provider
+            // Note: zScore=0.0 placeholder — DefaultImportanceProvider computes it
+            // internally from nearestDistance via its SurpriseDetector reference.
+            ImportanceContext ctx = new ImportanceContext(
+                    text, vector, hints, profile, null,
+                    nearestDist, 0.0, true);
+            return importanceProvider.score(ctx);
+        } catch (Exception e) {
+            log.error("Failed to estimate importance: {}", e.getMessage(), e);
+            throw new com.spectrayan.spector.commons.error.SpectorServerException(
+                    com.spectrayan.spector.commons.error.ErrorCode.INTERNAL_ERROR, e,
+                    "Importance estimation failed");
+        }
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ImportanceProvider.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ImportanceProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.memory.model.ImportanceContext;
+import com.spectrayan.spector.memory.model.ImportanceResult;
+
+/**
+ * Service Provider Interface (SPI) for determining the importance of a candidate memory.
+ */
+public interface ImportanceProvider {
+
+    /**
+     * Computes importance for a candidate memory.
+     * <p>Implementations receive all available context and return a scored result
+     * with an explainability breakdown. The core engine calls this during both
+     * pre-flight estimation ({@code estimateImportance}) and actual ingestion
+     * ({@code remember}).</p>
+     *
+     * @param context all inputs available at importance-scoring time
+     * @return the scored result including breakdown for explainability
+     */
+    ImportanceResult score(ImportanceContext context);
+
+    /**
+     * Returns a baseline provider that always returns neutral importance (1.0).
+     * <p>Use for tests, minimal configurations, and backward compatibility.</p>
+     *
+     * @return a baseline ImportanceProvider
+     */
+    static ImportanceProvider baseline() {
+        return ctx -> ImportanceResult.baseline();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -25,7 +25,7 @@ import com.spectrayan.spector.memory.metamemory.MemoryInsight;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.CognitiveResult;
-import com.spectrayan.spector.memory.model.ImportanceEstimate;
+import com.spectrayan.spector.memory.model.ImportanceResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.IngestionContext;
 import com.spectrayan.spector.memory.model.RecallOptions;
@@ -274,13 +274,13 @@ public interface SpectorMemory extends AutoCloseable {
      * @param hints optional ICNU hints (null = novelty-only estimate)
      * @return importance estimate with novelty, fusion, nearest memory, and profile weights
      */
-    ImportanceEstimate estimateImportance(String text,
+    ImportanceResult estimateImportance(String text,
                                           com.spectrayan.spector.memory.neurodivergent.IngestionHints hints);
 
     /**
      * Convenience overload — estimates importance with novelty-only (no ICNU hints).
      */
-    default ImportanceEstimate estimateImportance(String text) {
+    default ImportanceResult estimateImportance(String text) {
         return estimateImportance(text, null);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -132,6 +132,9 @@ public final class SpectorMemoryBuilder {
     //  Salience profile provider (enterprise SPI) 
     SalienceProfileProvider salienceProfileProvider;
 
+    //  Importance provider SPI (#481) 
+    ImportanceProvider importanceProvider;
+
     //  Data encryption SPI 
     DataEncryptor dataEncryptor = DataEncryptor.NOOP;
 
@@ -400,6 +403,22 @@ public final class SpectorMemoryBuilder {
      */
     public SpectorMemoryBuilder salienceProfileProvider(SalienceProfileProvider provider) {
         this.salienceProfileProvider = provider;
+        return this;
+    }
+
+    /**
+     * Sets a custom importance provider to replace the default importance scoring pipeline.
+     *
+     * <p>If not set, the engine uses {@link com.spectrayan.spector.memory.dopamine.DefaultImportanceProvider}
+     * which preserves the existing Welford + ICNU + Flashbulb + salience-boost pipeline.</p>
+     *
+     * @param provider the custom importance provider (null = use default)
+     * @return this builder
+     * @since 1.2.0
+     * @see ImportanceProvider
+     */
+    public SpectorMemoryBuilder importanceProvider(ImportanceProvider provider) {
+        this.importanceProvider = provider;
         return this;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -22,6 +22,7 @@ import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.provider.embedding.ParallelEmbeddingPipeline;
 import com.spectrayan.spector.memory.amygdala.ValenceTracker;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
+import com.spectrayan.spector.memory.dopamine.DefaultImportanceProvider;
 import com.spectrayan.spector.memory.graph.CognitiveGraphFacade;
 import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
@@ -83,7 +84,7 @@ public final class SpectorMemoryFactory {
             MemoryIndex index,
             ScalarQuantizer quantizer,
             PartitionManager partitionManager,
-            ImportanceEstimator importanceEstimator,
+            ImportanceProvider importanceProvider,
             ReflectionOrchestrator reflectionOrchestrator,
             ReinforcementHandler reinforcementHandler,
             ValenceTracker valenceTracker,
@@ -152,10 +153,17 @@ public final class SpectorMemoryFactory {
         RetrievalIndexBuilder.RetrievalIndices retrieval =
                 RetrievalIndexBuilder.build(builder, cortex, index);
 
+        //  Importance Provider (#481 SPI) 
+        ImportanceProvider importanceProvider = builder.importanceProvider != null
+                ? builder.importanceProvider
+                : new DefaultImportanceProvider(
+                        bio.surpriseDetector(), bio.flashbulbPolicy(), bio.icnuWeights());
+
         //  Ingestion target 
         int activePartitionIndex = 0;
         CognitiveIngestionTarget cognitiveTarget = CognitiveIngestionTargetBuilder.build(
-                builder, cortex, bio, graphs, retrieval, index, wal, activePartitionIndex);
+                builder, cortex, bio, graphs, retrieval, index, wal, activePartitionIndex,
+                importanceProvider);
 
         //  Partition manager (+ #443 frozen-partition registry, roll callback, text resolver) 
         PartitionManager partitionManager = PartitionManagerBuilder.build(
@@ -199,9 +207,6 @@ public final class SpectorMemoryFactory {
                 builder, embeddingProvider, cortex, bio, graphs, retrieval, index, partitionManager, wal);
 
         //  Extracted Components 
-        ImportanceEstimator importanceEstimator = new ImportanceEstimator(
-                bio.surpriseDetector(), bio.flashbulbPolicy(), bio.icnuWeights(), cortex.quantizer());
-
         ReflectionOrchestrator reflectionOrchestrator = new ReflectionOrchestrator(
                 bio.reflectDaemon(), graphs.hebbianGraph(), graphs.temporalChain(), graphs.entityDirectory(),
                 graphs.hyperEntityGraph(), wal, builder.temporalRetentionDays);
@@ -230,7 +235,7 @@ public final class SpectorMemoryFactory {
 
         return new SubsystemBundle(
                 cognitiveTarget, embeddingProvider, recallPipeline, index, cortex.quantizer(),
-                partitionManager, importanceEstimator, reflectionOrchestrator,
+                partitionManager, importanceProvider, reflectionOrchestrator,
                 reinforcementHandler, bio.valenceTracker(), bio.coActivationTracker(),
                 bio.suppressionSet(), bio.habituationPenalty(), bio.prospectiveScheduler(),
                 bio.introspector(), bio.lateralEvaluator(), wal, graphs.hebbianGraph(), graphs.temporalChain(),

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dopamine/DefaultImportanceProvider.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dopamine/DefaultImportanceProvider.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.dopamine;
+
+import com.spectrayan.spector.memory.ImportanceProvider;
+import com.spectrayan.spector.memory.model.ImportanceBreakdown;
+import com.spectrayan.spector.memory.model.ImportanceContext;
+import com.spectrayan.spector.memory.model.ImportanceResult;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
+import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link ImportanceProvider} that evaluates memory items
+ * for novelty, ICNU salience fusion, and dynamic boosts based on a persona's profile.
+ */
+public final class DefaultImportanceProvider implements ImportanceProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultImportanceProvider.class);
+
+    private final SurpriseDetector surpriseDetector;
+    private final FlashbulbPolicy flashbulbPolicy;
+    private final IcnuWeights defaultIcnuWeights;
+
+    /**
+     * Constructs a new DefaultImportanceProvider.
+     *
+     * @param surpriseDetector   the detector for novelty and surprise
+     * @param flashbulbPolicy    the policy determining flashbulb memory triggers
+     * @param defaultIcnuWeights the default ICNU weights to fall back on
+     */
+    public DefaultImportanceProvider(SurpriseDetector surpriseDetector,
+                                     FlashbulbPolicy flashbulbPolicy,
+                                     IcnuWeights defaultIcnuWeights) {
+        this.surpriseDetector = surpriseDetector;
+        this.flashbulbPolicy = flashbulbPolicy;
+        this.defaultIcnuWeights = defaultIcnuWeights;
+    }
+
+    @Override
+    public ImportanceResult score(ImportanceContext ctx) {
+        double zScore;
+        float noveltyOnlyImportance;
+        
+        float nearestDistance = ctx.nearestDistance();
+
+        // Step 3: Compute novelty
+        if (ctx.readOnly()) {
+            // Read-only peek — don't modify Welford stats
+            zScore = surpriseDetector.stats().count() >= 20
+                    ? surpriseDetector.stats().zScore(nearestDistance) : 0.0;
+            noveltyOnlyImportance = surpriseDetector.stats().count() >= 20
+                    ? SurpriseDetector.zScoreToImportance(zScore) : 1.0f;
+        } else {
+            // Compute and update stats
+            noveltyOnlyImportance = surpriseDetector.computeImportance(nearestDistance);
+            zScore = surpriseDetector.stats().count() >= 20
+                    ? surpriseDetector.stats().zScore(nearestDistance) : 0.0;
+        }
+
+        float noveltyNorm = Math.clamp(noveltyOnlyImportance / 10.0f, 0f, 1f);
+
+        // Step 4: ICNU fusion
+        float fusedImportance;
+        IngestionHints hints = ctx.hints();
+        SalienceProfile salienceProfile = ctx.salienceProfile();
+
+        IcnuWeights effectiveIcnuWeights = (salienceProfile != null && salienceProfile.hasIcnuOverride())
+                ? salienceProfile.icnuWeights()
+                : defaultIcnuWeights;
+
+        if (hints != null && !hints.isEmpty()) {
+            // Gaming detection logging (matches original CognitiveIngestionTarget)
+            if (hints.interest() == 1.0f && hints.challenge() == 1.0f
+                    && hints.urgency() == 1.0f) {
+                log.warn("ICNU anomaly: all-max hints (I=1.0, C=1.0, U=1.0) — possible gaming");
+            }
+            fusedImportance = effectiveIcnuWeights.fuse(hints, noveltyNorm);
+        } else {
+            fusedImportance = noveltyOnlyImportance;
+        }
+
+        // Steps 3c - 3e: Apply salience boosts
+        float topicBoost = 1.0f;
+        float selfBoost = 1.0f;
+        float agentBoost = 1.0f;
+
+        if (salienceProfile != null) {
+            float[] vector = ctx.vector();
+            
+            // Step 3c: Salience-based topic boost
+            if (vector != null && salienceProfile.hasInterests()) {
+                topicBoost = salienceProfile.computeTopicBoost(vector);
+                if (topicBoost != 1.0f) {
+                    fusedImportance = Math.clamp(fusedImportance * topicBoost, 0.05f, 10.0f);
+                }
+            }
+
+            // Step 3d: Persona self-relevance boost
+            if (vector != null && salienceProfile.hasPersona()) {
+                selfBoost = salienceProfile.computeSelfRelevanceBoost(vector);
+                if (selfBoost != 1.0f) {
+                    fusedImportance = Math.clamp(fusedImportance * selfBoost, 0.05f, 10.0f);
+                }
+            }
+
+            // Step 3e: Agent expertise relevance boost
+            if (salienceProfile.hasAgentRelevanceBoost()) {
+                agentBoost = salienceProfile.agentRelevanceBoost();
+                fusedImportance = Math.clamp(fusedImportance * agentBoost, 0.05f, 10.0f);
+            }
+        }
+
+        // Step 5: Flashbulb check
+        boolean wouldBeFlashbulb = false;
+        var flashbulbResult = flashbulbPolicy.evaluate(zScore);
+        if (flashbulbResult.isFlashbulb()) {
+            wouldBeFlashbulb = true;
+            fusedImportance = flashbulbResult.importance();
+        }
+
+        // Build ICNU weights description
+        String weightsDesc = String.format(
+                "I=%.0f%% C=%.0f%% N=%.0f%% U=%.0f%% (threshold=%.2f, steepness=%.1f)",
+                effectiveIcnuWeights.interest() * 100, effectiveIcnuWeights.challenge() * 100,
+                effectiveIcnuWeights.novelty() * 100, effectiveIcnuWeights.urgency() * 100,
+                effectiveIcnuWeights.threshold(), effectiveIcnuWeights.steepness());
+
+        // Finalize breakdown and result
+        ImportanceBreakdown breakdown = new ImportanceBreakdown(
+                noveltyNorm, zScore, noveltyOnlyImportance, fusedImportance,
+                topicBoost, selfBoost, agentBoost, weightsDesc,
+                null, nearestDistance);
+
+        return new ImportanceResult(fusedImportance, wouldBeFlashbulb, breakdown);
+    }
+}
+

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ImportanceBreakdown.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ImportanceBreakdown.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+
+/**
+ * Provides a detailed breakdown of how the importance score was calculated.
+ *
+ * @param noveltyScore          the base novelty score
+ * @param noveltyZScore         the statistical z-score for the novelty
+ * @param noveltyOnlyImportance the importance derived solely from novelty
+ * @param icnuFusedImportance   the importance after fusing ICNU features
+ * @param topicBoost            the boost applied based on topic relevance
+ * @param selfRelevanceBoost    the boost applied based on self-relevance
+ * @param agentRelevanceBoost   the boost applied based on agent-relevance
+ * @param icnuWeightsDesc       description of the weights used for ICNU fusion
+ * @param nearestMemoryId       the ID of the nearest memory found, may be null
+ * @param nearestDistance       the distance to the nearest memory
+ */
+public record ImportanceBreakdown(
+    float noveltyScore,
+    double noveltyZScore,
+    float noveltyOnlyImportance,
+    float icnuFusedImportance,
+    float topicBoost,
+    float selfRelevanceBoost,
+    float agentRelevanceBoost,
+    String icnuWeightsDesc,
+    String nearestMemoryId,
+    float nearestDistance
+) {
+    /**
+     * Creates an empty breakdown with all neutral values.
+     *
+     * @return a baseline ImportanceBreakdown
+     */
+    public static ImportanceBreakdown empty() {
+        return new ImportanceBreakdown(0f, 0.0, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, "", null, Float.MAX_VALUE);
+    }
+
+    /**
+     * Generates a formatted summary suitable for MCP tool responses.
+     *
+     * @return a formatted multiline string summarizing the importance breakdown
+     */
+    public String toSummary() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("📊 Importance Breakdown\n");
+        sb.append("  Novelty:           ").append(String.format("%.2f", noveltyScore))
+                .append(" (z-score=").append(String.format("%.2f", noveltyZScore)).append(")\n");
+        sb.append("  Novelty-only:      ").append(String.format("%.2f", noveltyOnlyImportance)).append(" / 10.0\n");
+        sb.append("  ICNU-fused:        ").append(String.format("%.2f", icnuFusedImportance)).append(" / 10.0\n");
+        if (topicBoost != 1.0f) {
+            sb.append("  Topic boost:       ").append(String.format("%.2f", topicBoost)).append("x\n");
+        }
+        if (selfRelevanceBoost != 1.0f) {
+            sb.append("  Self-relevance:    ").append(String.format("%.2f", selfRelevanceBoost)).append("x\n");
+        }
+        if (agentRelevanceBoost != 1.0f) {
+            sb.append("  Agent relevance:   ").append(String.format("%.2f", agentRelevanceBoost)).append("x\n");
+        }
+        if (nearestMemoryId != null) {
+            sb.append("  Nearest:           '").append(nearestMemoryId)
+                    .append("' (dist=").append(String.format("%.4f", nearestDistance)).append(")\n");
+        }
+        sb.append("  ICNU weights:      ").append(icnuWeightsDesc);
+        return sb.toString();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ImportanceContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ImportanceContext.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
+
+/**
+ * Consolidates all inputs required for computing the importance of a memory.
+ *
+ * @param text            the text content of the memory
+ * @param vector          the vector embeddings for the memory text
+ * @param hints           the ingestion hints containing ICNU (Interest, Competence, Novelty, Urgency) values, may be null
+ * @param salienceProfile the salience profile associated with the memory context, may be null
+ * @param targetTier      the target memory tier, may be null
+ * @param nearestDistance the distance to the nearest existing memory
+ * @param noveltyZScore   the novelty z-score based on existing memories
+ * @param readOnly        whether this context is evaluated in a read-only scenario
+ */
+public record ImportanceContext(
+    String text,
+    float[] vector,
+    IngestionHints hints,
+    SalienceProfile salienceProfile,
+    MemoryType targetTier,
+    float nearestDistance,
+    double noveltyZScore,
+    boolean readOnly
+) {
+    /**
+     * Returns true if ICNU hints were provided by the caller.
+     *
+     * @return true if hints are present and not empty, false otherwise
+     */
+    public boolean hasHints() {
+        return hints != null && !hints.isEmpty();
+    }
+
+    /**
+     * Returns true if a salience profile with interests is available.
+     *
+     * @return true if a salience profile is present, false otherwise
+     */
+    public boolean hasSalienceProfile() {
+        return salienceProfile != null;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ImportanceResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ImportanceResult.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * Represents the result of an importance computation from an ImportanceProvider.
+ * This record replaces the former ImportanceEstimate record.
+ *
+ * @param importance  the computed importance score (typically 0.0 to 10.0)
+ * @param isFlashbulb true if the memory represents a flashbulb event pinned at max importance
+ * @param breakdown   the detailed breakdown of how the importance score was derived
+ */
+public record ImportanceResult(
+    float importance,
+    boolean isFlashbulb,
+    ImportanceBreakdown breakdown
+) {
+    /**
+     * Creates a baseline result with neutral importance and an empty breakdown.
+     *
+     * @return a baseline ImportanceResult
+     */
+    public static ImportanceResult baseline() {
+        return new ImportanceResult(1.0f, false, ImportanceBreakdown.empty());
+    }
+
+    /**
+     * Generates a formatted summary suitable for MCP tool responses.
+     *
+     * @return a formatted multiline string summarizing the result
+     */
+    public String toSummary() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("📊 Importance Result\n");
+        sb.append("  Importance:   ").append(String.format("%.2f", importance)).append(" / 10.0\n");
+        if (isFlashbulb) {
+            sb.append("  ⚡ FLASHBULB: Extreme outlier — pinned at max importance\n");
+        }
+        sb.append(breakdown.toSummary());
+        return sb.toString();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/package-info.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/package-info.java
@@ -20,7 +20,7 @@
  * <h3>Records (immutable data carriers)</h3>
  * <ul>
  *   <li>{@link com.spectrayan.spector.memory.model.CognitiveResult} — a single recall result with score breakdown</li>
- *   <li>{@link com.spectrayan.spector.memory.model.ImportanceEstimate} — pre-ingestion importance computation</li>
+ *   <li>{@link com.spectrayan.spector.memory.model.ImportanceResult} — importance computation result with explainability breakdown</li>
  *   <li>{@link com.spectrayan.spector.memory.model.IngestionContext} — consolidated ingestion metadata (hints, entities, edges)</li>
  *   <li>{@link com.spectrayan.spector.memory.model.RecallOptions} — full recall configuration (topK, alpha, beta, filters, etc.)</li>
  *   <li>{@link com.spectrayan.spector.memory.model.RecallTrace} — step-by-step recall pipeline audit trail</li>

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -50,6 +50,9 @@ import com.spectrayan.spector.memory.error.SpectorHebbianException;
 import com.spectrayan.spector.memory.error.SpectorMemoryTierFullException;
 import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
 import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.ImportanceProvider;
+import com.spectrayan.spector.memory.model.ImportanceContext;
+import com.spectrayan.spector.memory.model.ImportanceResult;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +106,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     private final MemoryWal wal;
     private final WorkingRecordMemory workingStore;  // nullable
     private final IcnuWeights icnuWeights;
+    private final ImportanceProvider importanceProvider;
     private final VectorIndex semanticIndex;  // nullable  --  HNSW for semantic recall
     private final TagExtractor tagExtractor;
     private final boolean normalizeAtIngest;
@@ -157,14 +161,15 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      TextAppendMemory textDataStore,
                                      int activePartitionIndex,
                                      MemorySpladeIndex spladeIndex,
-                                     SparseEmbeddingProvider spladeProvider) {
+                                     SparseEmbeddingProvider spladeProvider,
+                                     ImportanceProvider importanceProvider) {
         this(quantizer, surpriseDetector, flashbulbPolicy, cognitiveRouter,
                 index, wal, workingStore, icnuWeights, semanticIndex,
                 tagExtractor, normalizeAtIngest,
                 hebbianGraph, temporalChain, entityExtractor,
                 entityDirectory, hyperEntityGraph,
                 bm25Index, textDataStore, activePartitionIndex,
-                spladeIndex, spladeProvider, DataEncryptor.NOOP);
+                spladeIndex, spladeProvider, DataEncryptor.NOOP, importanceProvider);
     }
 
     /**
@@ -191,7 +196,8 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      int activePartitionIndex,
                                      MemorySpladeIndex spladeIndex,
                                      SparseEmbeddingProvider spladeProvider,
-                                     DataEncryptor encryptor) {
+                                     DataEncryptor encryptor,
+                                     ImportanceProvider importanceProvider) {
         this.quantizer = quantizer;
         this.surpriseDetector = surpriseDetector;
         this.flashbulbPolicy = flashbulbPolicy;
@@ -200,6 +206,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         this.wal = wal;
         this.workingStore = workingStore;
         this.icnuWeights = icnuWeights != null ? icnuWeights : IcnuWeights.DEFAULT;
+        this.importanceProvider = importanceProvider != null ? importanceProvider : ImportanceProvider.baseline();
         this.semanticIndex = semanticIndex;
         this.tagExtractor = tagExtractor != null ? tagExtractor : new ContentTagExtractor();
         this.normalizeAtIngest = normalizeAtIngest;
@@ -301,7 +308,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                 tagExtractor, true,
                 null, null, null, null, null,
                 null, null, -1,
-                null, null);
+                null, null, null);
     }
 
     // ===============================================================
@@ -394,67 +401,15 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             nearestDist = computeL2Norm(vector);
         }
 
-        float importance;
-        // Step 3b: ICNU fusion  --  blend LLM hints with native novelty
-        // Use salience profile's ICNU weights if configured, otherwise system default
-        IcnuWeights effectiveIcnuWeights = salienceProfile.hasIcnuOverride()
-                ? salienceProfile.icnuWeights() : icnuWeights;
+        ImportanceContext importanceCtx = new ImportanceContext(
+                text, vector, hints, salienceProfile, type,
+                nearestDist, surpriseDetector.stats().zScore(nearestDist), false);
+        ImportanceResult importanceResult = importanceProvider.score(importanceCtx);
+        float importance = importanceResult.importance();
 
-        if (hints != null && !hints.isEmpty()) {
-            float rawNoveltyImportance = surpriseDetector.computeImportance(nearestDist);
-            float noveltyNorm = Math.clamp(rawNoveltyImportance / 10.0f, 0f, 1f);
-            importance = effectiveIcnuWeights.fuse(hints, noveltyNorm);
-
-            // Gaming detection logging
-            if (hints.interest() == 1.0f && hints.challenge() == 1.0f
-                    && hints.urgency() == 1.0f) {
-                log.warn("ICNU anomaly: all-max hints for '{}' (I=1.0, C=1.0, U=1.0)  --  possible gaming", sanitize(id));
-            }
-
-            log.debug("ICNU: id={}, I={}, C={}, N={}, U={}, fused={}",
-                    sanitize(id), hints.interest(), hints.challenge(), noveltyNorm,
-                    hints.urgency(), importance);
-        } else {
-            importance = surpriseDetector.computeImportance(nearestDist);
-        }
-
-        // Step 3c: Salience-based topic boost (semantic embedding matching)
-        if (salienceProfile.hasInterests()) {
-            float topicBoost = salienceProfile.computeTopicBoost(vector);
-            if (topicBoost != 1.0f) {
-                float preBoost = importance;
-                importance = Math.clamp(importance * topicBoost, 0.05f, 10.0f);
-                log.debug("Salience boost: id={}, pre={}, post={}, boost={}",
-                        id, preBoost, importance, topicBoost);
-            }
-        }
-
-        // Step 3d: Persona self-relevance boost (mPFC self-reference analog)
-        if (salienceProfile.hasPersona()) {
-            float selfBoost = salienceProfile.computeSelfRelevanceBoost(vector);
-            if (selfBoost != 1.0f) {
-                float preBoost = importance;
-                importance = Math.clamp(importance * selfBoost, 0.05f, 10.0f);
-                log.debug("Persona self-relevance boost: id={}, pre={}, post={}, boost={}",
-                        id, preBoost, importance, selfBoost);
-            }
-        }
-
-        // Step 3e: Agent expertise relevance boost (pre-computed from AgentSoul)
-        if (salienceProfile.hasAgentRelevanceBoost()) {
-            float agentBoost = salienceProfile.agentRelevanceBoost();
-            float preBoost = importance;
-            importance = Math.clamp(importance * agentBoost, 0.05f, 10.0f);
-            log.debug("Agent relevance boost: id={}, pre={}, post={}, boost={}",
-                    id, preBoost, importance, agentBoost);
-        }
-
-        // Step 4: Flashbulb check  --  extreme surprise gets full fidelity
-        double zScore = surpriseDetector.stats().zScore(nearestDist);
-        var flashbulb = flashbulbPolicy.evaluate(zScore);
+        // Step 4: Flashbulb check
         byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, type.ordinal());
-        if (flashbulb.isFlashbulb()) {
-            importance = flashbulb.importance();
+        if (importanceResult.isFlashbulb()) {
             flags = (byte) (flags | SynapticHeaderConstants.FLAG_PINNED);
         }
 
@@ -660,46 +615,15 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             nearestDist = computeL2Norm(vector);
         }
 
-        float importance;
-        // Use salience profile's ICNU weights if configured
-        IcnuWeights effectiveIcnuWeights = salienceProfile.hasIcnuOverride()
-                ? salienceProfile.icnuWeights() : icnuWeights;
-
-        if (hints != null && !hints.isEmpty()) {
-            float rawNoveltyImportance = surpriseDetector.computeImportance(nearestDist);
-            float noveltyNorm = Math.clamp(rawNoveltyImportance / 10.0f, 0f, 1f);
-            importance = effectiveIcnuWeights.fuse(hints, noveltyNorm);
-        } else {
-            importance = surpriseDetector.computeImportance(nearestDist);
-        }
-
-        // Salience-based topic boost (semantic embedding matching)
-        if (salienceProfile.hasInterests()) {
-            float topicBoost = salienceProfile.computeTopicBoost(vector);
-            if (topicBoost != 1.0f) {
-                importance = Math.clamp(importance * topicBoost, 0.05f, 10.0f);
-            }
-        }
-
-        // Persona self-relevance boost (mPFC self-reference analog)
-        if (salienceProfile.hasPersona()) {
-            float selfBoost = salienceProfile.computeSelfRelevanceBoost(vector);
-            if (selfBoost != 1.0f) {
-                importance = Math.clamp(importance * selfBoost, 0.05f, 10.0f);
-            }
-        }
-
-        // Agent expertise relevance boost (pre-computed from AgentSoul)
-        if (salienceProfile.hasAgentRelevanceBoost()) {
-            importance = Math.clamp(importance * salienceProfile.agentRelevanceBoost(), 0.05f, 10.0f);
-        }
+        ImportanceContext importanceCtx = new ImportanceContext(
+                text, vector, hints, salienceProfile, type,
+                nearestDist, surpriseDetector.stats().zScore(nearestDist), false);
+        ImportanceResult importanceResult = importanceProvider.score(importanceCtx);
+        float importance = importanceResult.importance();
 
         // Step 4: Flashbulb check
-        double zScore = surpriseDetector.stats().zScore(nearestDist);
-        var flashbulb = flashbulbPolicy.evaluate(zScore);
         byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, type.ordinal());
-        if (flashbulb.isFlashbulb()) {
-            importance = flashbulb.importance();
+        if (importanceResult.isFlashbulb()) {
             flags = (byte) (flags | SynapticHeaderConstants.FLAG_PINNED);
         }
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/CoreMemoryLifecycleTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/CoreMemoryLifecycleTest.java
@@ -326,8 +326,8 @@ class CoreMemoryLifecycleTest {
     @Order(100)
     @DisplayName("Estimate importance returns non-negative value")
     void estimateImportance_nonNegative() {
-        ImportanceEstimate estimate = memory.estimateImportance("A completely new topic");
+        ImportanceResult estimate = memory.estimateImportance("A completely new topic");
         assertThat(estimate).isNotNull();
-        assertThat(estimate.fusedImportance()).isGreaterThanOrEqualTo(0f);
+        assertThat(estimate.importance()).isGreaterThanOrEqualTo(0f);
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/model/MemoryModelTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/model/MemoryModelTest.java
@@ -117,41 +117,51 @@ class MemoryModelTest {
     }
 
     // ══════════════════════════════════════════════════════════════
-    // ImportanceEstimate
+    // ImportanceResult
     // ══════════════════════════════════════════════════════════════
 
     @Nested
-    @DisplayName("ImportanceEstimate")
-    class ImportanceEstimateTests {
+    @DisplayName("ImportanceResult")
+    class ImportanceResultTests {
 
         @Test
         @DisplayName("toSummary includes key fields")
         void toSummaryIncludesFields() {
-            var est = new ImportanceEstimate(0.82f, 1.5, 7.8f, 6.2f,
-                    "mem-42", 0.15f, false, "I=0.3, C=0.2, N=0.4, U=0.1");
-            var summary = est.toSummary();
-            assertThat(summary).contains("Novelty:");
-            assertThat(summary).contains("Fused:");
+            var breakdown = new ImportanceBreakdown(0.82f, 1.5, 6.2f, 7.8f,
+                    1.0f, 1.0f, 1.0f, "I=30% C=20% N=40% U=10%", "mem-42", 0.15f);
+            var result = new ImportanceResult(7.8f, false, breakdown);
+            var summary = result.toSummary();
+            assertThat(summary).contains("Importance");
             assertThat(summary).contains("mem-42");
-            assertThat(summary).contains("0.82");
         }
 
         @Test
         @DisplayName("toSummary handles null nearestMemoryId")
         void toSummaryNullNearest() {
-            var est = new ImportanceEstimate(0.5f, 0.0, 5.0f, 5.0f,
-                    null, 0.0f, false, "default");
-            var summary = est.toSummary();
-            assertThat(summary).contains("no existing memories");
+            var breakdown = new ImportanceBreakdown(0.5f, 0.0, 5.0f, 5.0f,
+                    1.0f, 1.0f, 1.0f, "default", null, 0.0f);
+            var result = new ImportanceResult(5.0f, false, breakdown);
+            var summary = result.toSummary();
+            assertThat(summary).doesNotContain("Nearest:");
         }
 
         @Test
         @DisplayName("toSummary shows FLASHBULB when true")
         void toSummaryFlashbulb() {
-            var est = new ImportanceEstimate(0.99f, 3.0, 10.0f, 9.5f,
-                    "mem-1", 0.01f, true, "weights");
-            var summary = est.toSummary();
+            var breakdown = new ImportanceBreakdown(0.99f, 3.0, 9.5f, 10.0f,
+                    1.0f, 1.0f, 1.0f, "weights", "mem-1", 0.01f);
+            var result = new ImportanceResult(10.0f, true, breakdown);
+            var summary = result.toSummary();
             assertThat(summary).contains("FLASHBULB");
+        }
+
+        @Test
+        @DisplayName("baseline returns neutral importance")
+        void baselineResult() {
+            var result = ImportanceResult.baseline();
+            assertThat(result.importance()).isEqualTo(1.0f);
+            assertThat(result.isFlashbulb()).isFalse();
+            assertThat(result.breakdown()).isNotNull();
         }
     }
 

--- a/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -377,7 +377,7 @@ public class MeteredSpectorMemory implements SpectorMemory {
     }
 
     @Override
-    public com.spectrayan.spector.memory.model.ImportanceEstimate estimateImportance(
+    public com.spectrayan.spector.memory.model.ImportanceResult estimateImportance(
             String text, com.spectrayan.spector.memory.neurodivergent.IngestionHints hints) {
         return delegate.estimateImportance(text, hints);
     }

--- a/nucleus/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
+++ b/nucleus/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
@@ -172,7 +172,7 @@ class MeteredSpectorMemoryTest {
         @Override public com.spectrayan.spector.memory.model.WhyNotExplanation whyNot(String memoryId, String queryText, RecallOptions options) { return null; }
         private final com.spectrayan.spector.memory.SpectorMemoryAdmin adminMock = org.mockito.Mockito.mock(com.spectrayan.spector.memory.SpectorMemoryAdmin.class);
         @Override public com.spectrayan.spector.memory.SpectorMemoryAdmin admin() { return adminMock; }
-        @Override public com.spectrayan.spector.memory.model.ImportanceEstimate estimateImportance(String text, com.spectrayan.spector.memory.neurodivergent.IngestionHints hints) { return null; }
+        @Override public com.spectrayan.spector.memory.model.ImportanceResult estimateImportance(String text, com.spectrayan.spector.memory.neurodivergent.IngestionHints hints) { return null; }
         @Override public com.spectrayan.spector.memory.model.CognitiveRecord inspect(String id) { return null; }
         @Override public java.util.List<com.spectrayan.spector.memory.model.CognitiveRecord> browse(String... tags) { return java.util.List.of(); }
         @Override public String exportJson() { return "[]"; }

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryComputeImportanceTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryComputeImportanceTool.java
@@ -23,7 +23,7 @@ import com.spectrayan.spector.commons.security.SpectorScopes;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import com.spectrayan.spector.mcp.schema.ToolSchemaBuilder;
-import com.spectrayan.spector.memory.model.ImportanceEstimate;
+import com.spectrayan.spector.memory.model.ImportanceResult;
 import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
 import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
@@ -119,7 +119,7 @@ public final class MemoryComputeImportanceTool extends MemoryToolHandler {
         }
 
         // Compute the primary estimate
-        ImportanceEstimate estimate = memory.estimateImportance(text, hints);
+        ImportanceResult estimate = memory.estimateImportance(text, hints);
 
         // Build response
         StringBuilder sb = new StringBuilder();
@@ -139,7 +139,7 @@ public final class MemoryComputeImportanceTool extends MemoryToolHandler {
         sb.append("\n\n🔬 ICNU Weight Variations:");
 
         // Show what importance would be with different weight presets
-        float noveltyNorm = estimate.noveltyScore();
+        float noveltyNorm = estimate.breakdown().noveltyScore();
 
         // Default weights (I=30% C=10% N=40% U=20%)
         if (hasHints) {
@@ -149,7 +149,7 @@ public final class MemoryComputeImportanceTool extends MemoryToolHandler {
 
             // Novelty-only (no LLM hints)
             sb.append(String.format("\n  NOVELTY   (pure novelty, no hints):     %.2f",
-                    estimate.noveltyOnlyImportance()));
+                    estimate.breakdown().noveltyOnlyImportance()));
 
             // Linear mode (no sigmoid gating)
             float linearFused = IcnuWeights.LINEAR.fuse(
@@ -169,19 +169,19 @@ public final class MemoryComputeImportanceTool extends MemoryToolHandler {
             sb.append(String.format("\n  URGENCY   (I=20%% C=10%% N=20%% U=50%%): %.2f", urgencyFused));
         } else {
             sb.append("\n  (Provide interest/challenge/urgency hints to see weight variations)");
-            sb.append(String.format("\n  NOVELTY-ONLY: %.2f", estimate.noveltyOnlyImportance()));
+            sb.append(String.format("\n  NOVELTY-ONLY: %.2f", estimate.breakdown().noveltyOnlyImportance()));
         }
 
         // Actionable advice
         sb.append("\n\n");
-        if (estimate.nearestMemoryId() != null && estimate.nearestDistance() < 0.15f) {
+        if (estimate.breakdown().nearestMemoryId() != null && estimate.breakdown().nearestDistance() < 0.15f) {
             sb.append("⚠️ Very close to existing memory '")
-                    .append(estimate.nearestMemoryId())
+                    .append(estimate.breakdown().nearestMemoryId())
                     .append("' — consider skipping or using memory_reinforce instead.");
-        } else if (estimate.fusedImportance() < 1.0f) {
+        } else if (estimate.importance() < 1.0f) {
             sb.append("💡 Low importance — this memory may fade quickly. "
                     + "Consider increasing interest or urgency if this is significant.");
-        } else if (estimate.fusedImportance() > 7.0f) {
+        } else if (estimate.importance() > 7.0f) {
             sb.append("🔥 High importance — this memory will be strongly retained.");
         } else {
             sb.append("✅ Moderate importance — this memory will be retained normally.");

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
@@ -181,7 +181,7 @@ public final class MemoryRememberTool extends MemoryToolHandler {
         IngestionContext context = ctxBuilder.build();
 
         // Compute importance estimate (read-only) to show what was assigned
-        com.spectrayan.spector.memory.model.ImportanceEstimate estimate = null;
+        com.spectrayan.spector.memory.model.ImportanceResult estimate = null;
         try {
             estimate = memory.estimateImportance(text, hints);
         } catch (Exception e) {
@@ -219,14 +219,14 @@ public final class MemoryRememberTool extends MemoryToolHandler {
 
         // Show computed importance feedback
         if (estimate != null) {
-            sb.append(String.format("\n📈 Importance: %.2f / 10.0", estimate.fusedImportance()));
-            sb.append(String.format(" (novelty=%.2f, z=%.2f)", estimate.noveltyScore(), estimate.noveltyZScore()));
-            if (estimate.wouldBeFlashbulb()) {
+            sb.append(String.format("\n📈 Importance: %.2f / 10.0", estimate.importance()));
+            sb.append(String.format(" (novelty=%.2f, z=%.2f)", estimate.breakdown().noveltyScore(), estimate.breakdown().noveltyZScore()));
+            if (estimate.isFlashbulb()) {
                 sb.append(" ⚡ FLASHBULB");
             }
-            if (estimate.nearestMemoryId() != null) {
+            if (estimate.breakdown().nearestMemoryId() != null) {
                 sb.append(String.format("\n🔗 Nearest: '%s' (dist=%.4f)",
-                        estimate.nearestMemoryId(), estimate.nearestDistance()));
+                        estimate.breakdown().nearestMemoryId(), estimate.breakdown().nearestDistance()));
             }
         }
 


### PR DESCRIPTION
## Summary

Extracts the dual-path importance scoring logic from `CognitiveIngestionTarget` (inline Steps 3b–3e + flashbulb) and `ImportanceEstimator` (read-only peek) into a pluggable **Service Provider Interface (SPI)**, following the existing `SalienceProfileProvider` pattern.

### Motivation

The importance scoring pipeline was:
1. **Duplicated** — identical novelty → ICNU → salience → flashbulb logic in both `ingest()` and `ingestCognitive()` methods
2. **Hardwired** — no way to swap algorithms without modifying core engine code
3. **Untestable in isolation** — `ImportanceEstimator` required `MemoryIndex` and `EmbeddingProvider` just to test scoring math

This SPI resolves all three by extracting a clean `ImportanceProvider.score(ImportanceContext) → ImportanceResult` contract.

## New Files (5)

| File | Purpose |
|:---|:---|
| `ImportanceProvider.java` | SPI interface with `score()` and `baseline()` factory |
| `ImportanceContext.java` | Input record: text, vector, hints, salienceProfile, targetTier, nearestDistance, noveltyZScore, readOnly |
| `ImportanceResult.java` | Output record replacing `ImportanceEstimate`: importance, isFlashbulb, breakdown |
| `ImportanceBreakdown.java` | Explainability: novelty, z-score, ICNU fusion, salience boosts, nearest memory |
| `DefaultImportanceProvider.java` | Unified implementation extracting logic from both ingestion paths |

## Modified Files (13)

### Core Engine (`spector-memory`)
- **`SpectorMemory.java`** — Return type `ImportanceEstimate` → `ImportanceResult`
- **`SpectorMemoryBuilder.java`** — Added `importanceProvider()` builder method
- **`SpectorMemoryFactory.java`** — Resolve provider (custom or default), updated `SubsystemBundle`
- **`CognitiveIngestionTargetBuilder.java`** — Accept + pass `ImportanceProvider`
- **`CognitiveIngestionTarget.java`** — Replace ~40 lines of inline importance logic with `provider.score()` in both `ingest()` and `ingestCognitive()`
- **`DefaultSpectorMemory.java`** — Replace `ImportanceEstimator` with `ImportanceProvider`
- **`package-info.java`** — Reference update

### Downstream Consumers
- **`MeteredSpectorMemory.java`** (spector-metrics) — Return type migration
- **`MemoryComputeImportanceTool.java`** (spector-mcp) — Access via `result.breakdown()`
- **`MemoryRememberTool.java`** (spector-mcp) — Access via `result.breakdown()`

### Tests
- **`MemoryModelTest.java`** — Rewritten for `ImportanceResult` + `ImportanceBreakdown` + new baseline test
- **`CoreMemoryLifecycleTest.java`** — Updated assertion
- **`MeteredSpectorMemoryTest.java`** — Updated stub type

## Usage

```java
// Custom provider
SpectorMemory memory = SpectorMemory.builder()
    .embeddingProvider(myProvider)
    .importanceProvider(ctx -> {
        // Custom scoring — full access to text, vector, hints, salience, etc.
        float score = myCustomAlgorithm(ctx);
        return new ImportanceResult(score, false, ImportanceBreakdown.empty());
    })
    .build();

// Default (preserves existing Welford + ICNU + Flashbulb + salience-boost pipeline)
SpectorMemory memory = SpectorMemory.builder()
    .embeddingProvider(myProvider)
    .build(); // DefaultImportanceProvider used automatically
```

## Architecture Decision

Follows the `SalienceProfileProvider` pattern:
- Single-method functional interface (`score`)
- Static `baseline()` factory for tests/defaults
- Context record consolidates all inputs
- Result record includes explainability breakdown
- `DefaultImportanceProvider` takes `SurpriseDetector`, `FlashbulbPolicy`, `IcnuWeights` — no `MemoryIndex` dependency

## Verification

- ✅ `mvn compile` passes across all 3 modules
- ✅ `MemoryModelTest` (4 tests) passes
- ✅ `MeteredSpectorMemoryTest` passes
- ✅ All commits have `Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>`

## Follow-up (not blocking)

- [ ] Delete deprecated `ImportanceEstimator.java`
- [ ] Delete deprecated `ImportanceEstimate.java`
- [ ] Write dedicated `DefaultImportanceProviderTest`
- [ ] Write `ImportanceProviderContractTest`

Closes #481