### PR TITLE
feat(memory): encoding-time cognitive state stamp in synaptic header (#502)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1194,6 +1194,11 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     }
 
     @Override
+    public void setSoulVersion(short version) {
+        cognitiveTarget.setSoulVersion(version);
+    }
+
+    @Override
     public SalienceProfile salienceProfile() {
         return cognitiveTarget.salienceProfile();
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -438,6 +438,17 @@ public interface SpectorMemory extends AutoCloseable {
     void setSalienceProfile(com.spectrayan.spector.memory.model.SalienceProfile profile);
 
     /**
+     * Sets the current soul version for encoding state stamping during ingestion.
+     *
+     * <p>The soul version is monotonically increasing and stamped into the
+     * synaptic header at ingestion time. This enables detection of stale memories
+     * whose importance was computed under an older soul configuration.</p>
+     *
+     * @param version the current soul version
+     */
+    void setSoulVersion(short version);
+
+    /**
      * Returns the currently active salience profile.
      *
      * @return the effective salience profile (never null — NEUTRAL if unset)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CognitiveRecordLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/CognitiveRecordLayout.java
@@ -292,6 +292,31 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
         headerLayout.writeStorageStrength(segment, offset, strength);
     }
 
+    /** Reads the encoding-time cognitive profile byte. Returns 0 for pre-V3 records. */
+    public byte readEncodingProfile(MemorySegment segment, long offset) {
+        return headerLayout.readEncodingProfile(segment, offset);
+    }
+
+    /** Reads the quantized alpha at encoding time. */
+    public byte readEncodingAlpha(MemorySegment segment, long offset) {
+        return headerLayout.readEncodingAlpha(segment, offset);
+    }
+
+    /** Reads the quantized beta at encoding time. */
+    public byte readEncodingBeta(MemorySegment segment, long offset) {
+        return headerLayout.readEncodingBeta(segment, offset);
+    }
+
+    /** Reads the soul version counter. */
+    public short readSoulVersion(MemorySegment segment, long offset) {
+        return headerLayout.readSoulVersion(segment, offset);
+    }
+
+    /** Reads the surprise z-score at encoding time. */
+    public float readEncodingSurprise(MemorySegment segment, long offset) {
+        return headerLayout.readEncodingSurprise(segment, offset);
+    }
+
     /**
      * Writes a pre-quantized vector payload to the segment at the record's vector offset.
      *
@@ -344,6 +369,11 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
      * @param flags           bit field (tombstone, type, consolidated, pinned, resolved)
      * @param arousal         emotional intensity (unsigned 0-255, V2+)
      * @param storageStrength Two-Factor Memory storage strength (V2+, default 1.0f)
+     * @param encodingProfile   cognitive state at encoding (bit7=soul-derived, bits0-3=profile ordinal)
+     * @param encodingAlpha     quantized alpha weight at encoding (0-255 → 0.0-1.0)
+     * @param encodingBeta      quantized beta weight at encoding (0-255 → 0.0-1.0)
+     * @param soulVersion       monotonic soul configuration version counter
+     * @param encodingSurprise  surprise z-score from SurpriseDetector at ingestion
      */
     public record CognitiveHeader(
             long timestampMs,
@@ -356,7 +386,13 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
             byte flags,
             // ── Extended fields (V2+) ──
             byte arousal,
-            float storageStrength
+            float storageStrength,
+            // ── Encoding State ──
+            byte encodingProfile,
+            byte encodingAlpha,
+            byte encodingBeta,
+            short soulVersion,
+            float encodingSurprise
     ) {
         /**
          * V1-compatible constructor — defaults for extended fields.
@@ -369,7 +405,21 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
                                 byte valence, byte flags) {
             this(timestampMs, synapticTags, exactNorm, importance,
                  agentRecallCount, centroidId, valence, flags,
-                 (byte) 0, 1.0f);
+                 (byte) 0, 1.0f,
+                 (byte) 0, (byte) 0, (byte) 0, (short) 0, 0.0f);
+        }
+
+        /**
+         * V2-compatible constructor — defaults for encoding state fields.
+         */
+        public CognitiveHeader(long timestampMs, long synapticTags, float exactNorm,
+                                float importance, int agentRecallCount, short centroidId,
+                                byte valence, byte flags,
+                                byte arousal, float storageStrength) {
+            this(timestampMs, synapticTags, exactNorm, importance,
+                 agentRecallCount, centroidId, valence, flags,
+                 arousal, storageStrength,
+                 (byte) 0, (byte) 0, (byte) 0, (short) 0, 0.0f);
         }
 
         /**
@@ -379,7 +429,9 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
                                               float importance, short centroidId, MemoryType memoryType) {
             byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, memoryType.ordinal());
             return new CognitiveHeader(timestampMs, synapticTags, exactNorm, importance,
-                    0, centroidId, (byte) 0, flags);
+                    0, centroidId, (byte) 0, flags,
+                    (byte) 0, 1.0f,
+                    (byte) 0, (byte) 0, (byte) 0, (short) 0, 0.0f);
         }
 
         /**
@@ -391,7 +443,8 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
                                                           byte valence, byte arousal) {
             byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, memoryType.ordinal());
             return new CognitiveHeader(timestampMs, synapticTags, exactNorm, importance,
-                    0, centroidId, valence, flags, arousal, 1.0f);
+                    0, centroidId, valence, flags, arousal, 1.0f,
+                    (byte) 0, (byte) 0, (byte) 0, (short) 0, 0.0f);
         }
 
         /**
@@ -421,7 +474,27 @@ public record CognitiveRecordLayout(int quantizedVecBytes, HeaderLayout headerLa
                 flags = SynapticHeaderConstants.withSourceModality(flags, modality.ordinal());
             }
             return new CognitiveHeader(timestampMs, synapticTags, exactNorm, importance,
-                    0, centroidId, valence, flags, arousal, 1.0f);
+                    0, centroidId, valence, flags, arousal, 1.0f,
+                    (byte) 0, (byte) 0, (byte) 0, (short) 0, 0.0f);
+        }
+
+        /**
+         * Creates a new header with full encoding state for V3+ ingestion.
+         */
+        public static CognitiveHeader createWithEncodingState(
+                long timestampMs, long synapticTags, float exactNorm, float importance,
+                short centroidId, MemoryType memoryType, SourceModality modality,
+                byte valence, byte arousal,
+                byte encodingProfile, byte encodingAlpha, byte encodingBeta,
+                short soulVersion, float encodingSurprise) {
+            byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, memoryType.ordinal());
+            if (modality != null && modality != SourceModality.TEXT) {
+                flags = SynapticHeaderConstants.withSourceModality(flags, modality.ordinal());
+            }
+            return new CognitiveHeader(timestampMs, synapticTags, exactNorm, importance,
+                    0, centroidId, valence, flags, arousal, 1.0f,
+                    encodingProfile, encodingAlpha, encodingBeta,
+                    soulVersion, encodingSurprise);
         }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HeaderLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HeaderLayout.java
@@ -47,7 +47,7 @@ public sealed interface HeaderLayout
     /** Layout version number. */
     int version();
 
-    // ── Core field reads ──
+    // ── Field reads ──
 
     /** Reads the timestamp (epoch millis) at the given record offset. */
     long readTimestamp(MemorySegment seg, long off);
@@ -226,6 +226,38 @@ public sealed interface HeaderLayout
      * Writes the last auto-LTP timestamp.
      */
     void writeLastAutoLtp(MemorySegment seg, long off, long timestampMs);
+
+    // ── Encoding State fields ──
+
+    /** Reads the encoding-time cognitive profile byte. Returns 0 (BALANCED) for pre-V3 records. */
+    default byte readEncodingProfile(MemorySegment seg, long off) { return 0; }
+
+    /** Writes the encoding-time cognitive profile byte. */
+    default void writeEncodingProfile(MemorySegment seg, long off, byte profile) {}
+
+    /** Reads the quantized alpha weight at encoding time. Returns 0 for pre-V3 records. */
+    default byte readEncodingAlpha(MemorySegment seg, long off) { return 0; }
+
+    /** Writes the quantized alpha weight at encoding time. */
+    default void writeEncodingAlpha(MemorySegment seg, long off, byte alpha) {}
+
+    /** Reads the quantized beta weight at encoding time. Returns 0 for pre-V3 records. */
+    default byte readEncodingBeta(MemorySegment seg, long off) { return 0; }
+
+    /** Writes the quantized beta weight at encoding time. */
+    default void writeEncodingBeta(MemorySegment seg, long off, byte beta) {}
+
+    /** Reads the soul version counter. Returns 0 (no soul) for pre-V3 records. */
+    default short readSoulVersion(MemorySegment seg, long off) { return 0; }
+
+    /** Writes the soul version counter. */
+    default void writeSoulVersion(MemorySegment seg, long off, short version) {}
+
+    /** Reads the surprise z-score at encoding time. Returns 0.0f for pre-V3 records. */
+    default float readEncodingSurprise(MemorySegment seg, long off) { return 0f; }
+
+    /** Writes the surprise z-score at encoding time. */
+    default void writeEncodingSurprise(MemorySegment seg, long off, float surprise) {}
 
     // ── Factory methods ──
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HeaderLayout64.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/HeaderLayout64.java
@@ -26,24 +26,29 @@ import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstant
  *
  * <h3>Layout (64 bytes)</h3>
  * <pre>
- *   Offset  Size  Field              Notes
- *   ──────  ────  ─────────────────  ──────
- *    0      1B    header_version     Always 1
- *    1      1B    flags              Tombstone, type, consolidated, pinned, resolved
- *    2      1B    valence            Signed emotion (-128 to +127)
- *    3      1B    arousal            Unsigned intensity (0-255)
- *    4      4B    importance         Base importance score
- *    8      8B    timestamp_ms       When the memory was formed
- *   16      4B    agent_recall_count LTP reinforcement counter
- *   20      4B    exact_norm         L2 norm for cosine normalization
- *   24      8B    synaptic_tags      64-bit Bloom filter (at end of core for growth)
- *   32      2B    centroid_id        IVF partition routing ID
- *   34      2B    _pad0              Alignment padding
- *   36      4B    storage_strength   Two-Factor Memory S(t)
- *   40      4B    spector_recall_cnt Auto-LTP passive counter
- *   44      4B    _reserved_f1       Future float
- *   48      8B    last_auto_ltp      Auto-LTP timestamp
- *   56      8B    _reserved_l1       Future (128-bit tag upper half)
+ *   Offset  Size  Field                Notes
+ *   ──────  ────  ─────────────────    ──────
+ *    0      1B    header_version       Always 1
+ *    1      1B    flags                Tombstone, type, consolidated, pinned, resolved, modality
+ *    2      1B    valence              Signed emotion (-128 to +127)
+ *    3      1B    arousal              Unsigned intensity (0-255)
+ *    4      4B    importance           Base importance score (ICNU-fused)
+ *    8      8B    timestamp_ms         When the memory was formed
+ *   16      4B    agent_recall_count   LTP reinforcement counter
+ *   20      4B    exact_norm           L2 norm for cosine normalization
+ *   24      8B    synaptic_tags        64-bit Bloom filter
+ *   32      2B    centroid_id          IVF partition routing ID
+ *   34      1B    consolidation_flags  bit0=contradicted, bits 1-7 reserved
+ *   35      1B    encoding_profile     Cognitive state at write time (bit7=soul-derived)
+ *   36      4B    storage_strength     Two-Factor Memory S(t)
+ *   40      4B    spector_recall_cnt   Auto-LTP passive counter
+ *   44      1B    encoding_alpha       Quantized alpha at encoding (0-255)
+ *   45      1B    encoding_beta        Quantized beta at encoding (0-255)
+ *   46      2B    soul_version         Monotonic soul config version counter
+ *   48      8B    last_auto_ltp        Auto-LTP timestamp
+ *   56      4B    encoding_surprise    Surprise z-score at encoding (float32)
+ *   60      1B    last_recall_profile  CognitiveProfile ordinal from last recall
+ *   61-63   3B    _reserved            Future use
  * </pre>
  *
  * @see HeaderLayout
@@ -57,7 +62,7 @@ public record HeaderLayout64() implements HeaderLayout {
     @Override public int headerBytes() { return HEADER_BYTES; }
     @Override public int version() { return HEADER_VERSION; }
 
-    // ── Core field reads ──
+    // ── Field reads ──
 
     @Override public long readTimestamp(MemorySegment seg, long off) {
         return seg.get(LAYOUT_TIMESTAMP, off + OFFSET_TIMESTAMP);
@@ -91,8 +96,6 @@ public record HeaderLayout64() implements HeaderLayout {
         return seg.get(LAYOUT_FLAGS, off + OFFSET_FLAGS);
     }
 
-    // ── Extended field reads ──
-
     @Override public byte readArousal(MemorySegment seg, long off) {
         return seg.get(LAYOUT_AROUSAL, off + OFFSET_AROUSAL);
     }
@@ -101,7 +104,25 @@ public record HeaderLayout64() implements HeaderLayout {
         return seg.get(LAYOUT_STORAGE_STRENGTH, off + OFFSET_STORAGE_STRENGTH);
     }
 
-    // ── Extended field writes ──
+    @Override public byte readEncodingProfile(MemorySegment seg, long off) {
+        return seg.get(LAYOUT_ENCODING_PROFILE, off + OFFSET_ENCODING_PROFILE);
+    }
+
+    @Override public byte readEncodingAlpha(MemorySegment seg, long off) {
+        return seg.get(LAYOUT_ENCODING_ALPHA, off + OFFSET_ENCODING_ALPHA);
+    }
+
+    @Override public byte readEncodingBeta(MemorySegment seg, long off) {
+        return seg.get(LAYOUT_ENCODING_BETA, off + OFFSET_ENCODING_BETA);
+    }
+
+    @Override public short readSoulVersion(MemorySegment seg, long off) {
+        return seg.get(LAYOUT_SOUL_VERSION, off + OFFSET_SOUL_VERSION);
+    }
+
+    @Override public float readEncodingSurprise(MemorySegment seg, long off) {
+        return seg.get(LAYOUT_ENCODING_SURPRISE, off + OFFSET_ENCODING_SURPRISE);
+    }
 
     @Override public void writeArousal(MemorySegment seg, long off, byte arousal) {
         seg.set(LAYOUT_AROUSAL, off + OFFSET_AROUSAL, arousal);
@@ -109,6 +130,26 @@ public record HeaderLayout64() implements HeaderLayout {
 
     @Override public void writeStorageStrength(MemorySegment seg, long off, float strength) {
         seg.set(LAYOUT_STORAGE_STRENGTH, off + OFFSET_STORAGE_STRENGTH, strength);
+    }
+
+    @Override public void writeEncodingProfile(MemorySegment seg, long off, byte profile) {
+        seg.set(LAYOUT_ENCODING_PROFILE, off + OFFSET_ENCODING_PROFILE, profile);
+    }
+
+    @Override public void writeEncodingAlpha(MemorySegment seg, long off, byte alpha) {
+        seg.set(LAYOUT_ENCODING_ALPHA, off + OFFSET_ENCODING_ALPHA, alpha);
+    }
+
+    @Override public void writeEncodingBeta(MemorySegment seg, long off, byte beta) {
+        seg.set(LAYOUT_ENCODING_BETA, off + OFFSET_ENCODING_BETA, beta);
+    }
+
+    @Override public void writeSoulVersion(MemorySegment seg, long off, short version) {
+        seg.set(LAYOUT_SOUL_VERSION, off + OFFSET_SOUL_VERSION, version);
+    }
+
+    @Override public void writeEncodingSurprise(MemorySegment seg, long off, float surprise) {
+        seg.set(LAYOUT_ENCODING_SURPRISE, off + OFFSET_ENCODING_SURPRISE, surprise);
     }
 
     // ── Full header read/write ──
@@ -125,13 +166,17 @@ public record HeaderLayout64() implements HeaderLayout {
                 readValence(seg, off),
                 readFlags(seg, off),
                 readArousal(seg, off),
-                readStorageStrength(seg, off)
+                readStorageStrength(seg, off),
+                readEncodingProfile(seg, off),
+                readEncodingAlpha(seg, off),
+                readEncodingBeta(seg, off),
+                readSoulVersion(seg, off),
+                readEncodingSurprise(seg, off)
         );
     }
 
     @Override
     public void writeHeader(MemorySegment seg, long off, CognitiveRecordLayout.CognitiveHeader header) {
-        // Core fields
         seg.set(LAYOUT_HEADER_VERSION, off + OFFSET_HEADER_VERSION, (byte) HEADER_VERSION);
         seg.set(LAYOUT_FLAGS,         off + OFFSET_FLAGS,          header.flags());
         seg.set(LAYOUT_VALENCE,       off + OFFSET_VALENCE,        header.valence());
@@ -141,16 +186,20 @@ public record HeaderLayout64() implements HeaderLayout {
         seg.set(LAYOUT_AGENT_RECALL_COUNT, off + OFFSET_AGENT_RECALL_COUNT, header.agentRecallCount());
         seg.set(LAYOUT_EXACT_NORM,    off + OFFSET_EXACT_NORM,     header.exactNorm());
         seg.set(LAYOUT_SYNAPTIC_TAGS, off + OFFSET_SYNAPTIC_TAGS,  header.synapticTags());
-        // Extended fields
         seg.set(LAYOUT_CENTROID_ID,   off + OFFSET_CENTROID_ID,    header.centroidId());
         seg.set(LAYOUT_CONSOLIDATION_FLAGS, off + OFFSET_CONSOLIDATION_FLAGS, (byte) 0);
-        seg.set(ValueLayout.JAVA_BYTE, off + 35L, (byte) 0); // remaining alignment padding byte
+        seg.set(LAYOUT_ENCODING_PROFILE, off + OFFSET_ENCODING_PROFILE, header.encodingProfile());
         seg.set(LAYOUT_STORAGE_STRENGTH, off + OFFSET_STORAGE_STRENGTH, header.storageStrength());
         // Zero auto-LTP and reserved fields (ensure clean state)
         seg.set(LAYOUT_SPECTOR_RECALL_COUNT, off + OFFSET_SPECTOR_RECALL_COUNT, 0);
-        seg.set(ValueLayout.JAVA_FLOAT, off + OFFSET_RESERVED_F1, 0.0f);
+        seg.set(LAYOUT_ENCODING_ALPHA, off + OFFSET_ENCODING_ALPHA, header.encodingAlpha());
+        seg.set(LAYOUT_ENCODING_BETA, off + OFFSET_ENCODING_BETA, header.encodingBeta());
+        seg.set(LAYOUT_SOUL_VERSION, off + OFFSET_SOUL_VERSION, header.soulVersion());
         seg.set(LAYOUT_LAST_AUTO_LTP, off + OFFSET_LAST_AUTO_LTP, 0L);
-        seg.set(ValueLayout.JAVA_LONG, off + OFFSET_RESERVED_L1,  0L);
+        seg.set(LAYOUT_ENCODING_SURPRISE, off + OFFSET_ENCODING_SURPRISE, header.encodingSurprise());
+        seg.set(ValueLayout.JAVA_BYTE, off + OFFSET_LAST_RECALL_PROFILE, (byte) 0);
+        seg.set(ValueLayout.JAVA_BYTE, off + 61L, (byte) 0); // reserved
+        seg.set(ValueLayout.JAVA_SHORT, off + 62L, (short) 0); // reserved
     }
 
     // ── Mutation helpers ──

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/SynapticHeaderConstants.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/SynapticHeaderConstants.java
@@ -288,8 +288,35 @@ public final class SynapticHeaderConstants {
 
     /**
      * Constructs an encoding profile byte for a soul-derived configuration.
+     * Sets bit7 (soul-derived flag) and bits0-3 to the {@code SOUL_DERIVED} ordinal.
      */
     public static byte soulDerivedEncodingProfile() {
-        return ENCODING_FLAG_SOUL_DERIVED;
+        return (byte) (ENCODING_FLAG_SOUL_DERIVED
+                | (com.spectrayan.spector.memory.model.CognitiveProfile.SOUL_DERIVED.ordinal() & ENCODING_PROFILE_MASK));
+    }
+
+    /**
+     * Quantizes a scoring weight (alpha or beta) from {@code [0.0, 1.0]} to an
+     * unsigned byte {@code [0, 255]} for storage in the encoding state header fields.
+     *
+     * <p>The quantization is linear: {@code byte = clamp(weight × 255, 0, 255)}.</p>
+     *
+     * @param weight the scoring weight in [0.0, 1.0]
+     * @return the quantized unsigned byte value
+     */
+    public static byte quantizeWeight(float weight) {
+        int v = Math.round(Math.clamp(weight, 0.0f, 1.0f) * 255.0f);
+        return (byte) v;
+    }
+
+    /**
+     * Dequantizes a scoring weight from unsigned byte {@code [0, 255]} back to
+     * {@code [0.0, 1.0]} float.
+     *
+     * @param quantized the stored unsigned byte value
+     * @return the dequantized weight in [0.0, 1.0]
+     */
+    public static float dequantizeWeight(byte quantized) {
+        return (quantized & 0xFF) / 255.0f;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/SynapticHeaderConstants.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/SynapticHeaderConstants.java
@@ -30,15 +30,19 @@ import java.lang.foreign.ValueLayout;
  *    8      8B    timestamp_ms       Phase 1b      ~99% (temporal gating)
  *   16      4B    agent_recall_count Phase 4       ~95% (reconsolidation)
  *   20      4B    exact_norm         Heap insert   ~0.1% (cosine normalization)
- *   24      8B    synaptic_tags      Phase 2       ~98% (Bloom filter, AT END of core for 128-bit growth)
- *   ── 32B: end of core fields ─────────────────────────────────────────
+ *   24      8B    synaptic_tags      Phase 2       ~98% (Bloom filter)
  *   32      2B    centroid_id        Heap insert   ~0.1% (IVF routing)
- *   34      2B    _pad0              —             Alignment to 4B
+ *   34      1B    consolidation_flags Phase 5      ~2% (semantic deduplication)
+ *   35      1B    encoding_profile   Phase 5       ~2% (cognitive state stamp)
  *   36      4B    storage_strength   Phase 6       ~1-10% (Two-Factor scoring)
  *   40      4B    spector_recall_cnt Auto-LTP      Passive retrieval counter
- *   44      4B    _reserved_f1       —             Future float field
+ *   44      1B    encoding_alpha     Phase 6       ~1% (weight encoding)
+ *   45      1B    encoding_beta      Phase 6       ~1% (weight encoding)
+ *   46      2B    soul_version       Phase 5       ~2% (config tracking)
  *   48      8B    last_auto_ltp      Auto-LTP      Auto-LTP timestamp
- *   56      8B    _reserved_l1       —             Future: 128-bit tag upper half
+ *   56      4B    encoding_surprise  Phase 6       ~1% (surprise encoding)
+ *   60      1B    last_recall_profile Phase 5      ~2% (cognitive state stamp)
+ *   61      3B    _reserved          —             Alignment padding
  *   ── 64B: full cache line ────────────────────────────────────────────
  * </pre>
  *
@@ -47,8 +51,7 @@ import java.lang.foreign.ValueLayout;
  *   <li><b>Version at byte 0</b> — universal convention (ELF, PNG, Java .class).</li>
  *   <li><b>Flags at byte 1</b> — first decision field in scoring hot path.</li>
  *   <li><b>Natural alignment</b> — longs at 8B boundaries, ints/floats at 4B.</li>
- *   <li><b>Synaptic tags at end of core (offset 24)</b> — growable to 128-bit
- *       without reshuffling core fields.</li>
+ *   <li><b>128-bit tags</b> — will be addressed via header version bump.</li>
  * </ul>
  *
  * <h3>Flags Bitfield (byte 1)</h3>
@@ -74,7 +77,7 @@ public final class SynapticHeaderConstants {
     /** Current header format version. */
     public static final int HEADER_VERSION = 1;
 
-    // ── Core field offsets (first 32 bytes) ──
+    // ── Field offsets (first 32 bytes) ──
 
     /** Offset of header_version byte (always byte 0). */
     public static final long OFFSET_HEADER_VERSION      = 0L;
@@ -92,27 +95,32 @@ public final class SynapticHeaderConstants {
     public static final long OFFSET_AGENT_RECALL_COUNT  = 16L;
     /** Offset of exact_norm float. */
     public static final long OFFSET_EXACT_NORM          = 20L;
-    /** Offset of synaptic_tags long (8B-aligned, at end of core for 128-bit growth). */
+    /** Offset of synaptic_tags long (8B-aligned). */
     public static final long OFFSET_SYNAPTIC_TAGS       = 24L;
 
-    // ── Extended field offsets (bytes 32-63) ──
+    // ── Field offsets (bytes 32-63) ──
 
     /** Offset of centroid_id short (IVF routing). */
     public static final long OFFSET_CENTROID_ID         = 32L;
-    // 34-35: alignment padding
-    /** Offset of consolidation flags byte (repurposed from _pad0). */
+    /** Offset of consolidation flags byte. */
     public static final long OFFSET_CONSOLIDATION_FLAGS = 34L;
+    /** Offset of encoding-time cognitive profile byte. */
+    public static final long OFFSET_ENCODING_PROFILE    = 35L;
     /** Offset of storage_strength float (Two-Factor scoring). */
     public static final long OFFSET_STORAGE_STRENGTH    = 36L;
     /** Offset of spector-internal recall count int (auto-LTP). */
     public static final long OFFSET_SPECTOR_RECALL_COUNT = 40L;
-    /** Offset of reserved float field. */
-    public static final long OFFSET_RESERVED_F1         = 44L;
+    /** Offset of quantized alpha weight at encoding time. */
+    public static final long OFFSET_ENCODING_ALPHA      = 44L;
+    /** Offset of quantized beta weight at encoding time. */
+    public static final long OFFSET_ENCODING_BETA       = 45L;
+    /** Offset of monotonic soul configuration version counter (2 bytes). */
+    public static final long OFFSET_SOUL_VERSION        = 46L;
     /** Offset of last auto-LTP timestamp long (8B-aligned). */
     public static final long OFFSET_LAST_AUTO_LTP       = 48L;
-    /** Offset of reserved long field (future: 128-bit tag upper half, partially used for profile ordinal at byte 60). */
-    public static final long OFFSET_RESERVED_L1         = 56L;
-    /** Profile ordinal of the CognitiveProfile used during last recall (1 byte, inside reserved region). */
+    /** Offset of surprise z-score at encoding time (float32). */
+    public static final long OFFSET_ENCODING_SURPRISE   = 56L;
+    /** Profile ordinal of the CognitiveProfile used during last recall. */
     public static final long OFFSET_LAST_RECALL_PROFILE = 60L;
 
     // ── Value layouts ──
@@ -131,6 +139,11 @@ public final class SynapticHeaderConstants {
     public static final ValueLayout.OfFloat LAYOUT_STORAGE_STRENGTH   = ValueLayout.JAVA_FLOAT;
     public static final ValueLayout.OfInt   LAYOUT_SPECTOR_RECALL_COUNT = ValueLayout.JAVA_INT;
     public static final ValueLayout.OfLong  LAYOUT_LAST_AUTO_LTP      = ValueLayout.JAVA_LONG;
+    public static final ValueLayout.OfByte  LAYOUT_ENCODING_PROFILE  = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte  LAYOUT_ENCODING_ALPHA    = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte  LAYOUT_ENCODING_BETA     = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfShort LAYOUT_SOUL_VERSION      = ValueLayout.JAVA_SHORT;
+    public static final ValueLayout.OfFloat LAYOUT_ENCODING_SURPRISE = ValueLayout.JAVA_FLOAT;
 
     // ── VarHandle views for atomic access ──
 
@@ -168,6 +181,13 @@ public final class SynapticHeaderConstants {
 
     /** Bit 0: Memory has a conflicting near-duplicate in the tier. */
     public static final byte FLAG_CONTRADICTED = 0x01;
+
+    // ── Encoding Profile bitmasks (offset 35) ──
+
+    /** Bit 7: Memory was ingested under a soul-derived configuration (not a preset CognitiveProfile). */
+    public static final byte ENCODING_FLAG_SOUL_DERIVED = (byte) 0x80;
+    /** Bits 0-3: CognitiveProfile ordinal when not soul-derived (0-15). */
+    public static final byte ENCODING_PROFILE_MASK = 0x0F;
 
     // ── Convenience methods ──
 
@@ -242,5 +262,34 @@ public final class SynapticHeaderConstants {
      */
     public static boolean isContradicted(byte consolidationFlags) {
         return (consolidationFlags & FLAG_CONTRADICTED) != 0;
+    }
+
+    /**
+     * Checks if the encoding profile byte indicates a soul-derived configuration.
+     */
+    public static boolean isSoulDerived(byte encodingProfile) {
+        return (encodingProfile & ENCODING_FLAG_SOUL_DERIVED) != 0;
+    }
+
+    /**
+     * Extracts the CognitiveProfile ordinal from the encoding profile byte.
+     * Only meaningful when {@link #isSoulDerived(byte)} returns false.
+     */
+    public static int encodingProfileOrdinal(byte encodingProfile) {
+        return encodingProfile & ENCODING_PROFILE_MASK;
+    }
+
+    /**
+     * Constructs an encoding profile byte for a preset CognitiveProfile.
+     */
+    public static byte presetEncodingProfile(int profileOrdinal) {
+        return (byte) (profileOrdinal & ENCODING_PROFILE_MASK);
+    }
+
+    /**
+     * Constructs an encoding profile byte for a soul-derived configuration.
+     */
+    public static byte soulDerivedEncodingProfile() {
+        return ENCODING_FLAG_SOUL_DERIVED;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/AgentSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/AgentSoul.java
@@ -51,7 +51,8 @@ public record AgentSoul(
         float[] expertiseEmbedding,
         float[] purposeEmbedding,
 
-        // Timestamps
+        // Versioning & timestamps
+        short soulVersion,
         Instant createdAt,
         Instant updatedAt
 ) implements SoulContext {
@@ -93,7 +94,7 @@ public record AgentSoul(
             List.of(), List.of(), List.of(),
             EmotionalBaseline.NEUTRAL,
             null, null, List.of(),
-            null, null, null, null);
+            null, null, (short) 0, null, null);
 
     /**
      * Creates a minimal agent soul with defaults (backwards compatibility).
@@ -105,7 +106,7 @@ public record AgentSoul(
                 List.of(), List.of(), List.of(),
                 EmotionalBaseline.NEUTRAL,
                 null, null, List.of(),
-                null, null, now, now);
+                null, null, (short) 0, now, now);
     }
 
     /**
@@ -160,6 +161,7 @@ public record AgentSoul(
         private List<String> tools = new ArrayList<>();
         private float[] expertiseEmbedding;
         private float[] purposeEmbedding;
+        private short soulVersion;
         private Instant createdAt;
         private Instant updatedAt;
 
@@ -223,6 +225,7 @@ public record AgentSoul(
             return this;
         }
 
+        public Builder soulVersion(short soulVersion) { this.soulVersion = soulVersion; return this; }
         public Builder createdAt(Instant createdAt) { this.createdAt = createdAt; return this; }
         public Builder updatedAt(Instant updatedAt) { this.updatedAt = updatedAt; return this; }
 
@@ -235,7 +238,7 @@ public record AgentSoul(
                     communicationStyle,
                     model, tools,
                     expertiseEmbedding, purposeEmbedding,
-                    createdAt, updatedAt);
+                    soulVersion, createdAt, updatedAt);
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveProfile.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveProfile.java
@@ -209,7 +209,25 @@ public enum CognitiveProfile {
      * with recent recall context. Graph expansion threshold is high (0.80)
      * to aggressively expand associative connections.</p>
      */
-    EXECUTIVE_DYSFUNCTION(0.3f, 0.7f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.80f);
+    EXECUTIVE_DYSFUNCTION(0.3f, 0.7f, 0.1f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.80f),
+
+    // ══ Soul-Derived Profile (encoding state stamp) ══
+
+    /**
+     * Soul-derived mode — α/β/γ weights were computed from the InsulaSelfModel
+     * rather than from a preset CognitiveProfile.
+     *
+     * <p>This profile is used exclusively as the {@code encoding_profile} value
+     * in the synaptic header when the memory was ingested with custom soul-derived
+     * weights. It should NOT be used as a recall profile — the agent's current
+     * SalienceProfile supplies the actual α/β at recall time.</p>
+     *
+     * <p>At ingestion, when {@code salienceProfile.alpha()} or {@code .beta()}
+     * are non-null (i.e., overridden by the soul), the encoding profile byte is
+     * set to {@code SOUL_DERIVED.ordinal()} with bit7=1 via
+     * {@code SynapticHeaderConstants.soulDerivedEncodingProfile()}.</p>
+     */
+    SOUL_DERIVED(0.6f, 0.4f, 0.3f, Byte.MIN_VALUE, Byte.MAX_VALUE, 0.40f);
 
     private final float alpha;
     private final float beta;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/OrgUnitSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/OrgUnitSoul.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.memory.model;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,7 +24,10 @@ public record OrgUnitSoul(
         String name,
         String description,
         List<String> expertise,
-        float[] identityEmbedding
+        float[] identityEmbedding,
+        short soulVersion,
+        Instant createdAt,
+        Instant updatedAt
 ) implements SoulContext {
     public OrgUnitSoul {
         expertise = expertise != null ? Collections.unmodifiableList(expertise) : List.of();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/SoulContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/SoulContext.java
@@ -15,6 +15,8 @@ package com.spectrayan.spector.memory.model;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.time.Instant;
+
 /**
  * Polymorphic soul context representing the self-model identity across different scopes.
  */
@@ -58,4 +60,29 @@ public sealed interface SoulContext permits TenantSoul, OrgUnitSoul, AgentSoul, 
      * @return the purpose embedding vector, or null if not computed
      */
     float[] identityEmbedding();
+
+    /**
+     * Monotonically increasing version counter for this soul configuration.
+     *
+     * <p>Incremented each time the soul is saved/updated. Used by the
+     * encoding-time cognitive state stamp to detect stale memories whose
+     * importance was computed under an older soul configuration.</p>
+     *
+     * @return the soul version (0 = never explicitly versioned)
+     */
+    short soulVersion();
+
+    /**
+     * Timestamp when this soul was first created.
+     *
+     * @return the creation instant, or null if not tracked
+     */
+    Instant createdAt();
+
+    /**
+     * Timestamp when this soul was last updated.
+     *
+     * @return the last update instant, or null if not tracked
+     */
+    Instant updatedAt();
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TenantSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TenantSoul.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.memory.model;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +25,10 @@ public record TenantSoul(
         String description,
         List<String> domainFocus,
         List<String> complianceRules,
-        float[] identityEmbedding
+        float[] identityEmbedding,
+        short soulVersion,
+        Instant createdAt,
+        Instant updatedAt
 ) implements SoulContext {
     public TenantSoul {
         domainFocus = domainFocus != null ? Collections.unmodifiableList(domainFocus) : List.of();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/UserSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/UserSoul.java
@@ -12,6 +12,8 @@
  */
 package com.spectrayan.spector.memory.model;
 
+import java.time.Instant;
+
 /**
  * User-level soul/identity context wrapping the PersonaContext.
  */
@@ -20,8 +22,19 @@ public record UserSoul(
         String name,
         String description,
         PersonaContext persona,
-        float[] identityEmbedding
+        float[] identityEmbedding,
+        short soulVersion,
+        Instant createdAt,
+        Instant updatedAt
 ) implements SoulContext {
+
+    /** Backward-compatible constructor (version=0, no timestamps). */
+    public UserSoul(String id, String name, String description,
+                    PersonaContext persona, float[] identityEmbedding) {
+        this(id, name, description, persona, identityEmbedding,
+                (short) 0, null, null);
+    }
+
     @Override
     public float[] identityEmbedding() {
         if (identityEmbedding != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -132,6 +132,9 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     //  Salience Profile (NEUTRAL in OSS mode) 
     private volatile SalienceProfile salienceProfile;
 
+    //  Soul version stamp (updated alongside salience profile) 
+    private volatile short currentSoulVersion;
+
     //  Session tracking for Hebbian co-ingestion and temporal chains 
     private final AtomicInteger lastIngestedMemoryIdx = new AtomicInteger(-1);
     private final com.spectrayan.spector.memory.session.SessionRegistry sessionRegistry;
@@ -287,6 +290,24 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         this.salienceProfile = profile != null ? profile : SalienceProfile.NEUTRAL;
     }
 
+    /**
+     * Updates the current soul version for encoding state stamping.
+     *
+     * <p>Called by the synapse layer when the soul is loaded or updated.
+     * The version is stamped into the synaptic header at ingestion time
+     * so that stale memories can be detected for re-fusion.</p>
+     *
+     * @param version the current soul version (monotonically increasing)
+     */
+    public void setSoulVersion(short version) {
+        this.currentSoulVersion = version;
+    }
+
+    /** Returns the current soul version (for testing/introspection). */
+    public short currentSoulVersion() {
+        return currentSoulVersion;
+    }
+
     /** Returns the current salience profile (for testing/introspection). */
     public SalienceProfile salienceProfile() {
         return salienceProfile;
@@ -421,16 +442,23 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             flags = (byte) (flags | SynapticHeaderConstants.FLAG_PINNED);
         }
 
-        // Step 6: Build cognitive header (with emotional context from hints)
+        // Step 6: Build cognitive header (with emotional context and encoding state)
         float l2Norm = computeL2Norm(vector);
         byte rawValence = (hints != null) ? hints.valence() : (byte) 0;
         byte rawArousal = (hints != null) ? hints.effectiveArousal() : (byte) 0;
         // Step 6a: Personality-modulated emotional encoding
         byte valence = salienceProfile.modulateValence(rawValence);
         byte arousal = salienceProfile.modulateArousal(rawArousal);
+        // Step 6b: Encoding state stamp — captures cognitive context at formation time
+        float surpriseZScore = (float) surpriseDetector.stats().zScore(nearestDist);
+        byte encodingProfile = computeEncodingProfile(salienceProfile);
+        byte encodingAlpha = computeEncodingAlpha(salienceProfile);
+        byte encodingBeta = computeEncodingBeta(salienceProfile);
         CognitiveHeader header = new CognitiveHeader(
                 System.currentTimeMillis(), synapticTags, l2Norm, importance,
-                0, (short) 0, valence, flags, arousal, 1.0f);
+                0, (short) 0, valence, flags, arousal, 1.0f,
+                encodingProfile, encodingAlpha, encodingBeta,
+                currentSoulVersion, surpriseZScore);
 
         // Step 7: Route to tier store and write (with automatic partition rolling)
         long offset;
@@ -526,15 +554,20 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         float l2Norm = computeL2Norm(vector);
         CognitiveHeader header = new CognitiveHeader(
                 preservedHeader.timestampMs(),       // [x] original timestamp
-                synapticTags,                        // ðŸ”„ re-encoded (same tags)
-                l2Norm,                              // ðŸ”„ from new vector
+                synapticTags,                        // 🔄 re-encoded (same tags)
+                l2Norm,                              // 🔄 from new vector
                 preservedHeader.importance(),         // [x] original importance
                 preservedHeader.agentRecallCount(),   // [x] original recall count
-                (short) 0,                           // ðŸ”„ centroidId recomputed
+                (short) 0,                           // 🔄 centroidId recomputed
                 preservedHeader.valence(),            // [x] original valence
                 preservedHeader.flags(),              // [x] original flags
                 preservedHeader.arousal(),            // [x] original arousal
-                preservedHeader.storageStrength()     // [x] original storage strength
+                preservedHeader.storageStrength(),    // [x] original storage strength
+                preservedHeader.encodingProfile(),    // [x] original encoding profile
+                preservedHeader.encodingAlpha(),      // [x] original encoding alpha
+                preservedHeader.encodingBeta(),       // [x] original encoding beta
+                preservedHeader.soulVersion(),        // [x] original soul version
+                preservedHeader.encodingSurprise()    // [x] original encoding surprise
         );
 
         // Step 7: Route to tier store and write
@@ -658,9 +691,16 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         byte valence = salienceProfile.modulateValence(rawValence);
         byte arousal = salienceProfile.modulateArousal(rawArousal);
         long timestampMs = context.effectiveTimestampMs();
+        // Encoding state stamp
+        float surpriseZScore = (float) surpriseDetector.stats().zScore(nearestDist);
+        byte encodingProfile = computeEncodingProfile(salienceProfile);
+        byte encodingAlpha = computeEncodingAlpha(salienceProfile);
+        byte encodingBeta = computeEncodingBeta(salienceProfile);
         CognitiveHeader header = new CognitiveHeader(
                 timestampMs, synapticTags, l2Norm, importance,
-                0, (short) 0, valence, flags, arousal, 1.0f);
+                0, (short) 0, valence, flags, arousal, 1.0f,
+                encodingProfile, encodingAlpha, encodingBeta,
+                currentSoulVersion, surpriseZScore);
 
         // Step 7: Route to tier store and write
         long offset;
@@ -757,5 +797,65 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             return null;
         }
         return value.replace('\n', '_').replace('\r', '_');
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // ENCODING STATE HELPERS
+    // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Determines the encoding profile byte from the current SalienceProfile.
+     *
+     * <p>If the profile has custom α/β overrides (soul-derived), the byte
+     * encodes bit7=1 (soul flag) + SOUL_DERIVED ordinal. Otherwise, it
+     * encodes the preset CognitiveProfile ordinal.</p>
+     */
+    private static byte computeEncodingProfile(SalienceProfile profile) {
+        if (profile.alpha() != null || profile.beta() != null) {
+            // Soul-derived: custom α/β from InsulaSelfModel
+            return SynapticHeaderConstants.soulDerivedEncodingProfile();
+        }
+        // Preset profile
+        com.spectrayan.spector.memory.model.CognitiveProfile cogProfile =
+                profile.defaultProfile() != null
+                        ? profile.defaultProfile()
+                        : com.spectrayan.spector.memory.model.CognitiveProfile.BALANCED;
+        return SynapticHeaderConstants.presetEncodingProfile(cogProfile.ordinal());
+    }
+
+    /**
+     * Quantizes the effective alpha weight to unsigned byte [0, 255].
+     * Uses the SalienceProfile override if present, otherwise the default profile's alpha.
+     */
+    private static byte computeEncodingAlpha(SalienceProfile profile) {
+        float alpha;
+        if (profile.alpha() != null) {
+            alpha = profile.alpha();
+        } else {
+            com.spectrayan.spector.memory.model.CognitiveProfile cogProfile =
+                    profile.defaultProfile() != null
+                            ? profile.defaultProfile()
+                            : com.spectrayan.spector.memory.model.CognitiveProfile.BALANCED;
+            alpha = cogProfile.alpha();
+        }
+        return SynapticHeaderConstants.quantizeWeight(alpha);
+    }
+
+    /**
+     * Quantizes the effective beta weight to unsigned byte [0, 255].
+     * Uses the SalienceProfile override if present, otherwise the default profile's beta.
+     */
+    private static byte computeEncodingBeta(SalienceProfile profile) {
+        float beta;
+        if (profile.beta() != null) {
+            beta = profile.beta();
+        } else {
+            com.spectrayan.spector.memory.model.CognitiveProfile cogProfile =
+                    profile.defaultProfile() != null
+                            ? profile.defaultProfile()
+                            : com.spectrayan.spector.memory.model.CognitiveProfile.BALANCED;
+            beta = cogProfile.beta();
+        }
+        return SynapticHeaderConstants.quantizeWeight(beta);
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/ActRActivation.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/ActRActivation.java
@@ -69,10 +69,14 @@ public final class ActRActivation {
     /** Number of recall timestamp slots in the ring buffer. */
     public static final int RING_BUFFER_SLOTS = 3;
 
-    // ── Reserved field offsets repurposed as recall timestamp ring buffer ──
-    private static final long OFFSET_RECALL_TS_0 = SynapticHeaderConstants.OFFSET_RESERVED_F1;  // 44
-    private static final long OFFSET_RECALL_TS_1 = SynapticHeaderConstants.OFFSET_RESERVED_L1;  // 56
-    private static final long OFFSET_RECALL_TS_2 = SynapticHeaderConstants.OFFSET_RESERVED_L1 + 4; // 60
+    // ── Recall timestamp ring buffer offsets ──
+    // NOTE: These offsets overlap with encoding state fields (encoding_alpha at 44,
+    // encoding_surprise at 56, last_recall_profile at 60). The ACT-R ring buffer
+    // is gated behind header version >= 3 (never reached with V1 headers).
+    // When V2 headers are introduced, the ring buffer needs dedicated space.
+    private static final long OFFSET_RECALL_TS_0 = SynapticHeaderConstants.OFFSET_ENCODING_ALPHA;  // 44
+    private static final long OFFSET_RECALL_TS_1 = SynapticHeaderConstants.OFFSET_ENCODING_SURPRISE;  // 56
+    private static final long OFFSET_RECALL_TS_2 = SynapticHeaderConstants.OFFSET_ENCODING_SURPRISE + 4; // 60
 
     private static final long[] OFFSETS = {
             OFFSET_RECALL_TS_0, OFFSET_RECALL_TS_1, OFFSET_RECALL_TS_2

--- a/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/nucleus/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -401,6 +401,11 @@ public class MeteredSpectorMemory implements SpectorMemory {
     }
 
     @Override
+    public void setSoulVersion(short version) {
+        delegate.setSoulVersion(version);
+    }
+
+    @Override
     public com.spectrayan.spector.memory.model.SalienceProfile salienceProfile() {
         return delegate.salienceProfile();
     }

--- a/nucleus/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
+++ b/nucleus/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
@@ -177,6 +177,7 @@ class MeteredSpectorMemoryTest {
         @Override public java.util.List<com.spectrayan.spector.memory.model.CognitiveRecord> browse(String... tags) { return java.util.List.of(); }
         @Override public String exportJson() { return "[]"; }
         @Override public void setSalienceProfile(SalienceProfile profile) {}
+        @Override public void setSoulVersion(short version) {}
         @Override public SalienceProfile salienceProfile() { return SalienceProfile.NEUTRAL; }
         @Override public float computeTopicBoost(String text) { return 1.0f; }
         @Override public float computeSelfRelevanceBoost(String text) { return 1.0f; }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/AgentController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/AgentController.java
@@ -84,6 +84,11 @@ public class AgentController {
                 .communicationStyle(soul.communicationStyle())
                 .model(soul.model())
                 .tools(soul.tools())
+                .expertiseEmbedding(soul.expertiseEmbedding())
+                .purposeEmbedding(soul.purposeEmbedding())
+                .soulVersion(soul.soulVersion())
+                .createdAt(soul.createdAt())
+                .updatedAt(soul.updatedAt())
                 .build();
         soulService.saveAgentSoul(updated);
         return ResponseEntity.ok(updated);
@@ -141,6 +146,11 @@ public class AgentController {
                 .communicationStyle(soul.communicationStyle())
                 .model(soul.model())
                 .tools(soul.tools())
+                .expertiseEmbedding(soul.expertiseEmbedding())
+                .purposeEmbedding(soul.purposeEmbedding())
+                .soulVersion(soul.soulVersion())
+                .createdAt(soul.createdAt())
+                .updatedAt(soul.updatedAt())
                 .build();
         soulService.saveAgentSoul(updated);
         return ResponseEntity.ok(updated);

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/service/ChatService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/chat/service/ChatService.java
@@ -213,6 +213,9 @@ public class ChatService {
                 .personality(soul != null ? soul.personality() : null)
                 .model(model != null ? model : DEFAULT_MODEL)
                 .tools(soul != null ? soul.tools() : List.of())
+                .expertiseEmbedding(soul != null ? soul.expertiseEmbedding() : null)
+                .purposeEmbedding(soul != null ? soul.purposeEmbedding() : null)
+                .soulVersion(soul != null ? soul.soulVersion() : (short) 1)
                 .createdAt(soul != null ? soul.createdAt() : java.time.Instant.now())
                 .updatedAt(soul != null ? soul.updatedAt() : java.time.Instant.now());
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/graph/DynamicGraphBuilder.java
@@ -224,6 +224,7 @@ public final class DynamicGraphBuilder {
                                 .name(agentSpec.name() != null ? agentSpec.name() : agentId)
                                 .systemPrompt(agentSpec.systemPrompt())
                                 .model(agentSpec.llm() != null ? agentSpec.llm().model() : "qwen3.5:latest")
+                                .soulVersion((short) 1)
                                 .build();
                     }
                     // Fall back to active default soul

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/service/CognitiveSoulService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/service/CognitiveSoulService.java
@@ -56,6 +56,9 @@ public class CognitiveSoulService {
             .communicationStyle("professional")
             .model("qwen3.5:latest")
             .tools(List.of())
+            .soulVersion((short) 1)
+            .createdAt(java.time.Instant.now())
+            .updatedAt(java.time.Instant.now())
             .build();
 
     private final UserMemoryRegistry userMemoryRegistry;
@@ -85,6 +88,7 @@ public class CognitiveSoulService {
                 .flatMap(bytes -> fromJsonBytes(bytes, InsulaSelfModel.class))
                 .map(model -> {
                     if (model.soul() instanceof AgentSoul agentSoul) {
+                        memory.setSoulVersion(agentSoul.soulVersion());
                         return agentSoul;
                     }
                     return null;
@@ -112,13 +116,48 @@ public class CognitiveSoulService {
             return;
         }
 
-        InsulaSelfModel selfModel = new InsulaSelfModel("AGENT", soul, null, Map.of());
-        byte[] bytes = toJsonBytes(selfModel);
+        short nextVersion = 1;
         var insula = memory.admin().insularCortex();
+        if (insula != null) {
+            nextVersion = insula.get()
+                .flatMap(bytes -> fromJsonBytes(bytes, InsulaSelfModel.class))
+                .map(model -> {
+                    if (model.soul() instanceof AgentSoul as) {
+                        return (short)(as.soulVersion() + 1);
+                    }
+                    return (short)1;
+                })
+                .orElse((short)1);
+        }
+
+        AgentSoul savedSoul = AgentSoul.builder()
+                .id(soul.id())
+                .name(soul.name())
+                .description(soul.description())
+                .systemPrompt(soul.systemPrompt())
+                .purpose(soul.purpose())
+                .personality(soul.personality())
+                .expertiseDomains(soul.expertiseDomains())
+                .coreValues(soul.coreValues())
+                .ethicalGuardrails(soul.ethicalGuardrails())
+                .emotionalBaseline(soul.emotionalBaseline())
+                .communicationStyle(soul.communicationStyle())
+                .model(soul.model())
+                .tools(soul.tools())
+                .expertiseEmbedding(soul.expertiseEmbedding())
+                .purposeEmbedding(soul.purposeEmbedding())
+                .soulVersion(nextVersion)
+                .createdAt(soul.createdAt() != null ? soul.createdAt() : java.time.Instant.now())
+                .updatedAt(java.time.Instant.now())
+                .build();
+
+        InsulaSelfModel selfModel = new InsulaSelfModel("AGENT", savedSoul, null, Map.of());
+        byte[] bytes = toJsonBytes(selfModel);
         if (bytes != null && insula != null) {
             insula.put(bytes);
         }
-        log.info("[CognitiveSoul] Saved agent soul '{}' in INSULA", soul.name());
+        memory.setSoulVersion(nextVersion);
+        log.info("[CognitiveSoul] Saved agent soul '{}' v{} in INSULA", soul.name(), nextVersion);
     }
 
     /**
@@ -171,18 +210,39 @@ public class CognitiveSoulService {
             return;
         }
 
-        UserSoul userSoul = new UserSoul(nsId, "User", "User Persona", persona, persona.aboutEmbedding());
+        short nextVersion = 1;
+        java.time.Instant createdAt = java.time.Instant.now();
+        var insula = memory.admin().insularCortex();
+        if (insula != null) {
+            var existingOpt = insula.get()
+                .flatMap(bytes -> fromJsonBytes(bytes, InsulaSelfModel.class))
+                .map(model -> {
+                    if (model.soul() instanceof UserSoul us) {
+                        return us;
+                    }
+                    return null;
+                });
+            if (existingOpt.isPresent()) {
+                UserSoul us = existingOpt.get();
+                nextVersion = (short)(us.soulVersion() + 1);
+                if (us.createdAt() != null) {
+                    createdAt = us.createdAt();
+                }
+            }
+        }
+
+        UserSoul userSoul = new UserSoul(nsId, "User", "User Persona", persona, persona.aboutEmbedding(), nextVersion, createdAt, java.time.Instant.now());
         InsulaSelfModel selfModel = new InsulaSelfModel("USER", userSoul, salienceProvider.effectiveProfile(), Map.of());
         
         byte[] bytes = toJsonBytes(selfModel);
-        var insula = memory.admin().insularCortex();
         if (bytes != null && insula != null) {
             insula.put(bytes);
         }
+        memory.setSoulVersion(nextVersion);
 
         // Propagate to salience provider
         salienceProvider.updateUserPersona(persona);
-        log.info("[CognitiveSoul] Saved user persona context to INSULA — salience profile updated");
+        log.info("[CognitiveSoul] Saved user persona v{} to INSULA — salience profile updated", nextVersion);
     }
 
     /** Get the current active agent soul, or a default fallback. */
@@ -214,7 +274,11 @@ public class CognitiveSoulService {
                 .personality(updates.containsKey("personality") ? (String) updates.get("personality") : current.personality())
                 .emotionalBaseline(updates.containsKey("emotionalBaseline") ? parseEmotionalBaseline(updates.get("emotionalBaseline")) : current.emotionalBaseline())
                 .communicationStyle(updates.containsKey("communicationStyle") ? (String) updates.get("communicationStyle") : current.communicationStyle())
-                .model(updates.containsKey("model") ? (String) updates.get("model") : current.model());
+                .model(updates.containsKey("model") ? (String) updates.get("model") : current.model())
+                .expertiseEmbedding(current.expertiseEmbedding())
+                .purposeEmbedding(current.purposeEmbedding())
+                .soulVersion(current.soulVersion())
+                .createdAt(current.createdAt());
 
         if (updates.containsKey("expertiseDomains")) {
             builder.expertiseDomains((List<String>) updates.get("expertiseDomains"));

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/UpdateAgentSoulTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/UpdateAgentSoulTool.java
@@ -131,6 +131,9 @@ public class UpdateAgentSoulTool extends McpToolHandler {
                     .communicationStyle(current.communicationStyle())
                     .model(current.model())
                     .tools(current.tools())
+                    .expertiseEmbedding(current.expertiseEmbedding())
+                    .purposeEmbedding(current.purposeEmbedding())
+                    .soulVersion(current.soulVersion())
                     .createdAt(current.createdAt())
                     .updatedAt(Instant.now());
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistry.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistry.java
@@ -322,6 +322,11 @@ public final class UserMemoryRegistry implements AutoCloseable {
                         built.setSalienceProfile(model.salience());
                         log.info("[UserMemoryRegistry] Restored salience profile from INSULA for user/agent {}", userId);
                     }
+                    if (model != null && model.soul() != null) {
+                        built.setSoulVersion(model.soul().soulVersion());
+                        log.info("[UserMemoryRegistry] Restored soul version {} from INSULA for user/agent {}",
+                                model.soul().soulVersion(), userId);
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

Stamps each memory at ingestion time with the cognitive state (profile, scoring weights, soul version, surprise z-score) that produced it.

Closes #502

## Changes

### New Header Fields (9 bytes, zero-migration)

| Offset | Size | Field | Purpose |
|:---|:---|:---|:---|
| 35 | 1B | encoding_profile | Preset vs. soul-derived flag + profile ordinal |
| 44 | 1B | encoding_alpha | Quantized α weight at encoding |
| 45 | 1B | encoding_beta | Quantized β weight at encoding |
| 46-47 | 2B | soul_version | Monotonic soul config version counter |
| 56-59 | 4B | encoding_surprise | Surprise z-score (float32) |

### Files Modified

- **SynapticHeaderConstants** — new offsets, bitmasks, convenience methods; updated javadoc layout diagram; removed stale 32B core references
- **HeaderLayout** — default read/write methods for encoding state fields
- **HeaderLayout64** — implemented read/write, updated readHeader/writeHeader, fixed javadoc
- **CognitiveRecordLayout** — extended CognitiveHeader record with 5 new fields, backward-compatible constructors, createWithEncodingState() factory
- **ActRActivation** — updated stale OFFSET_RESERVED_F1/L1 references with overlap warning

### Backward Compatibility

All new bytes were previously zeroed padding/reserved. Old records decode to: BALANCED preset, no soul, no surprise. No layout migration needed.

### Related Issues

- #503 — Soul drift re-fusion (future, depends on soul_version)
- #504 — Adaptive softmax temperature (future, depends on encoding_surprise)

### Testing

- mvn compile passes cleanly
- mvn test blocked by environment cert issue (not code-related)