### PR TITLE
feat(memory): directional contradiction resolution — CADP (#507)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/ConsolidationService.java
@@ -123,24 +123,49 @@ public final class ConsolidationService {
                 long offsetA = recordA.byteOffset();
                 long offsetB = recordB.byteOffset();
 
-                layout.markContradicted(segment, offsetA);
-                layout.markContradicted(segment, offsetB);
+                // ── CADP: Directional winner/loser determination (#507) ──
+                // Primary: newer memory wins. Secondary: higher storage strength.
+                // Tertiary: lower memory ID (lexicographic) for deterministic tiebreak.
+                CognitiveRecord winner;
+                CognitiveRecord loser;
+                long offsetLoser;
 
-                // Add CONTRADICTS relation as a 2-vertex typed hyperedge (ADR-0003 #459)
+                int cmp = Long.compare(recordA.timestampMs(), recordB.timestampMs());
+                if (cmp == 0) {
+                    cmp = Float.compare(recordA.storageStrength(), recordB.storageStrength());
+                }
+                if (cmp == 0) {
+                    cmp = pair.idB().compareTo(pair.idA()); // lower ID wins → A wins when B > A
+                }
+
+                if (cmp >= 0) {
+                    winner = recordA; loser = recordB;
+                    offsetLoser = offsetB;
+                } else {
+                    winner = recordB; loser = recordA;
+                    offsetLoser = offsetA;
+                }
+
+                // Only flag the loser (corrected memory)
+                layout.markContradicted(segment, offsetLoser);
+                log.info("Consolidation: CADP resolved — winner='{}' corrects loser='{}'",
+                        winner.id(), loser.id());
+
+                // Add directed CONTRADICTS hyperedge with CORRECTOR/CORRECTED roles (#507)
                 if (hyperEntityGraph != null) {
-                    int slotA = (int) ((offsetA - (semanticStore.isPersistent() ? CognitiveRecordMemory.METADATA_HEADER_BYTES : 0L)) / layout.stride());
-                    int slotB = (int) ((offsetB - (semanticStore.isPersistent() ? CognitiveRecordMemory.METADATA_HEADER_BYTES : 0L)) / layout.stride());
+                    int slotWinner = (int) ((winner.byteOffset() - (semanticStore.isPersistent() ? CognitiveRecordMemory.METADATA_HEADER_BYTES : 0L)) / layout.stride());
+                    int slotLoser = (int) ((loser.byteOffset() - (semanticStore.isPersistent() ? CognitiveRecordMemory.METADATA_HEADER_BYTES : 0L)) / layout.stride());
 
-                    List<Integer> entitiesA = memToEntities.get(slotA);
-                    List<Integer> entitiesB = memToEntities.get(slotB);
+                    List<Integer> entitiesWinner = memToEntities.get(slotWinner);
+                    List<Integer> entitiesLoser = memToEntities.get(slotLoser);
 
-                    if (entitiesA != null && entitiesB != null) {
-                        for (int eA : entitiesA) {
-                            for (int eB : entitiesB) {
-                                if (eA != eB) {
+                    if (entitiesWinner != null && entitiesLoser != null) {
+                        for (int eW : entitiesWinner) {
+                            for (int eL : entitiesLoser) {
+                                if (eW != eL) {
                                     hyperEntityGraph.addHyperedge(
-                                            new int[]{eA, eB},
-                                            new int[]{HyperEntityGraphMemory.ROLE_SUBJECT, HyperEntityGraphMemory.ROLE_CONTEXT},
+                                            new int[]{eW, eL},
+                                            new int[]{HyperEntityGraphMemory.ROLE_CORRECTOR, HyperEntityGraphMemory.ROLE_CORRECTED},
                                             1, // type id 1 = CONTRADICTS
                                             1.0f, -1, System.currentTimeMillis());
                                 }
@@ -151,6 +176,7 @@ public final class ConsolidationService {
 
                 processedIds.add(pair.idA());
                 processedIds.add(pair.idB());
+
 
             } else {
                 log.info("Consolidation: Merging duplicate memories '{}' and '{}'", pair.idA(), pair.idB());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
@@ -1043,6 +1043,10 @@ public final class HyperEntityGraphMemory extends AbstractGraphMemory<HyperEntit
     public static final int ROLE_CONTEXT = 3;
     /** Entity is an instrument or method. */
     public static final int ROLE_INSTRUMENT = 4;
+    /** Entity belongs to the correcting (winner) memory in a CONTRADICTS edge (CADP #507). */
+    public static final int ROLE_CORRECTOR = 5;
+    /** Entity belongs to the corrected (loser) memory in a CONTRADICTS edge (CADP #507). */
+    public static final int ROLE_CORRECTED = 6;
     /** Unspecified role. */
     public static final int ROLE_UNSPECIFIED = 0;
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/ConsolidationIntegrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/ConsolidationIntegrationTest.java
@@ -105,7 +105,7 @@ class ConsolidationIntegrationTest {
     }
 
     @Test
-    void testContradictoryDuplicatesFlagged() throws Exception {
+    void testContradictoryDuplicatesFlagged_cadpDirectional() throws Exception {
         // Create duplicate vectors
         float[] vector = new float[DIMENSIONS];
         vector[5] = 1.0f;
@@ -120,27 +120,32 @@ class ConsolidationIntegrationTest {
         llmProvider.registerResponse(" Paris", "YES");
         llmProvider.registerResponse(" Lyon", "YES");
 
-        // Store in SEMANTIC tier
+        // Store in SEMANTIC tier — fact-a first (older), fact-b second (newer)
         memory.remember("fact-a", textA, MemoryType.SEMANTIC, MemorySource.OBSERVED, "geography");
         memory.remember("fact-b", textB, MemoryType.SEMANTIC, MemorySource.OBSERVED, "geography");
 
         // Run consolidation
         memory.consolidate();
 
-        // Verify that the original memories still exist, but they are flagged as contradicted
+        // CADP: fact-b is newer (stored second) → winner. fact-a is older → loser.
         CognitiveRecord recordA = memory.inspect("fact-a");
         CognitiveRecord recordB = memory.inspect("fact-b");
 
         assertThat(recordA).isNotNull();
         assertThat(recordB).isNotNull();
-        assertThat(recordA.isContradicted()).isTrue();
-        assertThat(recordB.isContradicted()).isTrue();
+        assertThat(recordA.isContradicted())
+                .as("Older memory (loser) should be flagged as contradicted")
+                .isTrue();
+        assertThat(recordB.isContradicted())
+                .as("Newer memory (winner/corrector) should NOT be flagged")
+                .isFalse();
 
-        // Standard recall should filter/gate them out
+        // Standard recall should return the winner (fact-b) and hide the loser (fact-a)
         List<CognitiveResult> standardRecall = memory.recall("capital of France", RecallOptions.builder().includeContradictions(false).build());
-        assertThat(standardRecall).noneMatch(r -> "fact-a".equals(r.id()) || "fact-b".equals(r.id()));
+        assertThat(standardRecall).noneMatch(r -> "fact-a".equals(r.id()));
+        assertThat(standardRecall).anyMatch(r -> "fact-b".equals(r.id()));
 
-        // Recall with includeContradictions(true) should return them
+        // Recall with includeContradictions(true) should return both
         List<CognitiveResult> recallWithContradictions = memory.recall("capital of France", RecallOptions.builder().includeContradictions(true).build());
         assertThat(recallWithContradictions).anyMatch(r -> "fact-a".equals(r.id()));
         assertThat(recallWithContradictions).anyMatch(r -> "fact-b".equals(r.id()));


### PR DESCRIPTION
## Summary

Implement **CADP** (Contradiction-Aware Detection with directional resolution) for the memory consolidation pipeline.

**Problem**: When two memories contradict, both get `FLAG_CONTRADICTED` and are hidden from recall. The correcting fact is lost alongside the outdated fact.

**Solution**: Determine a winner (corrector) and loser (corrected) using a three-tier comparison:
1. **Timestamp** — newer memory wins (recency)
2. **Storage strength** — stronger memory wins (tiebreaker)
3. **Memory ID** — lexicographic order (deterministic fallback)

Only the loser receives `FLAG_CONTRADICTED`. The winner remains fully visible in standard recall.

## Changes

| File | Change |
|:---|:---|
| `HyperEntityGraphMemory.java` | Add `ROLE_CORRECTOR = 5` and `ROLE_CORRECTED = 6` role constants |
| `ConsolidationService.java` | Replace symmetric flagging with directional winner/loser determination |
| `ConsolidationIntegrationTest.java` | Update assertions for CADP directional behavior |

**3 files changed, 57 insertions, 22 deletions**

## What does NOT change (and why)

- `CognitiveScorer` — gates on `FLAG_CONTRADICTED` → only loser penalized
- `MemoryFilterPipeline` — filters `FLAG_CONTRADICTED` → only loser filtered
- `ContradictionDetector` — detection remains symmetric; directionality resolved in ConsolidationService
- `RecallOptions.includeContradictions` — works as-is for forensic/audit queries

## Test Results

```
Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Closes #507
