### PR TITLE
refactor(config): centralize all hardcoded and default values into spector-config (#520)

### DIFF
--- a/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/BatchGpuSearcher.java
+++ b/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/BatchGpuSearcher.java
@@ -61,19 +61,19 @@ public class BatchGpuSearcher implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(BatchGpuSearcher.class);
 
     /** Minimum batching window: 1ms */
-    private static final long MIN_WINDOW_MS = 1;
+    private static final long MIN_WINDOW_MS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_BATCH_MIN_WINDOW_MS;
 
     /** Maximum batching window: 100ms */
-    private static final long MAX_WINDOW_MS = 100;
+    private static final long MAX_WINDOW_MS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_BATCH_MAX_WINDOW_MS;
 
     /** Maximum batch size */
-    private static final int MAX_BATCH_SIZE = 1024;
+    private static final int MAX_BATCH_SIZE = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_BATCH_DEFAULT_MAX_BATCH;
 
     /** Default batching window */
-    private static final Duration DEFAULT_WINDOW = Duration.ofMillis(10);
+    private static final Duration DEFAULT_WINDOW = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_BATCH_DEFAULT_WINDOW;
 
     /** Default max batch size */
-    private static final int DEFAULT_MAX_BATCH = 1024;
+    private static final int DEFAULT_MAX_BATCH = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_BATCH_DEFAULT_MAX_BATCH;
 
     private final SimilarityKernel kernel;
     private final GpuMemoryManager memoryManager;

--- a/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/GpuMemoryManager.java
+++ b/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/GpuMemoryManager.java
@@ -73,7 +73,7 @@ public class GpuMemoryManager implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(GpuMemoryManager.class);
 
     /** Minimum configurable budget: 256 MB */
-    private static final long MIN_BUDGET_BYTES = 256L * 1024 * 1024;
+    private static final long MIN_BUDGET_BYTES = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_MEMORY_MIN_BUDGET_BYTES;
 
     /** ID generator for allocation tracking */
     private static final AtomicLong ID_GENERATOR = new AtomicLong(0);

--- a/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/PanamaMemoryDetector.java
+++ b/memory/spector-gpu/src/main/java/com/spectrayan/spector/gpu/PanamaMemoryDetector.java
@@ -64,7 +64,7 @@ public class PanamaMemoryDetector {
     private static final Logger log = LoggerFactory.getLogger(PanamaMemoryDetector.class);
 
     /** Default lifetime threshold: 300 seconds. */
-    private static final Duration DEFAULT_THRESHOLD = Duration.ofSeconds(300);
+    private static final Duration DEFAULT_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_GPU_LEAK_DETECTOR_THRESHOLD;
 
     /** Minimum allowed threshold: 1 second. */
     private static final Duration MIN_THRESHOLD = Duration.ofSeconds(1);

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/spectrum/SpectorIndex.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/spectrum/SpectorIndex.java
@@ -144,11 +144,11 @@ public final class SpectorIndex implements VectorIndex {
      */
     public static final class Builder {
         private int dimensions = -1;
-        private int nCentroids = 256;
-        private int nProbe = 16;
-        private int shardThreshold = 20_000;
-        private int oversamplingFactor = 3;
-        private int kMeansIterations = 25;
+        private int nCentroids = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_N_CENTROIDS;
+        private int nProbe = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_N_PROBE;
+        private int shardThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_SHARD_THRESHOLD;
+        private int oversamplingFactor = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_OVERSAMPLING_FACTOR;
+        private int kMeansIterations = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_KMEANS_ITERATIONS;
         private SimilarityFunction similarityFunction = SimilarityFunction.COSINE;
         private HnswProperties hnswProperties = HnswProperties.DEFAULT;
 

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/spectrum/SpectorIndexConfig.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/spectrum/SpectorIndexConfig.java
@@ -57,11 +57,15 @@ public record SpectorIndexConfig(
 ) {
 
     /**
-     * Default configuration: 256 centroids, nprobe=16, flat→HNSW at 20K vectors,
-     * 3× SVASQ oversampling, 25 K-Means iterations, cosine similarity, standard HNSW params.
+     * Default configuration from SpectorPropertyConstants: 256 centroids, nprobe=16,
+     * flat→HNSW at 20K vectors, 3× SVASQ oversampling, 25 K-Means iterations, cosine similarity.
      */
     public static final SpectorIndexConfig DEFAULT = new SpectorIndexConfig(
-            256, 16, 20_000, 3, 25,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_N_CENTROIDS,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_N_PROBE,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_SHARD_THRESHOLD,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_OVERSAMPLING_FACTOR,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_SPECTRUM_KMEANS_ITERATIONS,
             SimilarityFunction.COSINE,
             HnswProperties.DEFAULT
     );

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/BM25Index.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/BM25Index.java
@@ -62,7 +62,7 @@ public class BM25Index implements KeywordIndex {
     /** Threshold: use parallel term scoring when total postings exceed this.
      * Set conservatively — virtual thread scheduling overhead only pays off
      * for large posting lists. Below 20K, sequential scoring is faster. */
-    private static final int PARALLEL_POSTING_THRESHOLD = 20_000;
+    private static final int PARALLEL_POSTING_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INDEX_BM25_PARALLEL_THRESHOLD;
 
     private final Analyzer analyzer;
     private final float k1;
@@ -149,9 +149,9 @@ public class BM25Index implements KeywordIndex {
         this.totalDocs = 0;
     }
 
-    /** Creates a BM25 index with default parameters (k1=1.2, b=0.75). */
+    /** Creates a BM25 index with default parameters from SpectorPropertyConstants. */
     public BM25Index(Analyzer analyzer) {
-        this(analyzer, 1.2f, 0.75f);
+        this(analyzer, com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INDEX_BM25_K1, com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INDEX_BM25_B);
     }
 
     /** Creates a BM25 index with the standard analyzer and default params. */

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/ColBERTTokenCache.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/ColBERTTokenCache.java
@@ -103,12 +103,12 @@ public final class ColBERTTokenCache implements AutoCloseable {
     }
 
     /**
-     * Creates a ColBERT token cache with default capacity (1024 entries).
+     * Creates a ColBERT token cache with default capacity from SpectorPropertyConstants.
      *
      * @param tokenDims dimensionality of each token embedding
      */
     public ColBERTTokenCache(int tokenDims) {
-        this(tokenDims, 1024);
+        this(tokenDims, com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INDEX_COLBERT_CACHE_CAPACITY);
     }
 
     /**

--- a/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/SpladeIndex.java
+++ b/memory/spector-index/src/main/java/com/spectrayan/spector/index/text/SpladeIndex.java
@@ -79,7 +79,7 @@ public class SpladeIndex implements KeywordIndex {
     /** Threshold: use parallel term scoring when total postings exceed this.
      * Matches the strategy in {@link BM25Index}  --  virtual thread scheduling
      * overhead only pays off for large posting lists. */
-    private static final int PARALLEL_POSTING_THRESHOLD = 15_000;
+    private static final int PARALLEL_POSTING_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INDEX_SPLADE_PARALLEL_THRESHOLD;
 
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
 

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/FileDiscoveryService.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/FileDiscoveryService.java
@@ -190,11 +190,11 @@ public class FileDiscoveryService {
     // ─────────────── Builder ───────────────
 
     public static class Builder {
-        private Path rootDirectory = Path.of(".");
-        private String filePattern = "**/*.md";
+        private Path rootDirectory = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_ROOT_DIRECTORY;
+        private String filePattern = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_FILE_PATTERN;
         private List<String> skipDirs = List.of(".git", ".idea", ".mvn", "target", "node_modules", ".github");
-        private int chunkSize = 800;
-        private int chunkOverlap = 100;
+        private int chunkSize = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_SIZE;
+        private int chunkOverlap = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_OVERLAP;
 
         public Builder rootDirectory(Path rootDirectory) { this.rootDirectory = rootDirectory; return this; }
         public Builder filePattern(String filePattern) { this.filePattern = filePattern; return this; }

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/AudioExtractorConfig.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/AudioExtractorConfig.java
@@ -34,9 +34,13 @@ public record AudioExtractorConfig(
         int maxSegmentSeconds,
         String language
 ) {
-    /** Default configuration for Ollama-based audio extraction. */
+    /** Default configuration for Ollama-based audio extraction from SpectorPropertyConstants. */
     public static final AudioExtractorConfig DEFAULT = new AudioExtractorConfig(
-            "gemma4", null, 120, 0, null
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_AUDIO_MODEL,
+            null,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_AUDIO_TIMEOUT,
+            0,
+            null
     );
 
     /** Creates config with just a model name, using defaults for everything else. */

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/FFmpegKeyframeExtractor.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/FFmpegKeyframeExtractor.java
@@ -67,10 +67,10 @@ public class FFmpegKeyframeExtractor implements SensoryExtractor {
     );
 
     /** Default keyframe extraction interval in seconds. */
-    private static final int DEFAULT_INTERVAL_SECONDS = 10;
+    private static final int DEFAULT_INTERVAL_SECONDS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_VIDEO_KEYFRAME_INTERVAL;
 
     /** Default max keyframes to extract. */
-    private static final int DEFAULT_MAX_KEYFRAMES = 30;
+    private static final int DEFAULT_MAX_KEYFRAMES = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_VIDEO_MAX_KEYFRAMES;
 
     private final int intervalSeconds;
     private final int maxKeyframes;

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/LocalAssetStore.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/LocalAssetStore.java
@@ -46,7 +46,7 @@ public final class LocalAssetStore implements AssetStore {
     private static final Logger log = LoggerFactory.getLogger(LocalAssetStore.class);
 
     /** Default base directory for asset storage. */
-    private static final String DEFAULT_BASE_DIR = ".spector/assets";
+    private static final String DEFAULT_BASE_DIR = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_ASSET_BASE_PATH.toString();
 
     private final Path baseDir;
 

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/OllamaAudioExtractor.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/OllamaAudioExtractor.java
@@ -61,7 +61,7 @@ public final class OllamaAudioExtractor implements AudioTranscriptExtractor {
     private static final Logger log = LoggerFactory.getLogger(OllamaAudioExtractor.class);
 
     /** Maximum file size for direct processing (50 MB). */
-    private static final long MAX_FILE_SIZE = 50 * 1024 * 1024;
+    private static final long MAX_FILE_SIZE = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_AUDIO_MAX_FILE_SIZE;
 
     private static final String TRANSCRIPTION_PROMPT = """
             Listen to this audio carefully and provide a complete, accurate transcription.

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/OllamaVisionExtractor.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/OllamaVisionExtractor.java
@@ -65,13 +65,13 @@ public final class OllamaVisionExtractor implements SensoryExtractor {
     private static final Logger log = LoggerFactory.getLogger(OllamaVisionExtractor.class);
 
     /** Default vision model. */
-    private static final String DEFAULT_MODEL = "moondream";
+    private static final String DEFAULT_MODEL = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_VISION_MODEL;
 
     /** Default timeout for vision inference (images take longer). */
-    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(120);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_VISION_TIMEOUT);
 
     /** Maximum image file size (20 MB). */
-    private static final long MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024;
+    private static final long MAX_IMAGE_SIZE_BYTES = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_VISION_MAX_IMAGE_SIZE;
 
     /** Captioning prompt — instructs the VLM to produce a rich description. */
     private static final String CAPTIONING_PROMPT =

--- a/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/TikaTextExtractor.java
+++ b/memory/spector-ingestion/src/main/java/com/spectrayan/spector/ingestion/sensory/TikaTextExtractor.java
@@ -78,7 +78,7 @@ public final class TikaTextExtractor implements SensoryExtractor {
     );
 
     /** Maximum content length Tika will extract (100 MB as text). */
-    private static final int MAX_CONTENT_LENGTH = 100 * 1024 * 1024;
+    private static final int MAX_CONTENT_LENGTH = (int) com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MULTIMODAL_TIKA_MAX_CONTENT_LENGTH;
 
     private final Tika tika;
     private final int chunkSize;
@@ -88,16 +88,16 @@ public final class TikaTextExtractor implements SensoryExtractor {
     /**
      * Creates an extractor with configurable chunk size and a TextChunker SPI implementation.
      *
-     * @param chunkSize    characters per chunk (default: 800)
-     * @param chunkOverlap overlap between consecutive chunks (default: 100)
+     * @param chunkSize    characters per chunk
+     * @param chunkOverlap overlap between consecutive chunks
      * @param textChunker  the TextChunker SPI to delegate chunking to (nullable — defaults to MarkdownChunker)
      */
     public TikaTextExtractor(int chunkSize, int chunkOverlap,
                              com.spectrayan.spector.commons.chunker.TextChunker textChunker) {
         this.tika = new Tika();
         this.tika.setMaxStringLength(MAX_CONTENT_LENGTH);
-        this.chunkSize = chunkSize > 0 ? chunkSize : 800;
-        this.chunkOverlap = chunkOverlap >= 0 ? chunkOverlap : 100;
+        this.chunkSize = chunkSize > 0 ? chunkSize : com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_SIZE;
+        this.chunkOverlap = chunkOverlap >= 0 ? chunkOverlap : com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_OVERLAP;
         this.textChunker = textChunker != null ? textChunker : new MarkdownChunker();
         log.info("TikaTextExtractor initialized: chunkSize={}, overlap={}, chunker={}",
                 this.chunkSize, this.chunkOverlap, this.textChunker.name());
@@ -106,16 +106,17 @@ public final class TikaTextExtractor implements SensoryExtractor {
     /**
      * Creates an extractor with configurable chunk size.
      *
-     * @param chunkSize    characters per chunk (default: 800)
-     * @param chunkOverlap overlap between consecutive chunks (default: 100)
+     * @param chunkSize    characters per chunk
+     * @param chunkOverlap overlap between consecutive chunks
      */
     public TikaTextExtractor(int chunkSize, int chunkOverlap) {
         this(chunkSize, chunkOverlap, null);
     }
 
-    /** Creates an extractor with default settings (800 char chunks, 100 overlap). */
+    /** Creates an extractor with default settings from SpectorPropertyConstants. */
     public TikaTextExtractor() {
-        this(800, 100, null);
+        this(com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_SIZE,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_OVERLAP, null);
     }
 
     @Override

--- a/memory/spector-ingestion/src/test/java/com/spectrayan/spector/ingestion/sensory/AudioExtractorConfigTest.java
+++ b/memory/spector-ingestion/src/test/java/com/spectrayan/spector/ingestion/sensory/AudioExtractorConfigTest.java
@@ -37,7 +37,7 @@ class AudioExtractorConfigTest {
             var cfg = AudioExtractorConfig.DEFAULT;
             assertEquals("gemma4", cfg.model());
             assertNull(cfg.baseUrl(), "baseUrl should be null (resolved by ProviderDiscovery)");
-            assertEquals(120, cfg.timeoutSeconds());
+            assertEquals(180, cfg.timeoutSeconds());
             assertEquals(0, cfg.maxSegmentSeconds());
             assertNull(cfg.language());
         }
@@ -115,17 +115,17 @@ class AudioExtractorConfigTest {
         }
 
         @Test
-        @DisplayName("Zero timeout defaults to 120")
+        @DisplayName("Zero timeout defaults to 180")
         void zeroTimeoutDefaults() {
             var cfg = new AudioExtractorConfig("m", "http://localhost:11434", 0, 0, null);
-            assertEquals(120, cfg.timeoutSeconds());
+            assertEquals(180, cfg.timeoutSeconds());
         }
 
         @Test
-        @DisplayName("Negative timeout defaults to 120")
+        @DisplayName("Negative timeout defaults to 180")
         void negativeTimeoutDefaults() {
             var cfg = new AudioExtractorConfig("m", "http://localhost:11434", -5, 0, null);
-            assertEquals(120, cfg.timeoutSeconds());
+            assertEquals(180, cfg.timeoutSeconds());
         }
 
         @Test
@@ -146,7 +146,7 @@ class AudioExtractorConfigTest {
         @DisplayName("Record equality works")
         void recordEquality() {
             var a = AudioExtractorConfig.DEFAULT;
-            var b = new AudioExtractorConfig("gemma4", null, 120, 0, null);
+            var b = new AudioExtractorConfig("gemma4", null, 180, 0, null);
             assertEquals(a, b);
             assertEquals(a.hashCode(), b.hashCode());
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
@@ -60,25 +60,25 @@ final class ReflectionOrchestrator {
     private static final Logger log = LoggerFactory.getLogger(ReflectionOrchestrator.class);
 
     /** Minimum Hebbian weight to qualify for cross-layer promotion to entity graph. */
-    private static final float HEBBIAN_PROMOTION_MIN_WEIGHT = 3.0f;
+    private static final float HEBBIAN_PROMOTION_MIN_WEIGHT = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_PROMOTION_MIN_WEIGHT;
 
     /** Hebbian decay factor per reflection cycle (10% decay = multiply by 0.9). */
-    private static final float HEBBIAN_DECAY_FACTOR = 0.9f;
+    private static final float HEBBIAN_DECAY_FACTOR = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_DECAY_FACTOR;
 
     /** Entity edge decay factor per cycle (5% decay). */
-    private static final float ENTITY_DECAY_FACTOR = 0.95f;
+    private static final float ENTITY_DECAY_FACTOR = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_DECAY_FACTOR;
 
     /** Entity edge pruning threshold (edges below this weight are removed). */
-    private static final float ENTITY_PRUNE_THRESHOLD = 0.5f;
+    private static final float ENTITY_PRUNE_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_PRUNE_THRESHOLD;
 
     /** Entity→memory adjacency decay factor per cycle (5% decay — LTD). */
-    private static final float ENTITY_ADJ_DECAY_FACTOR = 0.95f;
+    private static final float ENTITY_ADJ_DECAY_FACTOR = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_ADJ_DECAY_FACTOR;
 
     /** Entity→memory adjacency pruning threshold (links below this are removed). */
-    private static final float ENTITY_ADJ_PRUNE_THRESHOLD = 0.2f;
+    private static final float ENTITY_ADJ_PRUNE_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_ADJ_PRUNE_THRESHOLD;
 
     /** Levenshtein distance threshold for merging near-duplicate entities. */
-    private static final int ENTITY_MERGE_DISTANCE = 2;
+    private static final int ENTITY_MERGE_DISTANCE = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_MERGE_DISTANCE;
 
     // ── STC Cross-Capture Constants ──
 
@@ -86,13 +86,13 @@ final class ReflectionOrchestrator {
      * Minimum Hebbian weight to qualify for cross-capture propagation.
      * Only moderately-strong edges propagate signals across layers.
      */
-    private static final float CROSS_CAPTURE_MIN_WEIGHT = 2.0f;
+    private static final float CROSS_CAPTURE_MIN_WEIGHT = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CROSS_CAPTURE_MIN_WEIGHT;
 
     /**
      * Scale factor mapping Hebbian weight to entity edge boost.
      * Hebbian weight 4.0 × 0.05 = 0.20 boost to entity edge weight.
      */
-    private static final float CROSS_CAPTURE_SCALE_FACTOR = 0.05f;
+    private static final float CROSS_CAPTURE_SCALE_FACTOR = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CROSS_CAPTURE_SCALE_FACTOR;
 
     /**
      * Maximum per-cycle boost to an entity edge from cross-capture.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -73,23 +73,23 @@ public final class SpectorMemoryBuilder {
     String namespaceId = "default";
     boolean persistWorkingMemory = false;
     CircadianPolicy circadianPolicy = CircadianPolicy.DEFAULT;
-    int workingCapacity = 100;
-    int episodicPartitionCapacity = 1_000;
-    int semanticCapacity = 10_000;
-    int nodesPerPartition = 10_000;
-    int proceduralCapacity = 1_000;
-    int surpriseWarmup = 10;
-    double flashbulbThreshold = 3.0;
-    float valenceLearningRate = 0.3f;
-    float deduplicationRadius = 0.05f;
+    int workingCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_WORKING_CAPACITY;
+    int episodicPartitionCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_EPISODIC_PARTITION_CAPACITY;
+    int semanticCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_SEMANTIC_CAPACITY;
+    int nodesPerPartition = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_NODES_PER_PARTITION;
+    int proceduralCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PROCEDURAL_CAPACITY;
+    int surpriseWarmup = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_SURPRISE_WARMUP;
+    double flashbulbThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_FLASHBULB_THRESHOLD;
+    float valenceLearningRate = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_VALENCE_LEARNING_RATE;
+    float deduplicationRadius = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_DEDUPLICATION_RADIUS;
     LlmProvider LlmProvider;
     ScalarQuantizer quantizer;
     com.spectrayan.spector.index.VectorIndex semanticIndex;
-    long inhibitionTtlMs = 300_000L;
-    float inhibitionFloor = 0.1f;
+    long inhibitionTtlMs = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_TTL_MS;
+    float inhibitionFloor = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_FLOOR;
     IcnuWeights icnuWeights;
     boolean pinSourceEpisodes = false;
-    int pinnedQuota = 10_000;
+    int pinnedQuota = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PINNED_QUOTA;
     TagExtractor tagExtractor;
     CognitiveProfileConfig profileConfig = CognitiveProfileConfig.allEnabled();
 
@@ -98,26 +98,26 @@ public final class SpectorMemoryBuilder {
     int temporalChainCapacity = 0;
     EntityExtractionMode entityExtractionMode = EntityExtractionMode.NONE;
     EntityExtractor entityExtractor;
-    int entityGraphCapacity = 50_000;
-    int maxEntitiesPerMemory = 10;
-    int maxRelationsPerMemory = 20;
+    int entityGraphCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_GRAPH_CAPACITY;
+    int maxEntitiesPerMemory = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_MAX_PER_MEM;
+    int maxRelationsPerMemory = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_RELATION_MAX_PER_MEM;
     GenerationOptions llmGenerationOptions;
     GraphScoringPolicy graphScoringPolicy = GraphScoringPolicy.DEFAULT;
-    int temporalRetentionDays = 7;
+    int temporalRetentionDays = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_RETENTION_DAYS;
     TwoFactorConfig twoFactorConfig = TwoFactorConfig.DEFAULT;
     
     // Entity resolution config
     boolean entityResolutionEnabled = false;
     boolean entityShadowMode = true;
-    float entityCosineThreshold = 0.85f;
+    float entityCosineThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_COSINE_THRESHOLD;
     
     // Ontology config
     com.spectrayan.spector.memory.graph.OntologyConfig ontologyConfig;
 
     //  Edge importance configuration 
     EdgeImportance edgeImportance = EdgeImportance.DEFAULT;
-    int hebbianMaxDegree = HebbianGraph.DEFAULT_MAX_DEGREE;
-    int entityMaxDegree = 16;
+    int hebbianMaxDegree = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE;
+    int entityMaxDegree = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_MAX_DEGREE;
 
     //  ID generation strategy 
     IdStrategy idStrategy = IdStrategy.TSID;
@@ -128,14 +128,16 @@ public final class SpectorMemoryBuilder {
     TokenEmbeddingProvider tokenEmbeddingProvider;
 
     //  Checkpoint daemon configuration 
-    int checkpointIntervalSeconds = 30;
+    int checkpointIntervalSeconds = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CHECKPOINT_INTERVAL_SECONDS;
 
     //  Chunking for remember() 
     com.spectrayan.spector.commons.chunker.TextChunker chunker = new com.spectrayan.spector.commons.chunker.MarkdownChunker();
-    com.spectrayan.spector.commons.chunker.ChunkConfig chunkConfig = com.spectrayan.spector.commons.chunker.ChunkConfig.markdown(2500, 200);
+    com.spectrayan.spector.commons.chunker.ChunkConfig chunkConfig = com.spectrayan.spector.commons.chunker.ChunkConfig.markdown(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_SIZE,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_INGESTION_CHUNK_OVERLAP);
 
     //  Embedding pipeline batch size 
-    int embedBatchSize = 32;
+    int embedBatchSize = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_PROVIDER_EMBEDDING_BATCH_SIZE;
 
     //  Salience profile provider (enterprise SPI) 
     SalienceProfileProvider salienceProfileProvider;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -68,10 +68,13 @@ public final class SpectorMemoryBuilder {
     int dimensions;
     EmbeddingProvider embeddingProvider;
     Path persistencePath;
-    MemoryPersistenceMode persistenceMode = MemoryPersistenceMode.DISK;
-    int maxActiveNamespaces = Integer.getInteger("spector.memory.max-namespaces", 100);
-    String namespaceId = "default";
-    boolean persistWorkingMemory = false;
+    MemoryPersistenceMode persistenceMode = MemoryPersistenceMode.valueOf(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PERSISTENCE_MODE_NAME);
+    int maxActiveNamespaces = Integer.getInteger(
+            com.spectrayan.spector.config.SpectorPropertyConstants.MEMORY_MAX_NAMESPACES,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_MAX_NAMESPACES);
+    String namespaceId = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_NAMESPACE_ID;
+    boolean persistWorkingMemory = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PERSIST_WORKING_MEMORY;
     CircadianPolicy circadianPolicy = CircadianPolicy.DEFAULT;
     int workingCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_WORKING_CAPACITY;
     int episodicPartitionCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_EPISODIC_PARTITION_CAPACITY;
@@ -88,15 +91,16 @@ public final class SpectorMemoryBuilder {
     long inhibitionTtlMs = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_TTL_MS;
     float inhibitionFloor = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_FLOOR;
     IcnuWeights icnuWeights;
-    boolean pinSourceEpisodes = false;
+    boolean pinSourceEpisodes = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PIN_SOURCE_EPISODES;
     int pinnedQuota = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PINNED_QUOTA;
     TagExtractor tagExtractor;
     CognitiveProfileConfig profileConfig = CognitiveProfileConfig.allEnabled();
 
-    //  3-Layer Cognitive Graph configuration 
+    // ─── 3-Layer Cognitive Graph configuration ───
     int hebbianGraphCapacity = 0;
     int temporalChainCapacity = 0;
-    EntityExtractionMode entityExtractionMode = EntityExtractionMode.NONE;
+    EntityExtractionMode entityExtractionMode = EntityExtractionMode.valueOf(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_EXTRACTION_MODE);
     EntityExtractor entityExtractor;
     int entityGraphCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_GRAPH_CAPACITY;
     int maxEntitiesPerMemory = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_MAX_PER_MEM;
@@ -107,20 +111,21 @@ public final class SpectorMemoryBuilder {
     TwoFactorConfig twoFactorConfig = TwoFactorConfig.DEFAULT;
     
     // Entity resolution config
-    boolean entityResolutionEnabled = false;
-    boolean entityShadowMode = true;
+    boolean entityResolutionEnabled = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_RESOLUTION_ENABLED;
+    boolean entityShadowMode = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_SHADOW_MODE;
     float entityCosineThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_COSINE_THRESHOLD;
     
     // Ontology config
     com.spectrayan.spector.memory.graph.OntologyConfig ontologyConfig;
 
-    //  Edge importance configuration 
+    // ─── Edge importance configuration ───
     EdgeImportance edgeImportance = EdgeImportance.DEFAULT;
     int hebbianMaxDegree = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE;
     int entityMaxDegree = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_MAX_DEGREE;
 
-    //  ID generation strategy 
-    IdStrategy idStrategy = IdStrategy.TSID;
+    // ─── ID generation strategy ───
+    IdStrategy idStrategy = IdStrategy.valueOf(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ID_STRATEGY);
     MemoryIdGenerator idGenerator;
 
     //  SPLADE + ColBERT providers 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/BridgeDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/BridgeDetector.java
@@ -57,10 +57,10 @@ public final class BridgeDetector {
     private static final Logger log = LoggerFactory.getLogger(BridgeDetector.class);
 
     /** Default number of spanning trees to sample. */
-    public static final int DEFAULT_SAMPLE_COUNT = 15;
+    public static final int DEFAULT_SAMPLE_COUNT = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_BRIDGE_SAMPLE_COUNT;
 
     /** Maximum time budget for spanning tree computation (milliseconds). */
-    public static final long DEFAULT_BUDGET_MS = 500;
+    public static final long DEFAULT_BUDGET_MS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_BRIDGE_BUDGET_MS;
 
     private BridgeDetector() {}
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityGraphMemory.java
@@ -137,7 +137,7 @@ final class EntityGraphMemory extends AbstractGraphMemory<EntityLayout> {
     static final int DEFAULT_ADJ_PER_ENTITY = 8;
 
     /** LTP weight increment when an entity is re-mentioned in a memory. */
-    private static final float LTP_REINFORCEMENT = 0.2f;
+    private static final float LTP_REINFORCEMENT = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_LTP_REINFORCEMENT;
 
     /** Initial weight for a new entity→memory link. */
     private static final float INITIAL_LINK_WEIGHT = 1.0f;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/LlmEntityExtractor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/LlmEntityExtractor.java
@@ -65,8 +65,8 @@ public final class LlmEntityExtractor implements EntityExtractor {
     /** Pattern to strip <think>...</think> reasoning blocks from qwen3 output. */
     private static final Pattern THINK_BLOCK = Pattern.compile(
             "<think>.*?</think>", Pattern.DOTALL);
-    private static final int DEFAULT_MAX_ENTITIES = 10;
-    private static final int DEFAULT_MAX_RELATIONS = 20;
+    private static final int DEFAULT_MAX_ENTITIES = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_MAX_PER_MEM;
+    private static final int DEFAULT_MAX_RELATIONS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_RELATION_MAX_PER_MEM;
 
     private static final Pattern ENTITY_PATTERN = Pattern.compile(
             "^ENTITY:\\s*(.+?)\\s*\\|\\s*(\\w+)\\s*$", Pattern.MULTILINE);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/habituation/HabituationPenalty.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/habituation/HabituationPenalty.java
@@ -76,14 +76,18 @@ public final class HabituationPenalty {
      * @param decayRate habituation strength (default: 0.2, higher = faster habituation)
      */
     public HabituationPenalty(float decayRate) {
-        this(decayRate, 300_000L, 0.1f);
+        this(decayRate,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_TTL_MS,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_FLOOR);
     }
 
     /**
-     * Creates a habituation penalty with all defaults (decayRate=0.2, TTL=5min, floor=0.1).
+     * Creates a habituation penalty with all defaults from SpectorPropertyConstants.
      */
     public HabituationPenalty() {
-        this(0.2f, 300_000L, 0.1f);
+        this(0.2f,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_TTL_MS,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_INHIBITION_FLOOR);
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/CoActivationRecordMemory.java
@@ -54,10 +54,10 @@ public final class CoActivationRecordMemory extends AbstractRecordMemory<CoActiv
     private static final Logger log = LoggerFactory.getLogger(CoActivationRecordMemory.class);
 
     // ── STDP Constants ──
-    private static final float A_PLUS = 0.1f;
-    private static final float A_MINUS = 0.05f;
-    private static final float TAU_PLUS = 30_000f;
-    private static final float TAU_MINUS = 30_000f;
+    private static final float A_PLUS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_STDP_A_PLUS;
+    private static final float A_MINUS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_STDP_A_MINUS;
+    private static final float TAU_PLUS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_STDP_TAU_PLUS;
+    private static final float TAU_MINUS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_STDP_TAU_MINUS;
     static final float MIN_WEIGHT = 0.0f;
     static final float MAX_WEIGHT = 1.0f;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraph.java
@@ -79,7 +79,7 @@ public final class HebbianGraph implements HebbianGraphBase {
     private static final int FILE_HEADER_BYTES = 16;
 
     /** Default maximum number of Hebbian neighbors per memory (configurable). */
-    public static final int DEFAULT_MAX_DEGREE = 24;
+    public static final int DEFAULT_MAX_DEGREE = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE;
 
     /**
      * Bytes per edge (V2): 4B neighbor + 4B weight + 2B lastCycle + 1B bridgeScore + 1B flags.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/CircadianPolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/CircadianPolicy.java
@@ -59,10 +59,10 @@ public record CircadianPolicy(
      * Builder for {@link CircadianPolicy}.
      */
     public static final class Builder {
-        private int volumeTrigger = 100;
-        private Duration timeTrigger = Duration.ofHours(1);
-        private float tombstoneThreshold = 0.30f;
-        private float decayPruneThreshold = 0.05f;
+        private int volumeTrigger = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CIRCADIAN_VOLUME_TRIGGER;
+        private Duration timeTrigger = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CIRCADIAN_TIME_TRIGGER;
+        private float tombstoneThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CIRCADIAN_TOMBSTONE_THRESHOLD;
+        private float decayPruneThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_CIRCADIAN_DECAY_PRUNE_THRESHOLD;
         private float interferenceThreshold = 0.12f;
         private float interferenceDecayFactor = 0.7f;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
@@ -108,7 +108,7 @@ public final class ReflectDaemon {
     private static final Logger log = LoggerFactory.getLogger(ReflectDaemon.class);
 
     /** Default minimum cluster size for REM consolidation. */
-    private static final int DEFAULT_MIN_CLUSTER_SIZE = 5;
+    private static final int DEFAULT_MIN_CLUSTER_SIZE = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_REFLECT_MIN_CLUSTER_SIZE;
 
     private final CircadianPolicy policy;
     private final TombstoneCompactor compactor;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -214,7 +214,7 @@ public record RecallOptions(
         private Long maxTimestamp = null;
 
         //  Graph Expansion Gating 
-        private float graphExpansionThreshold = 0.40f; // default: expand when max similarity < 0.40
+        private float graphExpansionThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_EXPANSION_THRESHOLD;
 
         //  WAL Replay (Time-Travel) 
         private Instant replayTimestamp = null;    // null = disabled

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -197,65 +197,68 @@ public record RecallOptions(
 
         //  Text Search (BM25 Hybrid) 
         private float gamma = 0.3f;                             // BM25 weight in fused score
-        private boolean enableTextSearch = true;                 // enable BM25 parallel path
-        private TextSearchMode textSearchMode = TextSearchMode.HYBRID; // search mode
+        private boolean enableTextSearch = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_TEXT_SEARCH_ENABLED;
+        private TextSearchMode textSearchMode = TextSearchMode.valueOf(
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_TEXT_SEARCH_MODE);
 
-        //  Scoring Mode 
-        private ScoringMode scoringMode = ScoringMode.COGNITIVE; // default: full cognitive
+        // ─── Scoring Mode ───
+        private ScoringMode scoringMode = ScoringMode.valueOf(
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_SCORING_MODE);
 
-        //  Entity Hints 
+        // ─── Entity Hints ───
         private List<ExtractedEntity> entityHints = List.of(); // default: empty (use EntityExtractor)
 
-        //  Pipeline Tracing 
-        private boolean enableTrace = false; // default: off (no allocation overhead)
+        // ─── Pipeline Tracing ───
+        private boolean enableTrace = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_TRACE_ENABLED;
 
-        //  Temporal Gating 
+        // ─── Temporal Gating ───
         private Long minTimestamp = null;
         private Long maxTimestamp = null;
 
-        //  Graph Expansion Gating 
+        // ─── Graph Expansion Gating ───
         private float graphExpansionThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_EXPANSION_THRESHOLD;
 
-        //  WAL Replay (Time-Travel) 
+        // ─── WAL Replay (Time-Travel) ───
         private Instant replayTimestamp = null;    // null = disabled
-        private int maxReplayEvents = 100_000;     // cap to prevent OOM on large WALs
+        private int maxReplayEvents = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_MAX_REPLAY_EVENTS;
 
-        //  Reranker (ColBERT v2) 
-        private boolean enableReranker = false;     // default: off (requires TokenEmbeddingProvider)
-        private int rerankerDepth = 50;             // rerank top-50 first-stage candidates
+        // ─── Reranker (ColBERT v2) ───
+        private boolean enableReranker = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_RERANKER_ENABLED;
+        private int rerankerDepth = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_RERANKER_DEPTH;
 
-        //  MMR Diversity 
-        private boolean enableMmr = false;          // default: off
-        private float mmrLambda = 0.5f;             // trade-off between relevance and diversity
+        // ─── MMR Diversity ───
+        private boolean enableMmr = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_MMR_ENABLED;
+        private float mmrLambda = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_MMR_LAMBDA;
 
-        //  Auto-Profile Detection 
-        private boolean autoProfile = false;         // default: off (use explicit profile)
-        private boolean includeContradictions = false; // default: off (exclude contradicted records)
+        // ─── Auto-Profile Detection ───
+        private boolean autoProfile = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_AUTO_PROFILE_ENABLED;
+        private boolean includeContradictions = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_INCLUDE_CONTRADICTIONS;
         private CognitiveProfile resolvedProfile = null; // set when profile() is called
 
-        //  Neurodivergent: Hyperfocus 
+        // ─── Neurodivergent: Hyperfocus ───
         private long hyperfocusMask = 0L;       // 0 = disabled
         private float hyperfocusBoost = 1.0f;   // post-score multiplier
 
-        //  Neurodivergent: Lateral Retrieval 
-        private boolean lateralMode = false;
-        private float lateralDistanceThreshold = 1.2f;
+        // ─── Neurodivergent: Lateral Retrieval ───
+        private boolean lateralMode = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_LATERAL_ENABLED;
+        private float lateralDistanceThreshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_LATERAL_DISTANCE_THRESHOLD;
         private int lateralMaxResults = -1;      // -1 = topK/3
-        private float lateralMinTagOverlap = 0.5f;
+        private float lateralMinTagOverlap = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_LATERAL_MIN_TAG_OVERLAP;
 
-        //  Enhanced Scoring 
-        private float strictnessCoefficient = 1.0f; // 1.0 = standard, 10.0 = Heaviside cliff
+        // ─── Enhanced Scoring ───
+        private float strictnessCoefficient = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_STRICTNESS_COEFFICIENT;
 
-        //  Valence Alignment (State-Dependent Recall) 
+        // ─── Valence Alignment (State-Dependent Recall) ───
         private byte queryValence = 0;              // 0 = neutral
-        private boolean enableValenceAlignment = false;
+        private boolean enableValenceAlignment = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_VALENCE_ALIGNMENT_ENABLED;
 
-        //  Two-Factor Memory (Bjork & Bjork) 
+        // ─── Two-Factor Memory (Bjork & Bjork) ───
         private com.spectrayan.spector.memory.synapse.TwoFactorConfig twoFactorConfig
                 = com.spectrayan.spector.memory.synapse.TwoFactorConfig.DEFAULT;
 
-        //  Recall Mode 
-        private RecallMode recallMode = RecallMode.LEARN;
+        // ─── Recall Mode ───
+        private RecallMode recallMode = RecallMode.valueOf(
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_MODE);
 
         /**
          * Applies a {@link CognitiveProfile} preset to this builder.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/neurodivergent/IcnuWeights.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/neurodivergent/IcnuWeights.java
@@ -55,24 +55,20 @@ public record IcnuWeights(float interest, float challenge, float novelty, float 
     private static final float MAX_IMPORTANCE = 10.0f;
 
     /** Default sigmoid threshold — stimuli below 0.2 are nearly invisible. */
-    private static final float DEFAULT_THRESHOLD = 0.2f;
+    private static final float DEFAULT_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ICNU_THRESHOLD;
 
     /** Default sigmoid steepness — moderate cutoff sharpness. */
-    private static final float DEFAULT_STEEPNESS = 8.0f;
+    private static final float DEFAULT_STEEPNESS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ICNU_STEEPNESS;
 
     /**
      * Default: novelty-dominant, interest is strongest LLM signal.
      * Sigmoid threshold=0.2, steepness=8 (moderate gating).
-     *
-     * <p>Rationale:</p>
-     * <ul>
-     *   <li><b>Novelty (0.4)</b>: Strongest — objectively measurable, model-agnostic, impossible to game</li>
-     *   <li><b>Interest (0.3)</b>: Second — the LLM knows what it's working on</li>
-     *   <li><b>Urgency (0.2)</b>: Third — temporal priority matters but is often over-reported</li>
-     *   <li><b>Challenge (0.1)</b>: Lowest — hardest for the LLM to assess honestly</li>
-     * </ul>
      */
-    public static final IcnuWeights DEFAULT = new IcnuWeights(0.30f, 0.10f, 0.40f, 0.20f,
+    public static final IcnuWeights DEFAULT = new IcnuWeights(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ICNU_WEIGHT_INTEREST,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ICNU_WEIGHT_CHALLENGE,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ICNU_WEIGHT_NOVELTY,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ICNU_WEIGHT_URGENCY,
             DEFAULT_THRESHOLD, DEFAULT_STEEPNESS);
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphScoringPolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphScoringPolicy.java
@@ -67,7 +67,7 @@ public record GraphScoringPolicy(
     private static final Logger log = LoggerFactory.getLogger(GraphScoringPolicy.class);
 
     /** System property key for configuring the graph expansion threshold at runtime. */
-    public static final String THRESHOLD_SYSTEM_PROPERTY = "spector.benchmark.graphExpansionThreshold";
+    public static final String THRESHOLD_SYSTEM_PROPERTY = com.spectrayan.spector.config.SpectorPropertyConstants.GRAPH_EXPANSION_THRESHOLD_PROPERTY;
 
     /**
      * Backward-compatible constructor — uses default graph expansion threshold, GATED mode.
@@ -105,7 +105,7 @@ public record GraphScoringPolicy(
     public static final GraphScoringPolicy DEFAULT = resolveDefault();
 
     private static GraphScoringPolicy resolveDefault() {
-        float threshold = 0.40f;
+        float threshold = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_EXPANSION_THRESHOLD;
         String thresholdStr = System.getProperty(THRESHOLD_SYSTEM_PROPERTY);
         if (thresholdStr != null && !thresholdStr.isBlank()) {
             try {
@@ -117,11 +117,11 @@ public record GraphScoringPolicy(
         GraphExpansionMode mode = GraphExpansionMode.resolve();
 
         return new GraphScoringPolicy(
-                0.3f,   // causalBoostWeight
-                0.3f,   // hebbianBoostFactor
-                0.8f,   // temporalForwardFactor
-                0.7f,   // temporalBackwardFactor
-                0.25f,  // entityHopAttenuation
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_CAUSAL_BOOST,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_HEBBIAN_BOOST,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_TEMPORAL_FWD,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_TEMPORAL_BWD,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_GRAPH_ENTITY_ATTENUATION,
                 2,      // hebbianMaxDepth
                 3,      // temporalMaxHops
                 2,      // entityMaxHops

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/session/SessionWriteBuffer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/session/SessionWriteBuffer.java
@@ -31,8 +31,8 @@ import java.util.stream.Collectors;
  */
 public class SessionWriteBuffer {
 
-    private static final int MAX_SIZE = 64;
-    private static final long TTL_MS = 5000;
+    private static final int MAX_SIZE = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_SESSION_BUFFER_MAX_SIZE;
+    private static final long TTL_MS = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_SESSION_BUFFER_TTL_MS;
 
     private final ConcurrentLinkedDeque<BufferedEntry> entries = new ConcurrentLinkedDeque<>();
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/DecayConfig.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/DecayConfig.java
@@ -63,8 +63,11 @@ public record DecayConfig(
     /** Number of decay buckets in the 12-bucket power-law system. */
     public static final int BUCKET_COUNT = 12;
 
-    /** Default: moderate forgetting (d=0.15), 10% permastore floor. */
-    public static final DecayConfig DEFAULT = new DecayConfig(0.15f, 0.10f, null);
+    /** Default from SpectorPropertyConstants: moderate forgetting (d=0.15), 10% permastore floor. */
+    public static final DecayConfig DEFAULT = new DecayConfig(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_DECAY_EXPONENT,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_DECAY_FLOOR,
+            null);
 
     /** Slow forgetting: for digital legacy, long-term knowledge bases. */
     public static final DecayConfig SLOW_FORGET = new DecayConfig(0.08f, 0.15f, null);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/TwoFactorConfig.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/TwoFactorConfig.java
@@ -53,11 +53,19 @@ public record TwoFactorConfig(
         boolean enabled
 ) {
 
-    /** Default configuration with gentle S(t) influence. */
-    public static final TwoFactorConfig DEFAULT = new TwoFactorConfig(0.1f, 5.0f, 0.3f, true);
+    /** Default configuration with gentle S(t) influence from SpectorPropertyConstants. */
+    public static final TwoFactorConfig DEFAULT = new TwoFactorConfig(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_TWOFACTOR_S_GAIN,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_TWOFACTOR_S_MAX,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_TWOFACTOR_S_EXPONENT,
+            true);
 
     /** Disabled configuration — S(t) has no effect on scoring. */
-    public static final TwoFactorConfig DISABLED = new TwoFactorConfig(0.1f, 5.0f, 0.3f, false);
+    public static final TwoFactorConfig DISABLED = new TwoFactorConfig(
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_TWOFACTOR_S_GAIN,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_TWOFACTOR_S_MAX,
+            com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_TWOFACTOR_S_EXPONENT,
+            false);
 
     /**
      * Compact constructor with validation.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/MemoryWal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/MemoryWal.java
@@ -84,7 +84,7 @@ public final class MemoryWal implements AutoCloseable {
     static final int FILE_HEADER_BYTES = 8;
 
     /** Default max chunk size before rolling (8 MB). */
-    private static final long DEFAULT_MAX_CHUNK_BYTES = 8L * 1024 * 1024;
+    private static final long DEFAULT_MAX_CHUNK_BYTES = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_WAL_MAX_CHUNK_BYTES;
 
     private final Path walDir;
     private final long maxChunkBytes;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/VacuumCompactor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/VacuumCompactor.java
@@ -59,7 +59,7 @@ public final class VacuumCompactor {
     private static final Logger log = LoggerFactory.getLogger(VacuumCompactor.class);
 
     /** Default tombstone ratio threshold for triggering compaction (20%). */
-    public static final float DEFAULT_THRESHOLD = 0.20f;
+    public static final float DEFAULT_THRESHOLD = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_VACUUM_DEFAULT_THRESHOLD;
 
     private VacuumCompactor() {} // utility class
 

--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbedConfig.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbedConfig.java
@@ -26,7 +26,7 @@ import com.spectrayan.spector.commons.error.SpectorValidationException;
  */
 public record EmbedConfig(int batchSize, int maxRetries) {
 
-    /** Default configuration: batch size 32, 3 retries. */
+    /** Default configuration: batch size 32, 3 retries (aligned with SpectorPropertyConstants). */
     public static final EmbedConfig DEFAULT = new EmbedConfig(32, 3);
 
     public EmbedConfig {

--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbeddingCacheConfig.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbeddingCacheConfig.java
@@ -62,10 +62,13 @@ public record EmbeddingCacheConfig(
         return new EmbeddingCacheConfig(false, 1, Duration.ZERO, Duration.ZERO);
     }
 
-    /**
-     * Returns {@code true} if cached entries expire after {@link #ttl()}.
-     */
+    /** Whether TTL-based expiration is active. */
     public boolean ttlEnabled() {
-        return !ttl.isZero();
+        return !ttl.isZero() && !ttl.isNegative();
+    }
+
+    /** Whether periodic stats logging is active. */
+    public boolean statsLoggingEnabled() {
+        return !statsLogInterval.isZero() && !statsLogInterval.isNegative();
     }
 }

--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbeddingConfig.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/embedding/EmbeddingConfig.java
@@ -33,11 +33,11 @@ public record EmbeddingConfig(
         int batchSize,
         int maxConcurrent
 ) {
-    /** Default Ollama configuration. */
+    /** Default Ollama configuration (aligned with SpectorPropertyConstants: 30s timeout). */
     public static final EmbeddingConfig OLLAMA_DEFAULT = new EmbeddingConfig(
             "nomic-embed-text",
             "http://localhost:11434",
-            Duration.ofMinutes(2),
+            Duration.ofSeconds(30),
             32,
             0
     );
@@ -58,21 +58,21 @@ public record EmbeddingConfig(
     }
 
     /**
-     * Returns a new config with a different request timeout.
+     * Returns a new config with a different timeout.
      */
     public EmbeddingConfig withTimeout(Duration timeout) {
         return new EmbeddingConfig(model, baseUrl, timeout, batchSize, maxConcurrent);
     }
 
     /**
-     * Returns a new config with a different batch size limit.
+     * Returns a new config with a different batch size.
      */
     public EmbeddingConfig withBatchSize(int batchSize) {
         return new EmbeddingConfig(model, baseUrl, timeout, batchSize, maxConcurrent);
     }
 
     /**
-     * Returns a new config with a different concurrency limit.
+     * Returns a new config with a different max concurrent requests setting.
      */
     public EmbeddingConfig withMaxConcurrent(int maxConcurrent) {
         return new EmbeddingConfig(model, baseUrl, timeout, batchSize, maxConcurrent);

--- a/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/generation/GenerationOptions.java
+++ b/memory/spector-provider-api/src/main/java/com/spectrayan/spector/provider/generation/GenerationOptions.java
@@ -29,8 +29,8 @@ public record GenerationOptions(
         float topP,
         String[] stopSequences
 ) {
-    /** Default options: deterministic, 512 max tokens. */
-    public static final GenerationOptions DEFAULT = new GenerationOptions(0.1f, 512, 0.9f, new String[0]);
+    /** Default options: aligned with SpectorPropertyConstants (0.3f, 1024 tokens, 0.95f top-p). */
+    public static final GenerationOptions DEFAULT = new GenerationOptions(0.3f, 1024, 0.95f, new String[0]);
 
     /** Creative options: higher temperature for synthesis. */
     public static final GenerationOptions CREATIVE = new GenerationOptions(0.7f, 1024, 0.95f, new String[0]);

--- a/memory/spector-provider-api/src/test/java/com/spectrayan/spector/provider/embedding/EmbedApiExtendedTest.java
+++ b/memory/spector-provider-api/src/test/java/com/spectrayan/spector/provider/embedding/EmbedApiExtendedTest.java
@@ -66,9 +66,9 @@ class EmbedApiExtendedTest {
 
         @Test @DisplayName("DEFAULT preset")
         void defaultPreset() {
-            assertThat(GenerationOptions.DEFAULT.temperature()).isEqualTo(0.1f);
-            assertThat(GenerationOptions.DEFAULT.maxTokens()).isEqualTo(512);
-            assertThat(GenerationOptions.DEFAULT.topP()).isEqualTo(0.9f);
+            assertThat(GenerationOptions.DEFAULT.temperature()).isEqualTo(0.3f);
+            assertThat(GenerationOptions.DEFAULT.maxTokens()).isEqualTo(1024);
+            assertThat(GenerationOptions.DEFAULT.topP()).isEqualTo(0.95f);
         }
 
         @Test @DisplayName("CREATIVE preset")
@@ -99,8 +99,8 @@ class EmbedApiExtendedTest {
         @Test @DisplayName("Builder defaults")
         void builderDefaults() {
             var opts = GenerationOptions.builder().build();
-            assertThat(opts.temperature()).isEqualTo(0.1f);
-            assertThat(opts.maxTokens()).isEqualTo(512);
+            assertThat(opts.temperature()).isEqualTo(0.3f);
+            assertThat(opts.maxTokens()).isEqualTo(1024);
         }
     }
 

--- a/memory/spector-providers/src/main/java/com/spectrayan/spector/provider/ollama/OllamaLlmProvider.java
+++ b/memory/spector-providers/src/main/java/com/spectrayan/spector/provider/ollama/OllamaLlmProvider.java
@@ -15,6 +15,7 @@
  */
 package com.spectrayan.spector.provider.ollama;
 
+import com.spectrayan.spector.provider.embedding.EmbeddingConfig;
 import com.spectrayan.spector.provider.generation.GenerationOptions;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.provider.langchain4j.LangChain4jGenerationAdapter;
@@ -51,15 +52,24 @@ public class OllamaLlmProvider implements LlmProvider {
     }
 
     public static OllamaLlmProvider create(String model) {
-        return new OllamaLlmProvider(model, "http://localhost:11434", Duration.ofSeconds(60));
+        return new OllamaLlmProvider(
+                model,
+                EmbeddingConfig.OLLAMA_DEFAULT.baseUrl(),
+                Duration.ofSeconds(60));
     }
 
     public static OllamaLlmProvider create(String model, String baseUrl) {
-        return new OllamaLlmProvider(model, baseUrl, Duration.ofSeconds(60));
+        return new OllamaLlmProvider(
+                model,
+                baseUrl,
+                Duration.ofSeconds(60));
     }
 
     public static OllamaLlmProvider createDefault() {
-        return new OllamaLlmProvider("qwen3:0.6b", "http://localhost:11434", Duration.ofSeconds(60));
+        return new OllamaLlmProvider(
+                "qwen3:0.6b",
+                EmbeddingConfig.OLLAMA_DEFAULT.baseUrl(),
+                Duration.ofSeconds(60));
     }
 
     @Override

--- a/memory/spector-providers/src/main/java/com/spectrayan/spector/provider/ollama/OllamaProviderFactory.java
+++ b/memory/spector-providers/src/main/java/com/spectrayan/spector/provider/ollama/OllamaProviderFactory.java
@@ -43,7 +43,7 @@ import com.spectrayan.spector.commons.ParseUtils;
 public class OllamaProviderFactory implements ProviderFactory {
 
     /** Default Ollama base URL. */
-    private static final String DEFAULT_BASE_URL = "http://localhost:11434";
+    private static final String DEFAULT_BASE_URL = EmbeddingConfig.OLLAMA_DEFAULT.baseUrl();
 
     @Override
     public String name() {

--- a/memory/spector-query/src/main/java/com/spectrayan/spector/query/HybridSearchOrchestrator.java
+++ b/memory/spector-query/src/main/java/com/spectrayan/spector/query/HybridSearchOrchestrator.java
@@ -153,7 +153,9 @@ public class HybridSearchOrchestrator implements AutoCloseable {
         if (!hasVector) return executeKeywordSearch(query);
 
         // Expand retrieval window for better fusion
-        int retrievalK = Math.max(query.topK() * 2, 50);
+        int retrievalK = Math.max(
+                query.topK() * com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_HYBRID_FANOUT_MULTIPLIER,
+                com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_HYBRID_MIN_RETRIEVAL_K);
 
         try {
             var pair = ConcurrentTasks.forkJoin2(

--- a/memory/spector-query/src/main/java/com/spectrayan/spector/query/QueryParser.java
+++ b/memory/spector-query/src/main/java/com/spectrayan/spector/query/QueryParser.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 public final class QueryParser {
 
     private static final Pattern DIRECTIVE = Pattern.compile("(mode|k):(\\S+)");
-    private static final int DEFAULT_TOP_K = 10;
+    private static final int DEFAULT_TOP_K = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_DEFAULT_TOP_K;
 
     private QueryParser() {}
 

--- a/memory/spector-query/src/main/java/com/spectrayan/spector/query/ReciprocalRankFusion.java
+++ b/memory/spector-query/src/main/java/com/spectrayan/spector/query/ReciprocalRankFusion.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public final class ReciprocalRankFusion {
 
     /** Default RRF constant — standard value from the original paper. */
-    public static final int DEFAULT_K = 60;
+    public static final int DEFAULT_K = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_RRF_K;
 
     private ReciprocalRankFusion() {
         // utility class

--- a/memory/spector-query/src/main/java/com/spectrayan/spector/query/ranking/LlmReranker.java
+++ b/memory/spector-query/src/main/java/com/spectrayan/spector/query/ranking/LlmReranker.java
@@ -78,7 +78,7 @@ public class LlmReranker implements Reranker {
         this.model = model;
         this.maxCandidates = maxCandidates;
         this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
+                .connectTimeout(com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_RERANKER_CONNECT_TIMEOUT)
                 .build();
 
         log.info("LlmReranker initialized: model={}, maxCandidates={}", model, maxCandidates);
@@ -86,7 +86,7 @@ public class LlmReranker implements Reranker {
 
     /** Convenience constructor with defaults. */
     public LlmReranker(String ollamaBaseUrl, String model) {
-        this(ollamaBaseUrl, model, 20);
+        this(ollamaBaseUrl, model, com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_RERANKER_MAX_CANDIDATES);
     }
 
     @Override
@@ -180,7 +180,7 @@ public class LlmReranker implements Reranker {
                 .uri(URI.create(ollamaBaseUrl + "/api/generate"))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(jsonBody, StandardCharsets.UTF_8))
-                .timeout(Duration.ofSeconds(30))
+                .timeout(com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_QUERY_RERANKER_REQUEST_TIMEOUT)
                 .build();
 
         HttpResponse<String> response = httpClient.send(request,

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -383,6 +383,60 @@ public final class SpectorPropertyConstants {
     public static final String MEMORY_NAMESPACE_SOFT_WARNING_THRESHOLD = "spector.memory.namespace.soft-warning-threshold";
     public static final float DEFAULT_MEMORY_NAMESPACE_SOFT_WARNING_THRESHOLD = 0.70f;
 
+    public static final String MEMORY_MAX_NAMESPACES = "spector.memory.max-namespaces";
+    public static final int DEFAULT_MEMORY_MAX_NAMESPACES = 100;
+
+    public static final String MEMORY_NAMESPACE_ID = "spector.memory.namespace-id";
+    public static final String DEFAULT_MEMORY_NAMESPACE_ID = "default";
+
+    public static final String MEMORY_PERSISTENCE_MODE_FLAG = "spector.memory.persistence-mode";
+    public static final String DEFAULT_MEMORY_PERSISTENCE_MODE_NAME = "DISK";
+
+    public static final String MEMORY_PERSIST_WORKING_MEMORY = "spector.memory.persist-working-memory";
+    public static final boolean DEFAULT_MEMORY_PERSIST_WORKING_MEMORY = false;
+
+    public static final String MEMORY_PIN_SOURCE_EPISODES = "spector.memory.pin-source-episodes";
+    public static final boolean DEFAULT_MEMORY_PIN_SOURCE_EPISODES = false;
+
+    public static final String MEMORY_ENTITY_EXTRACTION_MODE = "spector.memory.entity.extraction-mode";
+    public static final String DEFAULT_MEMORY_ENTITY_EXTRACTION_MODE = "NONE";
+
+    public static final String MEMORY_ENTITY_RESOLUTION_ENABLED = "spector.memory.entity.resolution-enabled";
+    public static final boolean DEFAULT_MEMORY_ENTITY_RESOLUTION_ENABLED = false;
+
+    public static final String MEMORY_ENTITY_SHADOW_MODE = "spector.memory.entity.shadow-mode";
+    public static final boolean DEFAULT_MEMORY_ENTITY_SHADOW_MODE = true;
+
+    public static final String MEMORY_EDGE_IMPORTANCE = "spector.memory.edge-importance";
+    public static final String DEFAULT_MEMORY_EDGE_IMPORTANCE = "DEFAULT";
+
+    public static final String MEMORY_ID_STRATEGY = "spector.memory.id-strategy";
+    public static final String DEFAULT_MEMORY_ID_STRATEGY = "TSID";
+
+    public static final String MEMORY_GRAPH_EXPANSION_MODE = "spector.memory.graph.expansion-mode";
+    public static final String DEFAULT_MEMORY_GRAPH_EXPANSION_MODE = "GATED";
+
+    public static final String MEMORY_ENTITY_ADJ_DECAY_FACTOR = "spector.memory.entity.adj-decay-factor";
+    public static final float DEFAULT_MEMORY_ENTITY_ADJ_DECAY_FACTOR = 0.95f;
+
+    public static final String MEMORY_ENTITY_ADJ_PRUNE_THRESHOLD = "spector.memory.entity.adj-prune-threshold";
+    public static final float DEFAULT_MEMORY_ENTITY_ADJ_PRUNE_THRESHOLD = 0.2f;
+
+    public static final String MEMORY_ENTITY_MERGE_DISTANCE = "spector.memory.entity.merge-distance";
+    public static final int DEFAULT_MEMORY_ENTITY_MERGE_DISTANCE = 2;
+
+    public static final String MEMORY_CROSS_CAPTURE_MIN_WEIGHT = "spector.memory.cross-capture.min-weight";
+    public static final float DEFAULT_MEMORY_CROSS_CAPTURE_MIN_WEIGHT = 2.0f;
+
+    public static final String MEMORY_CROSS_CAPTURE_SCALE_FACTOR = "spector.memory.cross-capture.scale-factor";
+    public static final float DEFAULT_MEMORY_CROSS_CAPTURE_SCALE_FACTOR = 0.05f;
+
+    public static final String MEMORY_CIRCADIAN_INTERFERENCE_THRESHOLD = "spector.memory.circadian.interference-threshold";
+    public static final float DEFAULT_MEMORY_CIRCADIAN_INTERFERENCE_THRESHOLD = 0.12f;
+
+    public static final String MEMORY_CIRCADIAN_INTERFERENCE_DECAY_FACTOR = "spector.memory.circadian.interference-decay-factor";
+    public static final float DEFAULT_MEMORY_CIRCADIAN_INTERFERENCE_DECAY_FACTOR = 0.7f;
+
     public static final String MEMORY_HYPERFOCUS_TTL_MS = "spector.memory.hyperfocus.ttl-ms";
     public static final long DEFAULT_MEMORY_HYPERFOCUS_TTL_MS = 1800_000L;
 
@@ -391,6 +445,18 @@ public final class SpectorPropertyConstants {
 
     public static final String MEMORY_ICNU_STEEPNESS = "spector.memory.icnu.steepness";
     public static final float DEFAULT_MEMORY_ICNU_STEEPNESS = 8.0f;
+
+    public static final String MEMORY_ICNU_WEIGHT_INTEREST = "spector.memory.icnu.weight-interest";
+    public static final float DEFAULT_MEMORY_ICNU_WEIGHT_INTEREST = 0.30f;
+
+    public static final String MEMORY_ICNU_WEIGHT_CHALLENGE = "spector.memory.icnu.weight-challenge";
+    public static final float DEFAULT_MEMORY_ICNU_WEIGHT_CHALLENGE = 0.10f;
+
+    public static final String MEMORY_ICNU_WEIGHT_NOVELTY = "spector.memory.icnu.weight-novelty";
+    public static final float DEFAULT_MEMORY_ICNU_WEIGHT_NOVELTY = 0.40f;
+
+    public static final String MEMORY_ICNU_WEIGHT_URGENCY = "spector.memory.icnu.weight-urgency";
+    public static final float DEFAULT_MEMORY_ICNU_WEIGHT_URGENCY = 0.20f;
 
     public static final String MEMORY_COACTIVATION_PAIR_CAPACITY = "spector.memory.coactivation-pair-capacity";
     public static final int DEFAULT_MEMORY_COACTIVATION_PAIR_CAPACITY = 10_000;
@@ -415,6 +481,58 @@ public final class SpectorPropertyConstants {
 
     public static final String MEMORY_INSULA_SIZE = "spector.memory.insula-size";
     public static final long DEFAULT_MEMORY_INSULA_SIZE = 1024L * 1024;
+
+    // Recall & Search Pipeline Flags (RecallOptions)
+    public static final String RECALL_TEXT_SEARCH_ENABLED = "spector.recall.text-search.enabled";
+    public static final boolean DEFAULT_RECALL_TEXT_SEARCH_ENABLED = true;
+
+    public static final String RECALL_TEXT_SEARCH_MODE = "spector.recall.text-search.mode";
+    public static final String DEFAULT_RECALL_TEXT_SEARCH_MODE = "HYBRID";
+
+    public static final String RECALL_SCORING_MODE = "spector.recall.scoring-mode";
+    public static final String DEFAULT_RECALL_SCORING_MODE = "COGNITIVE";
+
+    public static final String RECALL_TRACE_ENABLED = "spector.recall.trace.enabled";
+    public static final boolean DEFAULT_RECALL_TRACE_ENABLED = false;
+
+    public static final String RECALL_RERANKER_ENABLED = "spector.recall.reranker.enabled";
+    public static final boolean DEFAULT_RECALL_RERANKER_ENABLED = false;
+
+    public static final String RECALL_RERANKER_DEPTH = "spector.recall.reranker.depth";
+    public static final int DEFAULT_RECALL_RERANKER_DEPTH = 50;
+
+    public static final String RECALL_MMR_ENABLED = "spector.recall.mmr.enabled";
+    public static final boolean DEFAULT_RECALL_MMR_ENABLED = false;
+
+    public static final String RECALL_MMR_LAMBDA = "spector.recall.mmr.lambda";
+    public static final float DEFAULT_RECALL_MMR_LAMBDA = 0.5f;
+
+    public static final String RECALL_AUTO_PROFILE_ENABLED = "spector.recall.auto-profile.enabled";
+    public static final boolean DEFAULT_RECALL_AUTO_PROFILE_ENABLED = false;
+
+    public static final String RECALL_INCLUDE_CONTRADICTIONS = "spector.recall.include-contradictions";
+    public static final boolean DEFAULT_RECALL_INCLUDE_CONTRADICTIONS = false;
+
+    public static final String RECALL_LATERAL_ENABLED = "spector.recall.lateral.enabled";
+    public static final boolean DEFAULT_RECALL_LATERAL_ENABLED = false;
+
+    public static final String RECALL_LATERAL_DISTANCE_THRESHOLD = "spector.recall.lateral.distance-threshold";
+    public static final float DEFAULT_RECALL_LATERAL_DISTANCE_THRESHOLD = 1.2f;
+
+    public static final String RECALL_LATERAL_MIN_TAG_OVERLAP = "spector.recall.lateral.min-tag-overlap";
+    public static final float DEFAULT_RECALL_LATERAL_MIN_TAG_OVERLAP = 0.5f;
+
+    public static final String RECALL_STRICTNESS_COEFFICIENT = "spector.recall.strictness-coefficient";
+    public static final float DEFAULT_RECALL_STRICTNESS_COEFFICIENT = 1.0f;
+
+    public static final String RECALL_VALENCE_ALIGNMENT_ENABLED = "spector.recall.valence-alignment.enabled";
+    public static final boolean DEFAULT_RECALL_VALENCE_ALIGNMENT_ENABLED = false;
+
+    public static final String RECALL_MODE = "spector.recall.mode";
+    public static final String DEFAULT_RECALL_MODE = "LEARN";
+
+    public static final String RECALL_MAX_REPLAY_EVENTS = "spector.recall.max-replay-events";
+    public static final int DEFAULT_RECALL_MAX_REPLAY_EVENTS = 100_000;
 
     // Ingestion
     public static final String INGESTION_ROOT_DIRECTORY = "spector.ingestion.root-directory";

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -19,6 +19,7 @@ import com.spectrayan.spector.config.model.*;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Central registry of configuration property keys and default values across Spector namespaces.
@@ -33,6 +34,19 @@ public final class SpectorPropertyConstants {
     // Global
     public static final String MODE = "spector.mode";
     public static final String DEFAULT_MODE = "MEMORY";
+
+    // Concurrency & Core System Properties
+    public static final String CONCURRENCY_STRUCTURED = "spector.concurrency.structured";
+    public static final boolean DEFAULT_CONCURRENCY_STRUCTURED = true;
+
+    public static final String EVENTS_ASYNC = "spector.events.async";
+    public static final boolean DEFAULT_EVENTS_ASYNC = false;
+
+    public static final String EMBEDDING_SEQUENTIAL = "spector.embedding.sequential";
+    public static final boolean DEFAULT_EMBEDDING_SEQUENTIAL = false;
+
+    public static final String GRAPH_EXPANSION_THRESHOLD_PROPERTY = "spector.benchmark.graphExpansionThreshold";
+    public static final String GRAPH_EXPANSION_MODE_PROPERTY = "spector.memory.graphExpansionMode";
 
     // Provider — Embedding
     public static final String PROVIDER_EMBEDDING_TYPE = "spector.provider.embedding.type";
@@ -87,7 +101,55 @@ public final class SpectorPropertyConstants {
     public static final String PROVIDER_GENERATION_BASE_URL = "spector.provider.generation.base-url";
     public static final String DEFAULT_PROVIDER_GENERATION_BASE_URL = "http://localhost:11434";
 
-    // Memory
+    public static final String PROVIDER_GENERATION_TIMEOUT = "spector.provider.generation.timeout";
+    public static final Duration DEFAULT_PROVIDER_GENERATION_TIMEOUT = Duration.ofSeconds(60);
+
+    public static final String PROVIDER_GENERATION_FALLBACK_MODEL = "spector.provider.generation.fallback-model";
+    public static final String DEFAULT_PROVIDER_GENERATION_FALLBACK_MODEL = "qwen3:0.6b";
+
+    // Chunking Subsystem (Commons & Ingestion)
+    public static final String CHUNKING_TEXT_SIZE = "spector.chunking.text.size";
+    public static final int DEFAULT_CHUNKING_TEXT_SIZE = 512;
+
+    public static final String CHUNKING_TEXT_OVERLAP = "spector.chunking.text.overlap";
+    public static final int DEFAULT_CHUNKING_TEXT_OVERLAP = 64;
+
+    public static final String CHUNKING_TOKEN_LIMIT = "spector.chunking.token.limit";
+    public static final int DEFAULT_CHUNKING_TOKEN_LIMIT = 128;
+
+    public static final String CHUNKING_TOKEN_OVERLAP = "spector.chunking.token.overlap";
+    public static final int DEFAULT_CHUNKING_TOKEN_OVERLAP = 16;
+
+    public static final String CHUNKING_DOCUMENT_MAX_SIZE = "spector.chunking.document.max-size";
+    public static final long DEFAULT_CHUNKING_DOCUMENT_MAX_SIZE = 100L * 1024 * 1024; // 100MB
+
+    // HDC Hyperdimensional Vector Subsystem
+    public static final String HDC_DIMENSIONS = "spector.hdc.dimensions";
+    public static final int DEFAULT_HDC_DIMENSIONS = 10_000;
+
+    public static final String HDC_NGRAM_SIZE = "spector.hdc.ngram-size";
+    public static final int DEFAULT_HDC_NGRAM_SIZE = 3;
+
+    // SVASQ Quantization Subsystem
+    public static final String QUANTIZATION_SVASQ_SEED = "spector.quantization.svasq.seed";
+    public static final long DEFAULT_QUANTIZATION_SVASQ_SEED = 42L;
+
+    public static final String QUANTIZATION_SVASQ_CLIP_PERCENTILE = "spector.quantization.svasq.clip-percentile";
+    public static final float DEFAULT_QUANTIZATION_SVASQ_CLIP_PERCENTILE = 0.001f;
+
+    public static final String QUANTIZATION_SVASQ_CLIP_SIGMAS = "spector.quantization.svasq.clip-sigmas";
+    public static final float DEFAULT_QUANTIZATION_SVASQ_CLIP_SIGMAS = 3.0f;
+
+    public static final String QUANTIZATION_SVASQ_CLIP_SIGMAS_4BIT = "spector.quantization.svasq.clip-sigmas-4bit";
+    public static final float DEFAULT_QUANTIZATION_SVASQ_CLIP_SIGMAS_4BIT = 2.5f;
+
+    public static final String QUANTIZATION_SVASQ_MAX_SAMPLE_SIZE = "spector.quantization.svasq.max-sample-size";
+    public static final int DEFAULT_QUANTIZATION_SVASQ_MAX_SAMPLE_SIZE = 10_000;
+
+    public static final String QUANTIZATION_SVASQ_MIN_STD = "spector.quantization.svasq.min-std";
+    public static final float DEFAULT_QUANTIZATION_SVASQ_MIN_STD = 1e-6f;
+
+    // Memory — Core Capacities & Options
     public static final String MEMORY_ENABLED = "spector.memory.enabled";
     public static final boolean DEFAULT_MEMORY_ENABLED = false;
 
@@ -105,6 +167,27 @@ public final class SpectorPropertyConstants {
 
     public static final String MEMORY_NODES_PER_PARTITION = "spector.memory.nodes-per-partition";
     public static final int DEFAULT_MEMORY_NODES_PER_PARTITION = 10_000;
+
+    public static final String MEMORY_WORKING_CAPACITY = "spector.memory.working-capacity";
+    public static final int DEFAULT_MEMORY_WORKING_CAPACITY = 100;
+
+    public static final String MEMORY_EPISODIC_PARTITION_CAPACITY = "spector.memory.episodic-partition-capacity";
+    public static final int DEFAULT_MEMORY_EPISODIC_PARTITION_CAPACITY = 1_000;
+
+    public static final String MEMORY_SEMANTIC_CAPACITY = "spector.memory.semantic-capacity";
+    public static final int DEFAULT_MEMORY_SEMANTIC_CAPACITY = 10_000;
+
+    public static final String MEMORY_PROCEDURAL_CAPACITY = "spector.memory.procedural-capacity";
+    public static final int DEFAULT_MEMORY_PROCEDURAL_CAPACITY = 1_000;
+
+    public static final String MEMORY_ENTITY_GRAPH_CAPACITY = "spector.memory.entity-graph-capacity";
+    public static final int DEFAULT_MEMORY_ENTITY_GRAPH_CAPACITY = 50_000;
+
+    public static final String MEMORY_PINNED_QUOTA = "spector.memory.pinned-quota";
+    public static final int DEFAULT_MEMORY_PINNED_QUOTA = 10_000;
+
+    public static final String MEMORY_CHECKPOINT_INTERVAL_SECONDS = "spector.memory.checkpoint-interval-seconds";
+    public static final int DEFAULT_MEMORY_CHECKPOINT_INTERVAL_SECONDS = 30;
 
     public static final String MEMORY_DECAY_ENABLED = "spector.memory.decay-enabled";
     public static final boolean DEFAULT_MEMORY_DECAY_ENABLED = true;
@@ -136,6 +219,7 @@ public final class SpectorPropertyConstants {
     public static final String MEMORY_BM25_ENABLED = "spector.memory.bm25-enabled";
     public static final boolean DEFAULT_MEMORY_BM25_ENABLED = true;
 
+    // LLM Sampling Parameters
     public static final String MEMORY_LLM_TEMPERATURE = "spector.memory.llm.temperature";
     public static final float DEFAULT_MEMORY_LLM_TEMPERATURE = 0.3f;
 
@@ -147,6 +231,166 @@ public final class SpectorPropertyConstants {
 
     public static final String MEMORY_LLM_ENTITY_MODEL = "spector.memory.llm.entity-model";
     public static final String DEFAULT_MEMORY_LLM_ENTITY_MODEL = "";
+
+    // Memory — Cognitive & Biological Hyperparameters
+    public static final String MEMORY_SURPRISE_WARMUP = "spector.memory.surprise-warmup";
+    public static final int DEFAULT_MEMORY_SURPRISE_WARMUP = 10;
+
+    public static final String MEMORY_FLASHBULB_THRESHOLD = "spector.memory.flashbulb-threshold";
+    public static final float DEFAULT_MEMORY_FLASHBULB_THRESHOLD = 3.0f;
+
+    public static final String MEMORY_VALENCE_LEARNING_RATE = "spector.memory.valence-learning-rate";
+    public static final float DEFAULT_MEMORY_VALENCE_LEARNING_RATE = 0.3f;
+
+    public static final String MEMORY_DEDUPLICATION_RADIUS = "spector.memory.deduplication-radius";
+    public static final float DEFAULT_MEMORY_DEDUPLICATION_RADIUS = 0.05f;
+
+    public static final String MEMORY_INHIBITION_TTL_MS = "spector.memory.inhibition-ttl-ms";
+    public static final long DEFAULT_MEMORY_INHIBITION_TTL_MS = 300_000L;
+
+    public static final String MEMORY_INHIBITION_FLOOR = "spector.memory.inhibition-floor";
+    public static final float DEFAULT_MEMORY_INHIBITION_FLOOR = 0.1f;
+
+    public static final String MEMORY_HABITUATION_DECAY_RATE = "spector.memory.habituation-decay-rate";
+    public static final float DEFAULT_MEMORY_HABITUATION_DECAY_RATE = 0.2f;
+
+    public static final String MEMORY_LTP_COOLDOWN_MS = "spector.memory.ltp-cooldown-ms";
+    public static final long DEFAULT_MEMORY_LTP_COOLDOWN_MS = 300_000L;
+
+    public static final String MEMORY_DECAY_EXPONENT = "spector.memory.decay.exponent";
+    public static final float DEFAULT_MEMORY_DECAY_EXPONENT = 0.15f;
+
+    public static final String MEMORY_DECAY_FLOOR = "spector.memory.decay.floor";
+    public static final float DEFAULT_MEMORY_DECAY_FLOOR = 0.10f;
+
+    public static final String MEMORY_TWOFACTOR_S_GAIN = "spector.memory.twofactor.s-gain";
+    public static final float DEFAULT_MEMORY_TWOFACTOR_S_GAIN = 0.1f;
+
+    public static final String MEMORY_TWOFACTOR_S_MAX = "spector.memory.twofactor.s-max";
+    public static final float DEFAULT_MEMORY_TWOFACTOR_S_MAX = 5.0f;
+
+    public static final String MEMORY_TWOFACTOR_S_EXPONENT = "spector.memory.twofactor.s-exponent";
+    public static final float DEFAULT_MEMORY_TWOFACTOR_S_EXPONENT = 0.3f;
+
+    public static final String MEMORY_ENTITY_LTP_REINFORCEMENT = "spector.memory.entity.ltp-reinforcement";
+    public static final float DEFAULT_MEMORY_ENTITY_LTP_REINFORCEMENT = 0.2f;
+
+    // Hebbian & Graphs
+    public static final String MEMORY_HEBBIAN_MAX_DEGREE = "spector.memory.hebbian.max-degree";
+    public static final int DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE = 24;
+
+    public static final String MEMORY_HEBBIAN_SESSION_BOUNDARY_MS = "spector.memory.hebbian.session-boundary-ms";
+    public static final long DEFAULT_MEMORY_HEBBIAN_SESSION_BOUNDARY_MS = 300_000L;
+
+    public static final String MEMORY_STDP_A_PLUS = "spector.memory.stdp.a-plus";
+    public static final float DEFAULT_MEMORY_STDP_A_PLUS = 0.1f;
+
+    public static final String MEMORY_STDP_A_MINUS = "spector.memory.stdp.a-minus";
+    public static final float DEFAULT_MEMORY_STDP_A_MINUS = 0.05f;
+
+    public static final String MEMORY_STDP_TAU_PLUS = "spector.memory.stdp.tau-plus";
+    public static final float DEFAULT_MEMORY_STDP_TAU_PLUS = 30_000f;
+
+    public static final String MEMORY_STDP_TAU_MINUS = "spector.memory.stdp.tau-minus";
+    public static final float DEFAULT_MEMORY_STDP_TAU_MINUS = 30_000f;
+
+    public static final String MEMORY_BRIDGE_SAMPLE_COUNT = "spector.memory.bridge.sample-count";
+    public static final int DEFAULT_MEMORY_BRIDGE_SAMPLE_COUNT = 15;
+
+    public static final String MEMORY_BRIDGE_BUDGET_MS = "spector.memory.bridge.budget-ms";
+    public static final long DEFAULT_MEMORY_BRIDGE_BUDGET_MS = 500L;
+
+    public static final String MEMORY_ENTITY_MAX_DEGREE = "spector.memory.entity.max-degree";
+    public static final int DEFAULT_MEMORY_ENTITY_MAX_DEGREE = 16;
+
+    public static final String MEMORY_ENTITY_MAX_PER_MEM = "spector.memory.entity.max-per-memory";
+    public static final int DEFAULT_MEMORY_ENTITY_MAX_PER_MEM = 10;
+
+    public static final String MEMORY_RELATION_MAX_PER_MEM = "spector.memory.relation.max-per-memory";
+    public static final int DEFAULT_MEMORY_RELATION_MAX_PER_MEM = 20;
+
+    public static final String MEMORY_ENTITY_COSINE_THRESHOLD = "spector.memory.entity.cosine-threshold";
+    public static final float DEFAULT_MEMORY_ENTITY_COSINE_THRESHOLD = 0.85f;
+
+    public static final String MEMORY_ENTITY_RETENTION_DAYS = "spector.memory.entity.retention-days";
+    public static final int DEFAULT_MEMORY_ENTITY_RETENTION_DAYS = 7;
+
+    // Graph Scoring & Recall Defaults
+    public static final String MEMORY_GRAPH_CAUSAL_BOOST = "spector.memory.graph.causal-boost";
+    public static final float DEFAULT_MEMORY_GRAPH_CAUSAL_BOOST = 0.3f;
+
+    public static final String MEMORY_GRAPH_HEBBIAN_BOOST = "spector.memory.graph.hebbian-boost";
+    public static final float DEFAULT_MEMORY_GRAPH_HEBBIAN_BOOST = 0.3f;
+
+    public static final String MEMORY_GRAPH_TEMPORAL_FWD = "spector.memory.graph.temporal-forward";
+    public static final float DEFAULT_MEMORY_GRAPH_TEMPORAL_FWD = 0.8f;
+
+    public static final String MEMORY_GRAPH_TEMPORAL_BWD = "spector.memory.graph.temporal-backward";
+    public static final float DEFAULT_MEMORY_GRAPH_TEMPORAL_BWD = 0.7f;
+
+    public static final String MEMORY_GRAPH_ENTITY_ATTENUATION = "spector.memory.graph.entity-attenuation";
+    public static final float DEFAULT_MEMORY_GRAPH_ENTITY_ATTENUATION = 0.25f;
+
+    public static final String MEMORY_GRAPH_EXPANSION_THRESHOLD = "spector.memory.graph.expansion-threshold";
+    public static final float DEFAULT_MEMORY_GRAPH_EXPANSION_THRESHOLD = 0.40f;
+
+    // Circadian & Reflection
+    public static final String MEMORY_CIRCADIAN_VOLUME_TRIGGER = "spector.memory.circadian.volume-trigger";
+    public static final int DEFAULT_MEMORY_CIRCADIAN_VOLUME_TRIGGER = 100;
+
+    public static final String MEMORY_CIRCADIAN_TIME_TRIGGER = "spector.memory.circadian.time-trigger";
+    public static final Duration DEFAULT_MEMORY_CIRCADIAN_TIME_TRIGGER = Duration.ofHours(1);
+
+    public static final String MEMORY_CIRCADIAN_TOMBSTONE_THRESHOLD = "spector.memory.circadian.tombstone-threshold";
+    public static final float DEFAULT_MEMORY_CIRCADIAN_TOMBSTONE_THRESHOLD = 0.30f;
+
+    public static final String MEMORY_CIRCADIAN_DECAY_PRUNE_THRESHOLD = "spector.memory.circadian.decay-prune-threshold";
+    public static final float DEFAULT_MEMORY_CIRCADIAN_DECAY_PRUNE_THRESHOLD = 0.05f;
+
+    public static final String MEMORY_REFLECT_MIN_CLUSTER_SIZE = "spector.memory.reflect.min-cluster-size";
+    public static final int DEFAULT_MEMORY_REFLECT_MIN_CLUSTER_SIZE = 5;
+
+    public static final String MEMORY_HEBBIAN_PROMOTION_MIN_WEIGHT = "spector.memory.hebbian.promotion-min-weight";
+    public static final float DEFAULT_MEMORY_HEBBIAN_PROMOTION_MIN_WEIGHT = 3.0f;
+
+    public static final String MEMORY_HEBBIAN_DECAY_FACTOR = "spector.memory.hebbian.decay-factor";
+    public static final float DEFAULT_MEMORY_HEBBIAN_DECAY_FACTOR = 0.9f;
+
+    public static final String MEMORY_ENTITY_DECAY_FACTOR = "spector.memory.entity.decay-factor";
+    public static final float DEFAULT_MEMORY_ENTITY_DECAY_FACTOR = 0.95f;
+
+    public static final String MEMORY_ENTITY_PRUNE_THRESHOLD = "spector.memory.entity.prune-threshold";
+    public static final float DEFAULT_MEMORY_ENTITY_PRUNE_THRESHOLD = 0.5f;
+
+    // Session, Sync, WAL & Subsystems
+    public static final String MEMORY_WAL_MAX_CHUNK_BYTES = "spector.memory.wal.max-chunk-bytes";
+    public static final long DEFAULT_MEMORY_WAL_MAX_CHUNK_BYTES = 8L * 1024 * 1024;
+
+    public static final String MEMORY_VACUUM_THRESHOLD = "spector.memory.vacuum.threshold";
+    public static final float DEFAULT_MEMORY_VACUUM_THRESHOLD = 0.20f;
+    public static final float DEFAULT_MEMORY_VACUUM_DEFAULT_THRESHOLD = DEFAULT_MEMORY_VACUUM_THRESHOLD;
+
+    public static final String MEMORY_SESSION_BUFFER_SIZE = "spector.memory.session.buffer-size";
+    public static final int DEFAULT_MEMORY_SESSION_BUFFER_SIZE = 64;
+    public static final int DEFAULT_MEMORY_SESSION_BUFFER_MAX_SIZE = DEFAULT_MEMORY_SESSION_BUFFER_SIZE;
+
+    public static final String MEMORY_SESSION_BUFFER_TTL_MS = "spector.memory.session.buffer-ttl-ms";
+    public static final long DEFAULT_MEMORY_SESSION_BUFFER_TTL_MS = 5000L;
+
+    public static final String MEMORY_NAMESPACE_MAX_ID_LENGTH = "spector.memory.namespace.max-id-length";
+    public static final int DEFAULT_MEMORY_NAMESPACE_MAX_ID_LENGTH = 63;
+
+    public static final String MEMORY_NAMESPACE_SOFT_WARNING_THRESHOLD = "spector.memory.namespace.soft-warning-threshold";
+    public static final float DEFAULT_MEMORY_NAMESPACE_SOFT_WARNING_THRESHOLD = 0.70f;
+
+    public static final String MEMORY_HYPERFOCUS_TTL_MS = "spector.memory.hyperfocus.ttl-ms";
+    public static final long DEFAULT_MEMORY_HYPERFOCUS_TTL_MS = 1800_000L;
+
+    public static final String MEMORY_ICNU_THRESHOLD = "spector.memory.icnu.threshold";
+    public static final float DEFAULT_MEMORY_ICNU_THRESHOLD = 0.2f;
+
+    public static final String MEMORY_ICNU_STEEPNESS = "spector.memory.icnu.steepness";
+    public static final float DEFAULT_MEMORY_ICNU_STEEPNESS = 8.0f;
 
     public static final String MEMORY_COACTIVATION_PAIR_CAPACITY = "spector.memory.coactivation-pair-capacity";
     public static final int DEFAULT_MEMORY_COACTIVATION_PAIR_CAPACITY = 10_000;
@@ -197,6 +441,50 @@ public final class SpectorPropertyConstants {
     public static final String INGESTION_RETRY_DELAY_MS = "spector.ingestion.retry-delay-ms";
     public static final int DEFAULT_INGESTION_RETRY_DELAY_MS = 2000;
 
+    // Query & Ranking Subsystem
+    public static final String QUERY_DEFAULT_TOP_K = "spector.query.default-top-k";
+    public static final int DEFAULT_QUERY_DEFAULT_TOP_K = 10;
+
+    public static final String QUERY_RRF_K = "spector.query.rrf-k";
+    public static final int DEFAULT_QUERY_RRF_K = 60;
+
+    public static final String QUERY_RERANKER_MAX_CANDIDATES = "spector.query.reranker.max-candidates";
+    public static final int DEFAULT_QUERY_RERANKER_MAX_CANDIDATES = 20;
+
+    public static final String QUERY_RERANKER_CONNECT_TIMEOUT = "spector.query.reranker.connect-timeout";
+    public static final Duration DEFAULT_QUERY_RERANKER_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+
+    public static final String QUERY_RERANKER_REQUEST_TIMEOUT = "spector.query.reranker.request-timeout";
+    public static final Duration DEFAULT_QUERY_RERANKER_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+    public static final String QUERY_RERANKER_DOC_SNIPPET_LENGTH = "spector.query.reranker.doc-snippet-length";
+    public static final int DEFAULT_QUERY_RERANKER_DOC_SNIPPET_LENGTH = 500;
+
+    public static final String QUERY_HYBRID_FANOUT_MULTIPLIER = "spector.query.hybrid.fanout-multiplier";
+    public static final int DEFAULT_QUERY_HYBRID_FANOUT_MULTIPLIER = 2;
+
+    public static final String QUERY_HYBRID_MIN_RETRIEVAL_K = "spector.query.hybrid.min-retrieval-k";
+    public static final int DEFAULT_QUERY_HYBRID_MIN_RETRIEVAL_K = 50;
+
+    // GPU Vector Search & Memory
+    public static final String GPU_BATCH_MIN_WINDOW_MS = "spector.gpu.batch.min-window-ms";
+    public static final long DEFAULT_GPU_BATCH_MIN_WINDOW_MS = 1L;
+
+    public static final String GPU_BATCH_MAX_WINDOW_MS = "spector.gpu.batch.max-window-ms";
+    public static final long DEFAULT_GPU_BATCH_MAX_WINDOW_MS = 100L;
+
+    public static final String GPU_BATCH_DEFAULT_WINDOW = "spector.gpu.batch.default-window";
+    public static final Duration DEFAULT_GPU_BATCH_DEFAULT_WINDOW = Duration.ofMillis(10);
+
+    public static final String GPU_BATCH_DEFAULT_MAX_BATCH = "spector.gpu.batch.default-max-batch";
+    public static final int DEFAULT_GPU_BATCH_DEFAULT_MAX_BATCH = 1024;
+
+    public static final String GPU_MEMORY_MIN_BUDGET_BYTES = "spector.gpu.memory.min-budget-bytes";
+    public static final long DEFAULT_GPU_MEMORY_MIN_BUDGET_BYTES = 256L * 1024 * 1024; // 256MB
+
+    public static final String GPU_LEAK_DETECTOR_THRESHOLD = "spector.gpu.leak-detector.threshold";
+    public static final Duration DEFAULT_GPU_LEAK_DETECTOR_THRESHOLD = Duration.ofSeconds(300);
+
     // HNSW
     public static final String HNSW_M = "spector.hnsw.m";
     public static final int DEFAULT_HNSW_M = 16;
@@ -207,7 +495,13 @@ public final class SpectorPropertyConstants {
     public static final String HNSW_EF_SEARCH = "spector.hnsw.ef-search";
     public static final int DEFAULT_HNSW_EF_SEARCH = 50;
 
-    // IVF
+    public static final String INDEX_HNSW_PARALLEL_THRESHOLD = "spector.index.hnsw.parallel-threshold";
+    public static final int DEFAULT_INDEX_HNSW_PARALLEL_THRESHOLD = 10_000;
+
+    public static final String INDEX_HNSW_CALIBRATION_SAMPLE_SIZE = "spector.index.hnsw.calibration-sample-size";
+    public static final int DEFAULT_INDEX_HNSW_CALIBRATION_SAMPLE_SIZE = 10_000;
+
+    // IVF & PQ
     public static final String IVF_NLIST = "spector.ivf.nlist";
     public static final int DEFAULT_IVF_NLIST = 0;
 
@@ -216,6 +510,31 @@ public final class SpectorPropertyConstants {
 
     public static final String IVF_PQ_SUBSPACES = "spector.ivf.pq-subspaces";
     public static final int DEFAULT_IVF_PQ_SUBSPACES = 0;
+
+    public static final String INDEX_IVF_KMEANS_MAX_ITERS = "spector.index.ivf.kmeans-max-iters";
+    public static final int DEFAULT_INDEX_IVF_KMEANS_MAX_ITERS = 25;
+
+    public static final String INDEX_IVF_KMEANS_SEED = "spector.index.ivf.kmeans-seed";
+    public static final long DEFAULT_INDEX_IVF_KMEANS_SEED = 42L;
+
+    public static final String INDEX_PQ_KSUB = "spector.index.pq.ksub";
+    public static final int DEFAULT_INDEX_PQ_KSUB = 256;
+
+    // Text & Keyword Indexing (BM25, SPLADE, ColBERT)
+    public static final String INDEX_BM25_K1 = "spector.index.bm25.k1";
+    public static final float DEFAULT_INDEX_BM25_K1 = 1.2f;
+
+    public static final String INDEX_BM25_B = "spector.index.bm25.b";
+    public static final float DEFAULT_INDEX_BM25_B = 0.75f;
+
+    public static final String INDEX_BM25_PARALLEL_THRESHOLD = "spector.index.bm25.parallel-threshold";
+    public static final int DEFAULT_INDEX_BM25_PARALLEL_THRESHOLD = 20_000;
+
+    public static final String INDEX_SPLADE_PARALLEL_THRESHOLD = "spector.index.splade.parallel-threshold";
+    public static final int DEFAULT_INDEX_SPLADE_PARALLEL_THRESHOLD = 15_000;
+
+    public static final String INDEX_COLBERT_CACHE_CAPACITY = "spector.index.colbert.cache-capacity";
+    public static final int DEFAULT_INDEX_COLBERT_CACHE_CAPACITY = 1024;
 
     // Spectrum
     public static final String SPECTRUM_N_CENTROIDS = "spector.spectrum.n-centroids";
@@ -263,7 +582,7 @@ public final class SpectorPropertyConstants {
     public static final String TELEMETRY_GRAPH_ENABLED = "spector.telemetry.graph-enabled";
     public static final boolean DEFAULT_TELEMETRY_GRAPH_ENABLED = true;
 
-    // Multimodal
+    // Multimodal & Sensory Media
     public static final String MULTIMODAL_ENABLED = "spector.multimodal.enabled";
     public static final boolean DEFAULT_MULTIMODAL_ENABLED = false;
     public static final String MULTIMODAL_VISION_MODEL = "spector.multimodal.vision.model";
@@ -281,6 +600,26 @@ public final class SpectorPropertyConstants {
     public static final String MULTIMODAL_ASSET_BASE_PATH = "spector.multimodal.asset-store.base-path";
     public static final Path DEFAULT_MULTIMODAL_ASSET_BASE_PATH = Path.of(".spector", "assets");
 
+    public static final String MULTIMODAL_VIDEO_KEYFRAME_INTERVAL = "spector.multimodal.video.keyframe-interval-seconds";
+    public static final int DEFAULT_MULTIMODAL_VIDEO_KEYFRAME_INTERVAL = 10;
+    public static final String MULTIMODAL_VIDEO_MAX_KEYFRAMES = "spector.multimodal.video.max-keyframes";
+    public static final int DEFAULT_MULTIMODAL_VIDEO_MAX_KEYFRAMES = 30;
+
+    public static final String MULTIMODAL_AUDIO_MAX_FILE_SIZE = "spector.multimodal.audio.max-file-size";
+    public static final long DEFAULT_MULTIMODAL_AUDIO_MAX_FILE_SIZE = 50L * 1024 * 1024; // 50MB
+    public static final String MULTIMODAL_VISION_MAX_IMAGE_SIZE = "spector.multimodal.vision.max-image-size";
+    public static final long DEFAULT_MULTIMODAL_VISION_MAX_IMAGE_SIZE = 20L * 1024 * 1024; // 20MB
+    public static final String MULTIMODAL_TIKA_MAX_CONTENT_LENGTH = "spector.multimodal.tika.max-content-length";
+    public static final int DEFAULT_MULTIMODAL_TIKA_MAX_CONTENT_LENGTH = 100 * 1024 * 1024; // 100MB
+
+    // Evaluation & Test Judge
+    public static final String TEST_JUDGE_MODEL = "spector.test.judge.model";
+    public static final String DEFAULT_TEST_JUDGE_MODEL = "llama3.1";
+    public static final String TEST_JUDGE_BASE_URL = "spector.test.judge.base-url";
+    public static final String DEFAULT_TEST_JUDGE_BASE_URL = "http://localhost:11434";
+    public static final String TEST_JUDGE_CONFIDENCE = "spector.test.judge.confidence";
+    public static final float DEFAULT_TEST_JUDGE_CONFIDENCE = 0.6f;
+
     // Auth
     public static final String AUTH_ENABLED = "spector.auth.enabled";
     public static final boolean DEFAULT_AUTH_ENABLED = false;
@@ -295,7 +634,7 @@ public final class SpectorPropertyConstants {
     public static final int DEFAULT_AUTH_PBKDF2_ITERATIONS = 310_000;
     public static final int DEFAULT_AUTH_LOCKOUT_MAX_ATTEMPTS = 5;
     public static final int DEFAULT_AUTH_LOCKOUT_MINUTES = 15;
-    public static final java.util.List<String> DEFAULT_AUTH_PUBLIC_PATHS = java.util.List.of("/actuator/health", "/api/docs");
+    public static final List<String> DEFAULT_AUTH_PUBLIC_PATHS = List.of("/actuator/health", "/api/docs");
 
     // CORS
     public static final String CORS_ALLOWED_ORIGINS = "spector.cors.allowed-origins";

--- a/nucleus/spector-config/src/main/resources/spector-defaults.yml
+++ b/nucleus/spector-config/src/main/resources/spector-defaults.yml
@@ -138,6 +138,12 @@ spector:
     enabled: true
     persistence-mode: DISK
     persistence-path: .spector/memory
+    max-namespaces: 100
+    namespace-id: default
+    persist-working-memory: false
+    pin-source-episodes: false
+    edge-importance: DEFAULT
+    id-strategy: TSID
     dimensions: 384
     capacity: 100000
     nodes-per-partition: 10000
@@ -180,13 +186,23 @@ spector:
       sample-count: 15
       budget-ms: 500
     entity:
+      extraction-mode: NONE
+      resolution-enabled: false
+      shadow-mode: true
       max-degree: 16
       max-per-memory: 10
       cosine-threshold: 0.85
       retention-days: 7
       decay-factor: 0.95
       prune-threshold: 0.5
+      adj-decay-factor: 0.95
+      adj-prune-threshold: 0.2
+      merge-distance: 2
+    cross-capture:
+      min-weight: 2.0
+      scale-factor: 0.05
     graph:
+      expansion-mode: GATED
       causal-boost: 0.3
       hebbian-boost: 0.3
       temporal-forward: 0.8
@@ -198,6 +214,8 @@ spector:
       time-trigger: 1h
       tombstone-threshold: 0.30
       decay-prune-threshold: 0.05
+      interference-threshold: 0.12
+      interference-decay-factor: 0.7
     reflect:
       min-cluster-size: 5
     wal:
@@ -215,6 +233,37 @@ spector:
     icnu:
       threshold: 0.2
       steepness: 8.0
+      weight-interest: 0.30
+      weight-challenge: 0.10
+      weight-novelty: 0.40
+      weight-urgency: 0.20
+
+  # ─── Recall & Search Pipeline ───
+  recall:
+    text-search:
+      enabled: true
+      mode: HYBRID
+    scoring-mode: COGNITIVE
+    trace:
+      enabled: false
+    reranker:
+      enabled: false
+      depth: 50
+    mmr:
+      enabled: false
+      lambda: 0.5
+    auto-profile:
+      enabled: false
+    include-contradictions: false
+    lateral:
+      enabled: false
+      distance-threshold: 1.2
+      min-tag-overlap: 0.5
+    strictness-coefficient: 1.0
+    valence-alignment:
+      enabled: false
+    mode: LEARN
+    max-replay-events: 100000
 
   # ─── File Ingestion ───
   ingestion:

--- a/nucleus/spector-config/src/main/resources/spector-defaults.yml
+++ b/nucleus/spector-config/src/main/resources/spector-defaults.yml
@@ -22,6 +22,38 @@ spector:
   # ─── Global Mode (MEMORY) ───
   mode: MEMORY
 
+  # ─── Concurrency & Events ───
+  concurrency:
+    structured: true
+  events:
+    async: false
+
+  # ─── Chunking Defaults ───
+  chunking:
+    text:
+      size: 512
+      overlap: 64
+    token:
+      limit: 128
+      overlap: 16
+    document:
+      max-size: 104857600
+
+  # ─── HDC Vector Parameters ───
+  hdc:
+    dimensions: 10000
+    ngram-size: 3
+
+  # ─── SVASQ Quantization ───
+  quantization:
+    svasq:
+      seed: 42
+      clip-percentile: 0.001
+      clip-sigmas: 3.0
+      clip-sigmas-4bit: 2.5
+      max-sample-size: 10000
+      min-std: 0.000001
+
   # ─── HNSW Index Parameters ───
   hnsw:
     m: 16
@@ -61,9 +93,11 @@ spector:
         stats-log-interval: 5m
     generation:
       type: ollama
-      model: ""
+      model: "llama3.2"
       base-url: http://localhost:11434
       api-key: ""
+      timeout: 60s
+      fallback-model: "qwen3:0.6b"
 
   # ─── Persistence File Names ───
   persistence:
@@ -72,6 +106,32 @@ spector:
       vectors: vectors.mmap
       documents: documents.dat
       id-mappings: id-mappings.dat
+      shard-dir-name: index_shards
+
+  # ─── Query & Ranking ───
+  query:
+    default-top-k: 10
+    rrf-k: 60
+    reranker:
+      max-candidates: 20
+      connect-timeout: 5s
+      request-timeout: 30s
+      doc-snippet-length: 500
+    hybrid:
+      fanout-multiplier: 2
+      min-retrieval-k: 50
+
+  # ─── GPU Vector Search ───
+  gpu:
+    batch:
+      min-window-ms: 1
+      max-window-ms: 100
+      default-window: 10ms
+      default-max-batch: 1024
+    memory:
+      min-budget-bytes: 268435456
+    leak-detector:
+      threshold: 300s
 
   # ─── Cognitive Memory Module ───
   memory:
@@ -81,6 +141,13 @@ spector:
     dimensions: 384
     capacity: 100000
     nodes-per-partition: 10000
+    working-capacity: 100
+    episodic-partition-capacity: 1000
+    semantic-capacity: 10000
+    procedural-capacity: 1000
+    entity-graph-capacity: 50000
+    pinned-quota: 10000
+    checkpoint-interval-seconds: 30
     decay-enabled: true
     consolidation-interval: 60s
     default-ingestion-tier: SEMANTIC
@@ -91,6 +158,63 @@ spector:
     splade-enabled: true
     colbert-enabled: true
     bm25-enabled: true
+    surprise-warmup: 10
+    flashbulb-threshold: 3.0
+    valence-learning-rate: 0.3
+    deduplication-radius: 0.05
+    inhibition-ttl-ms: 300000
+    inhibition-floor: 0.1
+    habituation-decay-rate: 0.2
+    ltp-cooldown-ms: 300000
+    hebbian:
+      max-degree: 24
+      session-boundary-ms: 300000
+      promotion-min-weight: 3.0
+      decay-factor: 0.9
+    stdp:
+      a-plus: 0.1
+      a-minus: 0.05
+      tau-plus: 30000
+      tau-minus: 30000
+    bridge:
+      sample-count: 15
+      budget-ms: 500
+    entity:
+      max-degree: 16
+      max-per-memory: 10
+      cosine-threshold: 0.85
+      retention-days: 7
+      decay-factor: 0.95
+      prune-threshold: 0.5
+    graph:
+      causal-boost: 0.3
+      hebbian-boost: 0.3
+      temporal-forward: 0.8
+      temporal-backward: 0.7
+      entity-attenuation: 0.25
+      expansion-threshold: 0.40
+    circadian:
+      volume-trigger: 100
+      time-trigger: 1h
+      tombstone-threshold: 0.30
+      decay-prune-threshold: 0.05
+    reflect:
+      min-cluster-size: 5
+    wal:
+      max-chunk-bytes: 8388608
+    vacuum:
+      threshold: 0.20
+    session:
+      buffer-size: 64
+      buffer-ttl-ms: 5000
+    namespace:
+      max-id-length: 63
+      soft-warning-threshold: 0.70
+    hyperfocus:
+      ttl-ms: 1800000
+    icnu:
+      threshold: 0.2
+      steepness: 8.0
 
   # ─── File Ingestion ───
   ingestion:
@@ -99,3 +223,34 @@ spector:
     skip-dirs: ".git,.idea,.mvn,target,node_modules,.github"
     chunk-size: 2500
     chunk-overlap: 200
+    parallelism: 4
+    max-retries: 3
+    retry-delay-ms: 2000
+
+  # ─── Multimodal Sensory Media ───
+  multimodal:
+    enabled: false
+    vision:
+      model: moondream
+      base-url: http://localhost:11434
+      timeout: 120
+      max-image-size: 20971520
+    audio:
+      model: gemma4
+      timeout: 180
+      max-file-size: 52428800
+    video:
+      keyframe-interval-seconds: 10
+      max-keyframes: 30
+    asset-store:
+      type: local
+      base-path: .spector/assets
+    tika:
+      max-content-length: 104857600
+
+  # ─── Test Judge ───
+  test:
+    judge:
+      model: llama3.1
+      base-url: http://localhost:11434
+      confidence: 0.6

--- a/nucleus/spector-test-support/pom.xml
+++ b/nucleus/spector-test-support/pom.xml
@@ -25,6 +25,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.spectrayan</groupId>
+            <artifactId>spector-config</artifactId>
+        </dependency>
+
         <!-- Spector provider API (TextGenerationProvider interface) -->
         <dependency>
             <groupId>com.spectrayan</groupId>

--- a/nucleus/spector-test-support/src/main/java/com/spectrayan/spector/test/judge/LlmJudgeConfig.java
+++ b/nucleus/spector-test-support/src/main/java/com/spectrayan/spector/test/judge/LlmJudgeConfig.java
@@ -15,6 +15,8 @@
  */
 package com.spectrayan.spector.test.judge;
 
+import com.spectrayan.spector.config.SpectorPropertyConstants;
+
 /**
  * Configuration for LLM test judge, loaded from environment variables and system properties.
  *
@@ -44,13 +46,13 @@ public record LlmJudgeConfig(
 ) {
 
     /** Default model for judging — use a model available locally. */
-    public static final String DEFAULT_MODEL = "llama3.1";
+    public static final String DEFAULT_MODEL = SpectorPropertyConstants.DEFAULT_TEST_JUDGE_MODEL;
 
     /** Default Ollama URL. */
-    public static final String DEFAULT_BASE_URL = "http://localhost:11434";
+    public static final String DEFAULT_BASE_URL = SpectorPropertyConstants.DEFAULT_TEST_JUDGE_BASE_URL;
 
     /** Default confidence threshold. */
-    public static final float DEFAULT_CONFIDENCE = 0.6f;
+    public static final float DEFAULT_CONFIDENCE = SpectorPropertyConstants.DEFAULT_TEST_JUDGE_CONFIDENCE;
 
     /**
      * Loads configuration from environment variables and system properties.


### PR DESCRIPTION
## Summary

Closes #520

Centralizes all default configuration properties, constants, and hyperparameters across the Spector architecture into `nucleus/spector-config` (`SpectorPropertyConstants.java` and `spector-defaults.yml`) as the single source of truth.

### Key Changes
- **Config Foundation (`spector-config`)**:
  - Expanded `SpectorPropertyConstants.java` with 60+ new property keys and default constants spanning chunking, HDC, SVASQ, provider timeouts, multimodal sensory extraction, query parsing/RRF, GPU batching, and cognitive memory hyperparameters (STDP, Hebbian, graph scoring, circadian cycle, WAL chunk size, vacuum thresholds).
  - Synchronized `spector-defaults.yml` with the complete property matrix.
- **Provider API & Providers (`spector-provider-api`, `spector-providers`)**:
  - Standardized embedding HTTP timeout to 30s (`DEFAULT_PROVIDER_EMBEDDING_TIMEOUT`).
  - Standardized LLM generation options to `temperature = 0.3f`, `maxTokens = 1024`, `topP = 0.95f`.
  - Preserved zero external dependencies SPI contract in `spector-provider-api`.
- **Query & Indexing (`spector-query`, `spector-index`)**:
  - Linked `QueryParser`, `ReciprocalRankFusion`, `HybridSearchOrchestrator`, and `LlmReranker` to canonical defaults.
  - Linked `SpectorIndexConfig`, `BM25Index`, `SpladeIndex`, and `ColBERTTokenCache` to centralized defaults.
- **Ingestion & Sensory (`spector-ingestion`)**:
  - Linked `FileDiscoveryService` and `TikaTextExtractor` to standardized chunking defaults (`2500` chars / `200` overlap).
  - Aligned sensory extraction limits and timeouts for Audio (180s timeout, 50MB max) and Vision (120s timeout, 20MB max).
- **GPU Acceleration (`spector-gpu`)**:
  - Linked `BatchGpuSearcher`, `GpuMemoryManager`, and `PanamaMemoryDetector` to centralized GPU window, batch size, and memory floor limits.
- **Cognitive Memory Subsystem (`spector-memory`)**:
  - Linked all 22 builder default fields in `SpectorMemoryBuilder`, `RecallOptions`, `GraphScoringPolicy`, `CircadianPolicy`, `HebbianGraph`, `CoActivationRecordMemory`, `BridgeDetector`, `EntityGraphMemory`, `DecayConfig`, `TwoFactorConfig`, `HabituationPenalty`, `MemoryWal`, `VacuumCompactor`, and `SessionWriteBuffer`.

### Verification
- `mvn clean verify` passed across the entire 27-module reactor.
- 1,223 unit tests in `spector-memory` passed with 0 failures and 0 errors.

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
