### PR TITLE
feat(memory): ADR-0004 Phase 2 — Bundle migration of CHECKPOINT, entity names, and BM25 (#508)

### DIFF
--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/BM25Index.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/BM25Index.java
@@ -667,4 +667,161 @@ public class BM25Index implements KeywordIndex {
             return null;
         }
     }
+
+    // ── V4 Bundle Region I/O ──
+
+    /**
+     * Saves this BM25 index to a V4 bundle region MemorySegment.
+     *
+     * <p>Uses the same binary format as {@link #save(java.nio.file.Path)} but writes
+     * to a memory-mapped region instead of a file. The first 4 bytes store the
+     * total payload length, followed by the binary index data.</p>
+     *
+     * @param region the BM25 region MemorySegment
+     * @return number of bytes written, or -1 if region too small
+     */
+    public int saveToRegion(java.lang.foreign.MemorySegment region) {
+        rwLock.readLock().lock();
+        try {
+            java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+            java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+
+            // Header
+            dos.writeInt(MAGIC);
+            dos.writeInt(FORMAT_VERSION);
+            dos.writeInt(totalDocs);
+            dos.writeInt(invertedIndex.size());
+            dos.writeLong(totalDocLength);
+
+            // DocIds
+            int docCount = docIds.size();
+            dos.writeInt(docCount);
+            for (String id : docIds) {
+                byte[] idBytes = id.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                dos.writeInt(idBytes.length);
+                dos.write(idBytes);
+            }
+
+            // DocLengths
+            dos.writeInt(docCount);
+            for (int i = 0; i < docCount; i++) {
+                dos.writeInt(docLengthsArray[i]);
+            }
+
+            // Terms + Postings
+            dos.writeInt(invertedIndex.size());
+            for (var entry : invertedIndex.entrySet()) {
+                byte[] termBytes = entry.getKey().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                PostingList pl = entry.getValue();
+                dos.writeInt(termBytes.length);
+                dos.write(termBytes);
+                dos.writeInt(pl.size);
+                for (int i = 0; i < pl.size; i++) {
+                    dos.writeInt(pl.docIndices[i]);
+                    dos.writeInt(pl.termFrequencies[i]);
+                }
+            }
+
+            dos.flush();
+            byte[] data = baos.toByteArray();
+            int totalBytes = 4 + data.length; // 4-byte length prefix + payload
+
+            if (totalBytes > region.byteSize()) {
+                log.warn("BM25 index ({} bytes) exceeds region capacity ({}B)",
+                        totalBytes, region.byteSize());
+                return -1;
+            }
+
+            // Write length prefix then payload
+            region.set(java.lang.foreign.ValueLayout.JAVA_INT, 0, data.length);
+            java.lang.foreign.MemorySegment.copy(
+                    java.lang.foreign.MemorySegment.ofArray(data), 0,
+                    region, 4, data.length);
+
+            log.info("BM25 index saved to bundle region: {} docs, {} terms, {} bytes",
+                    totalDocs, invertedIndex.size(), totalBytes);
+            return totalBytes;
+
+        } catch (java.io.IOException e) {
+            log.error("Failed to save BM25 index to bundle region", e);
+            return -1;
+        } finally {
+            rwLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Loads a BM25 index from a V4 bundle region MemorySegment.
+     *
+     * @param region the BM25 region MemorySegment
+     * @return the loaded BM25Index, or null if no valid data present
+     */
+    public static BM25Index loadFromRegion(java.lang.foreign.MemorySegment region) {
+        if (region == null || region.byteSize() < 28) return null; // 4B len + 24B min header
+
+        int payloadLen = region.get(java.lang.foreign.ValueLayout.JAVA_INT, 0);
+        if (payloadLen <= 0 || 4 + payloadLen > region.byteSize()) return null;
+
+        byte[] data = new byte[payloadLen];
+        java.lang.foreign.MemorySegment.copy(region, 4,
+                java.lang.foreign.MemorySegment.ofArray(data), 0, payloadLen);
+
+        java.nio.ByteBuffer buf = java.nio.ByteBuffer.wrap(data);
+
+        // Header
+        int magic = buf.getInt();
+        if (magic != MAGIC) return null;
+        int version = buf.getInt();
+        if (version != FORMAT_VERSION) return null;
+        int savedTotalDocs = buf.getInt();
+        int termCount = buf.getInt();
+        long savedTotalDocLength = buf.getLong();
+
+        BM25Index idx = new BM25Index();
+
+        // DocIds
+        int docCount = buf.getInt();
+        for (int i = 0; i < docCount; i++) {
+            int idLen = buf.getInt();
+            byte[] idBytes = new byte[idLen];
+            buf.get(idBytes);
+            String id = new String(idBytes, java.nio.charset.StandardCharsets.UTF_8);
+            idx.docIds.add(id);
+            idx.docIdToIndex.put(id, i);
+        }
+
+        // DocLengths
+        int docLenCount = buf.getInt();
+        if (docLenCount > idx.docLengthsCapacity) {
+            idx.docLengthsCapacity = docLenCount;
+            idx.docLengthsArray = new int[docLenCount];
+        }
+        for (int i = 0; i < docLenCount; i++) {
+            idx.docLengthsArray[i] = buf.getInt();
+        }
+
+        // Terms + Postings
+        int savedTermCount = buf.getInt();
+        for (int t = 0; t < savedTermCount; t++) {
+            int termLen = buf.getInt();
+            byte[] termBytes = new byte[termLen];
+            buf.get(termBytes);
+            String term = new String(termBytes, java.nio.charset.StandardCharsets.UTF_8);
+
+            int postingsSize = buf.getInt();
+            PostingList pl = new PostingList(Math.max(postingsSize, 16));
+            for (int p = 0; p < postingsSize; p++) {
+                pl.add(buf.getInt(), buf.getInt());
+            }
+            idx.invertedIndex.put(term, pl);
+        }
+
+        idx.totalDocs = savedTotalDocs;
+        idx.totalDocLength = savedTotalDocLength;
+        idx.avgDocLength = savedTotalDocs > 0 ? (double) savedTotalDocLength / savedTotalDocs : 0;
+
+        log.info("BM25 index loaded from bundle region: {} docs, {} terms, {} bytes",
+                savedTotalDocs, savedTermCount, payloadLen + 4);
+        return idx;
+    }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
@@ -384,12 +384,12 @@ final class CognitiveCortexBuilder {
                 ),
                 new RegionSizeSpec(
                         RegionId.ENTITY_NAMES,
-                        64 + 16 + 8L * hyperCap * 16,
+                        64 + 16 + 8L * hyperCap * 16 + 32L * hyperCap, // adjacency + name index space
                         1,
                         8,
                         new com.spectrayan.spector.memory.kernel.layout.EntityDirectoryLayout().layoutId(),
                         new com.spectrayan.spector.memory.kernel.layout.EntityDirectoryLayout().schemaVersion(),
-                        false
+                        true  // growable — name index may exceed initial allocation
                 ),
                 new RegionSizeSpec(
                         RegionId.HYPERGRAPH,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
@@ -426,6 +426,15 @@ final class CognitiveCortexBuilder {
                         InsularLayout.LAYOUT_ID,
                         InsularLayout.SCHEMA_VERSION,
                         false
+                ),
+                new RegionSizeSpec(
+                        RegionId.CHECKPOINT,
+                        128L * 1024,
+                        1,
+                        0,
+                        0x434B5054,
+                        1,
+                        true
                 )
         );
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
@@ -309,6 +309,9 @@ final class CognitiveCortexBuilder {
         long typeRegistrySize = builder.typeRegistrySize;
         long insulaSize = builder.insulaSize;
 
+        // BM25 region sizing: header(24) + docIds(~48B/doc) + docLengths(4B/doc) + terms+postings(~80B/doc)
+        long bm25InitialSize = Math.max(64 * 1024, 24 + 132L * workingCap);
+
         return List.of(
                 new RegionSizeSpec(
                         RegionId.WORKING,
@@ -435,6 +438,15 @@ final class CognitiveCortexBuilder {
                         0x434B5054,
                         1,
                         true
+                ),
+                new RegionSizeSpec(
+                        RegionId.BM25,
+                        bm25InitialSize,
+                        1,
+                        0,
+                        0x42494458,  // "BIDX" magic
+                        1,
+                        true  // growable — term/posting lists grow dynamically
                 )
         );
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1429,6 +1429,18 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             } catch (Exception e) {
                 log.warn("Failed to save BM25 index on close: {}", e.getMessage());
             }
+            // V4 bundle: save to BM25 region
+            if (runtimeBundle != null) {
+                try {
+                    java.lang.foreign.MemorySegment bm25Region = runtimeBundle.regionSegment(
+                            com.spectrayan.spector.memory.kernel.bundle.RegionId.BM25);
+                    if (bm25Region != null) {
+                        bm25Index.partition(0).saveToRegion(bm25Region);
+                    }
+                } catch (Exception e) {
+                    log.debug("BM25 bundle region save on close failed: {}", e.getMessage());
+                }
+            }
         }
 
         PersistenceManager.flushAndClose(

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RetrievalIndexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RetrievalIndexBuilder.java
@@ -67,17 +67,42 @@ final class RetrievalIndexBuilder {
             textDataStore.readAll();
             index.setTextDataStore(textDataStore);
 
-            java.nio.file.Path bm25Path = StorageLayout.bm25BidxRuntime(basePath);
-            java.nio.file.Path v2Bm25 = resolvedPartitionDir != null ? resolvedPartitionDir.resolve(StorageLayout.FILE_BM25) : null;
-            java.nio.file.Path loadFrom = MigrationPathResolver.getNewerPath(bm25Path, v2Bm25, null);
-            if (loadFrom != null) {
-                bm25Path = loadFrom;
+            // V4 bundle path: try loading from BM25 region first
+            BM25Index loadedBm25 = null;
+            boolean usedBundleRegion = false;
+            if (cortex.useBundleMode() && cortex.runtimeBundle() != null) {
+                try {
+                    java.lang.foreign.MemorySegment bm25Region = cortex.runtimeBundle().regionSegment(
+                            com.spectrayan.spector.memory.kernel.bundle.RegionId.BM25);
+                    if (bm25Region != null) {
+                        loadedBm25 = BM25Index.loadFromRegion(bm25Region);
+                        if (loadedBm25 != null) {
+                            usedBundleRegion = true;
+                            log.info("BM25 loaded from bundle region: {} docs", loadedBm25.size());
+                        }
+                    }
+                } catch (Exception e) {
+                    log.debug("BM25 bundle region load failed, falling back to file: {}", e.getMessage());
+                }
             }
-            BM25Index loadedBm25 = BM25Index.load(bm25Path);
+
+            // V3 fallback: load from bm25.bidx file
+            if (loadedBm25 == null) {
+                java.nio.file.Path bm25Path = StorageLayout.bm25BidxRuntime(basePath);
+                java.nio.file.Path v2Bm25 = resolvedPartitionDir != null ? resolvedPartitionDir.resolve(StorageLayout.FILE_BM25) : null;
+                java.nio.file.Path loadFrom = MigrationPathResolver.getNewerPath(bm25Path, v2Bm25, null);
+                if (loadFrom != null) {
+                    bm25Path = loadFrom;
+                }
+                loadedBm25 = BM25Index.load(bm25Path);
+                if (loadedBm25 != null) {
+                    log.info("BM25 loaded from binary index: {} docs", loadedBm25.size());
+                }
+            }
+
             bm25Index = new MemoryBM25Index(1);
             if (loadedBm25 != null) {
                 bm25Index.setPartition(0, loadedBm25);
-                log.info("BM25 loaded from binary index: {} docs", loadedBm25.size());
             } else {
                 Map<String, String> allTexts = new java.util.HashMap<>();
                 for (var entry : index.locationMap().entrySet()) {
@@ -89,7 +114,20 @@ final class RetrievalIndexBuilder {
                 if (!allTexts.isEmpty()) {
                     bm25Index.rebuildPartition(0, allTexts);
                     log.info("Rebuilt BM25 index with {} documents from memory index", allTexts.size());
+                    // Save to file (V3 compat) and bundle region (V4)
+                    java.nio.file.Path bm25Path = StorageLayout.bm25BidxRuntime(basePath);
                     bm25Index.partition(0).save(bm25Path);
+                    if (cortex.useBundleMode() && cortex.runtimeBundle() != null) {
+                        try {
+                            java.lang.foreign.MemorySegment bm25Region = cortex.runtimeBundle().regionSegment(
+                                    com.spectrayan.spector.memory.kernel.bundle.RegionId.BM25);
+                            if (bm25Region != null) {
+                                bm25Index.partition(0).saveToRegion(bm25Region);
+                            }
+                        } catch (Exception e) {
+                            log.debug("BM25 bundle region save failed: {}", e.getMessage());
+                        }
+                    }
                 }
             }
         } else {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityDirectory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityDirectory.java
@@ -199,15 +199,24 @@ public final class EntityDirectory extends AbstractGraphMemory<EntityDirectoryLa
             this.adjHighWaterMark = 0;
         }
 
-        // Load names from sidecar
+        // Load names: try V4 bundle region first, then V3 sidecar
         if (!isNew && bundlePath != null) {
             try {
-                ConcurrentHashMap<String, Integer> names = EntityDirectorySerializer.loadNameIndexSidecar(bundlePath, null);
-                if (names != null) {
+                long nameIndexOffset = MemoryHeader.HEADER_BYTES + 16
+                        + (long) adjSegmentCapacity * ADJ_ENTRY_BYTES;
+                ConcurrentHashMap<String, Integer> names = EntityDirectorySerializer.loadNameIndexFromRegion(
+                        adjacencyRegionSlice, nameIndexOffset);
+                if (names != null && !names.isEmpty()) {
                     this.nameIndex.putAll(names);
+                } else {
+                    // V3 fallback: load from sidecar file
+                    names = EntityDirectorySerializer.loadNameIndexSidecar(bundlePath, null);
+                    if (names != null) {
+                        this.nameIndex.putAll(names);
+                    }
                 }
             } catch (Exception e) {
-                log.warn("Failed to load EntityDirectory name index sidecar: {}", e.getMessage());
+                log.warn("Failed to load EntityDirectory name index: {}", e.getMessage());
             }
         }
 
@@ -1125,7 +1134,15 @@ public final class EntityDirectory extends AbstractGraphMemory<EntityDirectoryLa
 
                 Path path = filePath != null ? filePath : mmapFilePath;
                 if (path != null) {
-                    EntityDirectorySerializer.saveNameIndexSidecar(this, path, encryptor);
+                    // V4 bundle path: write name index to ENTITY_NAMES region after adjacency data
+                    long nameIndexOffset = MemoryHeader.HEADER_BYTES + 16
+                            + (long) adjSegmentCapacity * ADJ_ENTRY_BYTES;
+                    int written = EntityDirectorySerializer.saveNameIndexToRegion(
+                            adjacencySegment, nameIndexOffset, nameIndex);
+                    if (written < 0) {
+                        // Fallback to sidecar file if region too small
+                        EntityDirectorySerializer.saveNameIndexSidecar(this, path, encryptor);
+                    }
                 }
             } finally {
                 lock.unlockRead(stamp);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityDirectorySerializer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityDirectorySerializer.java
@@ -200,4 +200,85 @@ final class EntityDirectorySerializer {
         }
         return names;
     }
+
+    // ── V4 Bundle Region Name Index Codec ──
+
+    /**
+     * Writes the name index to a V4 bundle ENTITY_NAMES region at the given offset.
+     *
+     * <p>Format: {@code [4B count][entries: (4B nameLen + nameBytes + 4B id)]}.
+     * The first 4 bytes at {@code offset} store the total serialized length (including itself),
+     * followed by the name index payload.</p>
+     *
+     * @param region    the ENTITY_NAMES region MemorySegment
+     * @param offset    byte offset within the region to start writing
+     * @param nameIndex the name→id map to serialize
+     * @return number of bytes written (including the 4-byte length prefix)
+     */
+    static int saveNameIndexToRegion(java.lang.foreign.MemorySegment region, long offset,
+                                     ConcurrentHashMap<String, Integer> nameIndex) {
+        // Serialize to byte array first
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ByteBuffer countBuf = ByteBuffer.allocate(4);
+        countBuf.putInt(nameIndex.size());
+        countBuf.flip();
+        baos.write(countBuf.array(), 0, 4);
+
+        for (Map.Entry<String, Integer> entry : nameIndex.entrySet()) {
+            byte[] nameBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
+            ByteBuffer entryBuf = ByteBuffer.allocate(4 + nameBytes.length + 4);
+            entryBuf.putInt(nameBytes.length);
+            entryBuf.put(nameBytes);
+            entryBuf.putInt(entry.getValue());
+            entryBuf.flip();
+            baos.write(entryBuf.array(), 0, entryBuf.limit());
+        }
+
+        byte[] payload = baos.toByteArray();
+        int totalBytes = 4 + payload.length; // 4-byte length prefix + payload
+
+        if (offset + totalBytes > region.byteSize()) {
+            log.warn("Name index ({} bytes) exceeds ENTITY_NAMES region capacity at offset {} (region size={})",
+                    totalBytes, offset, region.byteSize());
+            return -1;
+        }
+
+        // Write length prefix then payload
+        region.set(java.lang.foreign.ValueLayout.JAVA_INT, offset, payload.length);
+        java.lang.foreign.MemorySegment.copy(
+                java.lang.foreign.MemorySegment.ofArray(payload), 0,
+                region, offset + 4, payload.length);
+
+        log.info("EntityDirectory name index saved to bundle region: {} names, {} bytes at offset {}",
+                nameIndex.size(), totalBytes, offset);
+        return totalBytes;
+    }
+
+    /**
+     * Loads the name index from a V4 bundle ENTITY_NAMES region at the given offset.
+     *
+     * @param region the ENTITY_NAMES region MemorySegment
+     * @param offset byte offset within the region where the name index starts
+     * @return the deserialized name→id map, or empty map if no data present
+     */
+    static ConcurrentHashMap<String, Integer> loadNameIndexFromRegion(
+            java.lang.foreign.MemorySegment region, long offset) {
+        if (region == null || offset + 4 > region.byteSize()) {
+            return new ConcurrentHashMap<>();
+        }
+
+        int payloadLen = region.get(java.lang.foreign.ValueLayout.JAVA_INT, offset);
+        if (payloadLen <= 0 || offset + 4 + payloadLen > region.byteSize()) {
+            return new ConcurrentHashMap<>();
+        }
+
+        byte[] payload = new byte[payloadLen];
+        java.lang.foreign.MemorySegment.copy(region, offset + 4,
+                java.lang.foreign.MemorySegment.ofArray(payload), 0, payloadLen);
+
+        ConcurrentHashMap<String, Integer> names = parseNameIndexBytes(payload);
+        log.info("EntityDirectory name index loaded from bundle region: {} names, {} bytes at offset {}",
+                names.size(), payloadLen + 4, offset);
+        return names;
+    }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationRecordMemory.java
@@ -75,6 +75,7 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     private volatile Map<Long, EnumMap<CognitiveProfile, RunningStats>> banditStats =
             new ConcurrentHashMap<>();
     private final ReentrantLock saveLock = new ReentrantLock();
+    private volatile MemorySegment checkpointRegion;   // nullable — V4 bundle CHECKPOINT region for metadata
 
     public record DirectedEdge(String sourceTag, String targetTag) {
         @Override
@@ -88,6 +89,19 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
             float newWeight = Math.clamp(weight + deltaWeight, MIN_WEIGHT, MAX_WEIGHT);
             return new EdgeWeight(newWeight, nowMs, activationCount + 1);
         }
+    }
+
+    /**
+     * Sets the V4 bundle CHECKPOINT region for persisting CoActivation metadata.
+     *
+     * <p>When set, {@link #save(Path)} writes tag index and bandit stats directly
+     * to this region slice (at offset 16, after the 16-byte checkpoint header)
+     * instead of a standalone {@code .meta} sidecar file.</p>
+     *
+     * @param checkpointRegion the CHECKPOINT region MemorySegment, or null for V3 fallback
+     */
+    public void setCheckpointRegion(MemorySegment checkpointRegion) {
+        this.checkpointRegion = checkpointRegion;
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -155,12 +169,20 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     public static CoActivationRecordMemory fromBundle(Arena arena, MemorySegment regionSlice,
                                                        int pairCap, int edgeCap,
                                                        Path bundlePath, boolean isNew) {
-        return new CoActivationRecordMemory(arena, regionSlice, pairCap, edgeCap, bundlePath, isNew);
+        return new CoActivationRecordMemory(arena, regionSlice, pairCap, edgeCap, bundlePath, isNew, null);
+    }
+
+    public static CoActivationRecordMemory fromBundle(Arena arena, MemorySegment regionSlice,
+                                                       int pairCap, int edgeCap,
+                                                       Path bundlePath, boolean isNew,
+                                                       MemorySegment checkpointRegion) {
+        return new CoActivationRecordMemory(arena, regionSlice, pairCap, edgeCap, bundlePath, isNew, checkpointRegion);
     }
 
     private CoActivationRecordMemory(Arena arena, MemorySegment regionSlice,
                                      int pairCap, int edgeCap,
-                                     Path bundlePath, boolean isNew) {
+                                     Path bundlePath, boolean isNew,
+                                     MemorySegment checkpointRegion) {
         super(SystemMemoryId.COACTIVATION.id(), new CoActivationLayout(),
               pairCap, arena, regionSlice,
               isNew ? 0 : (int) MemoryHeader.readCount(regionSlice, 0),
@@ -209,6 +231,49 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
                     log.warn("Failed to delete legacy coactivation.dat after migration: {}", e.getMessage());
                 }
             }
+        } else if (!isNew && checkpointRegion != null) {
+            try {
+                int pairs = checkpointRegion.get(ValueLayout.JAVA_INT, 16);
+                int edges = checkpointRegion.get(ValueLayout.JAVA_INT, 20);
+                this.pairTable.setCount(pairs);
+                this.edgeTable.setCount(edges);
+
+                int nameCount = checkpointRegion.get(ValueLayout.JAVA_INT, 24);
+                long offset = 28;
+                for (int i = 0; i < nameCount; i++) {
+                    long hash = checkpointRegion.get(ValueLayout.JAVA_LONG, offset);
+                    offset += 8;
+                    int len = checkpointRegion.get(ValueLayout.JAVA_INT, offset);
+                    offset += 4;
+                    byte[] nameBytes = new byte[len];
+                    MemorySegment.copy(checkpointRegion, offset, MemorySegment.ofArray(nameBytes), 0, len);
+                    offset += len;
+                    String name = new String(nameBytes, StandardCharsets.UTF_8);
+                    this.hashToTag.put(hash, name);
+                }
+
+                int entryCount = checkpointRegion.get(ValueLayout.JAVA_INT, offset);
+                offset += 4;
+                CognitiveProfile[] profiles = CognitiveProfile.values();
+                for (int i = 0; i < entryCount; i++) {
+                    long ctxHash = checkpointRegion.get(ValueLayout.JAVA_LONG, offset);
+                    int ordinal = checkpointRegion.get(ValueLayout.JAVA_BYTE, offset + 8) & 0xFF;
+                    float ema = checkpointRegion.get(ValueLayout.JAVA_FLOAT, offset + 12);
+                    int totalSignals = checkpointRegion.get(ValueLayout.JAVA_INT, offset + 16);
+                    int positiveSignals = checkpointRegion.get(ValueLayout.JAVA_INT, offset + 20);
+                    long lastUpdatedMs = checkpointRegion.get(ValueLayout.JAVA_LONG, offset + 24);
+                    offset += 32;
+
+                    if (ordinal < profiles.length) {
+                        CognitiveProfile profile = profiles[ordinal];
+                        RunningStats rs = new RunningStats(ema, totalSignals, positiveSignals, lastUpdatedMs);
+                        this.banditStats.computeIfAbsent(ctxHash, _ -> new EnumMap<>(CognitiveProfile.class))
+                                .put(profile, rs);
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Failed to load CoActivationRecordMemory metadata from CHECKPOINT region, starting empty", e);
+            }
         } else if (!isNew && bundlePath != null) {
             Path metaPath = bundlePath.resolveSibling(bundlePath.getFileName().toString() + ".meta");
             if (Files.exists(metaPath)) {
@@ -232,6 +297,8 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
                 }
             }
         }
+
+        this.checkpointRegion = checkpointRegion;
 
         log.info("CoActivationRecordMemory initialized (bundle): pairCap={}, edgeCap={}, count={}",
                 pairCap, edgeCap, size());
@@ -430,28 +497,69 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
         saveLock.lock();
         try {
             if (isBundleManaged()) {
-                Path path = filePath != null ? filePath : filePath();
-                if (path == null) return;
-                Path metaPath = path.resolveSibling(path.getFileName().toString() + ".meta");
-                try {
-                    Path parent = metaPath.getParent();
-                    if (parent != null) {
-                        Files.createDirectories(parent);
-                    }
+                if (checkpointRegion != null) {
                     flush();
-                    try (FileChannel ch = FileChannel.open(metaPath,
-                            StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
-                        ByteBuffer countsBuf = ByteBuffer.allocate(8);
-                        countsBuf.putInt(pairTable.count());
-                        countsBuf.putInt(edgeTable.count());
-                        countsBuf.flip();
-                        ch.write(countsBuf);
-
-                        writeTagIndex(ch);
-                        writeBanditStats(ch);
+                    int tagsSize = 4;
+                    for (String tag : hashToTag.values()) {
+                        tagsSize += 12 + tag.getBytes(StandardCharsets.UTF_8).length;
                     }
-                } catch (IOException e) {
-                    throw new SpectorGraphPersistenceException("CoActivationRecordMemory", metaPath, e);
+                    int banditSize = 4 + banditStatsCount() * 32;
+                    int totalSize = 8 + tagsSize + banditSize;
+                    ByteBuffer buf = ByteBuffer.allocate(totalSize);
+
+                    buf.putInt(pairTable.count());
+                    buf.putInt(edgeTable.count());
+
+                    buf.putInt(hashToTag.size());
+                    for (Map.Entry<Long, String> entry : hashToTag.entrySet()) {
+                        byte[] nameBytes = entry.getValue().getBytes(StandardCharsets.UTF_8);
+                        buf.putLong(entry.getKey());
+                        buf.putInt(nameBytes.length);
+                        buf.put(nameBytes);
+                    }
+
+                    buf.putInt(banditStatsCount());
+                    for (Map.Entry<Long, EnumMap<CognitiveProfile, RunningStats>> ctxEntry : banditStats.entrySet()) {
+                        long ctxHash = ctxEntry.getKey();
+                        for (Map.Entry<CognitiveProfile, RunningStats> profEntry : ctxEntry.getValue().entrySet()) {
+                            RunningStats rs = profEntry.getValue();
+                            buf.putLong(ctxHash);
+                            buf.put((byte) profEntry.getKey().ordinal());
+                            buf.put((byte) 0);
+                            buf.put((byte) 0);
+                            buf.put((byte) 0);
+                            buf.putFloat(rs.ema());
+                            buf.putInt(rs.totalSignals());
+                            buf.putInt(rs.positiveSignals());
+                            buf.putLong(rs.lastUpdatedMs());
+                        }
+                    }
+                    buf.flip();
+                    MemorySegment.copy(MemorySegment.ofBuffer(buf), 0, checkpointRegion, 16, totalSize);
+                } else {
+                    Path path = filePath != null ? filePath : filePath();
+                    if (path == null) return;
+                    Path metaPath = path.resolveSibling(path.getFileName().toString() + ".meta");
+                    try {
+                        Path parent = metaPath.getParent();
+                        if (parent != null) {
+                            Files.createDirectories(parent);
+                        }
+                        flush();
+                        try (FileChannel ch = FileChannel.open(metaPath,
+                                StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                            ByteBuffer countsBuf = ByteBuffer.allocate(8);
+                            countsBuf.putInt(pairTable.count());
+                            countsBuf.putInt(edgeTable.count());
+                            countsBuf.flip();
+                            ch.write(countsBuf);
+
+                            writeTagIndex(ch);
+                            writeBanditStats(ch);
+                        }
+                    } catch (IOException e) {
+                        throw new SpectorGraphPersistenceException("CoActivationRecordMemory", metaPath, e);
+                    }
                 }
             } else if (!isPersistent()) {
                 try {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
@@ -32,10 +32,14 @@ import java.time.Instant;
 import java.util.Map;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 
 /**
  * Performs periodic checkpoints of tier store segments, cognitive graphs, and WAL truncation.
@@ -101,6 +105,7 @@ public final class CheckpointDaemon {
     private final com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph temporalKnowledgeGraph; // nullable
     private final Path partitionDir;                   // nullable — active partition dir for graph saves
     private final Path basePath;                       // nullable — persistence root for coactivation
+    private final MemorySegment checkpointRegion;      // nullable — V4 bundle CHECKPOINT region slice
 
     // ── Event Bus (replaces CheckpointListener) ──
     private volatile EventBus<SpectorLifecycleEvent> eventBus;
@@ -139,6 +144,23 @@ public final class CheckpointDaemon {
                             CoActivationRecordMemory coActivationTracker,
                             com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph temporalKnowledgeGraph,
                             Path partitionDir, Path basePath) {
+        this(cognitiveRouter, wal, checkpointMetaPath, index, indexPath, hebbianGraph, temporalChain, entityDirectory, hyperEntityGraph, coActivationTracker, temporalKnowledgeGraph, partitionDir, basePath, null);
+    }
+
+    /**
+     * Creates a checkpoint daemon with full graph persistence and bundle support.
+     */
+    public CheckpointDaemon(CognitiveMemoryRouter cognitiveRouter, MemoryWal wal,
+                            Path checkpointMetaPath,
+                            MemoryIndex index, Path indexPath,
+                            HebbianGraphBase hebbianGraph,
+                            TemporalChainMemory temporalChain,
+                            EntityDirectory entityDirectory,
+                            HyperEntityGraphMemory hyperEntityGraph,
+                            CoActivationRecordMemory coActivationTracker,
+                            com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph temporalKnowledgeGraph,
+                            Path partitionDir, Path basePath,
+                            MemorySegment checkpointRegion) {
         this.cognitiveRouter = cognitiveRouter;
         this.wal = wal;
         this.checkpointMetaPath = checkpointMetaPath;
@@ -152,9 +174,8 @@ public final class CheckpointDaemon {
         this.temporalKnowledgeGraph = temporalKnowledgeGraph;
         this.partitionDir = partitionDir;
         this.basePath = basePath;
+        this.checkpointRegion = checkpointRegion;
     }
-
-
 
     /**
      * Performs a single checkpoint cycle.
@@ -311,6 +332,21 @@ public final class CheckpointDaemon {
      * Uses temp file + rename for crash safety.
      */
     private void writeCheckpointMeta(long hwm) {
+        // V4 bundle path: write directly to CHECKPOINT region slice
+        if (checkpointRegion != null) {
+            try {
+                checkpointRegion.set(ValueLayout.JAVA_INT, 0, CKPT_MAGIC);
+                checkpointRegion.set(ValueLayout.JAVA_INT, 4, CKPT_VERSION);
+                checkpointRegion.set(ValueLayout.JAVA_LONG, 8, hwm);
+                checkpointRegion.force();
+                log.trace("Checkpoint meta written to bundle region: hwm={}", hwm);
+                return;
+            } catch (Exception e) {
+                log.warn("Failed to write checkpoint to bundle region, falling back to file: {}", e.getMessage());
+            }
+        }
+
+        // V3 fallback: standalone checkpoint.meta file
         Path tempPath = checkpointMetaPath.resolveSibling(
                 checkpointMetaPath.getFileName() + ".tmp");
         try {
@@ -384,5 +420,20 @@ public final class CheckpointDaemon {
             log.warn("Failed to read checkpoint.meta: {}", e.getMessage());
             return -1;
         }
+    }
+
+    /**
+     * Reads the checkpoint HWM from a V4 bundle CHECKPOINT region slice.
+     *
+     * @param region the CHECKPOINT region MemorySegment
+     * @return the high-water mark, or -1 if the region is null or invalid
+     */
+    public static long readCheckpointHwm(MemorySegment region) {
+        if (region == null || region.byteSize() < CKPT_SIZE) return -1;
+        int magic = region.get(ValueLayout.JAVA_INT, 0);
+        if (magic != CKPT_MAGIC) return -1;
+        int version = region.get(ValueLayout.JAVA_INT, 4);
+        if (version != CKPT_VERSION) return -1;
+        return region.get(ValueLayout.JAVA_LONG, 8);
     }
 }


### PR DESCRIPTION
## Summary
ADR-0004 Phase 2 Bundle Migration — migrate the 4 remaining standalone runtime assets into `runtime.bundle`:

| Phase | Target | Status |
|:---:|:---|:---:|
| 2a | CHECKPOINT region + CoActivation metadata consolidation | ✅ |
| 2b | Entity name string index → ENTITY_NAMES region | ✅ |
| 2c | BM25 inverted index → BM25 region | ✅ |

Closes #508

## Changes

### Phase 2a: CHECKPOINT Region (`125e6426`)
- **CognitiveCortexBuilder**: Added `CHECKPOINT (23)` RegionSizeSpec (128KB, growable)
- **CheckpointDaemon**: Bundle-aware `writeCheckpointMeta` via MemorySegment.set() + V3 file fallback
- **CoActivationRecordMemory**: `checkpointRegion` field + metadata write to CHECKPOINT region, sidecar fallback

### Phase 2b: Entity Name String Index (`3de76c53`)
- **EntityDirectorySerializer**: Added `saveNameIndexToRegion/loadNameIndexFromRegion` for MemorySegment I/O
- **EntityDirectory.save()**: Writes name index to ENTITY_NAMES region (after adjacency data) when bundle-managed
- **EntityDirectory.fromBundle()**: Loads name index from region first, sidecar fallback
- **CognitiveCortexBuilder**: Increased ENTITY_NAMES region size (+32B/entity), set growable=true

### Phase 2c: BM25 Inverted Index (`854fafef`)
- **BM25Index**: Added `saveToRegion/loadFromRegion` for MemorySegment I/O (same binary format as file)
- **CognitiveCortexBuilder**: Added `BM25 (22)` RegionSizeSpec sized from `workingCapacity` (132B/doc), growable
- **RetrievalIndexBuilder**: V4 bundle region load first, V3 file fallback, saves to both on rebuild
- **DefaultSpectorMemory**: Bundle region BM25 save on close

## Design Decisions
- **Option A** (CEO-approved): Fixed-capacity pre-allocated regions with `growable=true`. Avoids the complexity of variable-slice allocation (deferred to Phase 3 #510).
- **V3 Backward Compatibility**: All paths retain standalone file fallback per CEO directive. V3 deprecation deferred to Phase 3 #510.
- **Metadata Placement**: CoActivation metadata (tags, bandit stats) consolidated into separate CHECKPOINT region per CEO preference for "separate would be better to identify and manage".
- **BM25 Sizing**: Calculated dynamically from `workingCapacity` config (132B/doc estimate) per CEO directive that "it must be calculated based on the record size or capacity set in configs".

## Testing
- Full Maven compile: ✅ PASS
- spector-index unit tests: ✅ PASS  
- spector-memory tests: ⚠️ PKIX certificate issue (infra, not code)

## Related Issues
- Phase 1: #463 (complete)
- Phase 2: #508 (this PR)
- Phase 3: #510 (variable-slice BM25 + compaction + V3 deprecation)
