### PR TITLE
feat(memory): adaptive softmax retrieval temperature using surprise z-score (#504)

### DIFF
--- a/memory/spector-memory/README.md
+++ b/memory/spector-memory/README.md
@@ -58,6 +58,7 @@ spector-memory/
 │     ├── CognitiveScorer.java          (6-phase fused scoring hot-loop)
 │     ├── SynapticTagEncoder.java       (64-bit inline Bloom filter)
 │     ├── SynapticHeaderConstants.java  (offsets, masks, field sizes)
+│     ├── TemperatureSoftmax.java       (numerically stable retrieval temperature)
 │     └── DecayStrategy.java            (SIMD-friendly temporal decay)
 │
 ├── dopamine/                       ← "Dopamine System" — surprise & importance

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
@@ -82,7 +82,7 @@ public final class RecallPipelineBuilder {
                 graphs.entityDirectory(), graphs.hyperEntityGraph(), graphs.temporalKnowledgeGraph(), graphs.entityExtractor(),
                 builder.graphScoringPolicy, retrieval.bm25Index(),
                 retrieval.memorySpladeIndex(), builder.SparseEmbeddingProvider, retrieval.colbertReranker(),
-                recallHistory, mmrReranker);
+                recallHistory, mmrReranker, bio.surpriseDetector());
 
         recallPipeline.addListener(new LtpReconsolidationListener(index, partitionManager, wal));
         recallPipeline.addListener(new HebbianCoActivationListener(bio.coActivationTracker()));

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dopamine/SurpriseDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dopamine/SurpriseDetector.java
@@ -93,6 +93,23 @@ public final class SurpriseDetector {
     }
 
     /**
+     * Estimates the surprise z-score for a query without updating the running distribution.
+     *
+     * <p>Used during recall to dynamically adapt retrieval temperature based on
+     * prediction error. If the detector has not seen enough samples (&lt; warmupSamples),
+     * returns 0.0 (neutral baseline).</p>
+     *
+     * @param distanceToNearest L2 distance from query vector to nearest memory/centroid
+     * @return surprise z-score (0.0 if not warmed up)
+     */
+    public double querySurpriseZScore(float distanceToNearest) {
+        if (stats.count() < warmupSamples) {
+            return 0.0;
+        }
+        return stats.zScore(distanceToNearest);
+    }
+
+    /**
      * Maps a z-score to an importance value using a continuous sigmoid.
      *
      * <p>Produces a smooth, unique importance value for each memory instead of

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -114,7 +114,13 @@ public record RecallOptions(
         //  Consolidation & Contradictions 
         boolean includeContradictions,
         //  Resolved Profile (for header stamping) 
-        CognitiveProfile resolvedProfile
+        CognitiveProfile resolvedProfile,
+        //  Temperature & Adaptive Retrieval 
+        boolean adaptiveTemperature,
+        float baseTemperature,
+        float temperatureSurpriseCoefficient,
+        float minTemperature,
+        float maxTemperature
 ) {
 
     /** Default options: top 10, no filters, balanced scoring. */
@@ -130,6 +136,27 @@ public record RecallOptions(
     // ==============================================================
     // Composed sub-record accessors  --  progressive migration API
     // ==============================================================
+
+    /** Returns temperature parameters as a composed {@link TemperatureOptions}. */
+    public TemperatureOptions temperature() {
+        return new TemperatureOptions(adaptiveTemperature, baseTemperature,
+                temperatureSurpriseCoefficient, minTemperature, maxTemperature);
+    }
+
+    /**
+     * Computes the effective temperature for a given query surprise z-score.
+     *
+     * @param zSurprise query-side surprise z-score
+     * @return clamped effective temperature
+     */
+    public float computeEffectiveTemperature(double zSurprise) {
+        if (!adaptiveTemperature) {
+            return Math.clamp(baseTemperature, minTemperature, maxTemperature);
+        }
+        double positiveSurprise = Math.max(0.0, zSurprise);
+        float effective = (float) (baseTemperature * (1.0 + temperatureSurpriseCoefficient * positiveSurprise));
+        return Math.clamp(effective, minTemperature, maxTemperature);
+    }
 
     /** Returns filter parameters as a composed {@link FilterOptions}. */
     public FilterOptions filter() {
@@ -234,6 +261,13 @@ public record RecallOptions(
         private boolean autoProfile = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_AUTO_PROFILE_ENABLED;
         private boolean includeContradictions = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_INCLUDE_CONTRADICTIONS;
         private CognitiveProfile resolvedProfile = null; // set when profile() is called
+
+        // ─── Temperature & Adaptive Retrieval ───
+        private boolean adaptiveTemperature = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_ADAPTIVE_TEMPERATURE_ENABLED;
+        private float baseTemperature = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_BASE_TEMPERATURE;
+        private float temperatureSurpriseCoefficient = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_TEMPERATURE_SURPRISE_COEFFICIENT;
+        private float minTemperature = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_MIN_TEMPERATURE;
+        private float maxTemperature = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_MAX_TEMPERATURE;
 
         // ─── Neurodivergent: Hyperfocus ───
         private long hyperfocusMask = 0L;       // 0 = disabled
@@ -627,6 +661,57 @@ public record RecallOptions(
             return this;
         }
 
+        // ─── Temperature & Adaptive Retrieval ───
+
+        /**
+         * Enables/disables adaptive temperature based on query surprise z-score (default: false).
+         */
+        public Builder adaptiveTemperature(boolean enable) {
+            this.adaptiveTemperature = enable;
+            return this;
+        }
+
+        /**
+         * Sets the base temperature (default: 1.0).
+         */
+        public Builder baseTemperature(float baseTemp) {
+            this.baseTemperature = baseTemp;
+            return this;
+        }
+
+        /**
+         * Sets the temperature surprise coefficient kappa (default: 0.15).
+         */
+        public Builder temperatureSurpriseCoefficient(float kappa) {
+            this.temperatureSurpriseCoefficient = kappa;
+            return this;
+        }
+
+        /**
+         * Sets the minimum temperature clamping bound (default: 0.1).
+         */
+        public Builder minTemperature(float min) {
+            this.minTemperature = min;
+            return this;
+        }
+
+        /**
+         * Sets the maximum temperature clamping bound (default: 5.0).
+         */
+        public Builder maxTemperature(float max) {
+            this.maxTemperature = max;
+            return this;
+        }
+
+        /**
+         * Sets both min and max temperature clamping bounds.
+         */
+        public Builder temperatureBounds(float min, float max) {
+            this.minTemperature = min;
+            this.maxTemperature = max;
+            return this;
+        }
+
         /**
          * Sets the scoring mode (default: {@link ScoringMode#COGNITIVE}).
          *
@@ -733,7 +818,12 @@ public record RecallOptions(
                     enableMmr, mmrLambda,
                     autoProfile,
                     includeContradictions,
-                    resolvedProfile);
+                    resolvedProfile,
+                    adaptiveTemperature,
+                    baseTemperature,
+                    temperatureSurpriseCoefficient,
+                    minTemperature,
+                    maxTemperature);
             return options;
         }
     }
@@ -805,6 +895,24 @@ public record RecallOptions(
         if (recallMode == RecallMode.REPLAY && replayTimestamp == null) {
             String msg = "recallMode=REPLAY requires replayTimestamp to be set. "
                     + "Use RecallOptions.builder().replayTimestamp(Instant.parse(...)).build()";
+            warnings.add(msg);
+            VALIDATION_LOG.warn(msg);
+        }
+
+        // 6. Temperature bounds validation
+        if (minTemperature > maxTemperature) {
+            String msg = "minTemperature (" + minTemperature + ") is greater than maxTemperature ("
+                    + maxTemperature + ").";
+            warnings.add(msg);
+            VALIDATION_LOG.warn(msg);
+        }
+        if (baseTemperature <= 0.0f) {
+            String msg = "baseTemperature (" + baseTemperature + ") must be positive.";
+            warnings.add(msg);
+            VALIDATION_LOG.warn(msg);
+        }
+        if (minTemperature <= 0.0f) {
+            String msg = "minTemperature (" + minTemperature + ") must be positive.";
             warnings.add(msg);
             VALIDATION_LOG.warn(msg);
         }
@@ -887,6 +995,11 @@ public record RecallOptions(
         b.autoProfile = this.autoProfile;
         b.includeContradictions = this.includeContradictions;
         b.resolvedProfile = this.resolvedProfile;
+        b.adaptiveTemperature = this.adaptiveTemperature;
+        b.baseTemperature = this.baseTemperature;
+        b.temperatureSurpriseCoefficient = this.temperatureSurpriseCoefficient;
+        b.minTemperature = this.minTemperature;
+        b.maxTemperature = this.maxTemperature;
         return b;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TemperatureOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/TemperatureOptions.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import com.spectrayan.spector.config.SpectorPropertyConstants;
+
+/**
+ * Temperature and adaptive retrieval configuration for cognitive recall.
+ *
+ * <p>Modulates the breadth and sharpness of associative retrieval. When adaptive
+ * temperature is enabled, query-side surprise (prediction error) dynamically scales
+ * the temperature: high surprise expands retrieval breadth ($T &gt; 1.0$), while
+ * familiar queries focus retrieval ($T \le 1.0$).</p>
+ *
+ * @param adaptiveTemperature            whether adaptive temperature modulation is enabled
+ * @param baseTemperature                baseline temperature (default: 1.0)
+ * @param temperatureSurpriseCoefficient scaling coefficient \(\kappa\) for surprise (default: 0.15)
+ * @param minTemperature                 minimum clamping bound (default: 0.1)
+ * @param maxTemperature                 maximum clamping bound (default: 5.0)
+ */
+public record TemperatureOptions(
+        boolean adaptiveTemperature,
+        float baseTemperature,
+        float temperatureSurpriseCoefficient,
+        float minTemperature,
+        float maxTemperature
+) {
+
+    /** Default balanced temperature options. */
+    public static final TemperatureOptions DEFAULT = new TemperatureOptions(
+            SpectorPropertyConstants.DEFAULT_RECALL_ADAPTIVE_TEMPERATURE_ENABLED,
+            SpectorPropertyConstants.DEFAULT_RECALL_BASE_TEMPERATURE,
+            SpectorPropertyConstants.DEFAULT_RECALL_TEMPERATURE_SURPRISE_COEFFICIENT,
+            SpectorPropertyConstants.DEFAULT_RECALL_MIN_TEMPERATURE,
+            SpectorPropertyConstants.DEFAULT_RECALL_MAX_TEMPERATURE
+    );
+
+    /**
+     * Computes the effective temperature given a query surprise z-score.
+     *
+     * <p>Formula: \(T = \operatorname{clamp}(T_{\text{base}} \times (1 + \kappa \times \max(0, z_{\text{surprise}})), T_{\text{min}}, T_{\text{max}})\).</p>
+     *
+     * @param zSurprise query-side surprise z-score
+     * @return clamped effective temperature
+     */
+    public float computeEffective(double zSurprise) {
+        if (!adaptiveTemperature) {
+            return Math.clamp(baseTemperature, minTemperature, maxTemperature);
+        }
+        double positiveSurprise = Math.max(0.0, zSurprise);
+        float effective = (float) (baseTemperature * (1.0 + temperatureSurpriseCoefficient * positiveSurprise));
+        return Math.clamp(effective, minTemperature, maxTemperature);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -184,6 +184,9 @@ public final class RecallPipeline {
     private final GraphExpander graphExpander;
     private final SalienceAndHabituationScorer salienceScorer;
 
+    //  Surprise & Dopamine (nullable) 
+    private final com.spectrayan.spector.memory.dopamine.SurpriseDetector surpriseDetector;
+
     //  Neurodivergent: Lateral feedback tracking 
     // Maps memoryId  ->  RetrievalMode for the most recent recall.
     // Used by SpectorMemory.reinforce()/suppress() to feed LateralEvaluator.
@@ -369,6 +372,41 @@ public final class RecallPipeline {
                            ColBERTReranker colbertReranker,
                            RecallHistory recallHistory,
                            com.spectrayan.spector.memory.pipeline.reranker.MmrReranker mmrReranker) {
+        this(embeddingProvider, partitionRegistry, index, suppressionSet, habituationPenalty,
+                prospectiveScheduler, wal, calibrationMins, calibrationScales,
+                semanticRecallStrategy, coActivationTracker, hebbianGraph, temporalChain,
+                entityDirectory, hyperEntityGraph, temporalKnowledgeGraph, entityExtractor, graphScoringPolicy,
+                bm25Index, spladeIndex, spladeProvider, colbertReranker, recallHistory, mmrReranker, null);
+    }
+
+    /**
+     * Creates a recall pipeline with all subsystems including SurpriseDetector for adaptive retrieval temperature.
+     */
+    public RecallPipeline(EmbeddingProvider embeddingProvider,
+                           PartitionRegistry partitionRegistry,
+                           MemoryIndex index,
+                           SuppressionSet suppressionSet,
+                           HabituationPenalty habituationPenalty,
+                           ProspectiveScheduler prospectiveScheduler,
+                           MemoryWal wal,
+                           float[] calibrationMins,
+                           float[] calibrationScales,
+                           SemanticRecallStrategy semanticRecallStrategy,
+                           CoActivationRecordMemory coActivationTracker,
+                           HebbianGraphBase hebbianGraph,
+                           TemporalChainMemory temporalChain,
+                           EntityDirectory entityDirectory,
+                           com.spectrayan.spector.memory.graph.HyperEntityGraphMemory hyperEntityGraph,
+                           com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph temporalKnowledgeGraph,
+                           EntityExtractor entityExtractor,
+                           GraphScoringPolicy graphScoringPolicy,
+                           MemoryBM25Index bm25Index,
+                           MemorySpladeIndex spladeIndex,
+                           SparseEmbeddingProvider spladeProvider,
+                           ColBERTReranker colbertReranker,
+                           RecallHistory recallHistory,
+                           com.spectrayan.spector.memory.pipeline.reranker.MmrReranker mmrReranker,
+                           com.spectrayan.spector.memory.dopamine.SurpriseDetector surpriseDetector) {
         this.embeddingProvider = embeddingProvider;
         this.partitionRegistry = partitionRegistry;
         this.index = index;
@@ -392,6 +430,7 @@ public final class RecallPipeline {
         this.colbertReranker = colbertReranker;
         this.recallHistory = recallHistory;
         this.mmrReranker = mmrReranker;
+        this.surpriseDetector = surpriseDetector;
 
         //  Phase Components Initialization 
         this.candidateGatherer = new RecallCandidateGatherer(index, bm25Index);
@@ -409,6 +448,7 @@ public final class RecallPipeline {
                 temporalKnowledgeGraph, entityDirectory, entityExtractor);
     }
 
+    public com.spectrayan.spector.memory.dopamine.SurpriseDetector surpriseDetector() { return surpriseDetector; }
     public RecallCandidateGatherer candidateGatherer() { return candidateGatherer; }
     public CognitiveReranker cognitiveReranker() { return cognitiveReranker; }
     public GraphExpander graphExpander() { return graphExpander; }
@@ -446,6 +486,31 @@ public final class RecallPipeline {
     private void applyCognitiveScoring(List<CognitiveResult> allResults,
                                        RecallOptions options, long nowMs) {
         salienceScorer.applyCognitiveScoring(allResults, options, nowMs, coActivationTracker, graphScoringPolicy);
+    }
+
+    /**
+     * Estimates query-side surprise z-score and computes effective retrieval temperature.
+     */
+    private float computeEffectiveTemperature(float[] queryVector, RecallOptions options) {
+        if (!options.adaptiveTemperature()) {
+            return options.computeEffectiveTemperature(0.0);
+        }
+        double zSurprise = 0.0;
+        if (surpriseDetector != null && queryVector != null && partitionRegistry != null) {
+            try {
+                CognitiveMemoryRouter activeRouter = partitionRegistry.activeRouter();
+                if (activeRouter != null && activeRouter.working() != null) {
+                    float nearestDist = activeRouter.working().nearestDistance(
+                            queryVector, calibrationMins, calibrationScales);
+                    if (nearestDist != Float.MAX_VALUE) {
+                        zSurprise = surpriseDetector.querySurpriseZScore(nearestDist);
+                    }
+                }
+            } catch (RuntimeException e) {
+                log.debug("Failed to compute query surprise z-score: {}", e.getMessage());
+            }
+        }
+        return options.computeEffectiveTemperature(zSurprise);
     }
 
     private boolean runTierScan(List<CognitiveResult> allResults, float[] queryVector,
@@ -512,6 +577,12 @@ public final class RecallPipeline {
 
         // Filter suppressed memories (inhibition)  --  always active
         allResults.removeIf(r -> suppressionSet.isSuppressed(r.id()));
+
+        // Softmax temperature modulation (adaptive or explicit temperature)
+        float effectiveTemp = computeEffectiveTemperature(queryVector, options);
+        if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
+            com.spectrayan.spector.memory.synapse.TemperatureSoftmax.applySoftmaxTemperature(allResults, effectiveTemp);
+        }
 
         // Sort and limit
         allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
@@ -724,6 +795,16 @@ public final class RecallPipeline {
             }
         }
 
+        // Step 6d: Softmax temperature modulation (adaptive or explicit temperature)
+        float effectiveTemp = computeEffectiveTemperature(queryVector, options);
+        if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
+            com.spectrayan.spector.memory.synapse.TemperatureSoftmax.applySoftmaxTemperature(allResults, effectiveTemp);
+            allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+            if (allResults.size() > options.topK()) {
+                allResults = new ArrayList<>(allResults.subList(0, options.topK()));
+            }
+        }
+
         // Step 7: Fire async post-recall listeners (LTP reconsolidation + Hebbian)
         // In OBSERVE mode, listeners are skipped to prevent persistent mutations.
         if (options.recallMode() == RecallMode.LEARN && !listeners.isEmpty()) {
@@ -844,6 +925,14 @@ public final class RecallPipeline {
                         traceBuilder.addStep("VALENCE_ALIGN", r.score(), r.score() + bd.valenceAlignment(),
                                 totalCandidates, totalCandidates,
                                 String.format("alignment=%.4f", bd.valenceAlignment()));
+                    }
+
+                    // Phase 4.5: Temperature Softmax
+                    if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
+                        traceBuilder.addStep("TEMPERATURE_SOFTMAX", bd.finalScore(), r.score(),
+                                totalCandidates, totalCandidates,
+                                String.format("temperature=%.3f, adaptive=%b",
+                                        effectiveTemp, options.adaptiveTemperature()));
                     }
                 } else {
                     // No breakdown  --  just record final score

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/TemperatureSoftmax.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/TemperatureSoftmax.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.synapse;
+
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.ScoreBreakdown;
+
+import java.util.List;
+
+/**
+ * Numerically stable softmax retrieval temperature modulation.
+ *
+ * <h3>Biological &amp; Information-Theoretic Rationale</h3>
+ * <p>Retrieval temperature controls the entropy of the recall distribution:</p>
+ * <ul>
+ *   <li><b>\(T &gt; 1.0\) (High Temperature / Novel Query)</b>: Flattens the candidate score
+ *       distribution (higher entropy). Smaller differences between top-ranked candidates allow
+ *       novel and lateral associative memories to compete, expanding recall breadth.</li>
+ *   <li><b>\(T &lt; 1.0\) (Low Temperature / Familiar Query)</b>: Sharpens the distribution
+ *       (lower entropy). Emphasizes dominant matches while suppressing marginal candidates,
+ *       maximizing precision.</li>
+ *   <li><b>\(T = 1.0\) (Identity)</b>: Preserves the original cognitive scoring distribution.</li>
+ * </ul>
+ *
+ * <h3>Numerical Stability</h3>
+ * <p>To prevent exponential overflow or underflow with large scores, the computation
+ * shifts scores by the maximum scaled score:
+ * \[\text{shift} = \max_j (s_j / T)\]
+ * \[w_i = \exp(s_i / T - \text{shift})\]
+ * \[p_i = \frac{w_i}{\sum_j w_j}\]
+ * Rescaled score: \(s'_i = p_i \times \text{totalOriginalScore}\).</p>
+ */
+public final class TemperatureSoftmax {
+
+    private TemperatureSoftmax() {}
+
+    /**
+     * Applies temperature-modulated softmax scaling to a list of cognitive results in-place.
+     *
+     * @param results     the list of cognitive results to modulate
+     * @param temperature the effective retrieval temperature (must be &gt; 0)
+     */
+    public static void applySoftmaxTemperature(List<CognitiveResult> results, float temperature) {
+        if (results == null || results.size() <= 1) return;
+        if (Math.abs(temperature - 1.0f) < 1e-4f) return; // T = 1.0 is identity
+
+        int n = results.size();
+        float temp = Math.max(0.01f, temperature);
+
+        float maxScaled = -Float.MAX_VALUE;
+        float totalOriginalScore = 0.0f;
+        for (int i = 0; i < n; i++) {
+            float s = results.get(i).score();
+            totalOriginalScore += s;
+            float scaled = s / temp;
+            if (scaled > maxScaled) {
+                maxScaled = scaled;
+            }
+        }
+
+        double sumExp = 0.0;
+        double[] expWeights = new double[n];
+        for (int i = 0; i < n; i++) {
+            float scaled = results.get(i).score() / temp;
+            double w = Math.exp(scaled - maxScaled);
+            expWeights[i] = w;
+            sumExp += w;
+        }
+
+        if (sumExp <= 0.0 || Double.isNaN(sumExp)) return;
+
+        // Scale factor: redistribute totalOriginalScore proportionally according to softmax probability
+        double scaleMultiplier = totalOriginalScore > 0 ? totalOriginalScore : 1.0;
+
+        for (int i = 0; i < n; i++) {
+            CognitiveResult r = results.get(i);
+            double prob = expWeights[i] / sumExp;
+            float newScore = (float) (prob * scaleMultiplier);
+
+            ScoreBreakdown bd = r.breakdown() != null
+                    ? new ScoreBreakdown(
+                            r.breakdown().similarity(),
+                            r.breakdown().importanceDecay(),
+                            r.breakdown().tagBoostFactor(),
+                            r.breakdown().habituationPenalty(),
+                            r.breakdown().graphBoost(),
+                            r.breakdown().valenceAlignment(),
+                            newScore)
+                    : null;
+
+            results.set(i, new CognitiveResult(
+                    r.id(), r.text(), newScore, r.importance(), r.ageDays(),
+                    r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                    r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                    r.retrievalMode(), bd, r.trace(), r.sourceModality(), r.metadata()));
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/RecallOptionsValidationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/RecallOptionsValidationTest.java
@@ -184,4 +184,29 @@ class RecallOptionsValidationTest {
                 .build();
         assertThat(options.validate()).isEmpty();
     }
+
+    // ══════════════════════════════════════════════════════════════
+    // Temperature bounds validation
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    void invalidMinMaxTemperatureWarns() {
+        RecallOptions options = RecallOptions.builder()
+                .temperatureBounds(3.0f, 1.0f) // min > max
+                .build();
+        List<String> warnings = options.validate();
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0)).contains("minTemperature").contains("maxTemperature");
+    }
+
+    @Test
+    void negativeBaseTemperatureWarns() {
+        RecallOptions options = RecallOptions.builder()
+                .baseTemperature(-0.5f)
+                .build();
+        List<String> warnings = options.validate();
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0)).contains("baseTemperature").contains("positive");
+    }
 }
+

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/dopamine/AdaptiveTemperatureBenchmarkTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/dopamine/AdaptiveTemperatureBenchmarkTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.dopamine;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.ScoreBreakdown;
+import com.spectrayan.spector.memory.synapse.TemperatureSoftmax;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Benchmark test verifying Shannon entropy and score distribution progression across temperature regimes.
+ */
+@DisplayName("Adaptive Temperature Benchmark & Entropy Verification")
+class AdaptiveTemperatureBenchmarkTest {
+
+    private List<CognitiveResult> buildDistribution(int size) {
+        List<CognitiveResult> results = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            float s = 1.0f / (1.0f + i * 0.2f); // Decaying scores: 1.0, 0.833, 0.714, ...
+            ScoreBreakdown bd = new ScoreBreakdown(s, 1f, 1f, 1f, 1f, 1f, s);
+            results.add(new CognitiveResult(
+                    "bench-" + i, "Bench candidate " + i, s, 5.0f, 1.0f,
+                    1, (byte) 0, MemoryType.SEMANTIC, MemorySource.OBSERVED,
+                    new String[]{"bench"}, 1.0f, 1.0f, RetrievalMode.STANDARD, bd, null, null, null
+            ));
+        }
+        return results;
+    }
+
+    private double calculateShannonEntropy(List<CognitiveResult> results) {
+        double sum = results.stream().mapToDouble(CognitiveResult::score).sum();
+        if (sum <= 0) return 0.0;
+        double entropy = 0.0;
+        for (CognitiveResult r : results) {
+            double p = r.score() / sum;
+            if (p > 0) {
+                entropy -= p * (Math.log(p) / Math.log(2.0));
+            }
+        }
+        return entropy;
+    }
+
+    @Test
+    @DisplayName("Shannon entropy strictly increases monotonically with higher temperature")
+    void testEntropyMonotonicity() {
+        float[] temps = {0.2f, 0.5f, 1.0f, 2.0f, 4.0f};
+        double prevEntropy = -1.0;
+
+        for (float t : temps) {
+            List<CognitiveResult> candidates = buildDistribution(20);
+            TemperatureSoftmax.applySoftmaxTemperature(candidates, t);
+            double entropy = calculateShannonEntropy(candidates);
+
+            if (prevEntropy >= 0.0) {
+                assertThat(entropy).as("Entropy at T=" + t + " should be greater than at previous T")
+                        .isGreaterThan(prevEntropy);
+            }
+            prevEntropy = entropy;
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/dopamine/AdaptiveTemperatureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/dopamine/AdaptiveTemperatureTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.dopamine;
+
+import com.spectrayan.spector.config.SpectorPropertyConstants;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.ScoreBreakdown;
+import com.spectrayan.spector.memory.model.TemperatureOptions;
+import com.spectrayan.spector.memory.synapse.TemperatureSoftmax;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Unit test suite for Adaptive Softmax Retrieval Temperature (Issue #504).
+ */
+@DisplayName("Adaptive Retrieval Temperature Tests")
+class AdaptiveTemperatureTest {
+
+    @Nested
+    @DisplayName("Effective Temperature Calculation")
+    class EffectiveTemperatureCalculationTests {
+
+        @Test
+        @DisplayName("Returns base temperature when adaptive temperature is disabled")
+        void testDisabledAdaptiveTemperature() {
+            RecallOptions options = RecallOptions.builder()
+                    .adaptiveTemperature(false)
+                    .baseTemperature(1.2f)
+                    .build();
+
+            assertThat(options.computeEffectiveTemperature(3.5))
+                    .isCloseTo(1.2f, within(1e-5f));
+            assertThat(options.computeEffectiveTemperature(-2.0))
+                    .isCloseTo(1.2f, within(1e-5f));
+        }
+
+        @Test
+        @DisplayName("Ignores negative surprise z-scores and keeps base temperature")
+        void testNegativeSurpriseZScore() {
+            RecallOptions options = RecallOptions.builder()
+                    .adaptiveTemperature(true)
+                    .baseTemperature(1.0f)
+                    .temperatureSurpriseCoefficient(0.15f)
+                    .build();
+
+            // max(0, -1.5) = 0 -> T = 1.0 * (1 + 0.15 * 0) = 1.0
+            assertThat(options.computeEffectiveTemperature(-1.5))
+                    .isCloseTo(1.0f, within(1e-5f));
+        }
+
+        @Test
+        @DisplayName("Scales temperature proportionally for positive surprise z-scores")
+        void testPositiveSurpriseZScore() {
+            RecallOptions options = RecallOptions.builder()
+                    .adaptiveTemperature(true)
+                    .baseTemperature(1.0f)
+                    .temperatureSurpriseCoefficient(0.15f)
+                    .build();
+
+            // z = 2.0 -> T = 1.0 * (1 + 0.15 * 2.0) = 1.30
+            assertThat(options.computeEffectiveTemperature(2.0))
+                    .isCloseTo(1.30f, within(1e-5f));
+
+            // z = 4.0 -> T = 1.0 * (1 + 0.15 * 4.0) = 1.60
+            assertThat(options.computeEffectiveTemperature(4.0))
+                    .isCloseTo(1.60f, within(1e-5f));
+        }
+
+        @Test
+        @DisplayName("Clamps temperature at minTemperature and maxTemperature bounds")
+        void testTemperatureClamping() {
+            RecallOptions options = RecallOptions.builder()
+                    .adaptiveTemperature(true)
+                    .baseTemperature(1.0f)
+                    .temperatureSurpriseCoefficient(0.5f)
+                    .temperatureBounds(0.2f, 2.5f)
+                    .build();
+
+            // Extreme outlier z = 10.0 -> raw T = 1.0 * (1 + 0.5 * 10.0) = 6.0 -> clamped to 2.5
+            assertThat(options.computeEffectiveTemperature(10.0))
+                    .isCloseTo(2.5f, within(1e-5f));
+
+            // Low base temp with negative z -> clamped to min
+            RecallOptions lowOptions = RecallOptions.builder()
+                    .adaptiveTemperature(false)
+                    .baseTemperature(0.05f)
+                    .minTemperature(0.2f)
+                    .maxTemperature(3.0f)
+                    .build();
+
+            assertThat(lowOptions.computeEffectiveTemperature(0.0))
+                    .isCloseTo(0.2f, within(1e-5f));
+        }
+
+        @Test
+        @DisplayName("Composed TemperatureOptions sub-record accessor works cleanly")
+        void testTemperatureOptionsAccessor() {
+            RecallOptions options = RecallOptions.builder()
+                    .adaptiveTemperature(true)
+                    .baseTemperature(1.5f)
+                    .temperatureSurpriseCoefficient(0.20f)
+                    .temperatureBounds(0.5f, 4.0f)
+                    .build();
+
+            TemperatureOptions to = options.temperature();
+            assertThat(to.adaptiveTemperature()).isTrue();
+            assertThat(to.baseTemperature()).isEqualTo(1.5f);
+            assertThat(to.temperatureSurpriseCoefficient()).isEqualTo(0.20f);
+            assertThat(to.minTemperature()).isEqualTo(0.5f);
+            assertThat(to.maxTemperature()).isEqualTo(4.0f);
+
+            assertThat(to.computeEffective(2.0))
+                    .isCloseTo(1.5f * (1.0f + 0.20f * 2.0f), within(1e-5f));
+        }
+    }
+
+    @Nested
+    @DisplayName("SurpriseDetector Query-Side Peek")
+    class SurpriseDetectorPeekTests {
+
+        @Test
+        @DisplayName("Returns 0.0 z-score during warmup period without mutating count")
+        void testWarmupBehavior() {
+            SurpriseDetector detector = new SurpriseDetector(20);
+
+            // Feed 5 samples
+            for (int i = 0; i < 5; i++) {
+                detector.computeImportance(0.5f);
+            }
+            assertThat(detector.stats().count()).isEqualTo(5);
+
+            // Query peek should return 0.0 and not increment sample count
+            double peekZ = detector.querySurpriseZScore(1.8f);
+            assertThat(peekZ).isEqualTo(0.0);
+            assertThat(detector.stats().count()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("Computes accurate z-score after warmup without side effects")
+        void testPostWarmupPeek() {
+            SurpriseDetector detector = new SurpriseDetector(10);
+
+            // Feed 15 identical distances of 1.0f except variance
+            for (int i = 0; i < 15; i++) {
+                detector.computeImportance(1.0f + (i % 3) * 0.1f);
+            }
+            long countBefore = detector.stats().count();
+
+            double peekZ = detector.querySurpriseZScore(2.5f);
+            assertThat(peekZ).isGreaterThan(1.0);
+            assertThat(detector.stats().count()).isEqualTo(countBefore);
+        }
+    }
+
+    @Nested
+    @DisplayName("Temperature Softmax Transformation")
+    class TemperatureSoftmaxTests {
+
+        private List<CognitiveResult> createSampleCandidates() {
+            List<CognitiveResult> results = new ArrayList<>();
+            results.add(createResult("m1", 0.90f));
+            results.add(createResult("m2", 0.70f));
+            results.add(createResult("m3", 0.50f));
+            results.add(createResult("m4", 0.30f));
+            return results;
+        }
+
+        private CognitiveResult createResult(String id, float score) {
+            ScoreBreakdown bd = new ScoreBreakdown(score, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, score);
+            return new CognitiveResult(
+                    id, "Text for " + id, score, 5.0f, 1.0f,
+                    1, (byte) 0, MemoryType.SEMANTIC, MemorySource.OBSERVED,
+                    new String[]{"test"}, 1.0f, 1.0f, RetrievalMode.STANDARD, bd, null, null, null
+            );
+        }
+
+        @Test
+        @DisplayName("T = 1.0 leaves candidate scores unchanged (identity)")
+        void testIdentityTemperature() {
+            List<CognitiveResult> candidates = createSampleCandidates();
+            float[] origScores = candidates.stream().map(CognitiveResult::score).mapToDouble(f -> f).collect(
+                    () -> new float[candidates.size()],
+                    (arr, val) -> arr[resultsIndex(candidates, val)] = (float) val,
+                    (a, b) -> {}
+            );
+            List<Float> original = candidates.stream().map(CognitiveResult::score).toList();
+
+            TemperatureSoftmax.applySoftmaxTemperature(candidates, 1.0f);
+
+            for (int i = 0; i < candidates.size(); i++) {
+                assertThat(candidates.get(i).score()).isCloseTo(original.get(i), within(1e-5f));
+            }
+        }
+
+        private int resultsIndex(List<CognitiveResult> list, double val) {
+            for (int i = 0; i < list.size(); i++) {
+                if (Math.abs(list.get(i).score() - val) < 1e-6) return i;
+            }
+            return 0;
+        }
+
+        @Test
+        @DisplayName("T > 1.0 flattens distribution (reduces top-to-bottom ratio)")
+        void testHighTemperatureFlattening() {
+            List<CognitiveResult> candidates = createSampleCandidates();
+            float originalRatio = candidates.get(0).score() / candidates.get(3).score(); // 0.90 / 0.30 = 3.0
+
+            TemperatureSoftmax.applySoftmaxTemperature(candidates, 3.0f);
+
+            float newRatio = candidates.get(0).score() / candidates.get(3).score();
+            // Higher temperature flattens score ratios (makes retrieval broader/softer)
+            assertThat(newRatio).isLessThan(originalRatio);
+            assertThat(candidates.get(0).score()).isGreaterThan(candidates.get(1).score());
+            assertThat(candidates.get(1).score()).isGreaterThan(candidates.get(2).score());
+            assertThat(candidates.get(2).score()).isGreaterThan(candidates.get(3).score());
+        }
+
+        @Test
+        @DisplayName("T < 1.0 sharpens distribution (increases top candidate dominance)")
+        void testLowTemperatureSharpening() {
+            List<CognitiveResult> candidates = createSampleCandidates();
+            float originalRatio = candidates.get(0).score() / candidates.get(3).score(); // 3.0
+
+            TemperatureSoftmax.applySoftmaxTemperature(candidates, 0.3f);
+
+            float newRatio = candidates.get(0).score() / candidates.get(3).score();
+            // Lower temperature sharpens score ratios (concentrates probability on top hit)
+            assertThat(newRatio).isGreaterThan(originalRatio);
+        }
+
+        @Test
+        @DisplayName("Handles single item or empty list gracefully")
+        void testEdgeCases() {
+            List<CognitiveResult> empty = new ArrayList<>();
+            TemperatureSoftmax.applySoftmaxTemperature(empty, 2.0f);
+            assertThat(empty).isEmpty();
+
+            List<CognitiveResult> single = new ArrayList<>();
+            single.add(createResult("s1", 0.75f));
+            TemperatureSoftmax.applySoftmaxTemperature(single, 2.0f);
+            assertThat(single.get(0).score()).isEqualTo(0.75f);
+        }
+
+        @Test
+        @DisplayName("Numerical stability: handles large and small scores without NaN or Infinity")
+        void testNumericalStability() {
+            List<CognitiveResult> largeScores = new ArrayList<>();
+            largeScores.add(createResult("l1", 1000.0f));
+            largeScores.add(createResult("l2", 950.0f));
+            largeScores.add(createResult("l3", 500.0f));
+
+            TemperatureSoftmax.applySoftmaxTemperature(largeScores, 0.1f);
+
+            for (CognitiveResult r : largeScores) {
+                assertThat(Float.isNaN(r.score())).isFalse();
+                assertThat(Float.isInfinite(r.score())).isFalse();
+                assertThat(r.score()).isGreaterThanOrEqualTo(0.0f);
+            }
+        }
+    }
+}

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -537,6 +537,21 @@ public final class SpectorPropertyConstants {
     public static final String RECALL_MAX_REPLAY_EVENTS = "spector.recall.max-replay-events";
     public static final int DEFAULT_RECALL_MAX_REPLAY_EVENTS = 100_000;
 
+    public static final String RECALL_ADAPTIVE_TEMPERATURE_ENABLED = "spector.recall.adaptive-temperature.enabled";
+    public static final boolean DEFAULT_RECALL_ADAPTIVE_TEMPERATURE_ENABLED = false;
+
+    public static final String RECALL_BASE_TEMPERATURE = "spector.recall.base-temperature";
+    public static final float DEFAULT_RECALL_BASE_TEMPERATURE = 1.0f;
+
+    public static final String RECALL_TEMPERATURE_SURPRISE_COEFFICIENT = "spector.recall.temperature-surprise-coefficient";
+    public static final float DEFAULT_RECALL_TEMPERATURE_SURPRISE_COEFFICIENT = 0.15f;
+
+    public static final String RECALL_MIN_TEMPERATURE = "spector.recall.min-temperature";
+    public static final float DEFAULT_RECALL_MIN_TEMPERATURE = 0.1f;
+
+    public static final String RECALL_MAX_TEMPERATURE = "spector.recall.max-temperature";
+    public static final float DEFAULT_RECALL_MAX_TEMPERATURE = 5.0f;
+
     // Ingestion
     public static final String INGESTION_ROOT_DIRECTORY = "spector.ingestion.root-directory";
     public static final Path DEFAULT_INGESTION_ROOT_DIRECTORY = Path.of(".");


### PR DESCRIPTION
## Summary

Implements **Adaptive Softmax Retrieval Temperature** for Spector Memory (Issue #504). Modulates cognitive retrieval breadth and distribution sharpness dynamically based on query surprise (prediction error), expanding associative recall when exploring novel contexts and sharpening focus for familiar queries.

## Key Changes

1. **Configuration (`spector-config`)**:
   - Added `RECALL_ADAPTIVE_TEMPERATURE_ENABLED`, `RECALL_BASE_TEMPERATURE`, `RECALL_TEMPERATURE_SURPRISE_COEFFICIENT`, `RECALL_MIN_TEMPERATURE`, and `RECALL_MAX_TEMPERATURE` constants to `SpectorPropertyConstants`.

2. **Model (`spector-memory`)**:
   - Created `TemperatureOptions` composed sub-record with `computeEffective(double zSurprise)`.
   - Extended `RecallOptions` and `RecallOptions.Builder` with fluent builders, validation bounds checks, and `temperature()` accessor.

3. **Dopamine & Synapse Machinery**:
   - Added non-mutating `SurpriseDetector.querySurpriseZScore(float distanceToNearest)` for query-side prediction error estimation.
   - Created `TemperatureSoftmax` for numerically stable shifted softmax temperature scaling.

4. **Pipeline Integration (`RecallPipeline`)**:
   - Injected `SurpriseDetector` into `RecallPipeline` via `RecallPipelineBuilder`.
   - Integrated softmax temperature modulation stage before top-K truncation in both vector and text recall paths.
   - Added `TEMPERATURE_SOFTMAX` pipeline trace step when tracing is enabled.

5. **Tests & Benchmarks**:
   - Unit tests in `AdaptiveTemperatureTest` covering effective temperature calculations, warmup behavior, and numerical stability.
   - Shannon entropy verification across temperature regimes in `AdaptiveTemperatureBenchmarkTest`.
   - Validation test assertions in `RecallOptionsValidationTest`.

Closes #504

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>