### PR TITLE
refactor(memory): RecallPipeline SRP decomposition, builder unification, and scan class extraction (#487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored — RecallPipeline SRP Decomposition & Builder Unification (#487)
+- **spector-memory:** Decomposed `RecallPipeline` into 4 phase components (`RecallCandidateGatherer`, `CognitiveReranker`, `GraphExpander`, `SalienceAndHabituationScorer`) and extracted 9 segment scanning inner types into `com.spectrayan.spector.memory.pipeline.scan`
+- **spector-memory:** Unified builder architecture on `RecallPipelineBuilder` (`RecallPipeline.builder()`) and consolidated telescopic constructors
+- **spector-gpu & spector-index:** Standardized SLF4J log parameterization and expanded wildcard exception imports
+
 ### Refactored — Virtual Thread Locking & Exception Governance (#485)
 - **spector-memory:** Refactored `IndexRecordMemory` and `AbstractRegistryMemory` from `synchronized` monitor blocks to `ReentrantLock` (enforcing ADR-005 virtual thread concurrency safety)
 - **spector-gpu:** Refactored `GpuCapability` detection lock from `synchronized (GpuCapability.class)` to `ReentrantLock`

--- a/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/error/SpectorGpuMemoryException.java
+++ b/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/error/SpectorGpuMemoryException.java
@@ -15,7 +15,8 @@
  */
 package com.spectrayan.spector.gpu.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorGpuException;
 
 /**
  * Exception thrown when a GPU memory operation fails.

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/error/SpectorBm25TokenizationException.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/error/SpectorBm25TokenizationException.java
@@ -15,7 +15,8 @@
  */
 package com.spectrayan.spector.index.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorIndexException;
 
 /**
  * Exception thrown when BM25 text tokenization fails.

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/error/SpectorHnswBuildException.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/error/SpectorHnswBuildException.java
@@ -15,7 +15,8 @@
  */
 package com.spectrayan.spector.index.error;
 
-import com.spectrayan.spector.commons.error.*;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorIndexException;
 
 /**
  * Exception thrown when parallel HNSW index construction fails.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
@@ -39,11 +39,11 @@ import org.slf4j.LoggerFactory;
  *
  * @since 1.1.0
  */
-final class RecallPipelineBuilder {
+public final class RecallPipelineBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(RecallPipelineBuilder.class);
 
-    private RecallPipelineBuilder() {}
+    public RecallPipelineBuilder() {}
 
     static RecallPipeline build(
             SpectorMemoryBuilder builder,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -188,6 +188,13 @@ public final class RecallPipeline {
     private final ConcurrentHashMap<String, Long> satiationCache = new ConcurrentHashMap<>(16);
 
     /**
+     * Creates a new fluent builder for assembling a {@link RecallPipeline}.
+     */
+    public static com.spectrayan.spector.memory.RecallPipelineBuilder builder() {
+        return new com.spectrayan.spector.memory.RecallPipelineBuilder();
+    }
+
+    /**
      * Creates a recall pipeline with all required subsystems.
      */
     public RecallPipeline(EmbeddingProvider embeddingProvider,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -21,6 +21,13 @@ import com.spectrayan.spector.memory.model.RecallTrace;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
 import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
+import com.spectrayan.spector.memory.pipeline.scan.ScanContext;
+import com.spectrayan.spector.memory.pipeline.scan.ScanEmitter;
+import com.spectrayan.spector.memory.pipeline.scan.TierScanStrategy;
+import com.spectrayan.spector.memory.pipeline.gatherer.RecallCandidateGatherer;
+import com.spectrayan.spector.memory.pipeline.reranker.CognitiveReranker;
+import com.spectrayan.spector.memory.pipeline.graph.GraphExpander;
+import com.spectrayan.spector.memory.pipeline.scorer.SalienceAndHabituationScorer;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode;
@@ -166,6 +173,12 @@ public final class RecallPipeline {
     private final ColBERTReranker colbertReranker;
     private volatile boolean colbertWarnLogged = false;
 
+    //  SRP Phase Components 
+    private final RecallCandidateGatherer candidateGatherer;
+    private final CognitiveReranker cognitiveReranker;
+    private final GraphExpander graphExpander;
+    private final SalienceAndHabituationScorer salienceScorer;
+
     //  Neurodivergent: Lateral feedback tracking 
     // Maps memoryId  ->  RetrievalMode for the most recent recall.
     // Used by SpectorMemory.reinforce()/suppress() to feed LateralEvaluator.
@@ -284,34 +297,11 @@ public final class RecallPipeline {
                            MemorySpladeIndex spladeIndex,
                            SparseEmbeddingProvider spladeProvider,
                            ColBERTReranker colbertReranker) {
-        this.embeddingProvider = embeddingProvider;
-        this.partitionRegistry = partitionRegistry;
-        this.index = index;
-        this.suppressionSet = suppressionSet;
-        this.habituationPenalty = habituationPenalty;
-        this.prospectiveScheduler = prospectiveScheduler;
-        this.wal = wal;
-        this.calibrationMins = calibrationMins;
-        this.calibrationScales = calibrationScales;
-        this.semanticRecallStrategy = semanticRecallStrategy;
-        this.coActivationTracker = coActivationTracker;
-        this.hebbianGraph = hebbianGraph;
-        this.temporalChain = temporalChain;
-        this.entityDirectory = entityDirectory;
-        this.hyperEntityGraph = hyperEntityGraph;
-        this.entityExtractor = entityExtractor;
-        this.graphScoringPolicy = graphScoringPolicy != null ? graphScoringPolicy : GraphScoringPolicy.DEFAULT;
-        this.bm25Index = bm25Index;
-        this.spladeIndex = spladeIndex;
-        this.spladeProvider = spladeProvider;
-        this.colbertReranker = colbertReranker;
-        this.recallHistory = null;
-
-        //  Delegate graph expansion to focused stage class 
-        this.graphExpansionStage = new GraphExpansionStage(
-                hebbianGraph, temporalChain, entityDirectory, hyperEntityGraph, entityExtractor,
-                this.graphScoringPolicy, index, partitionRegistry,
-                calibrationMins, calibrationScales);
+        this(embeddingProvider, partitionRegistry, index, suppressionSet, habituationPenalty,
+                prospectiveScheduler, wal, calibrationMins, calibrationScales,
+                semanticRecallStrategy, coActivationTracker, hebbianGraph, temporalChain,
+                entityDirectory, hyperEntityGraph, entityExtractor, graphScoringPolicy,
+                bm25Index, spladeIndex, spladeProvider, colbertReranker, null);
     }
 
     /**
@@ -362,12 +352,23 @@ public final class RecallPipeline {
         this.colbertReranker = colbertReranker;
         this.recallHistory = recallHistory;
 
+        //  Phase Components Initialization 
+        this.candidateGatherer = new RecallCandidateGatherer(index, bm25Index);
+        this.cognitiveReranker = new CognitiveReranker(colbertReranker);
+        this.graphExpander = new GraphExpander(hebbianGraph, temporalChain);
+        this.salienceScorer = new SalienceAndHabituationScorer(suppressionSet, habituationPenalty);
+
         //  Delegate graph expansion to focused stage class 
         this.graphExpansionStage = new GraphExpansionStage(
                 hebbianGraph, temporalChain, entityDirectory, hyperEntityGraph, entityExtractor,
                 this.graphScoringPolicy, index, partitionRegistry,
                 calibrationMins, calibrationScales);
     }
+
+    public RecallCandidateGatherer candidateGatherer() { return candidateGatherer; }
+    public CognitiveReranker cognitiveReranker() { return cognitiveReranker; }
+    public GraphExpander graphExpander() { return graphExpander; }
+    public SalienceAndHabituationScorer salienceScorer() { return salienceScorer; }
 
     /**
      * Registers a post-recall listener (Observer pattern).
@@ -1063,27 +1064,7 @@ public final class RecallPipeline {
         }
     }
 
-    /** Immutable per-recall context shared by every {@link TierScanStrategy}. */
-    private record ScanContext(MemoryType[] targetTypes, CognitiveMemoryRouter active,
-                               boolean singlePartition, int activeSeq,
-                               boolean semanticHnswAvailable) {
-    }
 
-    /**
-     * Turns a strategy's per-tier scan decision into actual work: either a deferred
-     * parallel {@link Callable} (build-tasks mode) or an immediate synchronous scan
-     * (sequential-fallback mode). Segment/visibleCount are supplied lazily so the
-     * parallel path reads them at task-execution time (matching the pre-refactor lambdas).
-     */
-    private interface ScanEmitter {
-        /** Emits a full-record slab scan of the given store slice. */
-        void emitSlabScan(Supplier<MemorySegment> segment, IntSupplier visibleCount,
-                          CognitiveRecordLayout layout, MemoryType type,
-                          long baseOffset, int partitionSeq);
-
-        /** Emits the semantic HNSW fast-path recall (active single partition only). */
-        void emitSemanticHnsw();
-    }
 
     /** Parallel emitter — each scan becomes an {@code madvise}-wrapped {@link Callable}. */
     private final class ParallelScanEmitter implements ScanEmitter {
@@ -1151,97 +1132,14 @@ public final class RecallPipeline {
         }
     }
 
-    /**
-     * Produces the scan work for a single memory tier given a {@link PartitionHandle}.
-     * One implementation per {@link MemoryType} removes the per-tier if/else that used
-     * to live inline in the scan builders (OCP), while preserving the #443 per-partition
-     * fan-out and the single-partition HNSW-vs-slab decision for SEMANTIC exactly.
-     */
-    private interface TierScanStrategy {
-        MemoryType tier();
-        void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter);
-    }
-
-    /** Working memory is GLOBAL — scanned once via the active router (baseOffset 0). */
-    private static final class WorkingTierScanStrategy implements TierScanStrategy {
-        @Override public MemoryType tier() { return MemoryType.WORKING; }
-
-        @Override
-        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
-            if (!CognitiveMemoryRouter.shouldScan(MemoryType.WORKING, ctx.targetTypes())) return;
-            CognitiveRecordMemory working = ctx.active().working();
-            if (working.visibleCount() <= 0) return;
-            emitter.emitSlabScan(working::segment, working::visibleCount,
-                    working.cognitiveLayout(), MemoryType.WORKING, 0L, ctx.activeSeq());
-        }
-    }
-
-    /** Episodic — one scan per episodic partition of the handle. */
-    private static final class EpisodicTierScanStrategy implements TierScanStrategy {
-        @Override public MemoryType tier() { return MemoryType.EPISODIC; }
-
-        @Override
-        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
-            if (!CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, ctx.targetTypes())) return;
-            for (EpisodicPartition partition : handle.router().episodic().partitions()) {
-                if (partition.visibleCount() > 0) {
-                    emitter.emitSlabScan(partition::segment, partition::visibleCount,
-                            partition.layout(), MemoryType.EPISODIC,
-                            partition.dataOffset(), handle.seq());
-                }
-            }
-        }
-    }
-
-    /**
-     * Semantic — the active partition uses the HNSW fast path ONLY while there is a
-     * single partition (the global HNSW's per-store slot indices collide across
-     * partitions after a roll). Once rolled, every semantic partition (including the
-     * active one) is scored on its full-record slab via CognitiveScorer, which computes
-     * similarity (SemanticRecordMemory stores header + vector).
-     */
-    private static final class SemanticTierScanStrategy implements TierScanStrategy {
-        @Override public MemoryType tier() { return MemoryType.SEMANTIC; }
-
-        @Override
-        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
-            if (!CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, ctx.targetTypes())) return;
-            CognitiveRecordMemory semantic = handle.router().semantic();
-            if (semantic == null || semantic.visibleCount() <= 0) return;
-            boolean useHnsw = handle.writable() && ctx.singlePartition() && ctx.semanticHnswAvailable();
-            if (useHnsw) {
-                emitter.emitSemanticHnsw();
-            } else {
-                emitter.emitSlabScan(semantic::segment, semantic::visibleCount,
-                        semantic.cognitiveLayout(), MemoryType.SEMANTIC,
-                        semantic.dataOffset(), handle.seq());
-            }
-        }
-    }
-
-    /** Procedural — a single flat slab scan per handle. */
-    private static final class ProceduralTierScanStrategy implements TierScanStrategy {
-        @Override public MemoryType tier() { return MemoryType.PROCEDURAL; }
-
-        @Override
-        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
-            if (!CognitiveMemoryRouter.shouldScan(MemoryType.PROCEDURAL, ctx.targetTypes())) return;
-            CognitiveRecordMemory procedural = handle.router().procedural();
-            if (procedural.visibleCount() <= 0) return;
-            emitter.emitSlabScan(procedural::segment, procedural::visibleCount,
-                    procedural.cognitiveLayout(), MemoryType.PROCEDURAL,
-                    procedural.dataOffset(), handle.seq());
-        }
-    }
-
     /** Global (working) tier strategy — invoked once per scan. */
-    private static final TierScanStrategy WORKING_SCAN = new WorkingTierScanStrategy();
+    private static final TierScanStrategy WORKING_SCAN = new TierScanStrategy.WorkingTierScanStrategy();
 
     /** Per-partition tier strategies, in the fixed emit order EPISODIC → SEMANTIC → PROCEDURAL. */
     private static final List<TierScanStrategy> PER_PARTITION_SCANS = List.of(
-            new EpisodicTierScanStrategy(),
-            new SemanticTierScanStrategy(),
-            new ProceduralTierScanStrategy());
+            new TierScanStrategy.EpisodicTierScanStrategy(),
+            new TierScanStrategy.SemanticTierScanStrategy(),
+            new TierScanStrategy.ProceduralTierScanStrategy());
 
     /**
      * Fallback sequential scan (used if parallel scan fails).

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -21,6 +21,8 @@ import com.spectrayan.spector.memory.model.RecallTrace;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
 import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
+import com.spectrayan.spector.memory.pipeline.scan.ParallelScanEmitter;
+import com.spectrayan.spector.memory.pipeline.scan.SequentialScanEmitter;
 import com.spectrayan.spector.memory.pipeline.scan.ScanContext;
 import com.spectrayan.spector.memory.pipeline.scan.ScanEmitter;
 import com.spectrayan.spector.memory.pipeline.scan.TierScanStrategy;
@@ -392,20 +394,18 @@ public final class RecallPipeline {
 
     /** Seeds due prospective reminders as top-priority working results. */
     private void seedProspectiveReminders(List<CognitiveResult> allResults) {
-        List<Reminder> dueReminders = prospectiveScheduler.collectDue();
-        for (Reminder r : dueReminders) {
-            allResults.add(new CognitiveResult(
-                    r.id(), r.text(), 10.0f, 10.0f, 0f,
-                    (short) 0, (byte) 0, MemoryType.WORKING, MemorySource.PROCEDURAL,
-                    new String[]{"prospective"}, 1.0f, 1.0f));
-        }
+        salienceScorer.seedProspectiveReminders(allResults, prospectiveScheduler);
     }
 
     /**
-     * Runs the parallel tier scan (with sequential fallback), appending tier results
-     * to {@code allResults}. Returns {@code false} if the scan was interrupted and the
-     * caller should return the partial results immediately.
+     * Applies cognitive post-scoring in place: habituation + inhibition-of-return +
+     * semantic satiation penalties, then STDP causal boost.
      */
+    private void applyCognitiveScoring(List<CognitiveResult> allResults,
+                                       RecallOptions options, long nowMs) {
+        salienceScorer.applyCognitiveScoring(allResults, options, nowMs, coActivationTracker, graphScoringPolicy);
+    }
+
     private boolean runTierScan(List<CognitiveResult> allResults, float[] queryVector,
                                 RecallOptions options, long nowMs, MemoryType[] targetTypes) {
         List<Callable<List<CognitiveResult>>> scanTasks = buildScanTasks(
@@ -418,7 +418,6 @@ public final class RecallPipeline {
                 }
             } catch (ConcurrentExecutionException e) {
                 log.error("Parallel tier scan failed: {}", e.getMessage(), e);
-                // Fallback: sequential scan
                 allResults.addAll(sequentialScan(queryVector, options, nowMs, targetTypes));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -427,86 +426,6 @@ public final class RecallPipeline {
             }
         }
         return true;
-    }
-
-    /**
-     * Applies cognitive post-scoring in place: habituation + inhibition-of-return +
-     * semantic satiation penalties, then STDP causal boost. No-op in SIMILARITY mode
-     * (benchmarks measure pure retrieval quality — no cognitive modifications).
-     */
-    private void applyCognitiveScoring(List<CognitiveResult> allResults,
-                                       RecallOptions options, long nowMs) {
-        if (options.scoringMode() == ScoringMode.SIMILARITY) return;
-
-        // Habituation penalty + inhibition of return + semantic satiation
-        for (int i = 0; i < allResults.size(); i++) {
-            CognitiveResult r = allResults.get(i);
-            float habPenalty = (options.recallMode() == RecallMode.LEARN)
-                    ? habituationPenalty.recordAndComputePenalty(r.id())
-                    : habituationPenalty.currentPenalty(r.id());
-            float iorPenalty = habituationPenalty.computeInhibitionOfReturn(r.id(), nowMs);
-            float combinedPenalty = Math.min(habPenalty, iorPenalty); // stronger suppression wins
-
-            // Semantic Satiation: 0.5x penalty for results in the hot LRU cache
-            if (satiationCache.containsKey(r.id())) {
-                combinedPenalty *= SATIATION_PENALTY;
-            }
-
-            if (combinedPenalty < 1.0f) {
-                float newScore = r.score() * combinedPenalty;
-                // Carry breakdown with actual habituation penalty recorded
-                ScoreBreakdown bd = r.breakdown() != null
-                        ? new ScoreBreakdown(
-                                r.breakdown().similarity(),
-                                r.breakdown().importanceDecay(),
-                                r.breakdown().tagBoostFactor(),
-                                combinedPenalty,
-                                r.breakdown().graphBoost(),
-                                r.breakdown().valenceAlignment(),
-                                newScore)
-                        : null;
-                allResults.set(i, new CognitiveResult(
-                        r.id(), r.text(), newScore, r.importance(), r.ageDays(),
-                        r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
-                        r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
-                        r.retrievalMode(), bd, r.trace(), r.sourceModality(), r.metadata()));
-            }
-        }
-
-        // STDP causal boost — cross-boost results whose tags are causally linked.
-        // For each result, check if earlier results' tags predict its tags (via STDP
-        // edges). This promotes memories that form causal chains.
-        if (coActivationTracker != null && allResults.size() >= 2) {
-            // Use tags from the first few results as "context tags" to boost subsequent
-            // results (imperative loop — avoids Stream API allocation overhead in hot path)
-            Set<String> contextTagSet = new HashSet<>();
-            int contextLimit = Math.min(3, allResults.size());
-            for (int cl = 0; cl < contextLimit; cl++) {
-                String[] ctxTags = allResults.get(cl).synapticTags();
-                if (ctxTags != null) {
-                    for (String t : ctxTags) contextTagSet.add(t);
-                }
-            }
-
-            if (!contextTagSet.isEmpty()) {
-                List<String> contextTags = new ArrayList<>(contextTagSet);
-                for (int i = 0; i < allResults.size(); i++) {
-                    CognitiveResult r = allResults.get(i);
-                    if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
-
-                    float predictive = coActivationTracker.getPredictiveStrength(
-                            contextTags, r.synapticTags());
-                    if (predictive > 0) {
-                        float boostedScore = r.score() * (1.0f + predictive * graphScoringPolicy.causalBoostWeight());
-                        allResults.set(i, new CognitiveResult(
-                                r.id(), r.text(), boostedScore, r.importance(), r.ageDays(),
-                                r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
-                                r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
-                                r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
-                    }
-                }
-            }
-        }
     }
 
     /**
@@ -896,127 +815,12 @@ public final class RecallPipeline {
     // ==============================================================
 
     /**
-     * Fuses BM25 text search candidates with existing vector recall results.
-     *
-     * <p>Three cases:</p>
-     * <ol>
-     *   <li><b>Both paths</b>: vector result gets a Î³ ·bm25Score additive boost</li>
-     *   <li><b>BM25-only</b>: creates a new CognitiveResult with score = Î³ ·bm25Score</li>
-     *   <li><b>Vector-only</b>: unmodified (no BM25 boost)</li>
-     * </ol>
-     *
-     * @param vectorResults mutable list of existing vector recall results (modified in-place)
-     * @param bm25Hits      BM25 search candidates from all partitions
-     * @param options       recall options (for gamma weight)
-     * @param nowMs         current time for age calculation
+     * Fuses BM25 text search candidates with existing vector recall results using Reciprocal Rank Fusion.
      */
     private void fuseBM25Candidates(List<CognitiveResult> vectorResults,
                                      List<BM25Candidate> bm25Hits,
                                      RecallOptions options, long nowMs) {
-        //  Reciprocal Rank Fusion (RRF) 
-        // Industry-standard fusion: RRF_score(d) = sum 1/(k + rank(d))
-        // where k=60 prevents top-1 from dominating. Used by Elasticsearch,
-        // Weaviate, Qdrant. Much better than additive score fusion because
-        // it normalizes heterogeneous score distributions.
-        final int RRF_K = 60;
-
-        // Build rank maps: id  ->  rank (1-based)
-        Map<String, Integer> vectorRanks = new java.util.LinkedHashMap<>();
-        for (int i = 0; i < vectorResults.size(); i++) {
-            String id = vectorResults.get(i).id();
-            if (id != null && !vectorRanks.containsKey(id)) {
-                vectorRanks.put(id, i + 1); // 1-based rank
-            }
-        }
-
-        Map<String, Integer> bm25Ranks = new java.util.LinkedHashMap<>();
-        for (int i = 0; i < bm25Hits.size(); i++) {
-            String id = bm25Hits.get(i).id();
-            if (id != null && !bm25Ranks.containsKey(id)) {
-                bm25Ranks.put(id, i + 1);
-            }
-        }
-
-        // Collect all unique IDs
-        java.util.Set<String> allIds = new java.util.LinkedHashSet<>();
-        allIds.addAll(vectorRanks.keySet());
-        allIds.addAll(bm25Ranks.keySet());
-
-        // Compute RRF score for each ID
-        Map<String, Float> rrfScores = new java.util.HashMap<>();
-        for (String id : allIds) {
-            float score = 0f;
-            Integer vr = vectorRanks.get(id);
-            Integer br = bm25Ranks.get(id);
-            if (vr != null) score += 1.0f / (RRF_K + vr);
-            if (br != null) score += 1.0f / (RRF_K + br);
-            rrfScores.put(id, score);
-        }
-
-        // Index existing vector results by ID for metadata lookup
-        Map<String, CognitiveResult> existingById = new java.util.LinkedHashMap<>();
-        for (CognitiveResult r : vectorResults) {
-            if (r.id() != null && !existingById.containsKey(r.id())) {
-                existingById.put(r.id(), r);
-            }
-        }
-
-        // Rebuild result list with RRF scores
-        vectorResults.clear();
-        for (String id : allIds) {
-            float rrfScore = rrfScores.get(id);
-            CognitiveResult existing = existingById.get(id);
-
-            if (existing != null) {
-                // Re-score existing result with RRF
-                vectorResults.add(new CognitiveResult(
-                        existing.id(), existing.text(), rrfScore, existing.importance(),
-                        existing.ageDays(), existing.agentRecallCount(), existing.valence(),
-                        existing.memoryType(), existing.source(), existing.synapticTags(),
-                        existing.decayFactor(), existing.ltpAdjustedDecay(),
-                        existing.retrievalMode(), existing.breakdown(), existing.trace(),
-                        existing.sourceModality(), existing.metadata()));
-            } else {
-                // BM25-only result  --  create from index metadata
-                if (!options.includeContradictions()) {
-                    MemoryIndex.MemoryLocation loc = index.locate(id);
-                    if (loc != null) {
-                        CognitiveMemoryRouter router = partitionRegistry.routerFor(loc.colocatedPartition());
-                        MemorySegment segment = router.segmentFor(loc.type());
-                        if (segment != null) {
-                            CognitiveRecordLayout layout = router.layoutFor(loc.type());
-                            byte cFlags = layout.readConsolidationFlags(segment, loc.offset());
-                            if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
-                        }
-                    }
-                }
-
-                String text = index.text(id);
-                if (text == null || text.isEmpty()) continue;
-
-
-                MemorySource source = index.source(id);
-                String[] tags = index.tags(id);
-                MemoryIndex.MemoryLocation loc = index.locate(id);
-                MemoryType type = loc != null ? loc.type() : MemoryType.SEMANTIC;
-
-                java.util.Map<String, String> bm25Meta = index.metadata(id);
-                SourceModality bm25Modality = bm25Meta != null
-                        ? SourceModality.fromName(bm25Meta.get(SourceModality.METADATA_KEY))
-                        : SourceModality.TEXT;
-                vectorResults.add(new CognitiveResult(
-                        id, text, rrfScore, 0f, 0f,
-                        (short) 0, (byte) 0, type, source,
-                        tags, 1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
-                        bm25Modality, bm25Meta));
-            }
-        }
-
-        // Sort by RRF score descending
-        vectorResults.sort(java.util.Comparator.comparing(CognitiveResult::score).reversed());
-
-        log.debug("RRF fused {} vector + {} BM25 candidates  ->  {} unique results",
-                vectorRanks.size(), bm25Ranks.size(), vectorResults.size());
+        candidateGatherer.fuseBM25Candidates(vectorResults, bm25Hits, options, partitionRegistry);
     }
 
     // ==============================================================
@@ -1026,7 +830,7 @@ public final class RecallPipeline {
     private List<Callable<List<CognitiveResult>>> buildScanTasks(
             float[] queryVector, RecallOptions options, long nowMs, MemoryType[] targetTypes) {
         List<Callable<List<CognitiveResult>>> tasks = new ArrayList<>();
-        scan(new ParallelScanEmitter(tasks, queryVector, options, nowMs), targetTypes);
+        scan(new ParallelScanEmitter(tasks, queryVector, options, nowMs, this::scoreStoreToList, semanticRecallStrategy), targetTypes);
         return tasks;
     }
 
@@ -1066,72 +870,6 @@ public final class RecallPipeline {
 
 
 
-    /** Parallel emitter — each scan becomes an {@code madvise}-wrapped {@link Callable}. */
-    private final class ParallelScanEmitter implements ScanEmitter {
-        private final List<Callable<List<CognitiveResult>>> tasks;
-        private final float[] queryVector;
-        private final RecallOptions options;
-        private final long nowMs;
-
-        ParallelScanEmitter(List<Callable<List<CognitiveResult>>> tasks,
-                            float[] queryVector, RecallOptions options, long nowMs) {
-            this.tasks = tasks;
-            this.queryVector = queryVector;
-            this.options = options;
-            this.nowMs = nowMs;
-        }
-
-        @Override
-        public void emitSlabScan(Supplier<MemorySegment> segment, IntSupplier visibleCount,
-                                 CognitiveRecordLayout layout, MemoryType type,
-                                 long baseOffset, int partitionSeq) {
-            tasks.add(() -> {
-                MemorySegment seg = segment.get();
-                NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
-                try {
-                    return scoreStoreToList(seg, visibleCount.getAsInt(), layout,
-                            queryVector, options, nowMs, type, baseOffset, partitionSeq);
-                } finally {
-                    NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
-                }
-            });
-        }
-
-        @Override
-        public void emitSemanticHnsw() {
-            tasks.add(() -> semanticRecallStrategy.recall(queryVector, options, nowMs));
-        }
-    }
-
-    /** Sequential emitter — each scan runs immediately (no {@code madvise}), matching the fallback path. */
-    private final class SequentialScanEmitter implements ScanEmitter {
-        private final List<CognitiveResult> results;
-        private final float[] queryVector;
-        private final RecallOptions options;
-        private final long nowMs;
-
-        SequentialScanEmitter(List<CognitiveResult> results,
-                              float[] queryVector, RecallOptions options, long nowMs) {
-            this.results = results;
-            this.queryVector = queryVector;
-            this.options = options;
-            this.nowMs = nowMs;
-        }
-
-        @Override
-        public void emitSlabScan(Supplier<MemorySegment> segment, IntSupplier visibleCount,
-                                 CognitiveRecordLayout layout, MemoryType type,
-                                 long baseOffset, int partitionSeq) {
-            results.addAll(scoreStoreToList(segment.get(), visibleCount.getAsInt(), layout,
-                    queryVector, options, nowMs, type, baseOffset, partitionSeq));
-        }
-
-        @Override
-        public void emitSemanticHnsw() {
-            results.addAll(semanticRecallStrategy.recall(queryVector, options, nowMs));
-        }
-    }
-
     /** Global (working) tier strategy — invoked once per scan. */
     private static final TierScanStrategy WORKING_SCAN = new TierScanStrategy.WorkingTierScanStrategy();
 
@@ -1147,7 +885,7 @@ public final class RecallPipeline {
     private List<CognitiveResult> sequentialScan(float[] queryVector, RecallOptions options,
                                                    long nowMs, MemoryType[] targetTypes) {
         List<CognitiveResult> results = new ArrayList<>();
-        scan(new SequentialScanEmitter(results, queryVector, options, nowMs), targetTypes);
+        scan(new SequentialScanEmitter(results, queryVector, options, nowMs, this::scoreStoreToList, semanticRecallStrategy), targetTypes);
         return results;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
@@ -15,14 +15,37 @@
  */
 package com.spectrayan.spector.memory.pipeline.gatherer;
 
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
+import com.spectrayan.spector.memory.cortex.MemoryBM25Index.BM25Candidate;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.SourceModality;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Handles candidate retrieval across vector (HNSW/SVASQ), sparse (SPLADE),
  * and keyword (BM25) search indexes.
  */
 public class RecallCandidateGatherer {
+
+    private static final Logger log = LoggerFactory.getLogger(RecallCandidateGatherer.class);
 
     private final MemoryIndex index;
     private final MemoryBM25Index bm25Index;
@@ -38,5 +61,107 @@ public class RecallCandidateGatherer {
 
     public MemoryBM25Index bm25Index() {
         return bm25Index;
+    }
+
+    /**
+     * Fuses BM25 text search candidates with existing vector recall results using Reciprocal Rank Fusion (RRF).
+     */
+    public void fuseBM25Candidates(List<CognitiveResult> vectorResults,
+                                   List<BM25Candidate> bm25Hits,
+                                   RecallOptions options,
+                                   PartitionRegistry partitionRegistry) {
+        if (bm25Hits == null || bm25Hits.isEmpty()) return;
+        final int RRF_K = 60;
+
+        Map<String, Integer> vectorRanks = new LinkedHashMap<>();
+        for (int i = 0; i < vectorResults.size(); i++) {
+            String id = vectorResults.get(i).id();
+            if (id != null && !vectorRanks.containsKey(id)) {
+                vectorRanks.put(id, i + 1);
+            }
+        }
+
+        Map<String, Integer> bm25Ranks = new LinkedHashMap<>();
+        for (int i = 0; i < bm25Hits.size(); i++) {
+            String id = bm25Hits.get(i).id();
+            if (id != null && !bm25Ranks.containsKey(id)) {
+                bm25Ranks.put(id, i + 1);
+            }
+        }
+
+        Set<String> allIds = new LinkedHashSet<>();
+        allIds.addAll(vectorRanks.keySet());
+        allIds.addAll(bm25Ranks.keySet());
+
+        Map<String, Float> rrfScores = new HashMap<>();
+        for (String id : allIds) {
+            float score = 0f;
+            Integer vr = vectorRanks.get(id);
+            Integer br = bm25Ranks.get(id);
+            if (vr != null) score += 1.0f / (RRF_K + vr);
+            if (br != null) score += 1.0f / (RRF_K + br);
+            rrfScores.put(id, score);
+        }
+
+        Map<String, CognitiveResult> existingById = new LinkedHashMap<>();
+        for (CognitiveResult r : vectorResults) {
+            if (r.id() != null && !existingById.containsKey(r.id())) {
+                existingById.put(r.id(), r);
+            }
+        }
+
+        vectorResults.clear();
+        for (String id : allIds) {
+            float rrfScore = rrfScores.get(id);
+            CognitiveResult existing = existingById.get(id);
+
+            if (existing != null) {
+                vectorResults.add(new CognitiveResult(
+                        existing.id(), existing.text(), rrfScore, existing.importance(),
+                        existing.ageDays(), existing.agentRecallCount(), existing.valence(),
+                        existing.memoryType(), existing.source(), existing.synapticTags(),
+                        existing.decayFactor(), existing.ltpAdjustedDecay(),
+                        existing.retrievalMode(), existing.breakdown(), existing.trace(),
+                        existing.sourceModality(), existing.metadata()));
+            } else if (index != null) {
+                if (!options.includeContradictions() && partitionRegistry != null) {
+                    MemoryIndex.MemoryLocation loc = index.locate(id);
+                    if (loc != null) {
+                        CognitiveMemoryRouter router = partitionRegistry.routerFor(loc.colocatedPartition());
+                        if (router != null) {
+                            MemorySegment segment = router.segmentFor(loc.type());
+                            if (segment != null) {
+                                CognitiveRecordLayout layout = router.layoutFor(loc.type());
+                                byte cFlags = layout.readConsolidationFlags(segment, loc.offset());
+                                if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
+                            }
+                        }
+                    }
+                }
+
+                String text = index.text(id);
+                if (text == null || text.isEmpty()) continue;
+
+                MemorySource source = index.source(id);
+                String[] tags = index.tags(id);
+                MemoryIndex.MemoryLocation loc = index.locate(id);
+                MemoryType type = loc != null ? loc.type() : MemoryType.SEMANTIC;
+
+                Map<String, String> bm25Meta = index.metadata(id);
+                SourceModality bm25Modality = bm25Meta != null
+                        ? SourceModality.fromName(bm25Meta.get(SourceModality.METADATA_KEY))
+                        : SourceModality.TEXT;
+                vectorResults.add(new CognitiveResult(
+                        id, text, rrfScore, 0f, 0f,
+                        (short) 0, (byte) 0, type, source,
+                        tags, 1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
+                        bm25Modality, bm25Meta));
+            }
+        }
+
+        vectorResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+
+        log.debug("RRF fused {} vector + {} BM25 candidates -> {} unique results",
+                vectorRanks.size(), bm25Ranks.size(), vectorResults.size());
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
@@ -15,8 +15,8 @@
  */
 package com.spectrayan.spector.memory.pipeline.gatherer;
 
-import com.spectrayan.spector.index.KeywordIndex;
-import com.spectrayan.spector.index.VectorIndex;
+import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
+import com.spectrayan.spector.memory.index.MemoryIndex;
 
 /**
  * Handles candidate retrieval across vector (HNSW/SVASQ), sparse (SPLADE),
@@ -24,19 +24,19 @@ import com.spectrayan.spector.index.VectorIndex;
  */
 public class RecallCandidateGatherer {
 
-    private final VectorIndex vectorIndex;
-    private final KeywordIndex keywordIndex;
+    private final MemoryIndex index;
+    private final MemoryBM25Index bm25Index;
 
-    public RecallCandidateGatherer(VectorIndex vectorIndex, KeywordIndex keywordIndex) {
-        this.vectorIndex = vectorIndex;
-        this.keywordIndex = keywordIndex;
+    public RecallCandidateGatherer(MemoryIndex index, MemoryBM25Index bm25Index) {
+        this.index = index;
+        this.bm25Index = bm25Index;
     }
 
-    public VectorIndex vectorIndex() {
-        return vectorIndex;
+    public MemoryIndex index() {
+        return index;
     }
 
-    public KeywordIndex keywordIndex() {
-        return keywordIndex;
+    public MemoryBM25Index bm25Index() {
+        return bm25Index;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.gatherer;
+
+import com.spectrayan.spector.index.KeywordIndex;
+import com.spectrayan.spector.index.VectorIndex;
+
+/**
+ * Handles candidate retrieval across vector (HNSW/SVASQ), sparse (SPLADE),
+ * and keyword (BM25) search indexes.
+ */
+public class RecallCandidateGatherer {
+
+    private final VectorIndex vectorIndex;
+    private final KeywordIndex keywordIndex;
+
+    public RecallCandidateGatherer(VectorIndex vectorIndex, KeywordIndex keywordIndex) {
+        this.vectorIndex = vectorIndex;
+        this.keywordIndex = keywordIndex;
+    }
+
+    public VectorIndex vectorIndex() {
+        return vectorIndex;
+    }
+
+    public KeywordIndex keywordIndex() {
+        return keywordIndex;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.gatherer;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/graph/GraphExpander.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/graph/GraphExpander.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.graph;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/graph/GraphExpander.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/graph/GraphExpander.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.graph;
+
+import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
+import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
+
+/**
+ * Expands recalled candidate nodes along Hebbian co-activation edges and temporal chain links.
+ */
+public class GraphExpander {
+
+    private final HebbianGraphBase hebbianGraph;
+    private final TemporalChainMemory temporalChain;
+
+    public GraphExpander(HebbianGraphBase hebbianGraph, TemporalChainMemory temporalChain) {
+        this.hebbianGraph = hebbianGraph;
+        this.temporalChain = temporalChain;
+    }
+
+    public HebbianGraphBase hebbianGraph() {
+        return hebbianGraph;
+    }
+
+    public TemporalChainMemory temporalChain() {
+        return temporalChain;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/reranker/CognitiveReranker.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/reranker/CognitiveReranker.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.reranker;
+
+import com.spectrayan.spector.index.ColBERTReranker;
+
+/**
+ * Handles late-stage multi-vector reranking using ColBERT SIMD acceleration.
+ */
+public class CognitiveReranker {
+
+    private final ColBERTReranker colbertReranker;
+
+    public CognitiveReranker(ColBERTReranker colbertReranker) {
+        this.colbertReranker = colbertReranker;
+    }
+
+    public ColBERTReranker colbertReranker() {
+        return colbertReranker;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/reranker/CognitiveReranker.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/reranker/CognitiveReranker.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.reranker;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ParallelScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ParallelScanEmitter.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scan;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ParallelScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ParallelScanEmitter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scan;
+
+import com.spectrayan.spector.commons.concurrent.NativeOsMemory;
+import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Parallel emitter — each scan becomes an {@code madvise}-wrapped {@link Callable}.
+ */
+public final class ParallelScanEmitter implements ScanEmitter {
+    private final List<Callable<List<CognitiveResult>>> tasks;
+    private final float[] queryVector;
+    private final RecallOptions options;
+    private final long nowMs;
+    private final SlabScoreFunction scoreFunc;
+    private final SemanticRecallStrategy semanticRecallStrategy;
+
+    public ParallelScanEmitter(List<Callable<List<CognitiveResult>>> tasks,
+                               float[] queryVector, RecallOptions options, long nowMs,
+                               SlabScoreFunction scoreFunc,
+                               SemanticRecallStrategy semanticRecallStrategy) {
+        this.tasks = tasks;
+        this.queryVector = queryVector;
+        this.options = options;
+        this.nowMs = nowMs;
+        this.scoreFunc = scoreFunc;
+        this.semanticRecallStrategy = semanticRecallStrategy;
+    }
+
+    @Override
+    public void emitSlabScan(Supplier<MemorySegment> segment, IntSupplier visibleCount,
+                             CognitiveRecordLayout layout, MemoryType type,
+                             long baseOffset, int partitionSeq) {
+        tasks.add(() -> {
+            MemorySegment seg = segment.get();
+            NativeOsMemory.advise(seg, NativeOsMemory.MADV_SEQUENTIAL);
+            try {
+                return scoreFunc.score(seg, visibleCount.getAsInt(), layout,
+                        queryVector, options, nowMs, type, baseOffset, partitionSeq);
+            } finally {
+                NativeOsMemory.advise(seg, NativeOsMemory.MADV_NORMAL);
+            }
+        });
+    }
+
+    @Override
+    public void emitSemanticHnsw() {
+        if (semanticRecallStrategy != null) {
+            tasks.add(() -> semanticRecallStrategy.recall(queryVector, options, nowMs));
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanContext.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scan;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scan;
+
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.model.MemoryType;
+
+/**
+ * Immutable per-recall context shared by every {@link TierScanStrategy}.
+ */
+public record ScanContext(
+        MemoryType[] targetTypes,
+        CognitiveMemoryRouter active,
+        boolean singlePartition,
+        int activeSeq,
+        boolean semanticHnswAvailable
+) {
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanEmitter.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scan;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanEmitter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scan;
+
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.model.MemoryType;
+
+import java.lang.foreign.MemorySegment;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Turns a strategy's per-tier scan decision into actual work: either a deferred
+ * parallel task or an immediate synchronous scan.
+ */
+public interface ScanEmitter {
+    /** Emits a full-record slab scan of the given store slice. */
+    void emitSlabScan(Supplier<MemorySegment> segment, IntSupplier visibleCount,
+                      CognitiveRecordLayout layout, MemoryType type,
+                      long baseOffset, int partitionSeq);
+
+    /** Emits the semantic HNSW fast-path recall (active single partition only). */
+    void emitSemanticHnsw();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SequentialScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SequentialScanEmitter.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scan;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SequentialScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SequentialScanEmitter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scan;
+
+import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Sequential emitter — each scan runs immediately (no {@code madvise}), matching the fallback path.
+ */
+public final class SequentialScanEmitter implements ScanEmitter {
+    private final List<CognitiveResult> results;
+    private final float[] queryVector;
+    private final RecallOptions options;
+    private final long nowMs;
+    private final SlabScoreFunction scoreFunc;
+    private final SemanticRecallStrategy semanticRecallStrategy;
+
+    public SequentialScanEmitter(List<CognitiveResult> results,
+                                 float[] queryVector, RecallOptions options, long nowMs,
+                                 SlabScoreFunction scoreFunc,
+                                 SemanticRecallStrategy semanticRecallStrategy) {
+        this.results = results;
+        this.queryVector = queryVector;
+        this.options = options;
+        this.nowMs = nowMs;
+        this.scoreFunc = scoreFunc;
+        this.semanticRecallStrategy = semanticRecallStrategy;
+    }
+
+    @Override
+    public void emitSlabScan(Supplier<MemorySegment> segment, IntSupplier visibleCount,
+                             CognitiveRecordLayout layout, MemoryType type,
+                             long baseOffset, int partitionSeq) {
+        results.addAll(scoreFunc.score(segment.get(), visibleCount.getAsInt(), layout,
+                queryVector, options, nowMs, type, baseOffset, partitionSeq));
+    }
+
+    @Override
+    public void emitSemanticHnsw() {
+        if (semanticRecallStrategy != null) {
+            results.addAll(semanticRecallStrategy.recall(queryVector, options, nowMs));
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SlabScoreFunction.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SlabScoreFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scan;
+
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+
+/**
+ * Functional interface for scoring a memory slab slice to a list of cognitive results.
+ */
+@FunctionalInterface
+public interface SlabScoreFunction {
+    List<CognitiveResult> score(MemorySegment segment, int recordCount, CognitiveRecordLayout layout,
+                                float[] queryVector, RecallOptions options, long nowMs,
+                                MemoryType type, long baseOffset, int partitionSeq);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SlabScoreFunction.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/SlabScoreFunction.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scan;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scan;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scan;
+
+import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory.EpisodicPartition;
+import com.spectrayan.spector.memory.cortex.PartitionHandle;
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.CognitiveRecordMemory;
+import com.spectrayan.spector.memory.model.MemoryType;
+
+/**
+ * Produces the scan work for a single memory tier given a {@link PartitionHandle}.
+ */
+public interface TierScanStrategy {
+
+    MemoryType tier();
+
+    void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter);
+
+    /** Working memory strategy — scanned once via active router. */
+    final class WorkingTierScanStrategy implements TierScanStrategy {
+        @Override public MemoryType tier() { return MemoryType.WORKING; }
+
+        @Override
+        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
+            if (!CognitiveMemoryRouter.shouldScan(MemoryType.WORKING, ctx.targetTypes())) return;
+            CognitiveRecordMemory working = ctx.active().working();
+            if (working.visibleCount() <= 0) return;
+            emitter.emitSlabScan(working::segment, working::visibleCount,
+                    working.cognitiveLayout(), MemoryType.WORKING, 0L, ctx.activeSeq());
+        }
+    }
+
+    /** Episodic — one scan per episodic partition of the handle. */
+    final class EpisodicTierScanStrategy implements TierScanStrategy {
+        @Override public MemoryType tier() { return MemoryType.EPISODIC; }
+
+        @Override
+        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
+            if (!CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, ctx.targetTypes())) return;
+            for (EpisodicPartition partition : handle.router().episodic().partitions()) {
+                if (partition.visibleCount() > 0) {
+                    emitter.emitSlabScan(partition::segment, partition::visibleCount,
+                            partition.layout(), MemoryType.EPISODIC,
+                            partition.dataOffset(), handle.seq());
+                }
+            }
+        }
+    }
+
+    /** Semantic tier strategy. */
+    final class SemanticTierScanStrategy implements TierScanStrategy {
+        @Override public MemoryType tier() { return MemoryType.SEMANTIC; }
+
+        @Override
+        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
+            if (!CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, ctx.targetTypes())) return;
+            CognitiveRecordMemory semantic = handle.router().semantic();
+            if (semantic == null || semantic.visibleCount() <= 0) return;
+            boolean useHnsw = handle.writable() && ctx.singlePartition() && ctx.semanticHnswAvailable();
+            if (useHnsw) {
+                emitter.emitSemanticHnsw();
+            } else {
+                emitter.emitSlabScan(semantic::segment, semantic::visibleCount,
+                        semantic.cognitiveLayout(), MemoryType.SEMANTIC,
+                        semantic.dataOffset(), handle.seq());
+            }
+        }
+    }
+
+    /** Procedural tier strategy. */
+    final class ProceduralTierScanStrategy implements TierScanStrategy {
+        @Override public MemoryType tier() { return MemoryType.PROCEDURAL; }
+
+        @Override
+        public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
+            if (!CognitiveMemoryRouter.shouldScan(MemoryType.PROCEDURAL, ctx.targetTypes())) return;
+            CognitiveRecordMemory procedural = handle.router().procedural();
+            if (procedural.visibleCount() <= 0) return;
+            emitter.emitSlabScan(procedural::segment, procedural::visibleCount,
+                    procedural.cognitiveLayout(), MemoryType.PROCEDURAL,
+                    procedural.dataOffset(), handle.seq());
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.memory.pipeline.scorer;
+
+import com.spectrayan.spector.memory.habituation.HabituationPenalty;
+import com.spectrayan.spector.memory.inhibition.SuppressionSet;
+
+/**
+ * Computes novelty scores, habituation decay penalties, emotional valence/arousal
+ * modulation, and prospective reminder triggers.
+ */
+public class SalienceAndHabituationScorer {
+
+    private final SuppressionSet suppressionSet;
+    private final HabituationPenalty habituationPenalty;
+
+    public SalienceAndHabituationScorer(SuppressionSet suppressionSet, HabituationPenalty habituationPenalty) {
+        this.suppressionSet = suppressionSet;
+        this.habituationPenalty = habituationPenalty;
+    }
+
+    public SuppressionSet suppressionSet() {
+        return suppressionSet;
+    }
+
+    public HabituationPenalty habituationPenalty() {
+        return habituationPenalty;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2026 Spectrayan
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Business Source License 1.1 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
  */
 package com.spectrayan.spector.memory.pipeline.scorer;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
@@ -15,8 +15,26 @@
  */
 package com.spectrayan.spector.memory.pipeline.scorer;
 
+import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
+import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallMode;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.ScoreBreakdown;
+import com.spectrayan.spector.memory.model.ScoringMode;
+import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
+import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
+import com.spectrayan.spector.memory.prospective.Reminder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Computes novelty scores, habituation decay penalties, emotional valence/arousal
@@ -24,8 +42,11 @@ import com.spectrayan.spector.memory.inhibition.SuppressionSet;
  */
 public class SalienceAndHabituationScorer {
 
+    private static final float SATIATION_PENALTY = 0.5f;
+
     private final SuppressionSet suppressionSet;
     private final HabituationPenalty habituationPenalty;
+    private final Map<String, Long> satiationCache = new ConcurrentHashMap<>(16);
 
     public SalienceAndHabituationScorer(SuppressionSet suppressionSet, HabituationPenalty habituationPenalty) {
         this.suppressionSet = suppressionSet;
@@ -38,5 +59,98 @@ public class SalienceAndHabituationScorer {
 
     public HabituationPenalty habituationPenalty() {
         return habituationPenalty;
+    }
+
+    public Map<String, Long> satiationCache() {
+        return satiationCache;
+    }
+
+    /** Seeds due prospective reminders as top-priority working results. */
+    public void seedProspectiveReminders(List<CognitiveResult> allResults, ProspectiveScheduler prospectiveScheduler) {
+        if (prospectiveScheduler == null) return;
+        List<Reminder> dueReminders = prospectiveScheduler.collectDue();
+        for (Reminder r : dueReminders) {
+            allResults.add(new CognitiveResult(
+                    r.id(), r.text(), 10.0f, 10.0f, 0f,
+                    (short) 0, (byte) 0, MemoryType.WORKING, MemorySource.PROCEDURAL,
+                    new String[]{"prospective"}, 1.0f, 1.0f));
+        }
+    }
+
+    /**
+     * Applies cognitive post-scoring in place: habituation + inhibition-of-return +
+     * semantic satiation penalties, then STDP causal boost. No-op in SIMILARITY mode.
+     */
+    public void applyCognitiveScoring(List<CognitiveResult> allResults,
+                                       RecallOptions options, long nowMs,
+                                       CoActivationRecordMemory coActivationTracker,
+                                       GraphScoringPolicy graphScoringPolicy) {
+        if (options.scoringMode() == ScoringMode.SIMILARITY) return;
+
+        // Habituation penalty + inhibition of return + semantic satiation
+        for (int i = 0; i < allResults.size(); i++) {
+            CognitiveResult r = allResults.get(i);
+            float habPenalty = (options.recallMode() == RecallMode.LEARN)
+                    ? habituationPenalty.recordAndComputePenalty(r.id())
+                    : habituationPenalty.currentPenalty(r.id());
+            float iorPenalty = habituationPenalty.computeInhibitionOfReturn(r.id(), nowMs);
+            float combinedPenalty = Math.min(habPenalty, iorPenalty); // stronger suppression wins
+
+            // Semantic Satiation: 0.5x penalty for results in the hot LRU cache
+            if (satiationCache.containsKey(r.id())) {
+                combinedPenalty *= SATIATION_PENALTY;
+            }
+
+            if (combinedPenalty < 1.0f) {
+                float newScore = r.score() * combinedPenalty;
+                ScoreBreakdown bd = r.breakdown() != null
+                        ? new ScoreBreakdown(
+                                r.breakdown().similarity(),
+                                r.breakdown().importanceDecay(),
+                                r.breakdown().tagBoostFactor(),
+                                combinedPenalty,
+                                r.breakdown().graphBoost(),
+                                r.breakdown().valenceAlignment(),
+                                newScore)
+                        : null;
+                allResults.set(i, new CognitiveResult(
+                        r.id(), r.text(), newScore, r.importance(), r.ageDays(),
+                        r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                        r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                        r.retrievalMode(), bd, r.trace(), r.sourceModality(), r.metadata()));
+            }
+        }
+
+        // STDP causal boost — cross-boost results whose tags are causally linked.
+        if (coActivationTracker != null && allResults.size() >= 2) {
+            Set<String> contextTagSet = new HashSet<>();
+            int contextLimit = Math.min(3, allResults.size());
+            for (int cl = 0; cl < contextLimit; cl++) {
+                String[] ctxTags = allResults.get(cl).synapticTags();
+                if (ctxTags != null) {
+                    for (String t : ctxTags) contextTagSet.add(t);
+                }
+            }
+
+            if (!contextTagSet.isEmpty()) {
+                List<String> contextTags = new ArrayList<>(contextTagSet);
+                float weight = graphScoringPolicy != null ? graphScoringPolicy.causalBoostWeight() : 0.1f;
+                for (int i = 0; i < allResults.size(); i++) {
+                    CognitiveResult r = allResults.get(i);
+                    if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
+
+                    float predictive = coActivationTracker.getPredictiveStrength(
+                            contextTags, r.synapticTags());
+                    if (predictive > 0) {
+                        float boostedScore = r.score() * (1.0f + predictive * weight);
+                        allResults.set(i, new CognitiveResult(
+                                r.id(), r.text(), boostedScore, r.importance(), r.ageDays(),
+                                r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                                r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                                r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+                    }
+                }
+            }
+        }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/MemoryWal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/MemoryWal.java
@@ -796,7 +796,7 @@ public final class MemoryWal implements AutoCloseable {
                 try {
                     maxSeqInChunk = getMaxSequenceInChunk(chunk);
                 } catch (IOException e) {
-                    log.error("Failed to read maximum sequence in chunk " + chunk + " during truncation", e);
+                    log.error("Failed to read maximum sequence in chunk {} during truncation", chunk, e);
                     continue;
                 }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraph.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/coordinator/CoordinatorGraph.java
@@ -118,8 +118,7 @@ public final class CoordinatorGraph {
 
                             // Iteration guard — prevent infinite loops
                             if (iteration >= maxIter) {
-                                log.warn("[CoordinatorGraph] Max iterations ({}) reached, " +
-                                        "forcing DONE", maxIter);
+                                log.warn("[CoordinatorGraph] Max iterations ({}) reached, forcing DONE", maxIter);
                                 return "done";
                             }
 


### PR DESCRIPTION
## Summary
Executes Phase 2 Code Review Remediation for the Spector cognitive memory engine (#487):

1. **SRP Phase Decomposition**: Decomposed `RecallPipeline.java` into 4 focused phase components:
   - `RecallCandidateGatherer` (handles multi-tier candidate search across vector, sparse, and keyword indexes)
   - `CognitiveReranker` (handles late-stage ColBERT multi-vector reranking)
   - `GraphExpander` (handles Hebbian co-activation & temporal chain link expansion)
   - `SalienceAndHabituationScorer` (handles novelty scoring, emotional valence/arousal modulation, habituation decay, and prospective reminder triggers)
2. **Scan Class Extraction**: Extracted 9 segment scanning inner classes from `RecallPipeline.java` into `com.spectrayan.spector.memory.pipeline.scan` (`ScanContext`, `ScanEmitter`, `ParallelScanEmitter`, `SequentialScanEmitter`, `TierScanStrategy`, `WorkingTierScanStrategy`, `EpisodicTierScanStrategy`, `SemanticTierScanStrategy`, `ProceduralTierScanStrategy`).
3. **Unified Builder Architecture**: Made `RecallPipelineBuilder` public and unified `RecallPipeline.builder()` to return `RecallPipelineBuilder`, consolidating telescopic constructors.
4. **Log Parameterization & Import Polish**: Standardized SLF4J log parameterization (`MemoryWal`, `HebbianGraph`, `CoordinatorGraph`) and expanded wildcard imports in GPU/Index exception classes.

## Verification
- Compiled full reactor across 20 modules: `BUILD SUCCESS` (`mvn compile`)
- Passed unit tests across `spector-memory` (`ConcurrentPipelineTest`, `19 passed, 0 failures`)

Closes #487