### PR TITLE
feat(cortex-ui): Graph Explorer ViewStrategy architecture and constellation view locking

### DIFF
--- a/cortex/spector-cortex/angular.json
+++ b/cortex/spector-cortex/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/cortex/spector-cortex/package-lock.json
+++ b/cortex/spector-cortex/package-lock.json
@@ -2463,9 +2463,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,9 +2480,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2503,9 +2497,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2523,9 +2514,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,9 +2531,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,9 +2548,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2583,9 +2565,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3024,9 +3003,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3048,9 +3024,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3072,9 +3045,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3096,9 +3066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3120,9 +3087,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3144,9 +3108,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3323,9 +3284,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3340,9 +3298,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3357,9 +3312,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3374,9 +3326,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3391,9 +3340,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3408,9 +3354,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3425,9 +3368,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3442,9 +3382,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3459,9 +3396,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3476,9 +3410,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3493,9 +3424,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3510,9 +3438,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3527,9 +3452,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.html
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.html
@@ -28,15 +28,12 @@
     </div>
 
     <div class="toolbar-controls">
-      <!-- View mode toggle -->
-      <div class="view-toggle">
-        <button mat-icon-button 
-                [matTooltip]="activeViewMode() === 'constellation' ? 'Switch to Cortex (Brain) View' : 'Switch to Constellation (Galaxy) View'"
-                (click)="switchView(activeViewMode() === 'constellation' ? 'cortex' : 'constellation')"
-                [class.cortex-active]="activeViewMode() === 'cortex'">
-          <mat-icon>{{ activeViewMode() === 'constellation' ? 'psychology' : 'auto_awesome' }}</mat-icon>
+      <!-- View mode toggle (disabled — Cortex View coming soon) -->
+      <div class="view-toggle" matTooltip="Cortex (Brain) View coming soon">
+        <button mat-icon-button [disabled]="true">
+          <mat-icon>auto_awesome</mat-icon>
         </button>
-        <span class="view-label cortex-mono">{{ activeViewMode() === 'constellation' ? 'CONSTELLATION' : 'CORTEX' }}</span>
+        <span class="view-label cortex-mono">CONSTELLATION</span>
       </div>
 
       <!-- Layer toggles -->

--- a/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.html
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.html
@@ -28,6 +28,17 @@
     </div>
 
     <div class="toolbar-controls">
+      <!-- View mode toggle -->
+      <div class="view-toggle">
+        <button mat-icon-button 
+                [matTooltip]="activeViewMode() === 'constellation' ? 'Switch to Cortex (Brain) View' : 'Switch to Constellation (Galaxy) View'"
+                (click)="switchView(activeViewMode() === 'constellation' ? 'cortex' : 'constellation')"
+                [class.cortex-active]="activeViewMode() === 'cortex'">
+          <mat-icon>{{ activeViewMode() === 'constellation' ? 'psychology' : 'auto_awesome' }}</mat-icon>
+        </button>
+        <span class="view-label cortex-mono">{{ activeViewMode() === 'constellation' ? 'CONSTELLATION' : 'CORTEX' }}</span>
+      </div>
+
       <!-- Layer toggles -->
       <mat-chip-set>
         <mat-chip [highlighted]="showHebbian()" (click)="showHebbian.set(!showHebbian())"

--- a/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.scss
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.scss
@@ -129,6 +129,36 @@ $text-muted: var(--mat-sys-outline);
   gap: 8px;
 }
 
+.view-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border: 1px solid rgba(0, 255, 204, 0.15);
+  border-radius: 8px;
+  background: rgba(0, 255, 204, 0.04);
+  margin-right: 8px;
+  
+  .view-label {
+    font-size: 10px;
+    letter-spacing: 1px;
+    color: rgba(0, 255, 204, 0.5);
+    white-space: nowrap;
+  }
+
+  button {
+    color: rgba(0, 255, 204, 0.6);
+    
+    &.cortex-active {
+      color: #ab47bc;
+      
+      & + .view-label {
+        color: rgba(171, 71, 188, 0.7);
+      }
+    }
+  }
+}
+
 ::ng-deep {
   .mat-mdc-chip-set {
     display: flex;

--- a/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.ts
@@ -312,6 +312,7 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
   }
 
   switchView(mode: 'constellation' | 'cortex'): void {
+    if (mode === 'cortex') return; // Cortex (Brain) view disabled for now
     if (mode === this.activeViewMode()) return;
     this.activeViewMode.set(mode);
     

--- a/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/graph-explorer.component.ts
@@ -31,18 +31,9 @@ import { QueryInputComponent } from '../query-input/query-input.component';
 import { environment } from '../../../environments/environment';
 import * as THREE from 'three';
 
-const TIER_COLORS: Record<string, number> = {
-  WORKING: 0xffb74d,
-  EPISODIC: 0x66bb6a,
-  SEMANTIC: 0x42a5f5,
-  PROCEDURAL: 0xab47bc,
-};
-
-const EDGE_TYPE_COLORS: Record<string, number> = {
-  HEBBIAN: 0x00ffcc,   // Cyan-green for sci-fi feel
-  TEMPORAL: 0x00bcd4,
-  ENTITY: 0xffc107,
-};
+import { GraphViewStrategy, ExplorerNode, ExplorerEdge, FiringParticle } from './strategies/view-strategy.interface';
+import { GalaxyViewStrategy } from './strategies/galaxy-view.strategy';
+import { BrainViewStrategy } from './strategies/brain-view.strategy';
 
 const STORAGE_KEY = 'spector.graph.camera';
 const MAX_PARTICLES = 50;
@@ -54,35 +45,6 @@ interface CameraState {
   radius: number;
 }
 
-interface ExplorerNode {
-  id: string;
-  tier: string;
-  text: string;
-  importance: number;
-  valence: number;
-  timestampMs: number;
-  position: THREE.Vector3;
-  velocity: THREE.Vector3;
-  mesh: THREE.Sprite;
-  glowMesh: THREE.Sprite;
-  labelSprite: THREE.Sprite;
-  selected: boolean;
-  baseSize: number;
-  visible: boolean;        // filter-driven visibility
-  targetOpacity: number;   // for ghost-fade animation
-}
-
-interface ExplorerEdge {
-  from: string;
-  to: string;
-  type: string;
-  weight: number;
-  relation: string | null;
-  line: THREE.Line;
-  labelSprite?: THREE.Sprite;
-  weightSprite?: THREE.Sprite;
-}
-
 interface HoverInfo {
   x: number;
   y: number;
@@ -90,17 +52,6 @@ interface HoverInfo {
   tier: string;
   text: string;
   importance: number;
-}
-
-/** Neuron-firing particle traveling along an edge */
-interface FiringParticle {
-  mesh: THREE.Sprite;
-  trailMesh: THREE.Sprite;
-  edgeIndex: number;
-  progress: number;
-  speed: number;
-  alive: boolean;
-  color: number;
 }
 
 /** Debug console line entry */
@@ -153,14 +104,16 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
   private particles: FiringParticle[] = [];
   private raycaster = new THREE.Raycaster();
   private mouse = new THREE.Vector2();
-  private gridGroup!: THREE.Group;
-  private dustParticles!: THREE.Points;
+
   private particleSpawnTimer = 0;
   private lastRealEventTime = 0; // timestamp of last real SSE event
 
   // Shared geometries/textures for particle pooling
   private particleTexture!: THREE.CanvasTexture;
   private trailTexture!: THREE.CanvasTexture;
+
+  readonly activeViewMode = signal<'constellation' | 'cortex'>('constellation');
+  private activeStrategy: GraphViewStrategy = new GalaxyViewStrategy();
 
   // Orbit state
   private isDragging = false;
@@ -356,6 +309,33 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
       this.selectedEdge.set(null);
       this.clearEdgeHighlight();
     }
+  }
+
+  switchView(mode: 'constellation' | 'cortex'): void {
+    if (mode === this.activeViewMode()) return;
+    this.activeViewMode.set(mode);
+    
+    // Dispose current strategy
+    this.activeStrategy.dispose(this.scene, this.nodes, this.edges, this.particles);
+    this.nodes = [];
+    this.edges = [];
+    this.particles = [];
+    
+    // Remove old scene children (except camera)
+    while (this.scene.children.length > 0) {
+      this.scene.remove(this.scene.children[0]);
+    }
+    
+    // Switch strategy
+    this.activeStrategy = mode === 'constellation'
+      ? new GalaxyViewStrategy()
+      : new BrainViewStrategy();
+    
+    // Re-init scene with new strategy
+    this.scene = this.activeStrategy.initScene(this.canvasContainer.nativeElement, this.camera);
+    
+    // Reload graph data
+    this.loadGraphData();
   }
 
   ngAfterViewInit(): void {
@@ -818,87 +798,13 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
 
   /** Position new nodes in a radial burst around a parent node */
   private addNodesToSceneAroundParent(apiNodes: GraphNode[], parent: ExplorerNode): void {
-    const nodeIdMap = new Map<string, ExplorerNode>();
-    for (const n of this.nodes) nodeIdMap.set(n.id, n);
-
-    const golden = (1 + Math.sqrt(5)) / 2;
-
-    for (let i = 0; i < apiNodes.length; i++) {
-      const n = apiNodes[i];
-      if (nodeIdMap.has(n.id)) continue;
-
-      const color = TIER_COLORS[n.tier] ?? 0x888888;
-      const importance = Math.max(0.1, Math.min(1.0, n.importance / 10));
-
-      // Radial burst around parent: golden spiral offset
-      const theta = (2 * Math.PI * i) / golden;
-      const phi = Math.acos(1 - (2 * (i + 0.5)) / Math.max(1, apiNodes.length));
-      const burstRadius = 8 + importance * 15;
-
-      const pos = new THREE.Vector3(
-        parent.position.x + burstRadius * Math.sin(phi) * Math.cos(theta),
-        parent.position.y + burstRadius * Math.sin(phi) * Math.sin(theta),
-        parent.position.z + burstRadius * Math.cos(phi),
-      );
-
-      const size = 0.3 + importance * 0.6;
-
-      // Star core sprite
-      const starTex = this.createStarTexture(color, 1.0);
-      const starMat = new THREE.SpriteMaterial({
-        map: starTex,
-        transparent: true,
-        depthTest: false,
-        blending: THREE.AdditiveBlending,
-      });
-      const mesh = new THREE.Sprite(starMat);
-      mesh.scale.set(0, 0, 1); // warp-in from zero
-      mesh.position.copy(pos);
-      this.scene.add(mesh);
-
-      // Outer glow halo
-      const glowTex = this.createStarTexture(color, 0.3);
-      const glowMat = new THREE.SpriteMaterial({
-        map: glowTex,
-        transparent: true,
-        depthTest: false,
-        blending: THREE.AdditiveBlending,
-      });
-      const glowMesh = new THREE.Sprite(glowMat);
-      glowMesh.scale.set(0, 0, 1);
-      glowMesh.position.copy(pos);
-      this.scene.add(glowMesh);
-
-      // Node label
-      const labelSprite = this.createNodeLabel(n.id, n.tier, importance, color);
-      labelSprite.position.copy(pos);
-      labelSprite.position.y += size * 3 + 0.8;
-      this.scene.add(labelSprite);
-
-      const explorerNode: ExplorerNode = {
-        id: n.id,
-        tier: n.tier,
-        text: n.textPreview,
-        importance: n.importance,
-        valence: n.valence ?? 0,
-        timestampMs: n.timestampMs ?? Date.now(),
-        position: pos,
-        velocity: new THREE.Vector3(
-          (Math.random() - 0.5) * 0.003,
-          (Math.random() - 0.5) * 0.003,
-          (Math.random() - 0.5) * 0.003,
-        ),
-        mesh,
-        glowMesh,
-        labelSprite,
-        selected: false,
-        baseSize: size,
-        visible: true,
-        targetOpacity: 1.0,
-      };
-      this.nodes.push(explorerNode);
-      nodeIdMap.set(n.id, explorerNode);
+    const newNodes = this.activeStrategy.addNodesAroundParent(apiNodes, this.nodes, parent);
+    for (const node of newNodes) {
+      this.scene.add(node.mesh);
+      this.scene.add(node.glowMesh);
+      this.scene.add(node.labelSprite);
     }
+    this.nodes.push(...newNodes);
   }
 
   /** Collapse back to the overview graph — clear expansion nodes */
@@ -1306,7 +1212,6 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
     const width = container.clientWidth;
     const height = container.clientHeight;
 
-    this.scene = new THREE.Scene();
     this.camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 2000);
     this.camera.position.z = this.orbitRadius;
 
@@ -1318,18 +1223,7 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
     this.renderer.toneMappingExposure = 1.2;
     container.appendChild(this.renderer.domElement);
 
-    this.scene.add(new THREE.AmbientLight(0xffffff, 0.4));
-    const pointLight = new THREE.PointLight(0xffffff, 0.8, 200);
-    pointLight.position.copy(this.camera.position);
-    this.scene.add(pointLight);
-
-    // Hexagonal wireframe grid
-    this.gridGroup = new THREE.Group();
-    this.createHexGrid();
-    this.scene.add(this.gridGroup);
-
-    // Cosmic dust particles (nebula)
-    this.createDustField();
+    this.scene = this.activeStrategy.initScene(container, this.camera);
 
     const observer = new ResizeObserver(() => {
       const w = container.clientWidth;
@@ -1341,87 +1235,6 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
     observer.observe(container);
   }
 
-  /** Hexagonal wireframe grid — sci-fi command center feel */
-  private createHexGrid(): void {
-    const gridMat = new THREE.LineBasicMaterial({
-      color: 0x00ffcc,
-      transparent: true,
-      opacity: 0.03,
-    });
-
-    // Equatorial and meridian circles with hex feel
-    for (let i = 0; i < 3; i++) {
-      const curve = new THREE.EllipseCurve(0, 0, 45, 45, 0, Math.PI * 2, false, 0);
-      const pts = curve.getPoints(6); // hexagonal shape
-      pts.push(pts[0].clone()); // close the hexagon
-      const geo = new THREE.BufferGeometry().setFromPoints(
-        pts.map((p) => {
-          if (i === 0) return new THREE.Vector3(p.x, 0, p.y);
-          if (i === 1) return new THREE.Vector3(p.x, p.y, 0);
-          return new THREE.Vector3(0, p.x, p.y);
-        }),
-      );
-      this.gridGroup.add(new THREE.Line(geo, gridMat));
-    }
-
-    // Concentric hex rings
-    for (const r of [15, 30, 60]) {
-      const curve = new THREE.EllipseCurve(0, 0, r, r, 0, Math.PI * 2, false, 0);
-      const pts = curve.getPoints(6);
-      pts.push(pts[0].clone());
-      const geo = new THREE.BufferGeometry().setFromPoints(
-        pts.map((p) => new THREE.Vector3(p.x, 0, p.y)),
-      );
-      this.gridGroup.add(
-        new THREE.Line(
-          geo,
-          new THREE.LineBasicMaterial({ color: 0x00ffcc, transparent: true, opacity: 0.02 }),
-        ),
-      );
-    }
-  }
-
-  /** Background dust — dense nebula with slow color cycling */
-  private createDustField(): void {
-    const count = 800;
-    const positions = new Float32Array(count * 3);
-    const colors = new Float32Array(count * 3);
-    const sizes = new Float32Array(count);
-
-    for (let i = 0; i < count; i++) {
-      const r = 50 + Math.random() * 120;
-      const theta = Math.random() * Math.PI * 2;
-      const phi = Math.acos(2 * Math.random() - 1);
-      positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
-      positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
-      positions[i * 3 + 2] = r * Math.cos(phi);
-
-      // Cyan-teal palette
-      const brightness = 0.2 + Math.random() * 0.4;
-      colors[i * 3] = brightness * 0.3;
-      colors[i * 3 + 1] = brightness * 0.8;
-      colors[i * 3 + 2] = brightness * 1.0;
-
-      sizes[i] = 0.06 + Math.random() * 0.12;
-    }
-
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    geo.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
-
-    const mat = new THREE.PointsMaterial({
-      size: 0.12,
-      vertexColors: true,
-      transparent: true,
-      opacity: 0.5,
-      blending: THREE.AdditiveBlending,
-      depthWrite: false,
-    });
-
-    this.dustParticles = new THREE.Points(geo, mat);
-    this.scene.add(this.dustParticles);
-  }
 
   /** Create shared particle textures (pooled, not per-particle) */
   private createParticleTextures(): void {
@@ -1495,147 +1308,31 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
 
   /** Add nodes to the THREE.js scene — with optional warp-in animation */
   private addNodesToScene(apiNodes: GraphNode[], warpIn: boolean): void {
-    const nodeIdMap = new Map<string, ExplorerNode>();
-    for (const n of this.nodes) nodeIdMap.set(n.id, n);
-
-    for (let i = 0; i < apiNodes.length; i++) {
-      const n = apiNodes[i];
-      if (nodeIdMap.has(n.id)) continue; // Skip duplicates
-
-      const color = TIER_COLORS[n.tier] ?? 0x888888;
-      const importance = Math.max(0.1, Math.min(1.0, n.importance / 10));
-      const offset = this.nodes.length + i;
-
-      // Volumetric golden spiral
-      const golden = (1 + Math.sqrt(5)) / 2;
-      const theta = (2 * Math.PI * offset) / golden;
-      const phi = Math.acos(1 - (2 * (offset + 0.5)) / Math.max(1, apiNodes.length + this.nodes.length));
-      const baseRadius = 15 + importance * 50;
-      const jitter = 1.0 + Math.sin(offset * 7.31) * 0.4;
-      const radius = baseRadius * jitter;
-
-      const pos = new THREE.Vector3(
-        radius * Math.sin(phi) * Math.cos(theta),
-        radius * Math.sin(phi) * Math.sin(theta),
-        radius * Math.cos(phi),
-      );
-
-      const size = 0.3 + importance * 0.6;
-
-      // Star core sprite
-      const starTex = this.createStarTexture(color, 1.0);
-      const starMat = new THREE.SpriteMaterial({
-        map: starTex,
-        transparent: true,
-        depthTest: false,
-        blending: THREE.AdditiveBlending,
-      });
-      const mesh = new THREE.Sprite(starMat);
-      mesh.scale.set(warpIn ? 0 : size * 3, warpIn ? 0 : size * 3, 1);
-      mesh.position.copy(pos);
-      this.scene.add(mesh);
-
-      // Outer glow halo sprite
-      const glowTex = this.createStarTexture(color, 0.3);
-      const glowMat = new THREE.SpriteMaterial({
-        map: glowTex,
-        transparent: true,
-        depthTest: false,
-        blending: THREE.AdditiveBlending,
-      });
-      const glowMesh = new THREE.Sprite(glowMat);
-      glowMesh.scale.set(warpIn ? 0 : size * 8, warpIn ? 0 : size * 8, 1);
-      glowMesh.position.copy(pos);
-      this.scene.add(glowMesh);
-
-      // Node label sprite
-      const labelSprite = this.createNodeLabel(n.id, n.tier, importance, color);
-      labelSprite.position.copy(pos);
-      labelSprite.position.y += size * 3 + 0.8;
-      this.scene.add(labelSprite);
-
-      const explorerNode: ExplorerNode = {
-        id: n.id,
-        tier: n.tier,
-        text: n.textPreview,
-        importance: n.importance,
-        valence: n.valence ?? 0,
-        timestampMs: n.timestampMs ?? Date.now(),
-        position: pos,
-        velocity: new THREE.Vector3(
-          (Math.random() - 0.5) * 0.005,
-          (Math.random() - 0.5) * 0.005,
-          (Math.random() - 0.5) * 0.005,
-        ),
-        mesh,
-        glowMesh,
-        labelSprite,
-        selected: false,
-        baseSize: size,
-        visible: true,
-        targetOpacity: 1.0,
-      };
-      this.nodes.push(explorerNode);
-      nodeIdMap.set(n.id, explorerNode);
+    const newNodes = this.activeStrategy.addNodes(apiNodes, this.nodes, warpIn);
+    for (const node of newNodes) {
+      this.scene.add(node.mesh);
+      this.scene.add(node.glowMesh);
+      this.scene.add(node.labelSprite);
     }
+    this.nodes.push(...newNodes);
   }
 
   /** Add edges to the scene */
   private addEdgesToScene(apiEdges: GraphEdge[]): void {
-    let hCount = this.hebbianCount(), tCount = this.temporalCount(), eCount = this.entityCount();
-    const nodeMap = new Map(this.nodes.map(n => [n.id, n]));
+    const newEdges = this.activeStrategy.addEdges(apiEdges, this.nodes, this.edges);
+    for (const edge of newEdges) {
+      this.scene.add(edge.line);
+      if (edge.labelSprite) this.scene.add(edge.labelSprite);
+      if (edge.weightSprite) this.scene.add(edge.weightSprite);
+    }
+    this.edges.push(...newEdges);
 
-    for (const e of apiEdges) {
-      const fromNode = nodeMap.get(e.fromId);
-      const toNode = nodeMap.get(e.toId);
-      if (!fromNode || !toNode) continue;
-
-      // Skip if already exists
-      if (this.edges.some(ex => ex.from === e.fromId && ex.to === e.toId && ex.type === e.type)) continue;
-
+    let hCount = 0, tCount = 0, eCount = 0;
+    for (const e of this.edges) {
       if (e.type === 'HEBBIAN') hCount++;
       else if (e.type === 'TEMPORAL') tCount++;
       else if (e.type === 'ENTITY') eCount++;
-
-      const color = EDGE_TYPE_COLORS[e.type] ?? 0x888888;
-      const material =
-        e.type === 'TEMPORAL'
-          ? new THREE.LineDashedMaterial({
-              color,
-              transparent: true,
-              opacity: 0.35,
-              dashSize: 1,
-              gapSize: 0.5,
-            })
-          : new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.3 });
-
-      const geo = new THREE.BufferGeometry().setFromPoints([fromNode.position, toNode.position]);
-      const line = new THREE.Line(geo, material);
-      if (e.type === 'TEMPORAL') line.computeLineDistances();
-      this.scene.add(line);
-
-      let labelSprite: THREE.Sprite | undefined;
-      if (e.type === 'ENTITY' && e.relation) {
-        labelSprite = this.createEdgeLabel(e.relation, fromNode.position, toNode.position, color);
-      }
-
-      let weightSprite: THREE.Sprite | undefined;
-      if (e.type === 'HEBBIAN' && e.weight > 0.05) {
-        weightSprite = this.createWeightBadge(e.weight, fromNode.position, toNode.position);
-      }
-
-      this.edges.push({
-        from: e.fromId,
-        to: e.toId,
-        type: e.type,
-        weight: e.weight,
-        relation: e.relation,
-        line,
-        labelSprite,
-        weightSprite,
-      });
     }
-
     this.hebbianCount.set(hCount);
     this.temporalCount.set(tCount);
     this.entityCount.set(eCount);
@@ -1682,48 +1379,10 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
   // ── Neuron firing particle system ───────────────────────
 
   private spawnFiringParticle(): void {
-    if (this.edges.length === 0 || this.particles.length >= MAX_PARTICLES) return;
-
-    // Pick a random visible edge
-    const visibleEdges = this.edges.filter(e => e.line.visible);
-    if (visibleEdges.length === 0) return;
-    const edge = visibleEdges[Math.floor(Math.random() * visibleEdges.length)];
-    const edgeIndex = this.edges.indexOf(edge);
-    const color = EDGE_TYPE_COLORS[edge.type] ?? 0x00ffcc;
-
-    // Create colored particle texture
-    const particleMat = new THREE.SpriteMaterial({
-      map: this.particleTexture,
-      transparent: true,
-      blending: THREE.AdditiveBlending,
-      depthTest: false,
-      color: new THREE.Color(color),
-    });
-    const mesh = new THREE.Sprite(particleMat);
-    mesh.scale.set(1.5, 1.5, 1);
-    this.scene.add(mesh);
-
-    // Trail
-    const trailMat = new THREE.SpriteMaterial({
-      map: this.trailTexture,
-      transparent: true,
-      blending: THREE.AdditiveBlending,
-      depthTest: false,
-      color: new THREE.Color(color),
-    });
-    const trailMesh = new THREE.Sprite(trailMat);
-    trailMesh.scale.set(3, 3, 1);
-    this.scene.add(trailMesh);
-
-    this.particles.push({
-      mesh,
-      trailMesh,
-      edgeIndex,
-      progress: 0,
-      speed: 0.015 + Math.random() * 0.025,
-      alive: true,
-      color,
-    });
+    const particle = this.activeStrategy.spawnParticle(this.edges, this.particles, this.scene, this.particleTexture, this.trailTexture);
+    if (particle) {
+      this.particles.push(particle);
+    }
   }
 
   /** Fire a burst of particles along edges — simulates neurons firing */
@@ -1748,237 +1407,12 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  // ── Scientific label sprites ────────────────────────────
 
-  private createNodeLabel(
-    id: string,
-    tier: string,
-    importance: number,
-    color: number,
-  ): THREE.Sprite {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d')!;
-    canvas.width = 512;
-    canvas.height = 160;
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    const tierCode = tier.substring(0, 3).toUpperCase();
-    const impPct = Math.round(importance * 100);
-    const shortId = id.replace('mem-', '#');
-    const displayText = `${tierCode} ${shortId}`;
-    const impText = `⬤ ${impPct}%`;
-
-    const hexColor = '#' + color.toString(16).padStart(6, '0');
-
-    const textMetrics = (() => {
-      ctx.font = 'bold 26px Consolas, "Courier New", monospace';
-      return ctx.measureText(displayText);
-    })();
-    const pillW = Math.max(textMetrics.width + 32, 140);
-    const pillH = 42;
-    const pillX = (canvas.width - pillW) / 2;
-    const pillY = 24;
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
-    ctx.beginPath();
-    ctx.roundRect(pillX, pillY, pillW, pillH, 10);
-    ctx.fill();
-
-    ctx.globalAlpha = 0.9;
-    ctx.font = 'bold 26px Consolas, "Courier New", monospace';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillStyle = hexColor;
-    ctx.fillText(displayText, canvas.width / 2, pillY + pillH / 2);
-
-    ctx.globalAlpha = 0.5;
-    const barW = 80;
-    const barH = 4;
-    const barX = (canvas.width - barW) / 2;
-    const barY = pillY + pillH + 10;
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.12)';
-    ctx.beginPath();
-    ctx.roundRect(barX, barY, barW, barH, 2);
-    ctx.fill();
-    ctx.fillStyle = hexColor;
-    ctx.beginPath();
-    ctx.roundRect(barX, barY, barW * Math.min(1, importance), barH, 2);
-    ctx.fill();
-
-    ctx.globalAlpha = 0.7;
-    ctx.font = '600 18px Consolas, "Courier New", monospace';
-    ctx.fillStyle = '#bbc4dd';
-    ctx.fillText(impText, canvas.width / 2, barY + barH + 16);
-
-    ctx.globalAlpha = 1.0;
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    const material = new THREE.SpriteMaterial({
-      map: texture,
-      transparent: true,
-      depthTest: false,
-    });
-    const sprite = new THREE.Sprite(material);
-    sprite.scale.set(8, 2.5, 1);
-    return sprite;
-  }
-
-  private createWeightBadge(weight: number, from: THREE.Vector3, to: THREE.Vector3): THREE.Sprite {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d')!;
-    canvas.width = 192;
-    canvas.height = 80;
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
-    ctx.beginPath();
-    ctx.roundRect(40, 16, 112, 48, 10);
-    ctx.fill();
-
-    ctx.font = 'bold 28px Consolas, "Courier New", monospace';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
-    ctx.fillText(weight.toFixed(2), canvas.width / 2, canvas.height / 2);
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    const material = new THREE.SpriteMaterial({
-      map: texture,
-      transparent: true,
-      depthTest: false,
-    });
-    const sprite = new THREE.Sprite(material);
-    sprite.scale.set(4, 1.6, 1);
-
-    const mid = new THREE.Vector3().addVectors(from, to).multiplyScalar(0.5);
-    mid.y -= 1.0;
-    sprite.position.copy(mid);
-    this.scene.add(sprite);
-    return sprite;
-  }
-
-  private createStarTexture(color: number, intensity: number): THREE.CanvasTexture {
-    const size = 128;
-    const canvas = document.createElement('canvas');
-    canvas.width = size;
-    canvas.height = size;
-    const ctx = canvas.getContext('2d')!;
-
-    const r = (color >> 16) & 0xff;
-    const g = (color >> 8) & 0xff;
-    const b = color & 0xff;
-
-    const cx = size / 2;
-    const cy = size / 2;
-    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, size / 2);
-
-    if (intensity > 0.6) {
-      grad.addColorStop(0.0, `rgba(255, 255, 255, ${intensity})`);
-      grad.addColorStop(0.15, `rgba(${r}, ${g}, ${b}, ${intensity * 0.9})`);
-      grad.addColorStop(0.4, `rgba(${r}, ${g}, ${b}, ${intensity * 0.4})`);
-      grad.addColorStop(1.0, `rgba(${r}, ${g}, ${b}, 0)`);
-    } else {
-      grad.addColorStop(0.0, `rgba(${r}, ${g}, ${b}, ${intensity})`);
-      grad.addColorStop(0.3, `rgba(${r}, ${g}, ${b}, ${intensity * 0.5})`);
-      grad.addColorStop(1.0, `rgba(${r}, ${g}, ${b}, 0)`);
-    }
-
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, size, size);
-
-    if (intensity > 0.6) {
-      ctx.globalCompositeOperation = 'lighter';
-      const spikeGrad = ctx.createRadialGradient(cx, cy, 0, cx, cy, size / 2);
-      spikeGrad.addColorStop(0.0, `rgba(255, 255, 255, 0.4)`);
-      spikeGrad.addColorStop(0.5, `rgba(${r}, ${g}, ${b}, 0.05)`);
-      spikeGrad.addColorStop(1.0, `rgba(${r}, ${g}, ${b}, 0)`);
-      ctx.fillStyle = spikeGrad;
-      ctx.fillRect(0, cy - 1, size, 2);
-      ctx.fillRect(cx - 1, 0, 2, size);
-    }
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    return texture;
-  }
-
-  private createEdgeLabel(
-    text: string,
-    from: THREE.Vector3,
-    to: THREE.Vector3,
-    color: number,
-  ): THREE.Sprite {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d')!;
-    canvas.width = 256;
-    canvas.height = 40;
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    const hexColor = '#' + color.toString(16).padStart(6, '0');
-    ctx.font = '600 16px Consolas, "Courier New", monospace';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.globalAlpha = 0.85;
-    ctx.fillStyle = hexColor;
-    ctx.fillText(text, canvas.width / 2, canvas.height / 2);
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    const material = new THREE.SpriteMaterial({
-      map: texture,
-      transparent: true,
-      depthTest: false,
-    });
-    const sprite = new THREE.Sprite(material);
-    sprite.scale.set(4, 0.7, 1);
-
-    const midpoint = new THREE.Vector3().addVectors(from, to).multiplyScalar(0.5);
-    midpoint.y += 0.4;
-    sprite.position.copy(midpoint);
-
-    this.scene.add(sprite);
-    return sprite;
-  }
 
   // ── Scene cleanup ───────────────────────────────────────
 
   private clearScene(): void {
-    // Dispose nodes
-    for (const node of this.nodes) {
-      this.scene.remove(node.mesh);
-      this.scene.remove(node.glowMesh);
-      this.scene.remove(node.labelSprite);
-      (node.mesh.material as THREE.SpriteMaterial).map?.dispose();
-      node.mesh.material.dispose();
-      (node.glowMesh.material as THREE.SpriteMaterial).map?.dispose();
-      node.glowMesh.material.dispose();
-      (node.labelSprite.material as THREE.SpriteMaterial).map?.dispose();
-      node.labelSprite.material.dispose();
-    }
-    // Dispose edges
-    for (const edge of this.edges) {
-      this.scene.remove(edge.line);
-      edge.line.geometry.dispose();
-      if (edge.labelSprite) {
-        this.scene.remove(edge.labelSprite);
-        (edge.labelSprite.material as THREE.SpriteMaterial).map?.dispose();
-        edge.labelSprite.material.dispose();
-      }
-      if (edge.weightSprite) {
-        this.scene.remove(edge.weightSprite);
-        (edge.weightSprite.material as THREE.SpriteMaterial).map?.dispose();
-        edge.weightSprite.material.dispose();
-      }
-    }
-    // Dispose particles
-    for (const p of this.particles) {
-      this.scene.remove(p.mesh);
-      p.mesh.material.dispose();
-      this.scene.remove(p.trailMesh);
-      p.trailMesh.material.dispose();
-    }
+    this.activeStrategy.dispose(this.scene, this.nodes, this.edges, this.particles);
     this.nodes = [];
     this.edges = [];
     this.particles = [];
@@ -2020,10 +1454,7 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
       this.lookAtTarget.z + this.orbitRadius * Math.sin(this.orbitPhi) * Math.sin(this.orbitTheta);
     this.camera.lookAt(this.lookAtTarget);
 
-    // Animate dust rotation
-    if (this.dustParticles) {
-      this.dustParticles.rotation.y += 0.001 * delta;
-    }
+
 
     // Apply filters
     this.applyFilters();
@@ -2033,162 +1464,13 @@ export class GraphExplorerComponent implements AfterViewInit, OnDestroy {
     const time = Date.now() * 0.001;
 
     // ── Animate nodes ──
-    for (let i = 0; i < this.nodes.length; i++) {
-      const node = this.nodes[i];
-      node.position.add(node.velocity);
-      node.mesh.position.copy(node.position);
-      node.glowMesh.position.copy(node.position);
-      if (node.position.length() > 120) node.velocity.multiplyScalar(-1);
-
-      // Ghost-fade animation: smoothly lerp opacity
-      const coreMat = node.mesh.material as THREE.SpriteMaterial;
-      const glowMat = node.glowMesh.material as THREE.SpriteMaterial;
-      const labelMat = node.labelSprite.material as THREE.SpriteMaterial;
-
-      const currentOpacity = coreMat.opacity;
-      const targetOpacity = node.targetOpacity;
-      const newOpacity = currentOpacity + (targetOpacity - currentOpacity) * Math.min(1, delta * 4);
-      coreMat.opacity = newOpacity;
-      glowMat.opacity = newOpacity * 0.5;
-      labelMat.opacity = node.visible ? 1.0 : 0.0;
-
-      // Star pulsing — recall mode matched nodes get sonar pulse
-      const isRecallMatched = this.recallMode() && this.recallMatchedIds().has(node.id);
-      const pulseAmp = isRecallMatched ? 0.5 : 0.15;
-      const pulseSpeed = isRecallMatched ? 3.0 : 1.5;
-      const pulse = 1.0 + pulseAmp * Math.sin(time * pulseSpeed + i * 0.7);
-      const coreScale = node.baseSize * 3 * pulse * (node.visible ? 1.0 : 0.5);
-      node.mesh.scale.set(coreScale, coreScale, 1);
-      const glowMultiplier = isRecallMatched ? 12 : 8;
-      const glowScale = node.baseSize * glowMultiplier * pulse * (node.visible ? 1.0 : 0.3);
-      node.glowMesh.scale.set(glowScale, glowScale, 1);
-
-      // Warp-in: scale from 0 to target
-      if (coreScale > 0 && node.mesh.scale.x < node.baseSize * 2) {
-        const warpScale = Math.min(node.baseSize * 3, node.mesh.scale.x + delta * node.baseSize * 10);
-        node.mesh.scale.set(warpScale, warpScale, 1);
-        node.glowMesh.scale.set(warpScale * 2.5, warpScale * 2.5, 1);
-      }
-
-      // Label position
-      node.labelSprite.position.copy(node.position);
-      node.labelSprite.position.y += node.baseSize * 4 + 2.0;
-      node.labelSprite.visible = showNodeLabels && node.visible;
-
-      if (showNodeLabels && node.visible) {
-        const dist = camPos.distanceTo(node.labelSprite.position);
-        const s = dist * 0.06;
-        node.labelSprite.scale.set(s * 3.2, s, 1);
-      }
-    }
+    this.activeStrategy.animateNodes(this.nodes, delta, time, showNodeLabels, camPos, this.recallMode(), this.recallMatchedIds());
 
     // ── Animate edges ──
-    for (const edge of this.edges) {
-      const fromNode = this.nodes.find((n) => n.id === edge.from);
-      const toNode = this.nodes.find((n) => n.id === edge.to);
-      if (fromNode && toNode) {
-        const positions = edge.line.geometry.attributes['position'] as THREE.BufferAttribute;
-        positions.setXYZ(0, fromNode.position.x, fromNode.position.y, fromNode.position.z);
-        positions.setXYZ(1, toNode.position.x, toNode.position.y, toNode.position.z);
-        positions.needsUpdate = true;
-
-        if (edge.labelSprite) {
-          const mid = new THREE.Vector3()
-            .addVectors(fromNode.position, toNode.position)
-            .multiplyScalar(0.5);
-          mid.y += 0.4;
-          edge.labelSprite.position.copy(mid);
-          const dist = camPos.distanceTo(mid);
-          const s = dist * 0.035;
-          edge.labelSprite.scale.set(s * 2.5, s * 0.5, 1);
-        }
-        if (edge.weightSprite) {
-          const mid = new THREE.Vector3()
-            .addVectors(fromNode.position, toNode.position)
-            .multiplyScalar(0.5);
-          mid.y -= 1.2;
-          edge.weightSprite.position.copy(mid);
-          const dist = camPos.distanceTo(mid);
-          const s = dist * 0.04;
-          edge.weightSprite.scale.set(s * 2.5, s, 1);
-        }
-      }
-
-      // Layer visibility + filter: both endpoints must be visible
-      const bothVisible = fromNode?.visible && toNode?.visible;
-      const layerVisible =
-        (edge.type === 'HEBBIAN' && this.showHebbian()) ||
-        (edge.type === 'TEMPORAL' && this.showTemporal()) ||
-        (edge.type === 'ENTITY' && this.showEntity());
-      edge.line.visible = layerVisible && !!bothVisible;
-      if (edge.labelSprite) {
-        edge.labelSprite.visible = edge.line.visible && this.orbitRadius < 150;
-      }
-      if (edge.weightSprite) {
-        edge.weightSprite.visible = edge.line.visible && showNodeLabels;
-      }
-    }
+    this.activeStrategy.animateEdges(this.edges, this.nodes, delta, this.showHebbian(), this.showTemporal(), this.showEntity(), showNodeLabels, this.orbitRadius, camPos);
 
     // ── Neuron firing particles ──
-    // Real SSE events / REST callbacks drive bursts via effects.
-    // Ambient disabled for testing.
-
-    for (const particle of this.particles) {
-      if (!particle.alive) continue;
-
-      particle.progress += particle.speed;
-      if (particle.progress >= 1) {
-        particle.alive = false;
-        this.scene.remove(particle.mesh);
-        particle.mesh.material.dispose();
-        this.scene.remove(particle.trailMesh);
-        particle.trailMesh.material.dispose();
-        continue;
-      }
-
-      const edge = this.edges[particle.edgeIndex];
-      if (!edge || !edge.line.visible) {
-        particle.alive = false;
-        this.scene.remove(particle.mesh);
-        particle.mesh.material.dispose();
-        this.scene.remove(particle.trailMesh);
-        particle.trailMesh.material.dispose();
-        continue;
-      }
-
-      const fromNode = this.nodes.find(n => n.id === edge.from);
-      const toNode = this.nodes.find(n => n.id === edge.to);
-      if (!fromNode || !toNode) continue;
-
-      const pos = new THREE.Vector3();
-      pos.lerpVectors(fromNode.position, toNode.position, particle.progress);
-      particle.mesh.position.copy(pos);
-
-      // Trail follows behind
-      const trailProgress = Math.max(0, particle.progress - 0.1);
-      particle.trailMesh.position.lerpVectors(fromNode.position, toNode.position, trailProgress);
-
-      // Fade in/out along path
-      const alpha = Math.sin(particle.progress * Math.PI);
-      (particle.mesh.material as THREE.SpriteMaterial).opacity = alpha * 0.95;
-      (particle.trailMesh.material as THREE.SpriteMaterial).opacity = alpha * 0.3;
-      particle.mesh.scale.setScalar(1.0 + alpha * 0.8);
-
-      // Pulse the source/destination nodes when particle arrives
-      if (particle.progress > 0.85) {
-        const glowMat = toNode.glowMesh.material as THREE.SpriteMaterial;
-        glowMat.opacity = Math.min(1, glowMat.opacity + delta * 2);
-        toNode.glowMesh.scale.setScalar(toNode.baseSize * 10);
-      }
-      if (particle.progress < 0.15) {
-        const glowMat = fromNode.glowMesh.material as THREE.SpriteMaterial;
-        glowMat.opacity = Math.min(1, glowMat.opacity + delta * 2);
-        fromNode.glowMesh.scale.setScalar(fromNode.baseSize * 10);
-      }
-    }
-
-    // Clean up dead particles
-    this.particles = this.particles.filter(p => p.alive);
+    this.particles = this.activeStrategy.animateParticles(this.particles, this.edges, this.nodes, delta, this.scene);
 
     this.renderer.render(this.scene, this.camera);
   }

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-geometry.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-geometry.factory.ts
@@ -162,7 +162,7 @@ function generateHemisphereGeometry(side: -1 | 1, material: THREE.MeshPhysicalMa
   const colors = [];
   const baseColor = new THREE.Color(0x8866cc);
   
-  const clipThreshold = side === 1 ? 0.2 : -0.2;
+  const clipThreshold = side === 1 ? 0.5 : -0.5;
   const newPositions = [];
 
   const tempVertex = new THREE.Vector3();
@@ -173,23 +173,24 @@ function generateHemisphereGeometry(side: -1 | 1, material: THREE.MeshPhysicalMa
   for (let i = 0; i < positions.count; i++) {
     tempVertex.fromBufferAttribute(positions, i);
     
-    // Scale to ellipsoid
-    tempVertex.x *= 1.0;
-    tempVertex.y *= 0.85;
-    tempVertex.z *= 1.1;
+    // Scale to brain-like ellipsoid: wider left-right, shorter top-bottom, elongated front-back
+    tempVertex.x *= 1.15;
+    tempVertex.y *= 0.75;
+    tempVertex.z *= 1.25;
 
     // Displacement
     const n = noise.fbm(tempVertex.x, tempVertex.y, tempVertex.z, 3, 0.2, 1.0);
     tempVertex.normalize().multiplyScalar(baseRadius + n * wrinkleDepth);
     
     // Apply ellipsoid scaling again for the final shape after noise
-    tempVertex.x *= 1.0;
-    tempVertex.y *= 0.85;
-    tempVertex.z *= 1.1;
+    tempVertex.x *= 1.15;
+    tempVertex.y *= 0.75;
+    tempVertex.z *= 1.25;
+    
     
     // Clip the middle to create the gap between hemispheres
     if ((side === 1 && tempVertex.x > clipThreshold) || (side === -1 && tempVertex.x < clipThreshold)) {
-      tempVertex.x = clipThreshold + (Math.random() * 0.1 - 0.05);
+      tempVertex.x = clipThreshold + (Math.random() * 0.05 - 0.025);
     }
     
     newPositions.push(tempVertex.x, tempVertex.y, tempVertex.z);
@@ -282,13 +283,29 @@ export function createBrainMist(): THREE.Points {
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
 
+  // Create a round point texture to avoid square particles
+  const canvas = document.createElement('canvas');
+  canvas.width = 32;
+  canvas.height = 32;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    const gradient = ctx.createRadialGradient(16, 16, 0, 16, 16, 16);
+    gradient.addColorStop(0, 'rgba(255, 255, 255, 0.6)');
+    gradient.addColorStop(0.4, 'rgba(255, 255, 255, 0.15)');
+    gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, 32, 32);
+  }
+  const pointTexture = new THREE.CanvasTexture(canvas);
+
   const material = new THREE.PointsMaterial({
-    size: 0.8,
+    size: 0.3,
+    map: pointTexture,
     vertexColors: true,
     transparent: true,
-    opacity: 0.2,
+    opacity: 0.15,
     blending: THREE.AdditiveBlending,
-    depthWrite: false
+    depthWrite: false,
   });
 
   return new THREE.Points(geometry, material);

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-geometry.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-geometry.factory.ts
@@ -1,0 +1,268 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Spector Cortex — Brain Geometry Factory
+// Copyright (c) 2025–2026 Spectrayan. Licensed under BSL 1.1.
+// ═══════════════════════════════════════════════════════════════════════
+
+import * as THREE from 'three';
+import { BRAIN_REGIONS } from './brain-regions';
+
+// -----------------------------------------------------------------------
+// Simple 3D Noise Implementation
+// -----------------------------------------------------------------------
+class SimpleNoise {
+  private p: number[] = new Array(512);
+  
+  constructor() {
+    const permutation = [
+      151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,140,36,103,30,69,142,8,99,37,240,21,10,23,
+      190, 6,148,247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,57,177,33,88,237,149,56,87,174,20,
+      125,136,171,168, 68,175,74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,60,211,133,230,220,
+      105,92,41,55,46,245,40,244,102,143,54, 65,25,63,161, 1,216,80,73,209,76,132,187,208, 89,18,169,200,
+      196,135,130,116,188,159,86,164,100,109,198,173,186, 3,64,52,217,226,250,124,123,5,202,38,147,118,126,
+      255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,119,248,152, 2,44,154,163, 70,
+      221,153,101,155,167, 43,172,9,129,22,39,253, 19,98,108,110,79,113,224,232,178,185, 112,104,218,246,
+      97,228,251,34,242,193,238,210,144,12,191,179,162,241, 81,51,145,235,249,14,239,107,49,192,214, 31,181,
+      199,106,157,184, 84,204,176,115,121,50,45,127, 4,150,254,138,236,205,93,222,114,67,29,24,72,243,141,
+      128,195,78,66,215,61,156,180
+    ];
+    for (let i = 0; i < 256; i++) {
+      this.p[i] = permutation[i];
+      this.p[i + 256] = permutation[i];
+    }
+  }
+  
+  private fade(t: number): number { return t * t * t * (t * (t * 6 - 15) + 10); }
+  private lerp(t: number, a: number, b: number): number { return a + t * (b - a); }
+  private grad(hash: number, x: number, y: number, z: number): number {
+    const h = hash & 15;
+    const u = h < 8 ? x : y;
+    const v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+    return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
+  }
+  
+  public noise3D(x: number, y: number, z: number): number {
+    let X = Math.floor(x) & 255;
+    let Y = Math.floor(y) & 255;
+    let Z = Math.floor(z) & 255;
+    x -= Math.floor(x);
+    y -= Math.floor(y);
+    z -= Math.floor(z);
+    const u = this.fade(x);
+    const v = this.fade(y);
+    const w = this.fade(z);
+    const A = this.p[X] + Y, AA = this.p[A] + Z, AB = this.p[A + 1] + Z;
+    const B = this.p[X + 1] + Y, BA = this.p[B] + Z, BB = this.p[B + 1] + Z;
+    return this.lerp(w, this.lerp(v, this.lerp(u, this.grad(this.p[AA], x, y, z),
+                                     this.grad(this.p[BA], x - 1, y, z)),
+                               this.lerp(u, this.grad(this.p[AB], x, y - 1, z),
+                                     this.grad(this.p[BB], x - 1, y - 1, z))),
+                       this.lerp(v, this.lerp(u, this.grad(this.p[AA + 1], x, y, z - 1),
+                                     this.grad(this.p[BA + 1], x - 1, y, z - 1)),
+                               this.lerp(u, this.grad(this.p[AB + 1], x, y - 1, z - 1),
+                                     this.grad(this.p[BB + 1], x - 1, y - 1, z - 1))));
+  }
+
+  public fbm(x: number, y: number, z: number, octaves: number, frequency: number, amplitude: number): number {
+    let total = 0;
+    let max = 0;
+    for (let i = 0; i < octaves; i++) {
+      total += this.noise3D(x * frequency, y * frequency, z * frequency) * amplitude;
+      max += amplitude;
+      amplitude *= 0.5;
+      frequency *= 2.0;
+    }
+    return total / max;
+  }
+}
+
+const noise = new SimpleNoise();
+
+// -----------------------------------------------------------------------
+// Brain Geometry Generation
+// -----------------------------------------------------------------------
+
+export function createBrainGeometry(): THREE.Group {
+  const brainGroup = new THREE.Group();
+
+  const baseMaterial = new THREE.MeshPhysicalMaterial({
+    transmission: 0.6,
+    roughness: 0.15,
+    thickness: 2.0,
+    color: 0x8866cc,
+    emissive: 0x220044,
+    emissiveIntensity: 0.15,
+    transparent: true,
+    opacity: 0.35,
+    side: THREE.DoubleSide,
+    vertexColors: true
+  });
+
+  const leftHemisphere = generateHemisphereGeometry(-1, baseMaterial);
+  const rightHemisphere = generateHemisphereGeometry(1, baseMaterial);
+
+  brainGroup.add(leftHemisphere);
+  brainGroup.add(rightHemisphere);
+
+  // Cerebellum
+  const cerebellumGeo = new THREE.SphereGeometry(3.5, 20, 16);
+  displaceCerebellumVertices(cerebellumGeo);
+  const cerebellumMat = baseMaterial.clone();
+  cerebellumMat.color.setHex(0xab47bc);
+  cerebellumMat.vertexColors = false; 
+  
+  const cerebellum = new THREE.Mesh(cerebellumGeo, cerebellumMat);
+  cerebellum.position.set(0, -5, -6);
+  brainGroup.add(cerebellum);
+
+  // Brain stem
+  const stemGeo = new THREE.CylinderGeometry(1.2, 0.6, 4, 12);
+  const stemMat = new THREE.MeshStandardMaterial({
+    color: 0x2a1a4a,
+    roughness: 0.9,
+    metalness: 0.1
+  });
+  const stem = new THREE.Mesh(stemGeo, stemMat);
+  stem.position.set(0, -8, -5);
+  stem.rotation.x = 0.2; // Slight tilt
+  brainGroup.add(stem);
+
+  return brainGroup;
+}
+
+function generateHemisphereGeometry(side: -1 | 1, material: THREE.MeshPhysicalMaterial): THREE.Mesh {
+  const geometry = new THREE.IcosahedronGeometry(10, 4);
+  const positions = geometry.attributes['position'];
+  const colors = [];
+  const baseColor = new THREE.Color(0x8866cc);
+  
+  const clipThreshold = side === 1 ? 0.2 : -0.2;
+  const newPositions = [];
+
+  const tempVertex = new THREE.Vector3();
+  const baseRadius = 10;
+  const wrinkleDepth = 1.2;
+
+  // Process vertices
+  for (let i = 0; i < positions.count; i++) {
+    tempVertex.fromBufferAttribute(positions, i);
+    
+    // Scale to ellipsoid
+    tempVertex.x *= 1.0;
+    tempVertex.y *= 0.85;
+    tempVertex.z *= 1.1;
+
+    // Displacement
+    const n = noise.fbm(tempVertex.x, tempVertex.y, tempVertex.z, 3, 0.2, 1.0);
+    tempVertex.normalize().multiplyScalar(baseRadius + n * wrinkleDepth);
+    
+    // Apply ellipsoid scaling again for the final shape after noise
+    tempVertex.x *= 1.0;
+    tempVertex.y *= 0.85;
+    tempVertex.z *= 1.1;
+    
+    // Clip the middle to create the gap between hemispheres
+    if ((side === 1 && tempVertex.x > clipThreshold) || (side === -1 && tempVertex.x < clipThreshold)) {
+      tempVertex.x = clipThreshold + (Math.random() * 0.1 - 0.05);
+    }
+    
+    newPositions.push(tempVertex.x, tempVertex.y, tempVertex.z);
+
+    // Color mixing based on brain regions
+    let nearestDist = Infinity;
+    let nearestColor = baseColor;
+
+    if (BRAIN_REGIONS && BRAIN_REGIONS.length > 0) {
+      for (const region of BRAIN_REGIONS) {
+        const center = region.center;
+        if (!center) continue;
+        
+        const regionPos = new THREE.Vector3(center[0], center[1], center[2]);
+        const dist = tempVertex.distanceTo(regionPos);
+        
+        if (dist < nearestDist) {
+          nearestDist = dist;
+          nearestColor = new THREE.Color(region.color || 0x8866cc);
+        }
+      }
+    }
+
+    // Blend vertex color with base color based on distance
+    const blendFactor = Math.max(0, 1.0 - (nearestDist / 8.0));
+    const vertexColor = baseColor.clone().lerp(nearestColor, blendFactor * 0.7);
+    colors.push(vertexColor.r, vertexColor.g, vertexColor.b);
+  }
+
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(newPositions, 3));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geometry.computeVertexNormals();
+
+  return new THREE.Mesh(geometry, material);
+}
+
+function displaceCerebellumVertices(geometry: THREE.BufferGeometry): void {
+  const positions = geometry.attributes['position'];
+  const tempVertex = new THREE.Vector3();
+  const newPositions = [];
+  
+  for (let i = 0; i < positions.count; i++) {
+    tempVertex.fromBufferAttribute(positions, i);
+    
+    const baseLength = tempVertex.length();
+    const n = noise.fbm(tempVertex.x, tempVertex.y, tempVertex.z, 2, 0.6, 1.0);
+    tempVertex.normalize().multiplyScalar(baseLength + n * 0.8);
+    
+    newPositions.push(tempVertex.x, tempVertex.y, tempVertex.z);
+  }
+  
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(newPositions, 3));
+  geometry.computeVertexNormals();
+}
+
+// -----------------------------------------------------------------------
+// Brain Mist Generation
+// -----------------------------------------------------------------------
+
+export function createBrainMist(): THREE.Points {
+  const particleCount = 300;
+  const positions = new Float32Array(particleCount * 3);
+  const colors = new Float32Array(particleCount * 3);
+  
+  const color1 = new THREE.Color(0x6644aa);
+  const color2 = new THREE.Color(0x88ccff);
+
+  for (let i = 0; i < particleCount; i++) {
+    // Distribute within an ellipsoid
+    let x, y, z;
+    do {
+      x = (Math.random() - 0.5) * 20;
+      y = (Math.random() - 0.5) * 17;
+      z = (Math.random() - 0.5) * 22;
+    } while ((x*x)/100 + (y*y)/72.25 + (z*z)/121 > 1); // Point in ellipsoid check
+    
+    positions[i * 3] = x;
+    positions[i * 3 + 1] = y;
+    positions[i * 3 + 2] = z;
+    
+    const mixRatio = Math.random();
+    const pColor = color1.clone().lerp(color2, mixRatio);
+    
+    colors[i * 3] = pColor.r;
+    colors[i * 3 + 1] = pColor.g;
+    colors[i * 3 + 2] = pColor.b;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+  const material = new THREE.PointsMaterial({
+    size: 0.8,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.2,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false
+  });
+
+  return new THREE.Points(geometry, material);
+}

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-geometry.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-geometry.factory.ts
@@ -85,20 +85,41 @@ export function createBrainGeometry(): THREE.Group {
   const brainGroup = new THREE.Group();
 
   const baseMaterial = new THREE.MeshPhysicalMaterial({
-    transmission: 0.6,
-    roughness: 0.15,
-    thickness: 2.0,
+    transmission: 0.95,
+    roughness: 0.1,
+    thickness: 0.5,
     color: 0x8866cc,
     emissive: 0x220044,
-    emissiveIntensity: 0.15,
+    emissiveIntensity: 0.08,
     transparent: true,
-    opacity: 0.35,
+    opacity: 0.08,
     side: THREE.DoubleSide,
-    vertexColors: true
+    vertexColors: true,
+    depthWrite: false,
   });
 
   const leftHemisphere = generateHemisphereGeometry(-1, baseMaterial);
   const rightHemisphere = generateHemisphereGeometry(1, baseMaterial);
+
+  // Create wireframe overlay for each hemisphere — renders behind the solid
+  const wireframeMat = new THREE.MeshBasicMaterial({
+    color: 0x8866cc,
+    wireframe: true,
+    transparent: true,
+    opacity: 0.06,
+    depthWrite: false,
+  });
+  const leftWire = new THREE.Mesh(leftHemisphere.geometry.clone(), wireframeMat);
+  leftWire.position.copy(leftHemisphere.position);
+  leftWire.renderOrder = -2;
+  brainGroup.add(leftWire);
+  const rightWire = new THREE.Mesh(rightHemisphere.geometry.clone(), wireframeMat);
+  rightWire.position.copy(rightHemisphere.position);
+  rightWire.renderOrder = -2;
+  brainGroup.add(rightWire);
+
+  leftHemisphere.renderOrder = -1;
+  rightHemisphere.renderOrder = -1;
 
   brainGroup.add(leftHemisphere);
   brainGroup.add(rightHemisphere);
@@ -108,10 +129,12 @@ export function createBrainGeometry(): THREE.Group {
   displaceCerebellumVertices(cerebellumGeo);
   const cerebellumMat = baseMaterial.clone();
   cerebellumMat.color.setHex(0xab47bc);
-  cerebellumMat.vertexColors = false; 
+  cerebellumMat.vertexColors = false;
+  cerebellumMat.opacity = 0.06;
   
   const cerebellum = new THREE.Mesh(cerebellumGeo, cerebellumMat);
   cerebellum.position.set(0, -5, -6);
+  cerebellum.renderOrder = -1;
   brainGroup.add(cerebellum);
 
   // Brain stem
@@ -119,11 +142,15 @@ export function createBrainGeometry(): THREE.Group {
   const stemMat = new THREE.MeshStandardMaterial({
     color: 0x2a1a4a,
     roughness: 0.9,
-    metalness: 0.1
+    metalness: 0.1,
+    transparent: true,
+    opacity: 0.15,
+    depthWrite: false,
   });
   const stem = new THREE.Mesh(stemGeo, stemMat);
   stem.position.set(0, -8, -5);
-  stem.rotation.x = 0.2; // Slight tilt
+  stem.rotation.x = 0.2;
+  stem.renderOrder = -1;
   brainGroup.add(stem);
 
   return brainGroup;

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-regions.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-regions.ts
@@ -1,0 +1,52 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Spector Cortex — Brain Regions Model
+// Copyright (c) 2025–2026 Spectrayan. Licensed under BSL 1.1.
+// ═══════════════════════════════════════════════════════════════════════
+
+export interface BrainRegion {
+  readonly name: string;
+  readonly tier: string;  // MemoryTier string
+  readonly center: readonly [number, number, number]; // region centroid in brain-local coords
+  readonly radius: number;  // bounding radius for node jitter placement
+  readonly color: number;   // hex color
+  readonly noiseFrequency: number; // surface wrinkle density for this region
+}
+
+export const BRAIN_REGIONS: readonly BrainRegion[] = [
+  { name: 'Prefrontal Cortex', tier: 'WORKING',    center: [0, 3, 8],    radius: 4, color: 0xffb74d, noiseFrequency: 0.3 },
+  { name: 'Hippocampus',       tier: 'EPISODIC',   center: [3.5, -2, 0], radius: 2.5, color: 0x66bb6a, noiseFrequency: 0.5 },
+  { name: 'Hippocampus (L)',   tier: 'EPISODIC',   center: [-3.5, -2, 0], radius: 2.5, color: 0x66bb6a, noiseFrequency: 0.5 },
+  { name: 'Temporal Cortex',   tier: 'SEMANTIC',   center: [7, 0, -2],   radius: 5, color: 0x42a5f5, noiseFrequency: 0.25 },
+  { name: 'Temporal Cortex (L)', tier: 'SEMANTIC', center: [-7, 0, -2],  radius: 5, color: 0x42a5f5, noiseFrequency: 0.25 },
+  { name: 'Cerebellum',        tier: 'PROCEDURAL', center: [0, -5, -6],  radius: 4, color: 0xab47bc, noiseFrequency: 0.6 },
+];
+
+export function getRegionsForTier(tier: string): BrainRegion[] {
+  return BRAIN_REGIONS.filter(r => r.tier === tier);
+}
+
+export function getRegionForTier(tier: string): BrainRegion {
+  const regions = getRegionsForTier(tier);
+  if (regions.length > 0) {
+    return regions[0];
+  }
+  
+  // Fallback to Temporal Cortex if no match
+  const fallback = BRAIN_REGIONS.find(r => r.name === 'Temporal Cortex');
+  return fallback || BRAIN_REGIONS[0];
+}
+
+export function jitterPositionInRegion(region: BrainRegion, index: number, total: number): [number, number, number] {
+  // Distribute nodes within the bounding sphere using a 3D golden spiral
+  const phi = Math.acos(1 - 2 * (index + 0.5) / total);
+  const theta = Math.PI * (1 + Math.sqrt(5)) * index;
+  
+  // Use cubic root to ensure uniform volume density
+  const r = region.radius * Math.cbrt((index + 0.5) / total);
+
+  const x = region.center[0] + r * Math.sin(phi) * Math.cos(theta);
+  const y = region.center[1] + r * Math.sin(phi) * Math.sin(theta);
+  const z = region.center[2] + r * Math.cos(phi);
+
+  return [x, y, z];
+}

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-regions.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/brain-regions.ts
@@ -13,12 +13,13 @@ export interface BrainRegion {
 }
 
 export const BRAIN_REGIONS: readonly BrainRegion[] = [
-  { name: 'Prefrontal Cortex', tier: 'WORKING',    center: [0, 3, 8],    radius: 4, color: 0xffb74d, noiseFrequency: 0.3 },
-  { name: 'Hippocampus',       tier: 'EPISODIC',   center: [3.5, -2, 0], radius: 2.5, color: 0x66bb6a, noiseFrequency: 0.5 },
-  { name: 'Hippocampus (L)',   tier: 'EPISODIC',   center: [-3.5, -2, 0], radius: 2.5, color: 0x66bb6a, noiseFrequency: 0.5 },
-  { name: 'Temporal Cortex',   tier: 'SEMANTIC',   center: [7, 0, -2],   radius: 5, color: 0x42a5f5, noiseFrequency: 0.25 },
-  { name: 'Temporal Cortex (L)', tier: 'SEMANTIC', center: [-7, 0, -2],  radius: 5, color: 0x42a5f5, noiseFrequency: 0.25 },
-  { name: 'Cerebellum',        tier: 'PROCEDURAL', center: [0, -5, -6],  radius: 4, color: 0xab47bc, noiseFrequency: 0.6 },
+  { name: 'Prefrontal Cortex',   tier: 'WORKING',    center: [0, 2, 10],     radius: 5,   color: 0xffb74d, noiseFrequency: 0.3 },
+  { name: 'Hippocampus',         tier: 'EPISODIC',   center: [5, -1, 0],     radius: 4,   color: 0x66bb6a, noiseFrequency: 0.5 },
+  { name: 'Hippocampus (L)',     tier: 'EPISODIC',   center: [-5, -1, 0],    radius: 4,   color: 0x66bb6a, noiseFrequency: 0.5 },
+  { name: 'Temporal Cortex',     tier: 'SEMANTIC',   center: [8, 1, -3],     radius: 6,   color: 0x42a5f5, noiseFrequency: 0.25 },
+  { name: 'Temporal Cortex (L)', tier: 'SEMANTIC',    center: [-8, 1, -3],    radius: 6,   color: 0x42a5f5, noiseFrequency: 0.25 },
+  { name: 'Parietal Cortex',     tier: 'SEMANTIC',    center: [0, 5, -2],     radius: 5,   color: 0x29b6f6, noiseFrequency: 0.25 },
+  { name: 'Cerebellum',          tier: 'PROCEDURAL',  center: [0, -5, -8],    radius: 5,   color: 0xab47bc, noiseFrequency: 0.6 },
 ];
 
 export function getRegionsForTier(tier: string): BrainRegion[] {
@@ -31,9 +32,8 @@ export function getRegionForTier(tier: string): BrainRegion {
     return regions[0];
   }
   
-  // Fallback to Temporal Cortex if no match
-  const fallback = BRAIN_REGIONS.find(r => r.name === 'Temporal Cortex');
-  return fallback || BRAIN_REGIONS[0];
+  // Fallback: cycle through ALL regions to distribute unknown tiers across the whole brain
+  return BRAIN_REGIONS[Math.floor(Math.random() * BRAIN_REGIONS.length)];
 }
 
 export function jitterPositionInRegion(region: BrainRegion, index: number, total: number): [number, number, number] {

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
@@ -67,7 +67,7 @@ export function createNeuronSoma(color: number, size: number, importance: number
   });
   
   const glowSprite = new THREE.Sprite(spriteMaterial);
-  const glowScale = size * 1.5;
+  const glowScale = size * 0.5;
   glowSprite.scale.set(glowScale, glowScale, 1);
   
   return { mesh, glowSprite };

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
@@ -1,0 +1,219 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Spector Cortex — Neuron Mesh Factory
+// Copyright (c) 2025–2026 Spectrayan. Licensed under BSL 1.1.
+// ═══════════════════════════════════════════════════════════════════════
+
+import * as THREE from 'three';
+
+export const EDGE_TYPE_COLORS: Record<string, number> = {
+  HEBBIAN: 0x00ffcc,
+  TEMPORAL: 0x00bcd4,
+  ENTITY: 0xffc107,
+};
+
+export const TIER_COLORS: Record<string, number> = {
+  WORKING: 0xffb74d,
+  EPISODIC: 0x66bb6a,
+  SEMANTIC: 0x42a5f5,
+  PROCEDURAL: 0xab47bc,
+};
+
+/**
+ * Creates a neuron cell body (soma).
+ */
+export function createNeuronSoma(color: number, size: number, importance: number): { mesh: THREE.Mesh; glowSprite: THREE.Sprite } {
+  const geometry = new THREE.SphereGeometry(size * 0.8, 16, 12);
+  const material = new THREE.MeshPhysicalMaterial({
+    color: color,
+    emissive: color,
+    emissiveIntensity: 0.2 + importance * 0.5,
+    transparent: true,
+    opacity: 0.7 + importance * 0.3,
+    roughness: 0.3,
+    metalness: 0.1
+  });
+  
+  const mesh = new THREE.Mesh(geometry, material);
+
+  // Soft radial glow sprite using CanvasTexture
+  const canvas = document.createElement('canvas');
+  canvas.width = 64;
+  canvas.height = 64;
+  const context = canvas.getContext('2d');
+  
+  if (context) {
+    const gradient = context.createRadialGradient(32, 32, 0, 32, 32, 32);
+    const c = new THREE.Color(color);
+    const r = Math.floor(c.r * 255);
+    const g = Math.floor(c.g * 255);
+    const b = Math.floor(c.b * 255);
+    
+    gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, 1)`);
+    gradient.addColorStop(0.2, `rgba(${r}, ${g}, ${b}, 0.8)`);
+    gradient.addColorStop(0.5, `rgba(${r}, ${g}, ${b}, 0.2)`);
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, 64, 64);
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  const spriteMaterial = new THREE.SpriteMaterial({
+    map: texture,
+    color: 0xffffff,
+    transparent: true,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false
+  });
+  
+  const glowSprite = new THREE.Sprite(spriteMaterial);
+  const glowScale = size * 4;
+  glowSprite.scale.set(glowScale, glowScale, 1);
+  
+  return { mesh, glowSprite };
+}
+
+// Pseudo-random generator for stable curve generation
+function hashVector(v1: THREE.Vector3, v2: THREE.Vector3): number {
+  const str = `${v1.x.toFixed(2)}_${v1.y.toFixed(2)}_${v1.z.toFixed(2)}_${v2.x.toFixed(2)}_${v2.y.toFixed(2)}_${v2.z.toFixed(2)}`;
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0;
+  }
+  return hash;
+}
+
+function random(seed: number): number {
+  const x = Math.sin(seed) * 10000;
+  return (x - Math.floor(x)) * 2 - 1; // Range: -1 to 1
+}
+
+/**
+ * Creates a curved dendrite/axon connection between two neurons.
+ */
+export function createDendriteCurve(fromPos: THREE.Vector3, toPos: THREE.Vector3, edgeType: string, weight: number): { tube: THREE.Mesh; curve: THREE.CatmullRomCurve3 } {
+  const distance = fromPos.distanceTo(toPos);
+  const curvature = Math.min(distance * 0.3, 8);
+  
+  const dir = new THREE.Vector3().subVectors(toPos, fromPos).normalize();
+  
+  // Create perpendicular vectors for offsetting control points
+  const up = new THREE.Vector3(0, 1, 0);
+  if (Math.abs(dir.dot(up)) > 0.99) {
+    up.set(1, 0, 0);
+  }
+  const perp1 = new THREE.Vector3().crossVectors(dir, up).normalize();
+  const perp2 = new THREE.Vector3().crossVectors(dir, perp1).normalize();
+  
+  const seed = hashVector(fromPos, toPos);
+  
+  // Control point 1 at ~25%
+  const cp1 = new THREE.Vector3().lerpVectors(fromPos, toPos, 0.25);
+  const offset1 = new THREE.Vector3()
+    .addScaledVector(perp1, random(seed) * curvature)
+    .addScaledVector(perp2, random(seed + 1) * curvature);
+  cp1.add(offset1);
+  
+  // Control point 2 at ~75%
+  const cp2 = new THREE.Vector3().lerpVectors(fromPos, toPos, 0.75);
+  const offset2 = new THREE.Vector3()
+    .addScaledVector(perp1, random(seed + 2) * curvature)
+    .addScaledVector(perp2, random(seed + 3) * curvature);
+  cp2.add(offset2);
+  
+  const curve = new THREE.CatmullRomCurve3([fromPos, cp1, cp2, toPos]);
+  
+  let tubeRadius = 0.02;
+  if (edgeType === 'HEBBIAN') tubeRadius = 0.03 + weight * 0.07;
+  else if (edgeType === 'TEMPORAL') tubeRadius = 0.02;
+  else if (edgeType === 'ENTITY') tubeRadius = 0.04;
+  
+  const geometry = new THREE.TubeGeometry(curve, 20, tubeRadius, 6, false);
+  
+  const color = EDGE_TYPE_COLORS[edgeType] || 0xffffff;
+  const emissiveIntensity = edgeType === 'HEBBIAN' ? 0.2 + weight * 0.5 : 0.3;
+  
+  const material = new THREE.MeshPhysicalMaterial({
+    color: color,
+    emissive: color,
+    emissiveIntensity: emissiveIntensity,
+    transparent: true,
+    opacity: 0.3 + weight * 0.4,
+    roughness: 0.4
+  });
+  
+  const tube = new THREE.Mesh(geometry, material);
+  
+  return { tube, curve };
+}
+
+/**
+ * Creates a tiny glowing bulb at the endpoint of a dendrite.
+ */
+export function createSynapticTerminal(position: THREE.Vector3, color: number): THREE.Mesh {
+  const geometry = new THREE.SphereGeometry(0.08, 8, 6);
+  const material = new THREE.MeshPhysicalMaterial({
+    color: color,
+    emissive: color,
+    emissiveIntensity: 0.8,
+    transparent: true,
+    opacity: 0.9,
+    roughness: 0.3
+  });
+  
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.copy(position);
+  return mesh;
+}
+
+/**
+ * Creates a 2D label sprite for a neuron.
+ */
+export function createNeuronLabel(id: string, tier: string, importance: number, color: number): THREE.Sprite {
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 64;
+  const context = canvas.getContext('2d');
+  
+  if (context) {
+    // Pill shape background
+    context.fillStyle = 'rgba(0, 0, 0, 0.6)';
+    context.beginPath();
+    context.roundRect(10, 10, 236, 44, 22);
+    context.fill();
+    
+    // Pill border
+    context.strokeStyle = `rgba(${(color >> 16) & 255}, ${(color >> 8) & 255}, ${color & 255}, 0.8)`;
+    context.lineWidth = 2;
+    context.stroke();
+    
+    // Label text
+    context.fillStyle = '#ffffff';
+    context.font = 'bold 20px sans-serif';
+    context.textAlign = 'left';
+    context.textBaseline = 'middle';
+    context.fillText(`◉ ${id}`, 25, 32);
+    
+    // Tier text
+    context.fillStyle = `rgba(${(color >> 16) & 255}, ${(color >> 8) & 255}, ${color & 255}, 1)`;
+    context.font = '16px sans-serif';
+    context.textAlign = 'right';
+    context.fillText(tier, 230, 32);
+  }
+  
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.minFilter = THREE.LinearFilter;
+  
+  const spriteMaterial = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthTest: false
+  });
+  
+  const sprite = new THREE.Sprite(spriteMaterial);
+  sprite.scale.set(10, 2.5, 1);
+  
+  return sprite;
+}

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
@@ -26,9 +26,9 @@ export function createNeuronSoma(color: number, size: number, importance: number
   const material = new THREE.MeshPhysicalMaterial({
     color: color,
     emissive: color,
-    emissiveIntensity: 0.2 + importance * 0.5,
+    emissiveIntensity: 0.4 + importance * 0.6,
     transparent: true,
-    opacity: 0.7 + importance * 0.3,
+    opacity: 0.85 + importance * 0.15,
     roughness: 0.3,
     metalness: 0.1
   });
@@ -125,10 +125,10 @@ export function createDendriteCurve(fromPos: THREE.Vector3, toPos: THREE.Vector3
   
   const curve = new THREE.CatmullRomCurve3([fromPos, cp1, cp2, toPos]);
   
-  let tubeRadius = 0.02;
-  if (edgeType === 'HEBBIAN') tubeRadius = 0.03 + weight * 0.07;
-  else if (edgeType === 'TEMPORAL') tubeRadius = 0.02;
-  else if (edgeType === 'ENTITY') tubeRadius = 0.04;
+  let tubeRadius = 0.06;
+  if (edgeType === 'HEBBIAN') tubeRadius = 0.08 + weight * 0.15;
+  else if (edgeType === 'TEMPORAL') tubeRadius = 0.05;
+  else if (edgeType === 'ENTITY') tubeRadius = 0.10;
   
   const geometry = new THREE.TubeGeometry(curve, 20, tubeRadius, 6, false);
   
@@ -140,7 +140,7 @@ export function createDendriteCurve(fromPos: THREE.Vector3, toPos: THREE.Vector3
     emissive: color,
     emissiveIntensity: emissiveIntensity,
     transparent: true,
-    opacity: 0.3 + weight * 0.4,
+    opacity: 0.5 + weight * 0.4,
     roughness: 0.4
   });
   
@@ -153,7 +153,7 @@ export function createDendriteCurve(fromPos: THREE.Vector3, toPos: THREE.Vector3
  * Creates a tiny glowing bulb at the endpoint of a dendrite.
  */
 export function createSynapticTerminal(position: THREE.Vector3, color: number): THREE.Mesh {
-  const geometry = new THREE.SphereGeometry(0.08, 8, 6);
+  const geometry = new THREE.SphereGeometry(0.15, 8, 6);
   const material = new THREE.MeshPhysicalMaterial({
     color: color,
     emissive: color,
@@ -213,7 +213,7 @@ export function createNeuronLabel(id: string, tier: string, importance: number, 
   });
   
   const sprite = new THREE.Sprite(spriteMaterial);
-  sprite.scale.set(10, 2.5, 1);
+  sprite.scale.set(3, 0.75, 1);
   
   return sprite;
 }

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
@@ -22,7 +22,7 @@ export const TIER_COLORS: Record<string, number> = {
  * Creates a neuron cell body (soma).
  */
 export function createNeuronSoma(color: number, size: number, importance: number): { mesh: THREE.Mesh; glowSprite: THREE.Sprite } {
-  const geometry = new THREE.SphereGeometry(size * 0.8, 16, 12);
+  const geometry = new THREE.SphereGeometry(size * 0.3, 10, 8);
   const material = new THREE.MeshPhysicalMaterial({
     color: color,
     emissive: color,
@@ -67,7 +67,7 @@ export function createNeuronSoma(color: number, size: number, importance: number
   });
   
   const glowSprite = new THREE.Sprite(spriteMaterial);
-  const glowScale = size * 0.5;
+  const glowScale = size * 0.15;
   glowSprite.scale.set(glowScale, glowScale, 1);
   
   return { mesh, glowSprite };

--- a/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/models/neuron-mesh.factory.ts
@@ -67,7 +67,7 @@ export function createNeuronSoma(color: number, size: number, importance: number
   });
   
   const glowSprite = new THREE.Sprite(spriteMaterial);
-  const glowScale = size * 4;
+  const glowScale = size * 1.5;
   glowSprite.scale.set(glowScale, glowScale, 1);
   
   return { mesh, glowSprite };
@@ -213,7 +213,7 @@ export function createNeuronLabel(id: string, tier: string, importance: number, 
   });
   
   const sprite = new THREE.Sprite(spriteMaterial);
-  sprite.scale.set(3, 0.75, 1);
+  sprite.scale.set(1.8, 0.45, 1);
   
   return sprite;
 }

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
@@ -79,7 +79,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         const pos = jitterPositionInRegion(region, indexInRegion, nodesInThisRegion);
         const position = new THREE.Vector3(pos[0], pos[1], pos[2]);
 
-        const baseSize = 0.5 + (node.importance || 0) * 0.2;
+        const baseSize = 0.2 + (node.importance || 0) * 0.15;
         const { mesh, glowSprite } = createNeuronSoma(color, baseSize, node.importance || 0);
 
         mesh.position.copy(position);
@@ -314,7 +314,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         const newScale = THREE.MathUtils.lerp(curScale, target, delta * 5);
         node.mesh.scale.set(newScale, newScale, newScale);
         
-        const glowTarget = node.baseSize * 0.5 * glowPulseScale;
+        const glowTarget = node.baseSize * 0.15 * glowPulseScale;
         const newGlowScale = THREE.MathUtils.lerp(node.glowMesh.scale.x, glowTarget, delta * 5);
         node.glowMesh.scale.set(newGlowScale, newGlowScale, 1);
         
@@ -323,7 +323,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         }
       } else {
         node.mesh.scale.set(scale, scale, scale);
-        const glowScale = node.baseSize * 0.5 * glowPulseScale;
+        const glowScale = node.baseSize * 0.15 * glowPulseScale;
         node.glowMesh.scale.set(glowScale, glowScale, 1);
       }
     }

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
@@ -312,7 +312,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         const newScale = THREE.MathUtils.lerp(curScale, target, delta * 5);
         node.mesh.scale.set(newScale, newScale, newScale);
         
-        const glowTarget = node.baseSize * 4 * glowPulseScale;
+        const glowTarget = node.baseSize * 1.5 * glowPulseScale;
         const newGlowScale = THREE.MathUtils.lerp(node.glowMesh.scale.x, glowTarget, delta * 5);
         node.glowMesh.scale.set(newGlowScale, newGlowScale, 1);
         
@@ -321,7 +321,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         }
       } else {
         node.mesh.scale.set(scale, scale, scale);
-        const glowScale = node.baseSize * 4 * glowPulseScale;
+        const glowScale = node.baseSize * 1.5 * glowPulseScale;
         node.glowMesh.scale.set(glowScale, glowScale, 1);
       }
     }

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
@@ -64,17 +64,19 @@ export class BrainViewStrategy implements GraphViewStrategy {
       const color = TIER_COLORS[tier] || 0xffffff;
       
       nodes.forEach((node, index) => {
+        // Alternate between bilateral regions (left/right) using index
         let regionIndex = 0;
         if (regions.length > 1) {
-          const toggleKey = `${tier}_${node.id}`;
-          this.regionToggle[toggleKey] = !this.regionToggle[toggleKey];
-          regionIndex = this.regionToggle[toggleKey] ? 1 : 0;
+          regionIndex = index % regions.length;
         }
         
         const region = regions[regionIndex] || regions[0];
         if (!region) return;
 
-        const pos = jitterPositionInRegion(region, index, nodes.length);
+        // Distribute nodes within the chosen region
+        const nodesInThisRegion = Math.ceil(nodes.length / regions.length);
+        const indexInRegion = Math.floor(index / regions.length);
+        const pos = jitterPositionInRegion(region, indexInRegion, nodesInThisRegion);
         const position = new THREE.Vector3(pos[0], pos[1], pos[2]);
 
         const baseSize = 0.5 + (node.importance || 0) * 0.2;
@@ -312,7 +314,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         const newScale = THREE.MathUtils.lerp(curScale, target, delta * 5);
         node.mesh.scale.set(newScale, newScale, newScale);
         
-        const glowTarget = node.baseSize * 1.5 * glowPulseScale;
+        const glowTarget = node.baseSize * 0.5 * glowPulseScale;
         const newGlowScale = THREE.MathUtils.lerp(node.glowMesh.scale.x, glowTarget, delta * 5);
         node.glowMesh.scale.set(newGlowScale, newGlowScale, 1);
         
@@ -321,7 +323,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         }
       } else {
         node.mesh.scale.set(scale, scale, scale);
-        const glowScale = node.baseSize * 1.5 * glowPulseScale;
+        const glowScale = node.baseSize * 0.5 * glowPulseScale;
         node.glowMesh.scale.set(glowScale, glowScale, 1);
       }
     }

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
@@ -23,7 +23,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
 
   initScene(container: HTMLElement, camera: THREE.PerspectiveCamera): THREE.Scene {
     const scene = new THREE.Scene();
-    scene.fog = new THREE.FogExp2(0x0a0512, 0.015);
+    scene.fog = new THREE.FogExp2(0x0a0512, 0.008);
 
     this.brainGroup = createBrainGeometry();
     scene.add(this.brainGroup);
@@ -31,12 +31,17 @@ export class BrainViewStrategy implements GraphViewStrategy {
     this.brainMist = createBrainMist();
     scene.add(this.brainMist);
 
-    const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.8);
     scene.add(ambientLight);
 
-    const directionalLight = new THREE.DirectionalLight(0xffaaee, 1.0);
+    const directionalLight = new THREE.DirectionalLight(0xffaaee, 1.2);
     directionalLight.position.set(10, 20, 15);
     scene.add(directionalLight);
+
+    // Add a second light from below for hemisphere illumination
+    const bottomLight = new THREE.DirectionalLight(0x8866cc, 0.4);
+    bottomLight.position.set(-5, -15, -10);
+    scene.add(bottomLight);
 
     this.scene = scene;
     return scene;
@@ -85,7 +90,7 @@ export class BrainViewStrategy implements GraphViewStrategy {
         }
 
         const labelSprite = createNeuronLabel(node.id, node.tier, node.importance || 0, color);
-        labelSprite.position.copy(position).add(new THREE.Vector3(0, baseSize * 2, 0));
+        labelSprite.position.copy(position).add(new THREE.Vector3(0, baseSize * 1.2, 0));
         labelSprite.visible = false;
 
         this.scene!.add(mesh);
@@ -94,6 +99,9 @@ export class BrainViewStrategy implements GraphViewStrategy {
 
         mesh.userData['id'] = node.id;
         mesh.userData['type'] = 'node';
+        mesh.renderOrder = 1;
+        glowSprite.renderOrder = 0;
+        labelSprite.renderOrder = 2;
 
         newNodes.push({
           id: node.id,
@@ -266,8 +274,8 @@ export class BrainViewStrategy implements GraphViewStrategy {
       const distToCamera = node.position.distanceTo(cameraPos);
       
       if (node.labelSprite) {
-        node.labelSprite.position.copy(node.position).add(new THREE.Vector3(0, node.baseSize * 2, 0));
-        node.labelSprite.visible = showLabels && distToCamera < 40;
+      node.labelSprite.position.copy(node.position).add(new THREE.Vector3(0, node.baseSize * 1.2, 0));
+        node.labelSprite.visible = showLabels && distToCamera < 30;
       }
 
       node.mesh.visible = node.visible;

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/brain-view.strategy.ts
@@ -1,0 +1,541 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Spector Cortex — Brain View Strategy
+// Copyright (c) 2025–2026 Spectrayan. Licensed under BSL 1.1.
+// ═══════════════════════════════════════════════════════════════════════
+
+import * as THREE from 'three';
+import { GraphNode, GraphEdge } from '../../../core/services/memory-table.service';
+import { GraphViewStrategy, ExplorerNode, ExplorerEdge, FiringParticle } from './view-strategy.interface';
+import { createBrainGeometry, createBrainMist } from '../models/brain-geometry.factory';
+import { getRegionsForTier, jitterPositionInRegion } from '../models/brain-regions';
+import { createNeuronSoma, createDendriteCurve, createSynapticTerminal, createNeuronLabel, TIER_COLORS, EDGE_TYPE_COLORS } from '../models/neuron-mesh.factory';
+
+export class BrainViewStrategy implements GraphViewStrategy {
+  readonly name = 'cortex';
+
+  private scene: THREE.Scene | null = null;
+  private brainGroup: THREE.Group | null = null;
+  private brainMist: THREE.Points | null = null;
+  private dendriteCurves: Map<number, THREE.CatmullRomCurve3> = new Map();
+  private synapticTerminals: THREE.Mesh[] = [];
+  
+  private regionToggle: Record<string, boolean> = {};
+
+  initScene(container: HTMLElement, camera: THREE.PerspectiveCamera): THREE.Scene {
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x0a0512, 0.015);
+
+    this.brainGroup = createBrainGeometry();
+    scene.add(this.brainGroup);
+
+    this.brainMist = createBrainMist();
+    scene.add(this.brainMist);
+
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+    scene.add(ambientLight);
+
+    const directionalLight = new THREE.DirectionalLight(0xffaaee, 1.0);
+    directionalLight.position.set(10, 20, 15);
+    scene.add(directionalLight);
+
+    this.scene = scene;
+    return scene;
+  }
+
+  addNodes(apiNodes: GraphNode[], existingNodes: ExplorerNode[], warpIn: boolean): ExplorerNode[] {
+    const newNodes: ExplorerNode[] = [];
+    if (!this.scene) return newNodes;
+
+    const nodesByTier: Record<string, GraphNode[]> = {};
+    for (const node of apiNodes) {
+      if (!nodesByTier[node.tier]) {
+        nodesByTier[node.tier] = [];
+      }
+      nodesByTier[node.tier].push(node);
+    }
+
+    for (const [tier, nodes] of Object.entries(nodesByTier)) {
+      const regions = getRegionsForTier(tier);
+      const color = TIER_COLORS[tier] || 0xffffff;
+      
+      nodes.forEach((node, index) => {
+        let regionIndex = 0;
+        if (regions.length > 1) {
+          const toggleKey = `${tier}_${node.id}`;
+          this.regionToggle[toggleKey] = !this.regionToggle[toggleKey];
+          regionIndex = this.regionToggle[toggleKey] ? 1 : 0;
+        }
+        
+        const region = regions[regionIndex] || regions[0];
+        if (!region) return;
+
+        const pos = jitterPositionInRegion(region, index, nodes.length);
+        const position = new THREE.Vector3(pos[0], pos[1], pos[2]);
+
+        const baseSize = 0.5 + (node.importance || 0) * 0.2;
+        const { mesh, glowSprite } = createNeuronSoma(color, baseSize, node.importance || 0);
+
+        mesh.position.copy(position);
+        glowSprite.position.copy(position);
+
+        if (warpIn) {
+          mesh.scale.set(0.01, 0.01, 0.01);
+          glowSprite.scale.set(0.01, 0.01, 0.01);
+          mesh.userData['warpIn'] = true;
+        }
+
+        const labelSprite = createNeuronLabel(node.id, node.tier, node.importance || 0, color);
+        labelSprite.position.copy(position).add(new THREE.Vector3(0, baseSize * 2, 0));
+        labelSprite.visible = false;
+
+        this.scene!.add(mesh);
+        this.scene!.add(glowSprite);
+        this.scene!.add(labelSprite);
+
+        mesh.userData['id'] = node.id;
+        mesh.userData['type'] = 'node';
+
+        newNodes.push({
+          id: node.id,
+          tier: node.tier,
+          text: node.textPreview || node.id,
+          importance: node.importance || 0,
+          valence: node.valence || 0,
+          timestampMs: node.timestampMs || Date.now(),
+          position: position,
+          velocity: new THREE.Vector3(),
+          mesh: mesh as any,
+          glowMesh: glowSprite,
+          labelSprite: labelSprite,
+          selected: false,
+          baseSize: baseSize,
+          visible: true,
+          targetOpacity: 1.0
+        });
+      });
+    }
+
+    return newNodes;
+  }
+
+  addNodesAroundParent(apiNodes: GraphNode[], existingNodes: ExplorerNode[], parent: ExplorerNode): ExplorerNode[] {
+    const newNodes = this.addNodes(apiNodes, existingNodes, true);
+    
+    newNodes.forEach((node, i) => {
+      const angle = (i / newNodes.length) * Math.PI * 2;
+      const radius = 3 + (node.importance * 2);
+      
+      const targetPos = new THREE.Vector3(
+        parent.position.x + Math.cos(angle) * radius,
+        parent.position.y + (Math.random() - 0.5) * 2,
+        parent.position.z + Math.sin(angle) * radius
+      );
+      
+      node.position.copy(targetPos);
+      node.mesh.position.copy(targetPos);
+      node.glowMesh.position.copy(targetPos);
+      node.labelSprite.position.copy(targetPos).add(new THREE.Vector3(0, node.baseSize * 2, 0));
+    });
+    
+    return newNodes;
+  }
+
+  addEdges(apiEdges: GraphEdge[], nodes: ExplorerNode[], existingEdges: ExplorerEdge[]): ExplorerEdge[] {
+    const newEdges: ExplorerEdge[] = [];
+    if (!this.scene) return newEdges;
+    
+    for (const edge of apiEdges) {
+      const fromNode = nodes.find(n => n.id === edge.fromId);
+      const toNode = nodes.find(n => n.id === edge.toId);
+      
+      if (fromNode && toNode) {
+        const { tube, curve } = createDendriteCurve(fromNode.position, toNode.position, edge.type, edge.weight || 1);
+        
+        const color = EDGE_TYPE_COLORS[edge.type] || 0xffffff;
+        const fromTerminal = createSynapticTerminal(fromNode.position, color);
+        const toTerminal = createSynapticTerminal(toNode.position, color);
+        
+        this.synapticTerminals.push(fromTerminal, toTerminal);
+        this.scene.add(fromTerminal);
+        this.scene.add(toTerminal);
+        
+        tube.userData = { type: 'edge', from: edge.fromId, to: edge.toId, edgeType: edge.type };
+        this.scene.add(tube);
+        
+        let labelSprite: THREE.Sprite | undefined;
+        let weightSprite: THREE.Sprite | undefined;
+        
+        if (edge.relation) {
+          labelSprite = this.createEdgeLabel(edge.relation, color);
+          labelSprite.visible = false;
+          this.scene.add(labelSprite);
+        }
+        
+        if (edge.weight) {
+          weightSprite = this.createWeightLabel(edge.weight, color);
+          weightSprite.visible = false;
+          this.scene.add(weightSprite);
+        }
+        
+        const explorerEdge: ExplorerEdge = {
+          from: edge.fromId,
+          to: edge.toId,
+          type: edge.type,
+          weight: edge.weight || 1,
+          relation: edge.relation || null,
+          line: tube as any,
+          labelSprite: labelSprite,
+          weightSprite: weightSprite
+        };
+        
+        (explorerEdge.line as any).__curve = curve;
+        
+        const globalIndex = (existingEdges?.length || 0) + newEdges.length;
+        this.dendriteCurves.set(globalIndex, curve);
+        
+        newEdges.push(explorerEdge);
+      }
+    }
+    
+    return newEdges;
+  }
+
+  private createEdgeLabel(text: string, color: number): THREE.Sprite {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 32;
+    const context = canvas.getContext('2d');
+    if (context) {
+      context.fillStyle = 'rgba(0,0,0,0.5)';
+      context.beginPath();
+      context.roundRect(0, 0, 128, 32, 16);
+      context.fill();
+
+      context.strokeStyle = `rgba(${(color >> 16) & 255}, ${(color >> 8) & 255}, ${color & 255}, 0.8)`;
+      context.lineWidth = 1;
+      context.stroke();
+
+      context.fillStyle = '#ffffff';
+      context.font = '12px sans-serif';
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.fillText(text.substring(0, 15), 64, 16);
+    }
+    const texture = new THREE.CanvasTexture(canvas);
+    const spriteMaterial = new THREE.SpriteMaterial({ map: texture, depthTest: false });
+    const sprite = new THREE.Sprite(spriteMaterial);
+    sprite.scale.set(4, 1, 1);
+    return sprite;
+  }
+
+  private createWeightLabel(weight: number, color: number): THREE.Sprite {
+    const canvas = document.createElement('canvas');
+    canvas.width = 32;
+    canvas.height = 32;
+    const context = canvas.getContext('2d');
+    if (context) {
+      context.fillStyle = `rgba(${(color >> 16) & 255}, ${(color >> 8) & 255}, ${color & 255}, 0.8)`;
+      context.beginPath();
+      context.arc(16, 16, 16, 0, Math.PI * 2);
+      context.fill();
+
+      context.fillStyle = '#000000';
+      context.font = 'bold 12px sans-serif';
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.fillText(weight.toFixed(1), 16, 16);
+    }
+    const texture = new THREE.CanvasTexture(canvas);
+    const spriteMaterial = new THREE.SpriteMaterial({ map: texture, depthTest: false });
+    const sprite = new THREE.Sprite(spriteMaterial);
+    sprite.scale.set(1.5, 1.5, 1);
+    return sprite;
+  }
+
+  animateNodes(nodes: ExplorerNode[], delta: number, time: number, showLabels: boolean, cameraPos: THREE.Vector3, recallMode: boolean, recallMatchedIds: Set<string>): void {
+    const driftSpeed = 0.05;
+
+    for (const node of nodes) {
+      node.position.x += Math.sin(time * 0.5 + node.position.y) * driftSpeed * delta;
+      node.position.y += Math.cos(time * 0.4 + node.position.z) * driftSpeed * delta;
+      node.position.z += Math.sin(time * 0.6 + node.position.x) * driftSpeed * delta;
+      
+      node.mesh.position.copy(node.position);
+      node.glowMesh.position.copy(node.position);
+
+      const distToCamera = node.position.distanceTo(cameraPos);
+      
+      if (node.labelSprite) {
+        node.labelSprite.position.copy(node.position).add(new THREE.Vector3(0, node.baseSize * 2, 0));
+        node.labelSprite.visible = showLabels && distToCamera < 40;
+      }
+
+      node.mesh.visible = node.visible;
+      node.glowMesh.visible = node.visible;
+
+      if (!node.visible) continue;
+
+      const material = (node.mesh as any).material as THREE.Material;
+      if (material && 'opacity' in material) {
+        (material as any).opacity = THREE.MathUtils.lerp((material as any).opacity, node.targetOpacity, delta * 2);
+      }
+
+      let pulseScale = 1.0;
+      let glowPulseScale = 1.0;
+      
+      if (recallMode && recallMatchedIds.has(node.id)) {
+        pulseScale = 1.2 + Math.sin(time * 5) * 0.2;
+        glowPulseScale = 1.5 + Math.sin(time * 5) * 0.5;
+      } else {
+        pulseScale = 1.0 + Math.sin(time * 2 + node.position.x) * 0.05;
+        glowPulseScale = 1.0 + Math.sin(time * 2 + node.position.y) * 0.1;
+      }
+      
+      if (node.selected) {
+        pulseScale *= 1.3;
+        glowPulseScale *= 1.5;
+      }
+
+      const scale = node.baseSize * pulseScale;
+      
+      if (node.mesh.userData['warpIn']) {
+        const curScale = node.mesh.scale.x;
+        const target = scale;
+        const newScale = THREE.MathUtils.lerp(curScale, target, delta * 5);
+        node.mesh.scale.set(newScale, newScale, newScale);
+        
+        const glowTarget = node.baseSize * 4 * glowPulseScale;
+        const newGlowScale = THREE.MathUtils.lerp(node.glowMesh.scale.x, glowTarget, delta * 5);
+        node.glowMesh.scale.set(newGlowScale, newGlowScale, 1);
+        
+        if (Math.abs(newScale - target) < 0.01) {
+          node.mesh.userData['warpIn'] = false;
+        }
+      } else {
+        node.mesh.scale.set(scale, scale, scale);
+        const glowScale = node.baseSize * 4 * glowPulseScale;
+        node.glowMesh.scale.set(glowScale, glowScale, 1);
+      }
+    }
+  }
+
+  animateEdges(edges: ExplorerEdge[], nodes: ExplorerNode[], delta: number, showHebbian: boolean, showTemporal: boolean, showEntity: boolean, showLabels: boolean, orbitRadius: number, cameraPos: THREE.Vector3): void {
+    for (let i = 0; i < edges.length; i++) {
+      const edge = edges[i];
+      
+      let isVisible = false;
+      if (edge.type === 'HEBBIAN' && showHebbian) isVisible = true;
+      if (edge.type === 'TEMPORAL' && showTemporal) isVisible = true;
+      if (edge.type === 'ENTITY' && showEntity) isVisible = true;
+      
+      const fromNode = nodes.find(n => n.id === edge.from);
+      const toNode = nodes.find(n => n.id === edge.to);
+      
+      if (fromNode && toNode && (!fromNode.visible || !toNode.visible)) {
+        isVisible = false;
+      }
+      
+      edge.line.visible = isVisible;
+      
+      if (edge.labelSprite) edge.labelSprite.visible = isVisible && showLabels;
+      if (edge.weightSprite) edge.weightSprite.visible = isVisible && showLabels;
+      
+      if (!isVisible) continue;
+      
+      const curve = (edge.line as any).__curve as THREE.CatmullRomCurve3;
+      if (curve) {
+        if (edge.labelSprite || edge.weightSprite) {
+          const midPoint = curve.getPoint(0.5);
+          if (edge.labelSprite) edge.labelSprite.position.copy(midPoint).add(new THREE.Vector3(0, 0.5, 0));
+          if (edge.weightSprite) edge.weightSprite.position.copy(midPoint).add(new THREE.Vector3(0, -0.5, 0));
+        }
+      }
+    }
+  }
+
+  animateParticles(particles: FiringParticle[], edges: ExplorerEdge[], nodes: ExplorerNode[], delta: number, scene: THREE.Scene): FiringParticle[] {
+    const activeParticles: FiringParticle[] = [];
+
+    for (const particle of particles) {
+      if (!particle.alive) continue;
+
+      particle.progress += particle.speed * delta;
+      
+      if (particle.progress >= 1.0) {
+        particle.alive = false;
+        scene.remove(particle.mesh);
+        scene.remove(particle.trailMesh);
+        
+        const edge = edges[particle.edgeIndex];
+        if (edge) {
+          const toNode = nodes.find(n => n.id === edge.to);
+          if (toNode) {
+            toNode.glowMesh.scale.multiplyScalar(1.2);
+          }
+        }
+        continue;
+      }
+
+      const edge = edges[particle.edgeIndex];
+      if (edge) {
+        const curve = (edge.line as any).__curve as THREE.CatmullRomCurve3;
+        if (curve) {
+          const point = curve.getPoint(particle.progress);
+          particle.mesh.position.copy(point);
+          
+          const trailProgress = Math.max(0, particle.progress - 0.05);
+          const trailPoint = curve.getPoint(trailProgress);
+          particle.trailMesh.position.copy(trailPoint);
+          
+          const alpha = Math.sin(particle.progress * Math.PI);
+          (particle.mesh.material as THREE.SpriteMaterial).opacity = alpha;
+          (particle.trailMesh.material as THREE.SpriteMaterial).opacity = alpha * 0.5;
+          
+          activeParticles.push(particle);
+        } else {
+          particle.alive = false;
+          scene.remove(particle.mesh);
+          scene.remove(particle.trailMesh);
+        }
+      } else {
+        particle.alive = false;
+        scene.remove(particle.mesh);
+        scene.remove(particle.trailMesh);
+      }
+    }
+
+    return activeParticles;
+  }
+
+  spawnParticle(edges: ExplorerEdge[], particles: FiringParticle[], scene: THREE.Scene, particleTexture: THREE.CanvasTexture, trailTexture: THREE.CanvasTexture): FiringParticle | null {
+    const visibleEdges = edges.filter(e => e.line.visible);
+    if (visibleEdges.length === 0) return null;
+
+    const randomIndex = Math.floor(Math.random() * visibleEdges.length);
+    const edge = visibleEdges[randomIndex];
+    const edgeIndex = edges.indexOf(edge);
+    
+    let color = 0xffffff;
+    if (edge.type === 'HEBBIAN') color = EDGE_TYPE_COLORS['HEBBIAN'];
+    else if (edge.type === 'TEMPORAL') color = EDGE_TYPE_COLORS['TEMPORAL'];
+    else if (edge.type === 'ENTITY') color = EDGE_TYPE_COLORS['ENTITY'];
+
+    const particleMat = new THREE.SpriteMaterial({
+      map: particleTexture,
+      color: color,
+      transparent: true,
+      opacity: 0,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false
+    });
+    
+    const trailMat = new THREE.SpriteMaterial({
+      map: trailTexture,
+      color: color,
+      transparent: true,
+      opacity: 0,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false
+    });
+
+    const mesh = new THREE.Sprite(particleMat);
+    const trailMesh = new THREE.Sprite(trailMat);
+    
+    mesh.scale.set(0.6, 0.6, 1);
+    trailMesh.scale.set(0.8, 0.8, 1);
+    
+    scene.add(mesh);
+    scene.add(trailMesh);
+
+    return {
+      mesh,
+      trailMesh,
+      edgeIndex,
+      progress: 0,
+      speed: 0.5 + Math.random() * 0.5,
+      alive: true,
+      color
+    };
+  }
+
+  dispose(scene: THREE.Scene, nodes: ExplorerNode[], edges: ExplorerEdge[], particles: FiringParticle[]): void {
+    if (this.brainGroup) {
+      scene.remove(this.brainGroup);
+      this.brainGroup.children.forEach(c => {
+        if (c instanceof THREE.Mesh) {
+          if (c.geometry) c.geometry.dispose();
+          if (c.material) (c.material as THREE.Material).dispose();
+        }
+      });
+      this.brainGroup = null;
+    }
+    
+    if (this.brainMist) {
+      scene.remove(this.brainMist);
+      if (this.brainMist.geometry) this.brainMist.geometry.dispose();
+      if (this.brainMist.material) (this.brainMist.material as THREE.Material).dispose();
+      this.brainMist = null;
+    }
+    
+    for (const node of nodes) {
+      scene.remove(node.mesh as any);
+      scene.remove(node.glowMesh);
+      if (node.labelSprite) scene.remove(node.labelSprite);
+      
+      const mesh = node.mesh as any;
+      if (mesh.geometry) mesh.geometry.dispose();
+      if (mesh.material) mesh.material.dispose();
+      
+      if (node.glowMesh.material) {
+        const mat = node.glowMesh.material as THREE.SpriteMaterial;
+        if (mat.map) mat.map.dispose();
+        mat.dispose();
+      }
+      
+      if (node.labelSprite && node.labelSprite.material) {
+        const mat = node.labelSprite.material as THREE.SpriteMaterial;
+        if (mat.map) mat.map.dispose();
+        mat.dispose();
+      }
+    }
+    
+    for (const edge of edges) {
+      scene.remove(edge.line as any);
+      if (edge.labelSprite) scene.remove(edge.labelSprite);
+      if (edge.weightSprite) scene.remove(edge.weightSprite);
+      
+      const mesh = edge.line as any;
+      if (mesh.geometry) mesh.geometry.dispose();
+      if (mesh.material) mesh.material.dispose();
+      
+      if (edge.labelSprite && edge.labelSprite.material) {
+        const mat = edge.labelSprite.material as THREE.SpriteMaterial;
+        if (mat.map) mat.map.dispose();
+        mat.dispose();
+      }
+      
+      if (edge.weightSprite && edge.weightSprite.material) {
+        const mat = edge.weightSprite.material as THREE.SpriteMaterial;
+        if (mat.map) mat.map.dispose();
+        mat.dispose();
+      }
+    }
+    
+    for (const particle of particles) {
+      scene.remove(particle.mesh);
+      scene.remove(particle.trailMesh);
+      if (particle.mesh.material) (particle.mesh.material as THREE.Material).dispose();
+      if (particle.trailMesh.material) (particle.trailMesh.material as THREE.Material).dispose();
+    }
+    
+    for (const terminal of this.synapticTerminals) {
+      scene.remove(terminal);
+      if (terminal.geometry) terminal.geometry.dispose();
+      if (terminal.material) (terminal.material as THREE.Material).dispose();
+    }
+    
+    this.synapticTerminals = [];
+    this.dendriteCurves.clear();
+    this.scene = null;
+  }
+}

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/galaxy-view.strategy.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/galaxy-view.strategy.ts
@@ -1,0 +1,792 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Spector Cortex — Galaxy View Strategy
+// Copyright (c) 2025–2026 Spectrayan. Licensed under BSL 1.1.
+// ═══════════════════════════════════════════════════════════════════════
+
+import * as THREE from 'three';
+import { GraphNode, GraphEdge } from '../../../core/services/memory-table.service';
+import { GraphViewStrategy, ExplorerNode, ExplorerEdge, FiringParticle } from './view-strategy.interface';
+
+const TIER_COLORS: Record<string, number> = {
+  WORKING: 0xffb74d,
+  EPISODIC: 0x66bb6a,
+  SEMANTIC: 0x42a5f5,
+  PROCEDURAL: 0xab47bc,
+};
+
+const EDGE_TYPE_COLORS: Record<string, number> = {
+  HEBBIAN: 0x00ffcc,   // Cyan-green for sci-fi feel
+  TEMPORAL: 0x00bcd4,
+  ENTITY: 0xffc107,
+};
+
+export class GalaxyViewStrategy implements GraphViewStrategy {
+  readonly name = 'constellation';
+
+  private gridGroup: THREE.Group | null = null;
+  private dustParticles: THREE.Points | null = null;
+
+  initScene(container: HTMLElement, camera: THREE.PerspectiveCamera): THREE.Scene {
+    const scene = new THREE.Scene();
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+    const pointLight = new THREE.PointLight(0xffffff, 0.8, 200);
+    pointLight.position.copy(camera.position);
+    scene.add(pointLight);
+
+    // Hexagonal wireframe grid
+    this.gridGroup = new THREE.Group();
+    this.createHexGrid(this.gridGroup);
+    scene.add(this.gridGroup);
+
+    // Cosmic dust particles (nebula)
+    this.createDustField(scene);
+
+    return scene;
+  }
+
+  addNodes(apiNodes: GraphNode[], existingNodes: ExplorerNode[], warpIn: boolean): ExplorerNode[] {
+    const newNodes: ExplorerNode[] = [];
+    const nodeIdMap = new Map<string, ExplorerNode>();
+    for (const n of existingNodes) nodeIdMap.set(n.id, n);
+
+    for (let i = 0; i < apiNodes.length; i++) {
+      const n = apiNodes[i];
+      if (nodeIdMap.has(n.id)) continue; // Skip duplicates
+
+      const color = TIER_COLORS[n.tier] ?? 0x888888;
+      const importance = Math.max(0.1, Math.min(1.0, n.importance / 10));
+      const offset = existingNodes.length + newNodes.length;
+
+      // Volumetric golden spiral
+      const golden = (1 + Math.sqrt(5)) / 2;
+      const theta = (2 * Math.PI * offset) / golden;
+      const phi = Math.acos(1 - (2 * (offset + 0.5)) / Math.max(1, apiNodes.length + existingNodes.length));
+      const baseRadius = 15 + importance * 50;
+      const jitter = 1.0 + Math.sin(offset * 7.31) * 0.4;
+      const radius = baseRadius * jitter;
+
+      const pos = new THREE.Vector3(
+        radius * Math.sin(phi) * Math.cos(theta),
+        radius * Math.sin(phi) * Math.sin(theta),
+        radius * Math.cos(phi),
+      );
+
+      const size = 0.3 + importance * 0.6;
+
+      // Star core sprite
+      const starTex = this.createStarTexture(color, 1.0);
+      const starMat = new THREE.SpriteMaterial({
+        map: starTex,
+        transparent: true,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      });
+      const mesh = new THREE.Sprite(starMat);
+      mesh.scale.set(warpIn ? 0 : size * 3, warpIn ? 0 : size * 3, 1);
+      mesh.position.copy(pos);
+
+      // Outer glow halo sprite
+      const glowTex = this.createStarTexture(color, 0.3);
+      const glowMat = new THREE.SpriteMaterial({
+        map: glowTex,
+        transparent: true,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      });
+      const glowMesh = new THREE.Sprite(glowMat);
+      glowMesh.scale.set(warpIn ? 0 : size * 8, warpIn ? 0 : size * 8, 1);
+      glowMesh.position.copy(pos);
+
+      // Node label sprite
+      const labelSprite = this.createNodeLabel(n.id, n.tier, importance, color);
+      labelSprite.position.copy(pos);
+      labelSprite.position.y += size * 3 + 0.8;
+
+      const explorerNode: ExplorerNode = {
+        id: n.id,
+        tier: n.tier,
+        text: n.textPreview || '',
+        importance: n.importance,
+        valence: n.valence ?? 0,
+        timestampMs: n.timestampMs ?? Date.now(),
+        position: pos,
+        velocity: new THREE.Vector3(
+          (Math.random() - 0.5) * 0.005,
+          (Math.random() - 0.5) * 0.005,
+          (Math.random() - 0.5) * 0.005,
+        ),
+        mesh,
+        glowMesh,
+        labelSprite,
+        selected: false,
+        baseSize: size,
+        visible: true,
+        targetOpacity: 1.0,
+      };
+      newNodes.push(explorerNode);
+    }
+    return newNodes;
+  }
+
+  addNodesAroundParent(apiNodes: GraphNode[], existingNodes: ExplorerNode[], parent: ExplorerNode): ExplorerNode[] {
+    const newNodes: ExplorerNode[] = [];
+    const nodeIdMap = new Map<string, ExplorerNode>();
+    for (const n of existingNodes) nodeIdMap.set(n.id, n);
+
+    const golden = (1 + Math.sqrt(5)) / 2;
+
+    for (let i = 0; i < apiNodes.length; i++) {
+      const n = apiNodes[i];
+      if (nodeIdMap.has(n.id)) continue;
+
+      const color = TIER_COLORS[n.tier] ?? 0x888888;
+      const importance = Math.max(0.1, Math.min(1.0, n.importance / 10));
+
+      // Radial burst around parent: golden spiral offset
+      const theta = (2 * Math.PI * i) / golden;
+      const phi = Math.acos(1 - (2 * (i + 0.5)) / Math.max(1, apiNodes.length));
+      const burstRadius = 8 + importance * 15;
+
+      const pos = new THREE.Vector3(
+        parent.position.x + burstRadius * Math.sin(phi) * Math.cos(theta),
+        parent.position.y + burstRadius * Math.sin(phi) * Math.sin(theta),
+        parent.position.z + burstRadius * Math.cos(phi),
+      );
+
+      const size = 0.3 + importance * 0.6;
+
+      // Star core sprite
+      const starTex = this.createStarTexture(color, 1.0);
+      const starMat = new THREE.SpriteMaterial({
+        map: starTex,
+        transparent: true,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      });
+      const mesh = new THREE.Sprite(starMat);
+      mesh.scale.set(0, 0, 1); // warp-in from zero
+      mesh.position.copy(pos);
+
+      // Outer glow halo
+      const glowTex = this.createStarTexture(color, 0.3);
+      const glowMat = new THREE.SpriteMaterial({
+        map: glowTex,
+        transparent: true,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      });
+      const glowMesh = new THREE.Sprite(glowMat);
+      glowMesh.scale.set(0, 0, 1);
+      glowMesh.position.copy(pos);
+
+      // Node label
+      const labelSprite = this.createNodeLabel(n.id, n.tier, importance, color);
+      labelSprite.position.copy(pos);
+      labelSprite.position.y += size * 3 + 0.8;
+
+      const explorerNode: ExplorerNode = {
+        id: n.id,
+        tier: n.tier,
+        text: n.textPreview || '',
+        importance: n.importance,
+        valence: n.valence ?? 0,
+        timestampMs: n.timestampMs ?? Date.now(),
+        position: pos,
+        velocity: new THREE.Vector3(
+          (Math.random() - 0.5) * 0.003,
+          (Math.random() - 0.5) * 0.003,
+          (Math.random() - 0.5) * 0.003,
+        ),
+        mesh,
+        glowMesh,
+        labelSprite,
+        selected: false,
+        baseSize: size,
+        visible: true,
+        targetOpacity: 1.0,
+      };
+      newNodes.push(explorerNode);
+    }
+    return newNodes;
+  }
+
+  addEdges(apiEdges: GraphEdge[], nodes: ExplorerNode[], existingEdges: ExplorerEdge[]): ExplorerEdge[] {
+    const newEdges: ExplorerEdge[] = [];
+    const nodeMap = new Map(nodes.map(n => [n.id, n]));
+
+    for (const e of apiEdges) {
+      const fromNode = nodeMap.get(e.fromId);
+      const toNode = nodeMap.get(e.toId);
+      if (!fromNode || !toNode) continue;
+
+      // Skip if already exists
+      if (existingEdges.some(ex => ex.from === e.fromId && ex.to === e.toId && ex.type === e.type)) continue;
+
+      const color = EDGE_TYPE_COLORS[e.type] ?? 0x888888;
+      const material =
+        e.type === 'TEMPORAL'
+          ? new THREE.LineDashedMaterial({
+              color,
+              transparent: true,
+              opacity: 0.35,
+              dashSize: 1,
+              gapSize: 0.5,
+            })
+          : new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.3 });
+
+      const geo = new THREE.BufferGeometry().setFromPoints([fromNode.position, toNode.position]);
+      const line = new THREE.Line(geo, material);
+      if (e.type === 'TEMPORAL') line.computeLineDistances();
+
+      let labelSprite: THREE.Sprite | undefined;
+      if (e.type === 'ENTITY' && e.relation) {
+        labelSprite = this.createEdgeLabel(e.relation, fromNode.position, toNode.position, color);
+      }
+
+      let weightSprite: THREE.Sprite | undefined;
+      if (e.type === 'HEBBIAN' && e.weight > 0.05) {
+        weightSprite = this.createWeightBadge(e.weight, fromNode.position, toNode.position);
+      }
+
+      newEdges.push({
+        from: e.fromId,
+        to: e.toId,
+        type: e.type,
+        weight: e.weight,
+        relation: e.relation,
+        line,
+        labelSprite,
+        weightSprite,
+      });
+    }
+
+    return newEdges;
+  }
+
+  animateNodes(nodes: ExplorerNode[], delta: number, time: number, showLabels: boolean, cameraPos: THREE.Vector3, recallMode: boolean, recallMatchedIds: Set<string>): void {
+    if (this.dustParticles) {
+      this.dustParticles.rotation.y += 0.001 * delta;
+    }
+
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      node.position.add(node.velocity);
+      node.mesh.position.copy(node.position);
+      node.glowMesh.position.copy(node.position);
+      if (node.position.length() > 120) node.velocity.multiplyScalar(-1);
+
+      // Ghost-fade animation: smoothly lerp opacity
+      const coreMat = node.mesh.material as THREE.SpriteMaterial;
+      const glowMat = node.glowMesh.material as THREE.SpriteMaterial;
+      const labelMat = node.labelSprite.material as THREE.SpriteMaterial;
+
+      const currentOpacity = coreMat.opacity;
+      const targetOpacity = node.targetOpacity;
+      const newOpacity = currentOpacity + (targetOpacity - currentOpacity) * Math.min(1, delta * 4);
+      coreMat.opacity = newOpacity;
+      glowMat.opacity = newOpacity * 0.5;
+      labelMat.opacity = node.visible ? 1.0 : 0.0;
+
+      // Star pulsing — recall mode matched nodes get sonar pulse
+      const isRecallMatched = recallMode && recallMatchedIds.has(node.id);
+      const pulseAmp = isRecallMatched ? 0.5 : 0.15;
+      const pulseSpeed = isRecallMatched ? 3.0 : 1.5;
+      const pulse = 1.0 + pulseAmp * Math.sin(time * pulseSpeed + i * 0.7);
+      const coreScale = node.baseSize * 3 * pulse * (node.visible ? 1.0 : 0.5);
+      node.mesh.scale.set(coreScale, coreScale, 1);
+      const glowMultiplier = isRecallMatched ? 12 : 8;
+      const glowScale = node.baseSize * glowMultiplier * pulse * (node.visible ? 1.0 : 0.3);
+      node.glowMesh.scale.set(glowScale, glowScale, 1);
+
+      // Warp-in: scale from 0 to target
+      if (coreScale > 0 && node.mesh.scale.x < node.baseSize * 2) {
+        const warpScale = Math.min(node.baseSize * 3, node.mesh.scale.x + delta * node.baseSize * 10);
+        node.mesh.scale.set(warpScale, warpScale, 1);
+        node.glowMesh.scale.set(warpScale * 2.5, warpScale * 2.5, 1);
+      }
+
+      // Label position
+      node.labelSprite.position.copy(node.position);
+      node.labelSprite.position.y += node.baseSize * 4 + 2.0;
+      node.labelSprite.visible = showLabels && node.visible;
+
+      if (showLabels && node.visible) {
+        const dist = cameraPos.distanceTo(node.labelSprite.position);
+        const s = dist * 0.06;
+        node.labelSprite.scale.set(s * 3.2, s, 1);
+      }
+    }
+  }
+
+  animateEdges(edges: ExplorerEdge[], nodes: ExplorerNode[], delta: number, showHebbian: boolean, showTemporal: boolean, showEntity: boolean, showLabels: boolean, orbitRadius: number, cameraPos: THREE.Vector3): void {
+    for (const edge of edges) {
+      const fromNode = nodes.find((n) => n.id === edge.from);
+      const toNode = nodes.find((n) => n.id === edge.to);
+      if (fromNode && toNode) {
+        const positions = edge.line.geometry.attributes['position'] as THREE.BufferAttribute;
+        positions.setXYZ(0, fromNode.position.x, fromNode.position.y, fromNode.position.z);
+        positions.setXYZ(1, toNode.position.x, toNode.position.y, toNode.position.z);
+        positions.needsUpdate = true;
+
+        if (edge.labelSprite) {
+          const mid = new THREE.Vector3()
+            .addVectors(fromNode.position, toNode.position)
+            .multiplyScalar(0.5);
+          mid.y += 0.4;
+          edge.labelSprite.position.copy(mid);
+          const dist = cameraPos.distanceTo(mid);
+          const s = dist * 0.035;
+          edge.labelSprite.scale.set(s * 2.5, s * 0.5, 1);
+        }
+        if (edge.weightSprite) {
+          const mid = new THREE.Vector3()
+            .addVectors(fromNode.position, toNode.position)
+            .multiplyScalar(0.5);
+          mid.y -= 1.2;
+          edge.weightSprite.position.copy(mid);
+          const dist = cameraPos.distanceTo(mid);
+          const s = dist * 0.04;
+          edge.weightSprite.scale.set(s * 2.5, s, 1);
+        }
+      }
+
+      // Layer visibility + filter: both endpoints must be visible
+      const bothVisible = fromNode?.visible && toNode?.visible;
+      const layerVisible =
+        (edge.type === 'HEBBIAN' && showHebbian) ||
+        (edge.type === 'TEMPORAL' && showTemporal) ||
+        (edge.type === 'ENTITY' && showEntity);
+      edge.line.visible = layerVisible && !!bothVisible;
+      if (edge.labelSprite) {
+        edge.labelSprite.visible = edge.line.visible && orbitRadius < 150;
+      }
+      if (edge.weightSprite) {
+        edge.weightSprite.visible = edge.line.visible && showLabels;
+      }
+    }
+  }
+
+  animateParticles(particles: FiringParticle[], edges: ExplorerEdge[], nodes: ExplorerNode[], delta: number, scene: THREE.Scene): FiringParticle[] {
+    for (const particle of particles) {
+      if (!particle.alive) continue;
+
+      particle.progress += particle.speed;
+      if (particle.progress >= 1) {
+        particle.alive = false;
+        scene.remove(particle.mesh);
+        particle.mesh.material.dispose();
+        scene.remove(particle.trailMesh);
+        particle.trailMesh.material.dispose();
+        continue;
+      }
+
+      const edge = edges[particle.edgeIndex];
+      if (!edge || !edge.line.visible) {
+        particle.alive = false;
+        scene.remove(particle.mesh);
+        particle.mesh.material.dispose();
+        scene.remove(particle.trailMesh);
+        particle.trailMesh.material.dispose();
+        continue;
+      }
+
+      const fromNode = nodes.find(n => n.id === edge.from);
+      const toNode = nodes.find(n => n.id === edge.to);
+      if (!fromNode || !toNode) continue;
+
+      const pos = new THREE.Vector3();
+      pos.lerpVectors(fromNode.position, toNode.position, particle.progress);
+      particle.mesh.position.copy(pos);
+
+      // Trail follows behind
+      const trailProgress = Math.max(0, particle.progress - 0.1);
+      particle.trailMesh.position.lerpVectors(fromNode.position, toNode.position, trailProgress);
+
+      // Fade in/out along path
+      const alpha = Math.sin(particle.progress * Math.PI);
+      (particle.mesh.material as THREE.SpriteMaterial).opacity = alpha * 0.95;
+      (particle.trailMesh.material as THREE.SpriteMaterial).opacity = alpha * 0.3;
+      particle.mesh.scale.setScalar(1.0 + alpha * 0.8);
+
+      // Pulse the source/destination nodes when particle arrives
+      if (particle.progress > 0.85) {
+        const glowMat = toNode.glowMesh.material as THREE.SpriteMaterial;
+        glowMat.opacity = Math.min(1, glowMat.opacity + delta * 2);
+        toNode.glowMesh.scale.setScalar(toNode.baseSize * 10);
+      }
+      if (particle.progress < 0.15) {
+        const glowMat = fromNode.glowMesh.material as THREE.SpriteMaterial;
+        glowMat.opacity = Math.min(1, glowMat.opacity + delta * 2);
+        fromNode.glowMesh.scale.setScalar(fromNode.baseSize * 10);
+      }
+    }
+
+    return particles.filter(p => p.alive);
+  }
+
+  spawnParticle(edges: ExplorerEdge[], particles: FiringParticle[], scene: THREE.Scene, particleTexture: THREE.CanvasTexture, trailTexture: THREE.CanvasTexture): FiringParticle | null {
+    if (edges.length === 0) return null;
+
+    // Pick a random visible edge
+    const visibleEdges = edges.filter(e => e.line.visible);
+    if (visibleEdges.length === 0) return null;
+    const edge = visibleEdges[Math.floor(Math.random() * visibleEdges.length)];
+    const edgeIndex = edges.indexOf(edge);
+    const color = EDGE_TYPE_COLORS[edge.type] ?? 0x00ffcc;
+
+    // Create colored particle texture
+    const particleMat = new THREE.SpriteMaterial({
+      map: particleTexture,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      color: new THREE.Color(color),
+    });
+    const mesh = new THREE.Sprite(particleMat);
+    mesh.scale.set(1.5, 1.5, 1);
+    scene.add(mesh);
+
+    // Trail
+    const trailMat = new THREE.SpriteMaterial({
+      map: trailTexture,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      color: new THREE.Color(color),
+    });
+    const trailMesh = new THREE.Sprite(trailMat);
+    trailMesh.scale.set(3, 3, 1);
+    scene.add(trailMesh);
+
+    return {
+      mesh,
+      trailMesh,
+      edgeIndex,
+      progress: 0,
+      speed: 0.015 + Math.random() * 0.025,
+      alive: true,
+      color,
+    };
+  }
+
+  dispose(scene: THREE.Scene, nodes: ExplorerNode[], edges: ExplorerEdge[], particles: FiringParticle[]): void {
+    // Dispose nodes
+    for (const node of nodes) {
+      scene.remove(node.mesh);
+      scene.remove(node.glowMesh);
+      scene.remove(node.labelSprite);
+      (node.mesh.material as THREE.SpriteMaterial).map?.dispose();
+      node.mesh.material.dispose();
+      (node.glowMesh.material as THREE.SpriteMaterial).map?.dispose();
+      node.glowMesh.material.dispose();
+      (node.labelSprite.material as THREE.SpriteMaterial).map?.dispose();
+      node.labelSprite.material.dispose();
+    }
+    // Dispose edges
+    for (const edge of edges) {
+      scene.remove(edge.line);
+      edge.line.geometry.dispose();
+      if (edge.labelSprite) {
+        scene.remove(edge.labelSprite);
+        (edge.labelSprite.material as THREE.SpriteMaterial).map?.dispose();
+        edge.labelSprite.material.dispose();
+      }
+      if (edge.weightSprite) {
+        scene.remove(edge.weightSprite);
+        (edge.weightSprite.material as THREE.SpriteMaterial).map?.dispose();
+        edge.weightSprite.material.dispose();
+      }
+    }
+    // Dispose particles
+    for (const p of particles) {
+      scene.remove(p.mesh);
+      p.mesh.material.dispose();
+      scene.remove(p.trailMesh);
+      p.trailMesh.material.dispose();
+    }
+    // Dispose internally created elements
+    if (this.gridGroup) {
+      scene.remove(this.gridGroup);
+      this.gridGroup.children.forEach(c => {
+        if (c instanceof THREE.Line) {
+          c.geometry.dispose();
+          if (Array.isArray(c.material)) c.material.forEach(m => m.dispose());
+          else c.material.dispose();
+        }
+      });
+      this.gridGroup = null;
+    }
+    if (this.dustParticles) {
+      scene.remove(this.dustParticles);
+      this.dustParticles.geometry.dispose();
+      if (Array.isArray(this.dustParticles.material)) this.dustParticles.material.forEach(m => m.dispose());
+      else this.dustParticles.material.dispose();
+      this.dustParticles = null;
+    }
+  }
+
+  // ── Helper Methods ────────────────────────────────────────
+
+  private createHexGrid(group: THREE.Group): void {
+    const gridMat = new THREE.LineBasicMaterial({
+      color: 0x00ffcc,
+      transparent: true,
+      opacity: 0.03,
+    });
+
+    // Equatorial and meridian circles with hex feel
+    for (let i = 0; i < 3; i++) {
+      const curve = new THREE.EllipseCurve(0, 0, 45, 45, 0, Math.PI * 2, false, 0);
+      const pts = curve.getPoints(6); // hexagonal shape
+      pts.push(pts[0].clone()); // close the hexagon
+      const geo = new THREE.BufferGeometry().setFromPoints(
+        pts.map((p) => {
+          if (i === 0) return new THREE.Vector3(p.x, 0, p.y);
+          if (i === 1) return new THREE.Vector3(p.x, p.y, 0);
+          return new THREE.Vector3(0, p.x, p.y);
+        }),
+      );
+      group.add(new THREE.Line(geo, gridMat));
+    }
+
+    // Concentric hex rings
+    for (const r of [15, 30, 60]) {
+      const curve = new THREE.EllipseCurve(0, 0, r, r, 0, Math.PI * 2, false, 0);
+      const pts = curve.getPoints(6);
+      pts.push(pts[0].clone());
+      const geo = new THREE.BufferGeometry().setFromPoints(
+        pts.map((p) => new THREE.Vector3(p.x, 0, p.y)),
+      );
+      group.add(
+        new THREE.Line(
+          geo,
+          new THREE.LineBasicMaterial({ color: 0x00ffcc, transparent: true, opacity: 0.02 }),
+        ),
+      );
+    }
+  }
+
+  private createDustField(scene: THREE.Scene): void {
+    const count = 800;
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+    const sizes = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+      const r = 50 + Math.random() * 120;
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.acos(2 * Math.random() - 1);
+      positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+      positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+      positions[i * 3 + 2] = r * Math.cos(phi);
+
+      // Cyan-teal palette
+      const brightness = 0.2 + Math.random() * 0.4;
+      colors[i * 3] = brightness * 0.3;
+      colors[i * 3 + 1] = brightness * 0.8;
+      colors[i * 3 + 2] = brightness * 1.0;
+
+      sizes[i] = 0.06 + Math.random() * 0.12;
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    geo.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+
+    const mat = new THREE.PointsMaterial({
+      size: 0.12,
+      vertexColors: true,
+      transparent: true,
+      opacity: 0.5,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+
+    this.dustParticles = new THREE.Points(geo, mat);
+    scene.add(this.dustParticles);
+  }
+
+  private createStarTexture(color: number, intensity: number): THREE.CanvasTexture {
+    const size = 128;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d')!;
+
+    const r = (color >> 16) & 0xff;
+    const g = (color >> 8) & 0xff;
+    const b = color & 0xff;
+
+    const cx = size / 2;
+    const cy = size / 2;
+    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, size / 2);
+
+    if (intensity > 0.6) {
+      grad.addColorStop(0.0, `rgba(255, 255, 255, ${intensity})`);
+      grad.addColorStop(0.15, `rgba(${r}, ${g}, ${b}, ${intensity * 0.9})`);
+      grad.addColorStop(0.4, `rgba(${r}, ${g}, ${b}, ${intensity * 0.4})`);
+      grad.addColorStop(1.0, `rgba(${r}, ${g}, ${b}, 0)`);
+    } else {
+      grad.addColorStop(0.0, `rgba(${r}, ${g}, ${b}, ${intensity})`);
+      grad.addColorStop(0.3, `rgba(${r}, ${g}, ${b}, ${intensity * 0.5})`);
+      grad.addColorStop(1.0, `rgba(${r}, ${g}, ${b}, 0)`);
+    }
+
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, size, size);
+
+    if (intensity > 0.6) {
+      ctx.globalCompositeOperation = 'lighter';
+      const spikeGrad = ctx.createRadialGradient(cx, cy, 0, cx, cy, size / 2);
+      spikeGrad.addColorStop(0.0, `rgba(255, 255, 255, 0.4)`);
+      spikeGrad.addColorStop(0.5, `rgba(${r}, ${g}, ${b}, 0.05)`);
+      spikeGrad.addColorStop(1.0, `rgba(${r}, ${g}, ${b}, 0)`);
+      ctx.fillStyle = spikeGrad;
+      ctx.fillRect(0, cy - 1, size, 2);
+      ctx.fillRect(cx - 1, 0, 2, size);
+    }
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.minFilter = THREE.LinearFilter;
+    return texture;
+  }
+
+  private createNodeLabel(
+    id: string,
+    tier: string,
+    importance: number,
+    color: number,
+  ): THREE.Sprite {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    canvas.width = 512;
+    canvas.height = 160;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const tierCode = tier.substring(0, 3).toUpperCase();
+    const impPct = Math.round(importance * 100);
+    const shortId = id.replace('mem-', '#');
+    const displayText = tierCode + ' ' + shortId;
+    const impText = '\u2b24 ' + impPct + '%';
+
+    const hexColor = '#' + color.toString(16).padStart(6, '0');
+
+    const textMetrics = (() => {
+      ctx.font = 'bold 26px Consolas, "Courier New", monospace';
+      return ctx.measureText(displayText);
+    })();
+    const pillW = Math.max(textMetrics.width + 32, 140);
+    const pillH = 42;
+    const pillX = (canvas.width - pillW) / 2;
+    const pillY = 24;
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    ctx.beginPath();
+    ctx.roundRect(pillX, pillY, pillW, pillH, 10);
+    ctx.fill();
+
+    ctx.globalAlpha = 0.9;
+    ctx.font = 'bold 26px Consolas, "Courier New", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = hexColor;
+    ctx.fillText(displayText, canvas.width / 2, pillY + pillH / 2);
+
+    ctx.globalAlpha = 0.5;
+    const barW = 80;
+    const barH = 4;
+    const barX = (canvas.width - barW) / 2;
+    const barY = pillY + pillH + 10;
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.12)';
+    ctx.beginPath();
+    ctx.roundRect(barX, barY, barW, barH, 2);
+    ctx.fill();
+    ctx.fillStyle = hexColor;
+    ctx.beginPath();
+    ctx.roundRect(barX, barY, barW * Math.min(1, importance), barH, 2);
+    ctx.fill();
+
+    ctx.globalAlpha = 0.7;
+    ctx.font = '600 18px Consolas, "Courier New", monospace';
+    ctx.fillStyle = '#bbc4dd';
+    ctx.fillText(impText, canvas.width / 2, barY + barH + 16);
+
+    ctx.globalAlpha = 1.0;
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.minFilter = THREE.LinearFilter;
+    const material = new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthTest: false,
+    });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(8, 2.5, 1);
+    return sprite;
+  }
+
+  private createEdgeLabel(
+    text: string,
+    from: THREE.Vector3,
+    to: THREE.Vector3,
+    color: number,
+  ): THREE.Sprite {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    canvas.width = 256;
+    canvas.height = 40;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const hexColor = '#' + color.toString(16).padStart(6, '0');
+    ctx.font = '600 16px Consolas, "Courier New", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.globalAlpha = 0.85;
+    ctx.fillStyle = hexColor;
+    ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.minFilter = THREE.LinearFilter;
+    const material = new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthTest: false,
+    });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(4, 0.7, 1);
+    return sprite;
+  }
+
+  private createWeightBadge(weight: number, from: THREE.Vector3, to: THREE.Vector3): THREE.Sprite {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    canvas.width = 192;
+    canvas.height = 80;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+    ctx.beginPath();
+    ctx.roundRect(40, 16, 112, 48, 10);
+    ctx.fill();
+
+    ctx.font = 'bold 28px Consolas, "Courier New", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
+    ctx.fillText(weight.toFixed(2), canvas.width / 2, canvas.height / 2);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.minFilter = THREE.LinearFilter;
+    const material = new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthTest: false,
+    });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(4, 1.6, 1);
+    return sprite;
+  }
+}
+

--- a/cortex/spector-cortex/src/app/features/graph-explorer/strategies/view-strategy.interface.ts
+++ b/cortex/spector-cortex/src/app/features/graph-explorer/strategies/view-strategy.interface.ts
@@ -1,0 +1,68 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Spector Cortex — Graph View Strategy Interface
+// Copyright (c) 2025–2026 Spectrayan. Licensed under BSL 1.1.
+// ═══════════════════════════════════════════════════════════════════════
+
+import * as THREE from 'three';
+import { GraphNode, GraphEdge } from '../../../core/services/memory-table.service';
+
+export interface ExplorerNode {
+  id: string;
+  tier: string;
+  text: string;
+  importance: number;
+  valence: number;
+  timestampMs: number;
+  position: THREE.Vector3;
+  velocity: THREE.Vector3;
+  mesh: THREE.Sprite;
+  glowMesh: THREE.Sprite;
+  labelSprite: THREE.Sprite;
+  selected: boolean;
+  baseSize: number;
+  visible: boolean;
+  targetOpacity: number;
+}
+
+export interface ExplorerEdge {
+  from: string;
+  to: string;
+  type: string;
+  weight: number;
+  relation: string | null;
+  line: THREE.Line;
+  labelSprite?: THREE.Sprite;
+  weightSprite?: THREE.Sprite;
+}
+
+export interface FiringParticle {
+  mesh: THREE.Sprite;
+  trailMesh: THREE.Sprite;
+  edgeIndex: number;
+  progress: number;
+  speed: number;
+  alive: boolean;
+  color: number;
+}
+
+export interface GraphViewStrategy {
+  readonly name: 'constellation' | 'cortex';
+  
+  initScene(container: HTMLElement, camera: THREE.PerspectiveCamera): THREE.Scene;
+  
+  addNodes(apiNodes: GraphNode[], existingNodes: ExplorerNode[], warpIn: boolean): ExplorerNode[];
+  
+  addNodesAroundParent(apiNodes: GraphNode[], existingNodes: ExplorerNode[], parent: ExplorerNode): ExplorerNode[];
+  
+  addEdges(apiEdges: GraphEdge[], nodes: ExplorerNode[], existingEdges: ExplorerEdge[]): ExplorerEdge[];
+  
+  animateNodes(nodes: ExplorerNode[], delta: number, time: number, showLabels: boolean, cameraPos: THREE.Vector3, recallMode: boolean, recallMatchedIds: Set<string>): void;
+  
+  animateEdges(edges: ExplorerEdge[], nodes: ExplorerNode[], delta: number, showHebbian: boolean, showTemporal: boolean, showEntity: boolean, showLabels: boolean, orbitRadius: number, cameraPos: THREE.Vector3): void;
+  
+  animateParticles(particles: FiringParticle[], edges: ExplorerEdge[], nodes: ExplorerNode[], delta: number, scene: THREE.Scene): FiringParticle[];
+  
+  spawnParticle(edges: ExplorerEdge[], particles: FiringParticle[], scene: THREE.Scene, particleTexture: THREE.CanvasTexture, trailTexture: THREE.CanvasTexture): FiringParticle | null;
+  
+  dispose(scene: THREE.Scene, nodes: ExplorerNode[], edges: ExplorerEdge[], particles: FiringParticle[]): void;
+}

--- a/cortex/spector-cortex/src/environments/environment.ts
+++ b/cortex/spector-cortex/src/environments/environment.ts
@@ -6,13 +6,13 @@ export const environment = {
   production: false,
 
   /** Backend API base URL */
-  apiUrl: 'http://192.168.1.71:7070/api/v1',
+  apiUrl: 'http://localhost:7070/api/v1',
 
   /** API version prefix */
   apiVersion: 'v1',
 
   /** SSE event stream connects directly to backend (dev proxy buffers SSE) */
-  sseBaseUrl: 'http://192.168.1.71:7070/api/v1',
+  sseBaseUrl: 'http://localhost:7070/api/v1',
 
   /** Logging configuration */
   logging: {

--- a/cortex/spector-cortex/src/environments/environment.ts
+++ b/cortex/spector-cortex/src/environments/environment.ts
@@ -6,13 +6,13 @@ export const environment = {
   production: false,
 
   /** Backend API base URL */
-  apiUrl: 'http://localhost:7070/api/v1',
+  apiUrl: 'http://192.168.1.71:7070/api/v1',
 
   /** API version prefix */
   apiVersion: 'v1',
 
   /** SSE event stream connects directly to backend (dev proxy buffers SSE) */
-  sseBaseUrl: 'http://localhost:7070/api/v1',
+  sseBaseUrl: 'http://192.168.1.71:7070/api/v1',
 
   /** Logging configuration */
   logging: {


### PR DESCRIPTION
## Summary
This PR merges the initial UI work for Issue #489 (Brain Explorer View) into main, refactoring cortex-ui's Graph Explorer to use a clean GraphViewStrategy pattern (GalaxyViewStrategy & BrainViewStrategy).

Per product owner direction:
- The Brain View (Cortex View) implementation is parked for future development.
- The view mode toggle has been disabled in graph-explorer.component.html and graph-explorer.component.ts.
- The explorer is locked strictly to Constellation (Galaxy) View.

## Changes Included
- Refactored GraphExplorerComponent to adopt GraphViewStrategy design pattern.
- Extracted procedural brain geometry, neuron mesh factories, and region metadata into modular strategies.
- Added GalaxyViewStrategy for 3D constellation rendering with force layout and particle bursts.
- Disabled view toggle button ([disabled]="true") with tooltip indicating Cortex View is coming soon.

## Related Issue
Refs #489
