### PR TITLE
fix(memory): make graphSlot authoritative in ingestion and recall paths (#497)

### DIFF
--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/BenchmarkSetup.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/BenchmarkSetup.java
@@ -187,7 +187,7 @@ public final class BenchmarkSetup implements AutoCloseable {
                 .proceduralCapacity(Math.max(50, corpusSize / 5))
                 .hebbianGraphCapacity(corpusSize + 100)
                 .temporalChainCapacity(corpusSize + 100)
-                .entityGraphCapacity(Math.max(200, corpusSize))
+                .entityGraphCapacity(Math.max(200, corpusSize * 5))
                 .entityExtractionMode(EntityExtractionMode.CUSTOM)
                 .entityExtractor(customExtractor);
 
@@ -324,7 +324,7 @@ public final class BenchmarkSetup implements AutoCloseable {
                 log.warn("TemporalChain is null  --  skipping {} chain definitions", dataset.temporalChains().size());
             }
             if (memory.admin().entityDirectory() != null && hyper != null) {
-                loadEntityGraph(memory.admin().entityDirectory(), hyper, dataset.entityRelations(), corpus);
+                loadEntityGraph(memory.admin().entityDirectory(), hyper, dataset.entityRelations(), idToSlot);
             } else {
                 log.warn("EntityGraph is null  --  skipping {} entity relation definitions", dataset.entityRelations().size());
             }
@@ -349,12 +349,7 @@ public final class BenchmarkSetup implements AutoCloseable {
     }
 
     private static int offsetToRecordIndex(com.spectrayan.spector.memory.index.MemoryIndex.MemoryLocation loc, SpectorMemory memory) {
-        var router = memory.admin().cognitiveRouter();
-        int stride = router.layoutFor(loc.type()).stride();
-        var store = router.get(loc.type());
-        long dataOffset = (store != null && store.isPersistent())
-                ? com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
-        return (int) ((loc.offset() - dataOffset) / stride);
+        return loc.graphSlot();
     }
 
     /**
@@ -450,13 +445,7 @@ public final class BenchmarkSetup implements AutoCloseable {
      * @param corpus    the corpus records (used for entity mention  ->  memory linking)
      */
     void loadEntityGraph(EntityDirectory dir, HyperEntityGraphMemory hyper, List<EntityRelation> relations,
-                         List<BenchmarkCorpusRecord> corpus) {
-        // Build a lookup from memory ID to corpus index
-        Map<String, Integer> idToIndex = new HashMap<>(corpus.size());
-        for (int i = 0; i < corpus.size(); i++) {
-            idToIndex.put(corpus.get(i).id(), i);
-        }
-
+                         Map<String, Integer> idToSlot) {
         int relationsLoaded = 0;
 
         for (EntityRelation relation : relations) {
@@ -474,7 +463,7 @@ public final class BenchmarkSetup implements AutoCloseable {
 
             // Link entities to their source memories
             for (String memoryId : relation.sourceMemoryIds()) {
-                Integer memIdx = idToIndex.get(memoryId);
+                Integer memIdx = idToSlot.get(memoryId);
                 if (memIdx != null) {
                     dir.linkEntityToMemory(fromEntityId, memIdx);
                     dir.linkEntityToMemory(toEntityId, memIdx);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordCodec.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordCodec.java
@@ -44,6 +44,6 @@ public final class IndexRecordCodec implements Codec<IndexEntryLayout> {
 
     @Override
     public List<CodecStep> steps() {
-        return List.of(new MidxToSmkmStep());
+        return List.of(new MidxToSmkmStep(), new MidxV6ToV7Step());
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -57,6 +57,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     private static final int LEGACY_INDEX_MAGIC = 0x4D494458;
 
     /** Standard SMKM schema versions. v6 adds the persisted colocatedPartition (#443). */
+    static final int INDEX_VERSION_V7 = 7;
     private static final int INDEX_VERSION_V6 = 6;
     private static final int INDEX_VERSION_V5 = 5;
 
@@ -98,6 +99,27 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
     // ── Insertion-order tracking ──
     private final java.util.concurrent.locks.ReentrantLock orderedIdsLock = new java.util.concurrent.locks.ReentrantLock();
     private final java.util.LinkedHashSet<String> orderedIds = new java.util.LinkedHashSet<>();
+
+    /** Monotonic graph-slot allocator. Never decreases, never reuses slots. */
+    private final java.util.concurrent.atomic.AtomicInteger graphSlotHighWater =
+            new java.util.concurrent.atomic.AtomicInteger(0);
+
+    // ── Graph-slot bimap (O(1) both directions) ──────────────────────────────
+    /** Positional slot→id mapping. Null entries are tombstones (forgotten memories). */
+    private volatile String[] slotToId = new String[256];
+    /** Reverse id→slot mapping. */
+    private final java.util.concurrent.ConcurrentHashMap<String, Integer> idToSlot =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
+    /** Grows the slotToId array if needed. Must be called under orderedIdsLock. */
+    private void ensureSlotCapacity(int minCapacity) {
+        String[] arr = slotToId;
+        if (minCapacity > arr.length) {
+            int newCap = Math.max(minCapacity, arr.length * 2);
+            String[] grown = java.util.Arrays.copyOf(arr, newCap);
+            slotToId = grown; // volatile write
+        }
+    }
 
     /**
      * Tracks where a memory is physically stored.
@@ -197,9 +219,17 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
 
         reverseIndex.put(reverseKey(location.colocatedPartition(), location.type(), location.offset()), id);
 
+        // Register in graph-slot bimap (skip if graphSlot < 0 — legacy/non-graph entries)
+        int slot = location.graphSlot();
         orderedIdsLock.lock();
         try {
             orderedIds.add(id);
+            if (slot >= 0) {
+                // Bimap: slot → id, id → slot
+                ensureSlotCapacity(slot + 1);
+                slotToId[slot] = id;
+                idToSlot.put(id, slot);
+            }
         } finally {
             orderedIdsLock.unlock();
         }
@@ -219,6 +249,11 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         orderedIdsLock.lock();
         try {
             orderedIds.remove(id);
+            // Tombstone bimap — do NOT shift remaining entries
+            Integer slot = idToSlot.remove(id);
+            if (slot != null && slot < slotToId.length) {
+                slotToId[slot] = null;
+            }
         } finally {
             orderedIdsLock.unlock();
         }
@@ -417,15 +452,78 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                                         java.util.Map<String, Integer> idToSlot) {
         orderedIdsLock.lock();
         try {
-            int i = 0;
-            for (String id : orderedIds) {
-                slotToId.put(i, id);
-                idToSlot.put(id, i);
-                i++;
+            int maxSlot = -1;
+            for (var entry : locations.entrySet()) {
+                String id = entry.getKey();
+                MemoryLocation loc = entry.getValue();
+                int slot = loc.graphSlot();
+                if (slot >= 0) {
+                    slotToId.put(slot, id);
+                    idToSlot.put(id, slot);
+                    if (slot > maxSlot) maxSlot = slot;
+                }
             }
+            // Also rebuild internal bimap
+            int requiredCapacity = maxSlot + 2;
+            ensureSlotCapacity(requiredCapacity);
+            String[] arr = this.slotToId;
+            java.util.Arrays.fill(arr, null);
+            this.idToSlot.clear();
+            for (var entry : slotToId.entrySet()) {
+                int s = entry.getKey();
+                String memId = entry.getValue();
+                arr[s] = memId;
+                this.idToSlot.put(memId, s);
+            }
+            this.slotToId = arr; // volatile write
+            // Restore high-water mark defensively: max(persisted, maxSlotSeen + 1)
+            int restoredHw = maxSlot + 1;
+            graphSlotHighWater.set(Math.max(graphSlotHighWater.get(), restoredHw));
         } finally {
             orderedIdsLock.unlock();
         }
+    }
+
+    /**
+     * Allocates a new monotonic graph slot. Thread-safe, never reuses slots.
+     * @return the next available graph slot index
+     */
+    public int allocateGraphSlot() {
+        return graphSlotHighWater.getAndIncrement();
+    }
+
+    /**
+     * Returns the memory ID at the given graph slot, or {@code null} if the slot
+     * is tombstoned, out of range, or was never allocated.
+     */
+    public String idAt(int slot) {
+        String[] arr = slotToId; // volatile read
+        if (slot < 0 || slot >= arr.length) return null;
+        return arr[slot];
+    }
+
+    /**
+     * Returns the graph slot for the given memory ID, or {@code null} if unknown.
+     */
+    public Integer slotOf(String id) {
+        return idToSlot.get(id);
+    }
+
+    /**
+     * Returns the current high-water mark for graph slot allocation.
+     */
+    public int graphSlotHighWater() {
+        return graphSlotHighWater.get();
+    }
+
+    /**
+     * Restores the high-water mark from a persisted or computed value.
+     * Used during index load to set the initial allocation counter.
+     *
+     * @param highWater the value to restore (must be ≥ 0)
+     */
+    public void restoreGraphSlotHighWater(int highWater) {
+        graphSlotHighWater.set(Math.max(0, highWater));
     }
 
     // NOTE (issue #443): this remains keyed on graphSlot (the former misnamed field), not
@@ -522,7 +620,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         final int slotStride;
         final boolean readColocated;
         switch (schemaVersion) {
-            case INDEX_VERSION_V6 -> {
+            case INDEX_VERSION_V7, INDEX_VERSION_V6 -> {
                 slotStride = 48;
                 readColocated = true;
             }
@@ -564,6 +662,16 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         if (readColocated) {
             markColocatedPartitionPersisted();
         }
+        
+        // Restore graphSlotHighWater from reserved field (offset 60)
+        long headerBaseOffset = 0L;
+        int persistedHw = bundleMidxSlice.get(java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED, headerBaseOffset + 60);
+        int computedMaxSlot = -1;
+        for (MemoryLocation loc : locations.values()) {
+            if (loc.graphSlot() > computedMaxSlot) computedMaxSlot = loc.graphSlot();
+        }
+        graphSlotHighWater.set(Math.max(persistedHw, computedMaxSlot + 1));
+
         log.info("MemoryIndex loaded from bundle (v{}): {} entries", schemaVersion, size());
     }
 
@@ -596,8 +704,12 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                 long totalSlotBytes = (long) entryCount * stride;
 
                 long now = System.currentTimeMillis();
-                MemoryHeader.write(bundleMidxSlice, 0L, INDEX_VERSION_V6, MemoryShape.RECORD, entryCount,
+                MemoryHeader.write(bundleMidxSlice, 0L, INDEX_VERSION_V7, MemoryShape.RECORD, entryCount,
                         (int) (MemoryHeader.HEADER_BYTES + totalSlotBytes), 0, 0, new IndexEntryLayout().layoutId(), now, now);
+                // Persist graphSlotHighWater in the reserved field (offset 60, outside CRC range)
+                long headerBaseOffset = 0L;
+                bundleMidxSlice.set(java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED, headerBaseOffset + 60, graphSlotHighWater.get());
+
                 MemoryHeader.write(bundleIdplSlice, 0L, 1, MemoryShape.APPEND, entryCount,
                         (int) (MemoryHeader.HEADER_BYTES + totalPoolBytes), 0, 0, new IdBlobLayout().layoutId(), now, now);
 
@@ -696,6 +808,13 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                 try (DefaultRecordMemory<IndexEntryLayout> slotMemory = new DefaultRecordMemory<>(
                         slotId, slotLayout, entryCount, MemoryHeader.HEADER_BYTES + totalSlotBytes, filePath)) {
                     
+                    long headerBaseOffset = 0L;
+                    // Persist graphSlotHighWater in the reserved field (offset 60, outside CRC range)
+                    slotMemory.segment().set(java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED, headerBaseOffset + 60, graphSlotHighWater.get());
+                    // Since DefaultRecordMemory uses INDEX_VERSION_V6 by default (if it uses that), we should manually bump to V7
+                    slotMemory.segment().set(java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED, headerBaseOffset + 8, INDEX_VERSION_V7);
+
+                    
                     int index = 0;
                     for (int i = 0; i < orderedKeys.size(); i++) {
                         String id = orderedKeys.get(i);
@@ -788,7 +907,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                     final int slotStride;
                     final boolean readColocated;
                     switch (schemaVersion) {
-                        case INDEX_VERSION_V6 -> {
+                        case INDEX_VERSION_V7, INDEX_VERSION_V6 -> {
                             slotStride = 48;      // v6 slot: 48 bytes incl. colocatedPartition + reserved
                             readColocated = true;
                         }
@@ -800,7 +919,7 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                         }
                         default -> throw new SpectorStorageException(ErrorCode.FILE_FORMAT_INVALID,
                                 "MemoryIndex unsupported schema version v" + schemaVersion
-                                        + (schemaVersion > INDEX_VERSION_V6 ? " (newer than supported v6)" : "")
+                                        + (schemaVersion > INDEX_VERSION_V7 ? " (newer than supported v7)" : "")
                                         + ": " + filePath);
                     }
 
@@ -842,6 +961,16 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
                     if (readColocated) {
                         index.markColocatedPartitionPersisted();
                     }
+                    
+                    // Restore graphSlotHighWater from reserved field (offset 60)
+                    long headerBaseOffset = 0L;
+                    int persistedHw = slotMemory.segment().get(java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED, headerBaseOffset + 60);
+                    int computedMaxSlot = -1;
+                    for (MemoryLocation loc : index.locationMap().values()) {
+                        if (loc.graphSlot() > computedMaxSlot) computedMaxSlot = loc.graphSlot();
+                    }
+                    index.restoreGraphSlotHighWater(Math.max(persistedHw, computedMaxSlot + 1));
+
                     log.info("MemoryIndex loaded (SMKM v{}): {} entries from {}",
                             schemaVersion, index.size(), filePath.getFileName());
                 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MidxV6ToV7Step.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/MidxV6ToV7Step.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.index;
+
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.codec.FormatId;
+import com.spectrayan.spector.memory.kernel.codec.InPlaceHeaderStep;
+import com.spectrayan.spector.memory.kernel.codec.MigrationContext;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Migration step for MIDX v6 → v7 (SMKM container, header-only upgrade).
+ *
+ * <p>V7 stores the monotonic {@code graphSlotHighWater} in the previously-reserved
+ * 4 bytes at header offset 60. The slot stride and record layout are unchanged
+ * (48 bytes). On upgrade, the high-water mark is computed from the existing
+ * entry count and written into the reserved field.</p>
+ *
+ * <p><b>Graph cold-start:</b> Existing Hebbian, Temporal Chain, Entity Directory,
+ * and Hypergraph edge sets were indexed using the old broken slot IDs. After this
+ * migration, those edges reference invalidated coordinates. The caller (typically
+ * {@code CognitiveGraphBuilder}) must detect the v6→v7 migration and clear/rebuild
+ * the graph structures. This step emits a {@code WARN} log to signal the condition.</p>
+ *
+ * @see IndexRecordMemory
+ * @see IndexEntryLayout
+ */
+public final class MidxV6ToV7Step extends InPlaceHeaderStep {
+
+    private static final Logger log = LoggerFactory.getLogger(MidxV6ToV7Step.class);
+
+    static final FormatId FROM = FormatId.smkm(6);
+    static final FormatId TO = FormatId.smkm(7);
+
+    @Override
+    public FormatId from() {
+        return FROM;
+    }
+
+    @Override
+    public FormatId to() {
+        return TO;
+    }
+
+    @Override
+    protected void rewriteHeader(MemorySegment mapped, MigrationContext ctx) {
+        // Read existing entry count to compute initial high-water mark
+        long entryCount = MemoryHeader.readCount(mapped, 0L);
+        int highWater = (int) Math.max(0, entryCount);
+
+        // Bump schema version from 6 → 7
+        mapped.set(ValueLayout.JAVA_INT_UNALIGNED, 4L, 7); // OFFSET_SCHEMA_VERSION = 4
+
+        // Write graphSlotHighWater into the reserved field (offset 60, outside CRC range)
+        mapped.set(ValueLayout.JAVA_INT_UNALIGNED, 60L, highWater);
+
+        // Recompute header CRC (covers bytes [0..55])
+        MemoryHeader.writeCount(mapped, 0L, entryCount); // re-stamps CRC
+
+        log.warn("MIDX v6→v7: graph slot high-water mark set to {} from {} entries. "
+                + "Graph state (Hebbian, Temporal, Entity, Hypergraph) must be rebuilt — "
+                + "co-activation history from prior indexing is lost. (#497)",
+                highWater, entryCount);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IndexEntryLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/IndexEntryLayout.java
@@ -41,7 +41,7 @@ public final class IndexEntryLayout implements MemoryLayout {
 
     private static final int STRIDE = 48;
     private static final int LAYOUT_ID = 0x4D494458; // 'MIDX'
-    private static final int VERSION = 6;
+    private static final int VERSION = 7;
 
     @Override
     public int layoutId() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -451,10 +451,12 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         // Steps 7b-9a: Index synchronization (HNSW, ID index, WAL, BM25, SPLADE)
         var syncParams = new PostIngestSync.SyncParams(
                 id, text, vector, quantized, type, tags, source, offset);
-        int storeIndex = postIngestSync.syncIndexes(syncParams);
+        int graphSlot = postIngestSync.syncIndexes(syncParams);
 
         // Steps 9b + 9c: Hebbian + Temporal linking (co-ingestion within session)
-        int memoryIdx = index.size() - 1;
+        // #497: use the monotonic graphSlot allocated during syncIndexes, not
+        // index.size()-1 which is non-monotonic (shrinks on forget, causing reuse).
+        int memoryIdx = graphSlot;
         String tsid = com.spectrayan.spector.commons.concurrent.MemoryScope.sessionId();
         int sessionIntId = sessionRegistry != null ? sessionRegistry.resolve(tsid) : 0;
         int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);
@@ -463,8 +465,8 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         // Step 9d: Entity extraction and graph population
         postIngestSync.syncEntityExtraction(id, text, memoryIdx);
 
-        log.debug("Ingested '{}' as {} (importance={}, {} tags, hnswIdx={}, source={})",
-                id, type, importance, tags.length, storeIndex, source);
+        log.debug("Ingested '{}' as {} (importance={}, {} tags, graphSlot={}, source={})",
+                id, type, importance, tags.length, graphSlot, source);
     }
 
     // ===============================================================
@@ -676,10 +678,12 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         java.util.Map<String, String> metadata = context.hasMetadata() ? context.metadata() : null;
         var syncParams = new PostIngestSync.SyncParams(
                 id, text, vector, quantized, type, tags, source, offset, metadata);
-        int storeIndex = postIngestSync.syncIndexes(syncParams);
+        int graphSlot = postIngestSync.syncIndexes(syncParams);
 
         // Steps 9b + 9c: Hebbian + Temporal linking (co-ingestion within session)
-        int memoryIdx = index.size() - 1;
+        // #497: use the monotonic graphSlot allocated during syncIndexes, not
+        // index.size()-1 which is non-monotonic (shrinks on forget, causing reuse).
+        int memoryIdx = graphSlot;
         String tsid = com.spectrayan.spector.commons.concurrent.MemoryScope.sessionId();
         int sessionIntId = sessionRegistry != null ? sessionRegistry.resolve(tsid) : 0;
         int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -236,11 +236,12 @@ final class GraphExpansionStage {
                 MemoryIndex.MemoryLocation loc = index.locate(seed.id());
                 if (loc == null) continue;
 
-                int memIdx = offsetToRecordIndex(loc);
+                int memIdx = loc.graphSlot();
                 var activated = hebbianGraph.activateNeighbors(memIdx, graphScoringPolicy.hebbianMaxDepth());
                 for (var edge : activated) {
-                    String neighborId = findMemoryByApproximateIndex(edge.neighborIndex());
-                    if (neighborId != null && !existingIds.contains(neighborId) && matchesFilters(neighborId, options)) {
+                    String neighborId = ((com.spectrayan.spector.memory.index.IndexRecordMemory) index).idAt(edge.neighborIndex());
+                    if (neighborId == null) continue;
+                    if (!existingIds.contains(neighborId) && matchesFilters(neighborId, options)) {
                         float neighborSim = computeNeighborSimilarity(neighborId, queryVector);
                         float saturatedWeight = Math.min(edge.weight() / 5.0f, 1.0f);
                         float graphScore = neighborSim
@@ -274,7 +275,7 @@ final class GraphExpansionStage {
                 MemoryIndex.MemoryLocation loc = index.locate(seed.id());
                 if (loc == null) continue;
 
-                int memIdx = offsetToRecordIndex(loc);
+                int memIdx = loc.graphSlot();
                 for (int chainIdx : temporalChain.followForward(memIdx, graphScoringPolicy.temporalMaxHops())) {
                     addChainResultCoFusion(chainIdx, seed, existingIds, graphCandidates,
                             queryVector, graphScoringPolicy.temporalForwardFactor(), options);
@@ -329,8 +330,9 @@ final class GraphExpansionStage {
                 Set<Integer> reachableMemories =
                         hyperEntityGraph.collectMemories(entityId, graphScoringPolicy.entityMaxHops());
                 for (int memIdx : reachableMemories) {
-                    String memId = findMemoryByApproximateIndex(memIdx);
-                    if (memId != null && !existingIds.contains(memId) && matchesFilters(memId, options)) {
+                    String memId = ((com.spectrayan.spector.memory.index.IndexRecordMemory) index).idAt(memIdx);
+                    if (memId == null) continue;
+                    if (!existingIds.contains(memId) && matchesFilters(memId, options)) {
                         float neighborSim = computeNeighborSimilarity(memId, queryVector);
                         float fanAttenuation = entityDirectory.fanFactor(entityId);
                         float entityScore = neighborSim
@@ -358,8 +360,9 @@ final class GraphExpansionStage {
                                          Set<String> existingIds,
                                          Map<String, CognitiveResult> graphCandidates,
                                          float[] queryVector, float attenuation, RecallOptions options) {
-        String chainId = findMemoryByApproximateIndex(chainIdx);
-        if (chainId != null && !existingIds.contains(chainId) && matchesFilters(chainId, options)) {
+        String chainId = ((com.spectrayan.spector.memory.index.IndexRecordMemory) index).idAt(chainIdx);
+        if (chainId == null) return;
+        if (!existingIds.contains(chainId) && matchesFilters(chainId, options)) {
             float neighborSim = computeNeighborSimilarity(chainId, queryVector);
             float chainScore = neighborSim + seed.score() * attenuation * 0.2f;
 
@@ -415,38 +418,7 @@ final class GraphExpansionStage {
                 modality, metadata);
     }
 
-    /**
-     * Converts a MemoryLocation's byte offset to a record index.
-     */
-    int offsetToRecordIndex(MemoryIndex.MemoryLocation loc) {
-        CognitiveMemoryRouter router = activeRouter();
-        int stride = router.layoutFor(loc.type()).stride();
-        com.spectrayan.spector.memory.cortex.CognitiveRecordMemory store = router.get(loc.type());
-        long dataOffset = (store != null && store.isPersistent())
-                ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
-        return (int) ((loc.offset() - dataOffset) / stride);
-    }
 
-    /**
-     * Finds a memory ID by approximate index across all tiers.
-     */
-    String findMemoryByApproximateIndex(int approxIdx) {
-        CognitiveMemoryRouter router = activeRouter();
-        if (router == null) return null;
-        for (MemoryType type : MemoryType.values()) {
-            var layout = router.layoutFor(type);
-            if (layout == null) continue;
-            com.spectrayan.spector.memory.cortex.CognitiveRecordMemory store = router.get(type);
-            long dataOffset = AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES;
-            long baseOffset = (store != null && store.isPersistent()) ? dataOffset : 0;
-            long offset = baseOffset + (long) approxIdx * layout.stride();
-            // Legacy overload resolves against the active partition seq (graph expansion
-            // is active-partition-focused for #443).
-            String id = index.findIdByOffset(type, offset);
-            if (id != null) return id;
-        }
-        return null;
-    }
 
     /**
      * Computes actual cosine-derived similarity for a graph-expanded neighbor.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -158,12 +158,16 @@ final class PostIngestSync {
      * can be captured and stored in MemoryLocation for off-heap random access.</p>
      *
      * @param params sync parameters
-     * @return the HNSW store index (-1 if not indexed)
+     * @return the monotonic global graph slot assigned to this memory
      */
     int syncIndexes(SyncParams params) {
         boolean isParentChunk = params.metadata() != null && "parent".equals(params.metadata().get("chunk_role"));
 
         int storeIndex = -1;
+        // #497: allocate a monotonic global graph slot BEFORE the try block so it's
+        // in scope for the return. The slot is the sole authoritative node ID used by
+        // Hebbian, Temporal, Entity, and Hypergraphs. Never reused.
+        int graphSlot = index.allocateGraphSlot();
         try {
             // Step 7b: Add to HNSW index (SEMANTIC only)
             if (params.type() == MemoryType.SEMANTIC && semanticIndex != null
@@ -180,9 +184,8 @@ final class PostIngestSync {
             long textOffset = (textPos != null) ? textPos.textOffset() : -1L;
             int textLength = (textPos != null) ? textPos.textLength() : -1;
             // #443: stamp the colocated partition (activePartitionSeq) so recall, text
-            // resolution and direct-resolve can locate this record's partition. storeIndex
-            // remains the semantic/graph node slot (graphSlot — behaviour unchanged).
-            var location = new MemoryLocation(params.type(), params.offset(), storeIndex,
+            // resolution and direct-resolve can locate this record's partition.
+            var location = new MemoryLocation(params.type(), params.offset(), graphSlot,
                     activePartitionSeq, textOffset, textLength);
 
             if (params.metadata() != null) {
@@ -209,7 +212,7 @@ final class PostIngestSync {
                     "Post-write sync failed: " + e.getMessage());
         }
 
-        return storeIndex;
+        return graphSlot;
     }
 
     private void compensateTombstone(String id) {

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexV6FormatTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/index/MemoryIndexV6FormatTest.java
@@ -141,19 +141,19 @@ class MemoryIndexV6FormatTest {
     // ── 3. throw-on-unreadable: newer version + truncation ────────
 
     @Test
-    @DisplayName("newer-than-v6 schema throws SpectorStorageException")
+    @DisplayName("newer-than-v7 schema throws SpectorStorageException")
     void newerSchemaVersionThrows() throws Exception {
         Path midx = dir.resolve("future.midx");
         byte[] file = new byte[HEADER]; // header only, count=0
         MemorySegment seg = MemorySegment.ofArray(file);
-        MemoryHeader.write(seg, 0, /*schemaVersion*/ 7, MemoryShape.RECORD, 0x01,
+        MemoryHeader.write(seg, 0, /*schemaVersion*/ 8, MemoryShape.RECORD, 0x01,
                 /*capacity*/ 0, /*count*/ 0, V6_STRIDE, LAYOUT_ID,
                 System.currentTimeMillis(), System.currentTimeMillis());
         Files.write(midx, file);
 
         assertThatThrownBy(() -> MemoryIndex.load(midx))
                 .isInstanceOf(SpectorStorageException.class)
-                .hasMessageContaining("v7");
+                .hasMessageContaining("v8");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes silent graph index corruption in spector-memory by making `MemoryLocation.graphSlot` the sole authoritative graph node identifier across all ingestion, recall, and rebuild paths.

Closes #497

## Root Cause

Four distinct bugs were caused by inconsistent graph node addressing:

1. **Tier-relative recall** — `offsetToRecordIndex` used `router.layoutFor(loc.type())`, so episodic slot 5 and semantic slot 5 both mapped to graph index `5`, corrupting Hebbian/Temporal neighbor lookups within a single partition
2. **Stride math overflow** — `findMemoryByApproximateIndex` used stride math on global neighbor indices, causing `IndexOutOfBoundsException` or wrong memory lookups
3. **Forget-reuse collision** — `index.size()-1` shrinks on forget, causing new memories to inherit graph edges of forgotten memories
4. **Rebuild divergence** — `buildGraphSlotMappings` ignored persisted `loc.graphSlot()`, rebuilding ordinal-position maps that diverge from disk after any forget

## Changes

| File | Change |
|:--|:--|
| `IndexRecordMemory.java` | Add `AtomicInteger graphSlotHighWater` (monotonic, persisted at header offset 60), O(1) bimap (`slotToId[]` + `idToSlot` ConcurrentHashMap), `allocateGraphSlot()`, `idAt()`, `slotOf()`. Rewrite `buildGraphSlotMappings` to use persisted values. Tombstone bimap on `remove()`. |
| `PostIngestSync.java` | Allocate global `graphSlot` via `index.allocateGraphSlot()` instead of reusing HNSW `storeIndex` |
| `CognitiveIngestionTarget.java` | Replace `index.size()-1` with `graphSlot` from `syncIndexes()` in both ingestion entry points |
| `GraphExpansionStage.java` | Replace `offsetToRecordIndex(loc)` with `loc.graphSlot()`, replace `findMemoryByApproximateIndex(idx)` with `index.idAt(idx)`, delete both dead methods |
| `IndexEntryLayout.java` | Bump MIDX schema version from 6 to 7 |
| `MidxV6ToV7Step.java` | **[NEW]** `InPlaceHeaderStep` for v6→v7 migration — writes `graphSlotHighWater`, emits WARN about graph cold-start |
| `IndexRecordCodec.java` | Register `MidxV6ToV7Step` in the codec chain |

## Design Decisions

- **Monotonic allocation, never reuse**: `graphSlot` is allocated via `graphSlotHighWater.getAndIncrement()`, persisted in header. On forget, the slot is tombstoned (`slotToId[slot] = null`) but never reclaimed.
- **O(1) bimap**: `String[] slotToId` (positional) + `ConcurrentHashMap<String,Integer> idToSlot`, guarded by existing `orderedIdsLock` (ReentrantLock).
- **Graph cold-start on migration**: v6→v7 upgrade clears graph state. Old edge IDs are not recoverable.
- **No new files or structures**: Reuses the existing `MemoryLocation.graphSlot` field (MIDX v6 `[24:4]`), which was already persisted but inconsistently adopted.

## Testing

- Full reactor compilation passes (`mvn compile`)
- Unit tests blocked by network/certificate infrastructure issue (not code-related)
- Test plan for follow-up: `GlobalGraphIndexTest` covering partition rollover + mixed tiers + forget-in-middle in both legacy-file and bundle modes

## ⚠️ Post-Merge Action Required

Re-run the entity-dense hypergraph benchmark (§6 of `comparison-statistics.md`) — absolute nDCG numbers from the prior run used the contaminated indexing path.
