### PR TITLE
refactor(memory): virtual thread locking (ADR-005) & exception hardening (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored — Virtual Thread Locking & Exception Governance (#485)
+- **spector-memory:** Refactored `IndexRecordMemory` and `AbstractRegistryMemory` from `synchronized` monitor blocks to `ReentrantLock` (enforcing ADR-005 virtual thread concurrency safety)
+- **spector-gpu:** Refactored `GpuCapability` detection lock from `synchronized (GpuCapability.class)` to `ReentrantLock`
+- **spector-synapse:** Refactored `SqlQueryTool` schema caching from `synchronized (this)` to `ReentrantLock`
+- **spector-mcp:** Hardened `MemoryRememberTool` with diagnostic warning logs on metadata parsing / importance estimation fallbacks; wrapped raw `RuntimeException` rethrows in `McpToolHandler` with domain `SpectorInternalException`
+
 ### Changed — Enterprise Extraction
 - **spector-cortex:** Migrated to [spector-enterprise](https://github.com/spectrayan/spector-enterprise) — the `spector-cortex/` directory has been removed from this repository
 - **spector-node:** Core engine remains headless/embeddable — enterprise edition wraps it with management APIs, connectors, LLM providers, and the Cortex UI on a single Armeria port

--- a/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/GpuCapability.java
+++ b/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/GpuCapability.java
@@ -28,6 +28,8 @@ import java.lang.invoke.MethodHandle;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * Detects and reports GPU/CUDA capability at runtime via Panama FFM.
  *
@@ -46,6 +48,7 @@ import java.nio.file.Path;
 public final class GpuCapability {
 
     private static final Logger log = LoggerFactory.getLogger(GpuCapability.class);
+    private static final ReentrantLock DETECT_LOCK = new ReentrantLock();
 
     private static volatile GpuInfo cachedInfo;
 
@@ -85,11 +88,14 @@ public final class GpuCapability {
      */
     public static GpuInfo detect() {
         if (cachedInfo != null) return cachedInfo;
-        synchronized (GpuCapability.class) {
+        DETECT_LOCK.lock();
+        try {
             if (cachedInfo != null) return cachedInfo;
             cachedInfo = doDetect();
             log.info(cachedInfo.report());
             return cachedInfo;
+        } finally {
+            DETECT_LOCK.unlock();
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -96,6 +96,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     private final ConcurrentHashMap<String, java.util.Set<String>> tagToIds = new ConcurrentHashMap<>();
 
     // ── Insertion-order tracking ──
+    private final java.util.concurrent.locks.ReentrantLock orderedIdsLock = new java.util.concurrent.locks.ReentrantLock();
     private final java.util.LinkedHashSet<String> orderedIds = new java.util.LinkedHashSet<>();
 
     /**
@@ -196,8 +197,11 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
         reverseIndex.put(reverseKey(location.colocatedPartition(), location.type(), location.offset()), id);
 
-        synchronized (orderedIds) {
+        orderedIdsLock.lock();
+        try {
             orderedIds.add(id);
+        } finally {
+            orderedIdsLock.unlock();
         }
 
         if (tagArray != null) {
@@ -212,8 +216,11 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     public void remove(String id) {
         MemoryLocation loc = locations.remove(id);
         texts.remove(id);
-        synchronized (orderedIds) {
+        orderedIdsLock.lock();
+        try {
             orderedIds.remove(id);
+        } finally {
+            orderedIdsLock.unlock();
         }
         sources.remove(id);
         String[] removedTags = tags.remove(id);
@@ -394,8 +401,11 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     }
 
     public java.util.List<String> orderedIds() {
-        synchronized (orderedIds) {
+        orderedIdsLock.lock();
+        try {
             return new java.util.ArrayList<>(orderedIds);
+        } finally {
+            orderedIdsLock.unlock();
         }
     }
 
@@ -405,13 +415,16 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
     public void buildGraphSlotMappings(java.util.Map<Integer, String> slotToId,
                                         java.util.Map<String, Integer> idToSlot) {
-        synchronized (orderedIds) {
+        orderedIdsLock.lock();
+        try {
             int i = 0;
             for (String id : orderedIds) {
                 slotToId.put(i, id);
                 idToSlot.put(id, i);
                 i++;
             }
+        } finally {
+            orderedIdsLock.unlock();
         }
     }
 
@@ -481,8 +494,11 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                     idx.tags.putAll(legacy.tags);
                     idx.metadataMap.putAll(legacy.metadataMap);
                     idx.reverseIndex.putAll(legacy.reverseIndex);
-                    synchronized (idx.orderedIds) {
+                    idx.orderedIdsLock.lock();
+                    try {
                         idx.orderedIds.addAll(legacy.orderedIds);
+                    } finally {
+                        idx.orderedIdsLock.unlock();
                     }
                     idx.save(legacyMidx); // will write directly into bundle segments
                     try {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRegistryMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/AbstractRegistryMemory.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.Locale;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import com.spectrayan.spector.memory.kernel.AbstractMemory;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.layout.RegistryLayout;
@@ -32,6 +34,7 @@ import com.spectrayan.spector.memory.kernel.MemoryShape;
  */
 public abstract class AbstractRegistryMemory extends AbstractMemory<RegistryLayout> implements RegistryMemory {
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final ConcurrentHashMap<String, Integer> nameToId = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, String> idToName = new ConcurrentHashMap<>();
     private final AtomicInteger nextId = new AtomicInteger(0);
@@ -67,109 +70,124 @@ public abstract class AbstractRegistryMemory extends AbstractMemory<RegistryLayo
         return MemoryShape.REGISTRY;
     }
 
-    private synchronized void initializeFromSegment() {
-        nameToId.clear();
-        idToName.clear();
-        writeOffset = 0;
-        int entryCount = count; // count field in header tracks the number of entries
-        
-        long base = dataOffset();
-        int maxId = -1;
-        
-        for (int i = 0; i < entryCount; i++) {
-            if (base + writeOffset + 6 > segment().byteSize()) {
-                break; // Corrupted file bounds check
+    private void initializeFromSegment() {
+        lock.lock();
+        try {
+            nameToId.clear();
+            idToName.clear();
+            writeOffset = 0;
+            int entryCount = count; // count field in header tracks the number of entries
+            
+            long base = dataOffset();
+            int maxId = -1;
+            
+            for (int i = 0; i < entryCount; i++) {
+                if (base + writeOffset + 6 > segment().byteSize()) {
+                    break; // Corrupted file bounds check
+                }
+                int nameLen = Short.toUnsignedInt(segment().get(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset));
+                if (base + writeOffset + 2 + nameLen + 4 > segment().byteSize()) {
+                    break; // Corrupted file bounds check
+                }
+                
+                // Read name
+                byte[] nameBytes = new byte[nameLen];
+                MemorySegment.copy(segment(), ValueLayout.JAVA_BYTE, base + writeOffset + 2, nameBytes, 0, nameLen);
+                String name = new String(nameBytes, StandardCharsets.UTF_8);
+                
+                // Read ID
+                int id = segment().get(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen);
+                
+                nameToId.put(name, id);
+                idToName.put(id, name);
+                maxId = Math.max(maxId, id);
+                
+                writeOffset += 2 + nameLen + 4;
             }
-            int nameLen = Short.toUnsignedInt(segment().get(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset));
-            if (base + writeOffset + 2 + nameLen + 4 > segment().byteSize()) {
-                break; // Corrupted file bounds check
-            }
             
-            // Read name
-            byte[] nameBytes = new byte[nameLen];
-            MemorySegment.copy(segment(), ValueLayout.JAVA_BYTE, base + writeOffset + 2, nameBytes, 0, nameLen);
-            String name = new String(nameBytes, StandardCharsets.UTF_8);
-            
-            // Read ID
-            int id = segment().get(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen);
-            
-            nameToId.put(name, id);
-            idToName.put(id, name);
-            maxId = Math.max(maxId, id);
-            
-            writeOffset += 2 + nameLen + 4;
+            nextId.set(maxId + 1);
+        } finally {
+            lock.unlock();
         }
-        
-        nextId.set(maxId + 1);
     }
 
     @Override
-    public synchronized int intern(String name) {
-        if (name == null || name.isBlank()) {
-            return intern("OTHER");
+    public int intern(String name) {
+        lock.lock();
+        try {
+            if (name == null || name.isBlank()) {
+                return intern("OTHER");
+            }
+            String normalized = name.trim().toUpperCase(Locale.ROOT);
+            Integer existing = nameToId.get(normalized);
+            if (existing != null) {
+                return existing;
+            }
+
+            int newId = nextId.getAndIncrement();
+            byte[] nameBytes = normalized.getBytes(StandardCharsets.UTF_8);
+            int nameLen = nameBytes.length;
+
+            // Verify segment bounds
+            long base = dataOffset();
+            if (base + writeOffset + 2 + nameLen + 4 > segment().byteSize()) {
+                throw new IndexOutOfBoundsException("Registry memory segment is full: " + id());
+            }
+
+            if (wal != null && !bypassWal) {
+                wal.appendRegistryIntern(id.toString(), newId, normalized);
+            }
+
+            // Write name length
+            segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
+            // Write name bytes
+            MemorySegment.copy(MemorySegment.ofArray(nameBytes), 0, segment(), base + writeOffset + 2, nameLen);
+            // Write ID
+            segment().set(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen, newId);
+
+            // Update counts
+            writeOffset += 2 + nameLen + 4;
+            count++;
+            persistCount();
+
+            nameToId.put(normalized, newId);
+            idToName.put(newId, normalized);
+
+            return newId;
+        } finally {
+            lock.unlock();
         }
-        String normalized = name.trim().toUpperCase(Locale.ROOT);
-        Integer existing = nameToId.get(normalized);
-        if (existing != null) {
-            return existing;
-        }
-
-        int newId = nextId.getAndIncrement();
-        byte[] nameBytes = normalized.getBytes(StandardCharsets.UTF_8);
-        int nameLen = nameBytes.length;
-
-        // Verify segment bounds
-        long base = dataOffset();
-        if (base + writeOffset + 2 + nameLen + 4 > segment().byteSize()) {
-            throw new IndexOutOfBoundsException("Registry memory segment is full: " + id());
-        }
-
-        if (wal != null && !bypassWal) {
-            wal.appendRegistryIntern(id.toString(), newId, normalized);
-        }
-
-        // Write name length
-        segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
-        // Write name bytes
-        MemorySegment.copy(MemorySegment.ofArray(nameBytes), 0, segment(), base + writeOffset + 2, nameLen);
-        // Write ID
-        segment().set(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen, newId);
-
-        // Update counts
-        writeOffset += 2 + nameLen + 4;
-        count++;
-        persistCount();
-
-        nameToId.put(normalized, newId);
-        idToName.put(newId, normalized);
-
-        return newId;
     }
 
     /**
      * Directly inserts a name-to-ID mapping without allocating a new ID.
      * Used for loading/migration.
      */
-    public synchronized void putDirect(String name, int id) {
-        String normalized = name.trim().toUpperCase(Locale.ROOT);
-        nameToId.put(normalized, id);
-        idToName.put(id, normalized);
-        
-        int maxId = nextId.get();
-        if (id >= maxId) {
-            nextId.set(id + 1);
-        }
-        
-        byte[] nameBytes = normalized.getBytes(StandardCharsets.UTF_8);
-        int nameLen = nameBytes.length;
-        long base = dataOffset();
-        if (base + writeOffset + 2 + nameLen + 4 <= segment().byteSize()) {
-            segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
-            MemorySegment.copy(MemorySegment.ofArray(nameBytes), 0, segment(), base + writeOffset + 2, nameLen);
-            segment().set(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen, id);
-            writeOffset += 2 + nameLen + 4;
-            count++;
-            persistCount();
+    public void putDirect(String name, int id) {
+        lock.lock();
+        try {
+            String normalized = name.trim().toUpperCase(Locale.ROOT);
+            nameToId.put(normalized, id);
+            idToName.put(id, normalized);
+            
+            int maxId = nextId.get();
+            if (id >= maxId) {
+                nextId.set(id + 1);
+            }
+            
+            byte[] nameBytes = normalized.getBytes(StandardCharsets.UTF_8);
+            int nameLen = nameBytes.length;
+            long base = dataOffset();
+            if (base + writeOffset + 2 + nameLen + 4 <= segment().byteSize()) {
+                segment().set(ValueLayout.JAVA_SHORT_UNALIGNED, base + writeOffset, (short) nameLen);
+                MemorySegment.copy(MemorySegment.ofArray(nameBytes), 0, segment(), base + writeOffset + 2, nameLen);
+                segment().set(ValueLayout.JAVA_INT_UNALIGNED, base + writeOffset + 2 + nameLen, id);
+                writeOffset += 2 + nameLen + 4;
+                count++;
+                persistCount();
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/McpToolHandler.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/McpToolHandler.java
@@ -137,8 +137,11 @@ public abstract class McpToolHandler {
                 }
             }
             return sb.toString();
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new com.spectrayan.spector.commons.error.SpectorInternalException(
+                    com.spectrayan.spector.commons.error.ErrorCode.INTERNAL_ERROR, e, "Failed to extract text from MCP CallToolResult");
         }
     }
 

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
@@ -42,7 +42,12 @@ import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
  *
  * <p>Maps to {@link SpectorMemory#remember} with optional {@link IngestionHints}.</p>
  */
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public final class MemoryRememberTool extends MemoryToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryRememberTool.class);
 
     public MemoryRememberTool(SpectorMemory memory) {
         super(memory);
@@ -174,7 +179,7 @@ public final class MemoryRememberTool extends MemoryToolHandler {
                 }
             } catch (Exception e) {
                 // Non-fatal: metadata parsing failure shouldn't block ingestion
-                // Log and continue with text-only ingestion
+                log.warn("[MemoryRememberTool] Metadata parsing failed (proceeding with text-only ingestion): {}", e.getMessage());
             }
         }
 
@@ -186,6 +191,7 @@ public final class MemoryRememberTool extends MemoryToolHandler {
             estimate = memory.estimateImportance(text, hints);
         } catch (Exception e) {
             // Non-fatal: importance display is best-effort
+            log.warn("[MemoryRememberTool] Importance estimation failed: {}", e.getMessage());
         }
 
         // Ingest: auto-generate ID if not provided

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/SqlQueryTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/SqlQueryTool.java
@@ -47,6 +47,8 @@ import java.util.stream.Collectors;
  * bounded timeout (30 seconds), and returns the results as a Markdown table for agent
  * consumption.
  */
+import java.util.concurrent.locks.ReentrantLock;
+
 @Component
 public class SqlQueryTool extends McpToolHandler {
 
@@ -58,6 +60,7 @@ public class SqlQueryTool extends McpToolHandler {
     // SLF4J logger   
     private static final Logger log = LoggerFactory.getLogger(SqlQueryTool.class);
     // Schema Caching
+    private final ReentrantLock schemaLock = new ReentrantLock();
     private volatile String cachedSchema = null;
 
     // Allowed tables:
@@ -273,12 +276,15 @@ public class SqlQueryTool extends McpToolHandler {
     private String describeSchema() {
         String schema = cachedSchema;
         if (schema == null) {
-            synchronized (this) {
+            schemaLock.lock();
+            try {
                 schema = cachedSchema;
                 if (schema == null) {
                     schema = introspectSchema();
                     cachedSchema = schema;
                 }
+            } finally {
+                schemaLock.unlock();
             }
         }
         return schema;
@@ -286,8 +292,11 @@ public class SqlQueryTool extends McpToolHandler {
 
     // Recompute the schema on next request.
     public void refreshSchema() {
-        synchronized (this) {
+        schemaLock.lock();
+        try {
             cachedSchema = null;
+        } finally {
+            schemaLock.unlock();
         }
     }
 


### PR DESCRIPTION
Closes #485

### Summary of Changes
- **Virtual Thread Concurrency Safety (ADR-005 Compliance)**:
  - Refactored `IndexRecordMemory.java` (`synchronized (orderedIds)`) to `ReentrantLock`.
  - Refactored `AbstractRegistryMemory.java` (`synchronized` methods) to `ReentrantLock`.
  - Refactored `GpuCapability.java` (`synchronized (GpuCapability.class)`) to `ReentrantLock`.
  - Refactored `SqlQueryTool.java` (`synchronized (this)`) to `ReentrantLock`.
- **Exception Governance & Hardening**:
  - Added warning diagnostics to `MemoryRememberTool.java` fallback catch blocks.
  - Wrapped raw `RuntimeException` rethrows in `McpToolHandler.java` with domain `SpectorInternalException`.
- **Documentation**:
  - Updated `CHANGELOG.md` under `## [Unreleased]`.

### Verification
- Full reactor compilation: `mvn compile -pl memory/spector-memory,memory/spector-gpu,synapse/spector-mcp,synapse/spector-synapse -am` — **BUILD SUCCESS**
- Unit test suite: `mvn test -pl memory/spector-gpu,synapse/spector-mcp,synapse/spector-synapse` — **510 tests passed, 0 failures**.