### PR TITLE
feat(memory): multi-partition consolidation, reflection, and decay (#446)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -308,6 +308,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.namespaceId = builder.namespaceId;
         this.idGenerator = bundle.idGenerator();
         this.checkpointDaemon = bundle.checkpointDaemon();
+        if (this.checkpointDaemon != null) {
+            this.checkpointDaemon.setRouterSupplier(partitionManager::cognitiveRouter);
+        }
         this.daemonSupervisor = bundle.daemonSupervisor();
         this.bm25Index = bundle.bm25Index();
         this.chunker = builder.chunker;
@@ -920,7 +923,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     public ReflectReport reflect() {
         acquireLease();
         try {
-            return reflectionOrchestrator.reflect(partitionManager.cognitiveRouter(), index, cognitiveTarget);
+            return reflectionOrchestrator.reflect(partitionManager, index, cognitiveTarget);
         } finally {
             releaseLease();
         }
@@ -931,7 +934,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         acquireLease();
         try {
             batchConsolidator.consolidate(
-                    partitionManager.cognitiveRouter(),
+                    partitionManager,
                     index,
                     quantizer,
                     entityDirectory,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -74,7 +74,7 @@ import java.time.Instant;
  * @see StorageLayout
  * @see PartitionHandle
  */
-final class PartitionManager implements PartitionRegistry, AutoCloseable {
+public final class PartitionManager implements PartitionRegistry, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(PartitionManager.class);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
@@ -149,29 +149,28 @@ final class ReflectionOrchestrator {
     }
 
     /**
-     * Runs a full reflection cycle: REM consolidation, graph decay, temporal pruning,
-     * cross-layer promotion, and entity maintenance.
+     * Runs a full reflection cycle across all frozen and active partitions (#446):
+     * REM consolidation, graph decay, temporal pruning, cross-layer promotion, and entity maintenance.
      *
-     * @param cognitiveRouter the current cognitive memory router
-     * @param index      the memory index (for text lookups during consolidation)
+     * @param partitionManager the partition manager providing all open partition handles
+     * @param index            the memory index (for text lookups and graph slot resolution)
+     * @param ingestionTarget  the ingestion target for promoted semantic memories (active partition)
      * @return a {@link ReflectReport} summarizing what was consolidated, pruned, and promoted
      */
-    ReflectReport reflect(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, CognitiveIngestionTarget ingestionTarget) {
-        log.info("Manual reflection triggered");
+    ReflectReport reflect(PartitionManager partitionManager, MemoryIndex index, CognitiveIngestionTarget ingestionTarget) {
+        log.info("Manual reflection triggered across partitions");
 
         // Create metrics collector for this cycle
         var graphMetrics = new GraphHealthMetrics();
 
-        // Phase 1: REM cycle — episodic → semantic consolidation
-        ReflectReport daemonReport = reflectDaemon.runCycle(
-                cognitiveRouter.episodic(), ingestionTarget,
-                offset -> index.findTextByOffset(MemoryType.EPISODIC, offset));
+        // Phase 1: REM cycle — episodic → semantic consolidation across all partition handles
+        ReflectReport daemonReport = reflectDaemon.runCycle(partitionManager, ingestionTarget, index);
 
-        // Phase 2: Hebbian decay (synaptic homeostasis, arousal-modulated)
-        decayHebbianEdges(cognitiveRouter, graphMetrics);
+        // Phase 2: Hebbian decay (synaptic homeostasis, arousal-modulated across all partitions)
+        decayHebbianEdges(partitionManager, index, graphMetrics);
 
-        // Phase 3: Temporal chain pruning (age + importance)
-        int temporalPruned = pruneTemporalChain(cognitiveRouter);
+        // Phase 3: Temporal chain pruning (age + importance across all partitions)
+        int temporalPruned = pruneTemporalChain(partitionManager, index);
 
         // Phase 4: Cross-layer promotion (Hebbian → Entity)
         promoteCrossLayer();
@@ -206,7 +205,59 @@ final class ReflectionOrchestrator {
                 daemonReport.duration(), graphMetrics);
     }
 
+    /**
+     * Backward-compatible reflect overload using a single cognitive router.
+     */
+    ReflectReport reflect(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, CognitiveIngestionTarget ingestionTarget) {
+        log.info("Manual reflection triggered (single-router fallback)");
+
+        var graphMetrics = new GraphHealthMetrics();
+
+        ReflectReport daemonReport = reflectDaemon.runCycle(
+                cognitiveRouter != null ? cognitiveRouter.episodic() : null, ingestionTarget,
+                offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null);
+
+        decayHebbianEdges(cognitiveRouter, graphMetrics);
+        int temporalPruned = pruneTemporalChain(cognitiveRouter);
+
+        promoteCrossLayer();
+        crossCaptureHebbianToEntity(graphMetrics);
+        maintainEntityGraph(graphMetrics);
+        decayEntityAdjacency();
+        compactEntityAdjacency();
+        decayHyperEntityGraph();
+
+        if (graphMetrics.totalEdgesDecayed() > 0 || graphMetrics.totalEdgesSurviving() > 0) {
+            log.info("Reflect: graph health — {}", graphMetrics);
+        }
+
+        wal.append(WalEvent.EventType.REFLECT, "system", null);
+
+        return new ReflectReport(
+                daemonReport.consolidatedCount(), daemonReport.tombstonedCount(),
+                daemonReport.compactedPartitions(), temporalPruned,
+                daemonReport.duration(), graphMetrics);
+    }
+
     // ── Phase 2: Hebbian Decay ──
+
+    private void decayHebbianEdges(PartitionManager partitionManager, MemoryIndex index, GraphHealthMetrics metrics) {
+        try {
+            hebbianGraph.setDecayModulator(
+                    new SynapticDecayModulator(partitionManager, index, hebbianGraph.capacity()));
+
+            int decayed = hebbianGraph.decayEdges(HEBBIAN_DECAY_FACTOR, metrics);
+            hebbianGraph.setDecayModulator(null);
+
+            if (decayed > 0) {
+                log.info("Reflect: Hebbian graph decayed {} weak edges (arousal-modulated across partitions)", decayed);
+            }
+        } catch (RuntimeException e) {
+            hebbianGraph.setDecayModulator(null);
+            SpectorGraphDecayException ex = new SpectorGraphDecayException("Hebbian edge decay", e);
+            log.warn(ex.getMessage());
+        }
+    }
 
     private void decayHebbianEdges(CognitiveMemoryRouter cognitiveRouter, GraphHealthMetrics metrics) {
         try {
@@ -230,6 +281,41 @@ final class ReflectionOrchestrator {
     }
 
     // ── Phase 3: Temporal Pruning ──
+
+    private int pruneTemporalChain(PartitionManager partitionManager, MemoryIndex index) {
+        if (temporalChain == null) return 0;
+        try {
+            long cutoffMs = System.currentTimeMillis()
+                    - (long) temporalRetentionDays * 24 * 60 * 60 * 1000;
+
+            int agePruned = temporalChain.pruneOlderThan(cutoffMs);
+
+            int importancePruned = 0;
+            if (partitionManager != null && index != null) {
+                importancePruned = temporalChain.pruneByImportance(
+                        cutoffMs, TEMPORAL_IMPORTANCE_THRESHOLD,
+                        memIdx -> {
+                            try {
+                                String id = index.idAt(memIdx);
+                                if (id == null) return 0f;
+                                var loc = index.locate(id);
+                                if (loc == null) return 0f;
+                                var router = partitionManager.routerFor(loc.colocatedPartition());
+                                if (router == null) return 0f;
+                                var body = router.readRecordBody(loc, false);
+                                return body != null && body.header() != null ? body.header().importance() : 0f;
+                            } catch (RuntimeException e) {
+                                return 0f;
+                            }
+                        });
+            }
+
+            return agePruned + importancePruned;
+        } catch (RuntimeException e) {
+            log.warn("Temporal chain pruning failed: {}", e.getMessage());
+            return 0;
+        }
+    }
 
     private int pruneTemporalChain(CognitiveMemoryRouter cognitiveRouter) {
         if (temporalChain == null) return 0;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/AbstractConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/AbstractConsolidator.java
@@ -77,6 +77,62 @@ public abstract class AbstractConsolidator implements Consolidator {
      * @param enableMerge            whether to execute duplicate fusion for non-contradictions
      * @return true if the pair was processed (either resolved or merged), false otherwise
      */
+    /**
+     * Evaluates a candidate pair of memories across partitions. If contradictory, applies CADP resolution.
+     * If non-contradictory and {@code enableMerge} is true, merges the duplicate pair.
+     *
+     * @param recordA                first record
+     * @param recordB                second record
+     * @param partitionManager       partition manager resolving partition routers (optional)
+     * @param store                  cognitive tier store fallback (optional)
+     * @param quantizer              scalar quantizer (optional)
+     * @param entityDirectory        entity directory (optional)
+     * @param hyperEntityGraph       hypergraph memory (optional)
+     * @param temporalKnowledgeGraph temporal knowledge graph (optional)
+     * @param ingestionTarget        ingestion target for merged memories (optional)
+     * @param index                  memory index for tombstoning (optional)
+     * @param wal                    memory WAL for tombstoning (optional)
+     * @param enableMerge            whether to execute duplicate fusion for non-contradictions
+     * @return true if the pair was processed (either resolved or merged), false otherwise
+     */
+    protected boolean evaluateAndResolvePair(
+            CognitiveRecord recordA,
+            CognitiveRecord recordB,
+            com.spectrayan.spector.memory.PartitionManager partitionManager,
+            CognitiveRecordMemory store,
+            ScalarQuantizer quantizer,
+            EntityDirectory entityDirectory,
+            HyperEntityGraphMemory hyperEntityGraph,
+            TemporalKnowledgeGraph temporalKnowledgeGraph,
+            CognitiveIngestionTarget ingestionTarget,
+            MemoryIndex index,
+            MemoryWal wal,
+            boolean enableMerge) {
+
+        if (recordA == null || recordB == null) {
+            return false;
+        }
+
+        // 1. Contradiction classification
+        boolean isContradictory = contradictionDetector.areContradictory(recordA.text(), recordB.text());
+
+        if (isContradictory) {
+            log.info("Consolidator: Detected contradiction between '{}' and '{}'", recordA.id(), recordB.id());
+            CadpContradictionResolver.resolve(
+                    recordA, recordB, partitionManager, store, hyperEntityGraph, entityDirectory, temporalKnowledgeGraph);
+            return true;
+        } else if (enableMerge && memoryMerger != null && ingestionTarget != null && quantizer != null && index != null) {
+            log.info("Consolidator: Merging duplicate memories '{}' and '{}'", recordA.id(), recordB.id());
+            mergeDuplicate(recordA, recordB, partitionManager, store, quantizer, ingestionTarget, index, wal);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Evaluates a candidate pair in a single store (backward compatibility).
+     */
     protected boolean evaluateAndResolvePair(
             CognitiveRecord recordA,
             CognitiveRecord recordB,
@@ -89,35 +145,18 @@ public abstract class AbstractConsolidator implements Consolidator {
             MemoryIndex index,
             MemoryWal wal,
             boolean enableMerge) {
-
-        if (recordA == null || recordB == null || store == null) {
-            return false;
-        }
-
-        // 1. Contradiction classification
-        boolean isContradictory = contradictionDetector.areContradictory(recordA.text(), recordB.text());
-
-        if (isContradictory) {
-            log.info("Consolidator: Detected contradiction between '{}' and '{}'", recordA.id(), recordB.id());
-            CadpContradictionResolver.resolve(
-                    recordA, recordB, store, hyperEntityGraph, entityDirectory, temporalKnowledgeGraph);
-            return true;
-        } else if (enableMerge && memoryMerger != null && ingestionTarget != null && quantizer != null && index != null) {
-            log.info("Consolidator: Merging duplicate memories '{}' and '{}'", recordA.id(), recordB.id());
-            mergeDuplicate(recordA, recordB, store, quantizer, ingestionTarget, index, wal);
-            return true;
-        }
-
-        return false;
+        return evaluateAndResolvePair(recordA, recordB, null, store, quantizer,
+                entityDirectory, hyperEntityGraph, temporalKnowledgeGraph, ingestionTarget, index, wal, enableMerge);
     }
 
     /**
-     * Merges two non-contradictory duplicate records into a new consolidated memory,
+     * Merges two non-contradictory duplicate records across partitions into a new consolidated memory,
      * ingests it, and tombstones the original records.
      */
     protected void mergeDuplicate(
             CognitiveRecord recordA,
             CognitiveRecord recordB,
+            com.spectrayan.spector.memory.PartitionManager partitionManager,
             CognitiveRecordMemory store,
             ScalarQuantizer quantizer,
             CognitiveIngestionTarget ingestionTarget,
@@ -128,8 +167,8 @@ public abstract class AbstractConsolidator implements Consolidator {
         String newId = "cns-" + tsidGenerator.generate();
 
         // Tombstone old records in off-heap, WAL, and index
-        tombstoneRecord(recordA, store, index, wal);
-        tombstoneRecord(recordB, store, index, wal);
+        tombstoneRecord(recordA, partitionManager, store, index, wal);
+        tombstoneRecord(recordB, partitionManager, store, index, wal);
 
         byte semanticFlags = SynapticHeaderConstants.withMemoryType(
                 SynapticHeaderConstants.FLAG_CONSOLIDATED,
@@ -162,17 +201,43 @@ public abstract class AbstractConsolidator implements Consolidator {
     }
 
     /**
-     * Tombstones a record off-heap, logs to WAL, and removes it from the index.
+     * Merges two non-contradictory duplicate records in a single store (backward compatibility).
+     */
+    protected void mergeDuplicate(
+            CognitiveRecord recordA,
+            CognitiveRecord recordB,
+            CognitiveRecordMemory store,
+            ScalarQuantizer quantizer,
+            CognitiveIngestionTarget ingestionTarget,
+            MemoryIndex index,
+            MemoryWal wal) {
+        mergeDuplicate(recordA, recordB, null, store, quantizer, ingestionTarget, index, wal);
+    }
+
+    /**
+     * Tombstones a record off-heap in its colocated partition, logs to WAL, and removes it from the index.
      */
     protected void tombstoneRecord(
             CognitiveRecord record,
-            CognitiveRecordMemory store,
+            com.spectrayan.spector.memory.PartitionManager partitionManager,
+            CognitiveRecordMemory fallbackStore,
             MemoryIndex index,
             MemoryWal wal) {
 
-        MemorySegment segment = store.segment();
-        CognitiveRecordLayout layout = store.cognitiveLayout();
-        layout.tombstone(segment, record.byteOffset());
+        if (partitionManager != null) {
+            var router = partitionManager.routerFor(record.partitionIndex());
+            if (router != null) {
+                var layout = router.layoutFor(record.memoryType());
+                var segment = router.segmentFor(record.memoryType());
+                if (layout != null && segment != null) {
+                    layout.tombstone(segment, record.byteOffset());
+                }
+            }
+        } else if (fallbackStore != null) {
+            MemorySegment segment = fallbackStore.segment();
+            CognitiveRecordLayout layout = fallbackStore.cognitiveLayout();
+            layout.tombstone(segment, record.byteOffset());
+        }
 
         if (wal != null) {
             wal.appendForget(record.id());
@@ -181,6 +246,17 @@ public abstract class AbstractConsolidator implements Consolidator {
             index.remove(record.id());
         }
         log.debug("Consolidator: Tombstoned and de-indexed memory '{}'", record.id());
+    }
+
+    /**
+     * Tombstones a record off-heap, logs to WAL, and removes it from the index (backward compatibility).
+     */
+    protected void tombstoneRecord(
+            CognitiveRecord record,
+            CognitiveRecordMemory store,
+            MemoryIndex index,
+            MemoryWal wal) {
+        tombstoneRecord(record, null, store, index, wal);
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/BatchConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/BatchConsolidator.java
@@ -61,6 +61,81 @@ public final class BatchConsolidator extends AbstractConsolidator {
     }
 
     /**
+     * Executes the consolidation cycle across all partitions (frozen + active) (#446).
+     */
+    public void consolidate(com.spectrayan.spector.memory.PartitionManager partitionManager, MemoryIndex index, ScalarQuantizer quantizer,
+                            EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
+                            TemporalKnowledgeGraph temporalKnowledgeGraph,
+                            CognitiveIngestionTarget ingestionTarget,
+                            MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
+        if (partitionManager == null) {
+            return;
+        }
+
+        var handles = partitionManager.snapshot();
+        List<DuplicateDetector.PartitionStore> partitionStores = new java.util.ArrayList<>();
+        int totalVisible = 0;
+        for (var handle : handles) {
+            var semantic = handle.router() != null ? handle.router().semantic() : null;
+            if (semantic != null && semantic.visibleCount() > 0) {
+                partitionStores.add(new DuplicateDetector.PartitionStore(handle.seq(), semantic));
+                totalVisible += semantic.visibleCount();
+            }
+        }
+
+        if (totalVisible < 2 || partitionStores.isEmpty()) {
+            log.debug("BatchConsolidator: semantic store across partitions too small to run consolidation (totalVisible={})",
+                    totalVisible);
+            return;
+        }
+
+        log.info("BatchConsolidator: scanning semantic memory across {} partitions for duplicates... ({} visible)",
+                partitionStores.size(), totalVisible);
+        List<DuplicateDetector.DuplicatePair> duplicatePairs = duplicateDetector.findDuplicatesAcrossPartitions(partitionStores, index, quantizer);
+        if (duplicatePairs.isEmpty()) {
+            log.info("BatchConsolidator: no duplicate pairs found.");
+            return;
+        }
+
+        log.info("BatchConsolidator: found {} duplicate pairs. Evaluating contradictions & merging...", duplicatePairs.size());
+
+        Set<String> processedIds = new HashSet<>();
+
+        for (DuplicateDetector.DuplicatePair pair : duplicatePairs) {
+            if (processedIds.contains(pair.idA()) || processedIds.contains(pair.idB())) {
+                continue; // already handled in a previous merge/contradiction in this cycle
+            }
+
+            CognitiveRecord recordA = inspectFunction.apply(pair.idA());
+            CognitiveRecord recordB = inspectFunction.apply(pair.idB());
+
+            if (recordA == null || recordB == null || recordA.isTombstoned() || recordB.isTombstoned()) {
+                continue;
+            }
+
+            boolean processed = evaluateAndResolvePair(
+                    recordA,
+                    recordB,
+                    partitionManager,
+                    null,
+                    quantizer,
+                    entityDirectory,
+                    hyperEntityGraph,
+                    temporalKnowledgeGraph,
+                    ingestionTarget,
+                    index,
+                    wal,
+                    true // enable duplicate merge in batch mode
+            );
+
+            if (processed) {
+                processedIds.add(pair.idA());
+                processedIds.add(pair.idB());
+            }
+        }
+    }
+
+    /**
      * Executes the consolidation cycle across the semantic store with TemporalKnowledgeGraph bridge (#527).
      */
     public void consolidate(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, ScalarQuantizer quantizer,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/CadpContradictionResolver.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/CadpContradictionResolver.java
@@ -76,11 +76,12 @@ public final class CadpContradictionResolver {
     }
 
     /**
-     * Executes full CADP contradiction resolution between two contradictory memories.
+     * Executes full CADP contradiction resolution between two contradictory memories across partitions (#446).
      *
      * @param recordA                first record
      * @param recordB                second record
-     * @param store                  cognitive tier store
+     * @param partitionManager       partition manager resolving partition routers (optional)
+     * @param store                  cognitive tier store fallback (optional)
      * @param hyperEntityGraph       hypergraph memory (optional)
      * @param entityDirectory        entity directory (optional)
      * @param temporalKnowledgeGraph temporal knowledge graph (optional)
@@ -89,6 +90,7 @@ public final class CadpContradictionResolver {
     public static ResolutionResult resolve(
             CognitiveRecord recordA,
             CognitiveRecord recordB,
+            com.spectrayan.spector.memory.PartitionManager partitionManager,
             CognitiveRecordMemory store,
             HyperEntityGraphMemory hyperEntityGraph,
             EntityDirectory entityDirectory,
@@ -98,15 +100,47 @@ public final class CadpContradictionResolver {
         CognitiveRecord winner = result.winner();
         CognitiveRecord loser = result.loser();
 
-        // 1. Mark loser contradicted off-heap
-        MemorySegment segment = store.segment();
-        CognitiveRecordLayout layout = store.cognitiveLayout();
-        layout.markContradicted(segment, loser.byteOffset());
+        // 1. Mark loser contradicted off-heap on the partition where loser physically resides
+        if (partitionManager != null) {
+            var router = partitionManager.routerFor(loser.partitionIndex());
+            if (router != null) {
+                var layout = router.layoutFor(loser.memoryType());
+                var segment = router.segmentFor(loser.memoryType());
+                if (layout != null && segment != null) {
+                    layout.markContradicted(segment, loser.byteOffset());
+                }
+            }
+        } else if (store != null) {
+            MemorySegment segment = store.segment();
+            CognitiveRecordLayout layout = store.cognitiveLayout();
+            layout.markContradicted(segment, loser.byteOffset());
+        }
         log.info("CADP resolved: winner='{}' corrects loser='{}'", winner.id(), loser.id());
 
         // 2. Resolve entity references for winner and loser
-        int slotWinner = memorySlot(winner, store, layout);
-        int slotLoser = memorySlot(loser, store, layout);
+        int slotWinner = -1;
+        int slotLoser = -1;
+        if (partitionManager != null) {
+            var routerWinner = partitionManager.routerFor(winner.partitionIndex());
+            if (routerWinner != null) {
+                var storeWinner = routerWinner.get(winner.memoryType());
+                var layoutWinner = routerWinner.layoutFor(winner.memoryType());
+                if (storeWinner != null && layoutWinner != null) {
+                    slotWinner = memorySlot(winner, storeWinner, layoutWinner);
+                }
+            }
+            var routerLoser = partitionManager.routerFor(loser.partitionIndex());
+            if (routerLoser != null) {
+                var storeLoser = routerLoser.get(loser.memoryType());
+                var layoutLoser = routerLoser.layoutFor(loser.memoryType());
+                if (storeLoser != null && layoutLoser != null) {
+                    slotLoser = memorySlot(loser, storeLoser, layoutLoser);
+                }
+            }
+        } else if (store != null) {
+            slotWinner = memorySlot(winner, store, store.cognitiveLayout());
+            slotLoser = memorySlot(loser, store, store.cognitiveLayout());
+        }
 
         List<Integer> entitiesWinner = findEntitiesForSlot(entityDirectory, slotWinner);
         List<Integer> entitiesLoser = findEntitiesForSlot(entityDirectory, slotLoser);
@@ -146,6 +180,19 @@ public final class CadpContradictionResolver {
         }
 
         return result;
+    }
+
+    /**
+     * Executes full CADP contradiction resolution between two contradictory memories in a single store.
+     */
+    public static ResolutionResult resolve(
+            CognitiveRecord recordA,
+            CognitiveRecord recordB,
+            CognitiveRecordMemory store,
+            HyperEntityGraphMemory hyperEntityGraph,
+            EntityDirectory entityDirectory,
+            TemporalKnowledgeGraph temporalKnowledgeGraph) {
+        return resolve(recordA, recordB, null, store, hyperEntityGraph, entityDirectory, temporalKnowledgeGraph);
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/DuplicateDetector.java
@@ -46,70 +46,84 @@ public final class DuplicateDetector {
     public record DuplicatePair(int indexA, int indexB, String idA, String idB, float distance) {}
 
     /**
+     * Associates a partition sequence number with a tier memory store.
+     */
+    public record PartitionStore(int partitionSeq, CognitiveRecordMemory store) {}
+
+    private record ScannedEntry(int partitionSeq, int recordIndex, String id, float[] decodedVector) {}
+
+    /**
      * Scans the given store for duplicate pairs.
      */
     public List<DuplicatePair> findDuplicates(CognitiveRecordMemory store, MemoryIndex index, ScalarQuantizer quantizer) {
+        if (store == null) return List.of();
+        int partitionSeq = index != null ? index.activePartitionSeq() : 0;
+        return findDuplicatesAcrossPartitions(List.of(new PartitionStore(partitionSeq, store)), index, quantizer);
+    }
+
+    /**
+     * Scans multiple partition stores for duplicate pairs across frozen and active partitions (#446).
+     */
+    public List<DuplicatePair> findDuplicatesAcrossPartitions(
+            List<PartitionStore> partitionStores,
+            MemoryIndex index,
+            ScalarQuantizer quantizer) {
         List<DuplicatePair> pairs = new ArrayList<>();
-        int recordCount = store.visibleCount();
-        if (recordCount < 2) {
+        if (partitionStores == null || partitionStores.isEmpty() || index == null || quantizer == null) {
             return pairs;
         }
 
-        MemorySegment segment = store.segment();
-        CognitiveRecordLayout layout = store.cognitiveLayout();
-        long baseOffset = store.isPersistent() ? CognitiveRecordMemory.METADATA_HEADER_BYTES : 0L;
-        int stride = layout.stride();
-        int vecBytes = layout.quantizedVecBytes();
-        float[] mins = quantizer.mins();
-        float[] scales = quantizer.scales();
+        List<ScannedEntry> entries = new ArrayList<>();
 
-        byte[] quantizedBuf = new byte[vecBytes];
-        float[] decodedVector = new float[quantizer.dimensions()];
+        for (PartitionStore ps : partitionStores) {
+            CognitiveRecordMemory store = ps.store();
+            if (store == null) continue;
+            int recordCount = store.visibleCount();
+            if (recordCount == 0) continue;
 
-        for (int i = 0; i < recordCount; i++) {
-            long offsetI = baseOffset + (long) i * stride;
-            byte flagsI = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS, offsetI + SynapticHeaderConstants.OFFSET_FLAGS);
+            MemorySegment segment = store.segment();
+            CognitiveRecordLayout layout = store.cognitiveLayout();
+            long baseOffset = store.isPersistent() ? CognitiveRecordMemory.METADATA_HEADER_BYTES : 0L;
+            int stride = layout.stride();
+            int qVecBytes = layout.quantizedVecBytes();
+            byte[] quantizedBuf = new byte[qVecBytes];
 
-            // Skip tombstoned records
-            if (SynapticHeaderConstants.isTombstoned(flagsI)) {
-                continue;
-            }
+            for (int i = 0; i < recordCount; i++) {
+                long offset = baseOffset + (long) i * stride;
+                byte flags = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS, offset + SynapticHeaderConstants.OFFSET_FLAGS);
 
-            // Resolve ID of record A
-            String idA = index.findIdByOffset(store.type(), offsetI);
-            if (idA == null) {
-                continue;
-            }
-
-            // Read and dequantize vector A
-            long vecOffsetI = layout.vectorOffset(offsetI);
-            MemorySegment.copy(segment, java.lang.foreign.ValueLayout.JAVA_BYTE, vecOffsetI,
-                    MemorySegment.ofArray(quantizedBuf), java.lang.foreign.ValueLayout.JAVA_BYTE, 0, vecBytes);
-            quantizer.decode(quantizedBuf, 0, decodedVector, 0);
-
-            // Compare against subsequent records
-            for (int j = i + 1; j < recordCount; j++) {
-                long offsetJ = baseOffset + (long) j * stride;
-                byte flagsJ = segment.get(SynapticHeaderConstants.LAYOUT_FLAGS, offsetJ + SynapticHeaderConstants.OFFSET_FLAGS);
-
-                if (SynapticHeaderConstants.isTombstoned(flagsJ)) {
+                if (SynapticHeaderConstants.isTombstoned(flags)) {
                     continue;
                 }
 
-                String idB = index.findIdByOffset(store.type(), offsetJ);
-
-                if (idB == null) {
+                String id = index.findIdByOffset(ps.partitionSeq(), store.type(), offset);
+                if (id == null) {
                     continue;
                 }
 
-                // Compute calibrated L2 distance via SimilarityFunction
-                float dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
-                        decodedVector, segment, layout.vectorOffset(offsetJ),
-                        mins, scales, vecBytes);
+                long vecOffset = layout.vectorOffset(offset);
+                MemorySegment.copy(segment, java.lang.foreign.ValueLayout.JAVA_BYTE, vecOffset,
+                        MemorySegment.ofArray(quantizedBuf), java.lang.foreign.ValueLayout.JAVA_BYTE, 0, qVecBytes);
+                float[] decoded = new float[quantizer.dimensions()];
+                quantizer.decode(quantizedBuf, 0, decoded, 0);
 
+                entries.add(new ScannedEntry(ps.partitionSeq(), i, id, decoded));
+            }
+        }
+
+        int totalEntries = entries.size();
+        for (int i = 0; i < totalEntries; i++) {
+            ScannedEntry entryA = entries.get(i);
+            for (int j = i + 1; j < totalEntries; j++) {
+                ScannedEntry entryB = entries.get(j);
+                if (entryA.id().equals(entryB.id())) continue;
+
+                float dist = SimilarityFunction.EUCLIDEAN.compute(entryA.decodedVector(), entryB.decodedVector());
                 if (dist <= distanceThreshold) {
-                    log.debug("DuplicateDetector: found near-duplicate pair [{}, {}] with L2={}", idA, idB, dist);
-                    pairs.add(new DuplicatePair(i, j, idA, idB, dist));
+                    log.debug("DuplicateDetector: found near-duplicate pair [{}, {}] with L2={}",
+                            entryA.id(), entryB.id(), dist);
+                    pairs.add(new DuplicatePair(entryA.recordIndex(), entryB.recordIndex(),
+                            entryA.id(), entryB.id(), dist));
                 }
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
@@ -180,7 +180,7 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
                 continue;
             }
 
-            String idB = index.findIdByOffset(store.type(), offsetJ);
+            String idB = index.findIdByOffset(index.activePartitionSeq(), store.type(), offsetJ);
             if (idB == null || idB.equals(recordA.id())) {
                 continue;
             }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/AbstractCognitiveRecordMemory.java
@@ -353,7 +353,13 @@ public abstract class AbstractCognitiveRecordMemory
     }
 
     @Override
+    public boolean isFrozen() {
+        return frozen;
+    }
+
+    @Override
     public void force() {
+        if (frozen) return;
         super.flush();
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveMemoryRouter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveMemoryRouter.java
@@ -279,12 +279,12 @@ public final class CognitiveMemoryRouter implements AutoCloseable {
     public ProceduralRecordMemory procedural() { return proceduralStore; }
 
     /**
-     * Forces all persistent memory store segments to be written to disk.
+     * Forces all persistent, non-frozen memory store segments to be written to disk.
      * Used by {@code CheckpointDaemon} before recording a WAL checkpoint.
      */
     public void forceAll() {
         for (CognitiveRecordMemory store : stores.values()) {
-            if (store.isPersistent()) {
+            if (store.isPersistent() && !store.isFrozen()) {
                 store.force();
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveRecordMemory.java
@@ -119,6 +119,13 @@ public interface CognitiveRecordMemory extends RecordMemory<CognitiveRecordLayou
     void force();
 
     /**
+     * Returns true if this memory store is frozen (read-only / older partition).
+     */
+    default boolean isFrozen() {
+        return false;
+    }
+
+    /**
      * Closes the memory store and releases off-heap resources.
      */
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicLogMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicLogMemory.java
@@ -272,6 +272,35 @@ public final class EpisodicLogMemory extends AbstractAppendMemory<EpisodicLogLay
     }
 
     /**
+     * Scans this episodic log from beginning to current cursor, collecting the relative offsets
+     * of all live, non-consolidated turns (#446).
+     *
+     * @return list of offsets (relative to dataOffset) of unconsolidated turns
+     */
+    public List<Long> unconsolidatedTurnOffsets() {
+        List<Long> offsets = new ArrayList<>();
+        long base = dataOffset();
+        long limit = base + count;
+        long current = base;
+
+        while (current + SynapticHeaderConstants.HEADER_BYTES <= limit) {
+            byte flags = segment().get(SynapticHeaderConstants.LAYOUT_FLAGS, current + SynapticHeaderConstants.OFFSET_FLAGS);
+            int bodyLength = segment().get(ValueLayout.JAVA_INT_UNALIGNED, current + 56);
+            if (bodyLength < 0 || current + SynapticHeaderConstants.HEADER_BYTES + bodyLength > limit) {
+                break; // corrupt or incomplete entry
+            }
+
+            if (!SynapticHeaderConstants.isTombstoned(flags) && !SynapticHeaderConstants.isConsolidated(flags)) {
+                offsets.add(current - base);
+            }
+
+            current += SynapticHeaderConstants.HEADER_BYTES + bodyLength;
+        }
+
+        return offsets;
+    }
+
+    /**
      * Returns the number of bytes available for new records.
      */
     public long remainingBytes() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicRecordMemory.java
@@ -47,7 +47,11 @@ import com.spectrayan.spector.memory.error.SpectorMemoryTierFullException;
  *   <li>Flat SIMD scan via the scorer</li>
  *   <li>Persistent across JVM restarts via {@code FileChannel.map()}</li>
  * </ul>
+ *
+ * @deprecated As of Spector 1.3.0, replaced by {@link EpisodicLogMemory} (ADR-0006 log-structured
+ *             conversation store) and scheduled for removal in a future major release.
  */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class EpisodicRecordMemory extends AbstractCognitiveRecordMemory {
 
     private static final Logger log = LoggerFactory.getLogger(EpisodicRecordMemory.class);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/SynapticDecayModulator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/SynapticDecayModulator.java
@@ -12,14 +12,18 @@
  */
 package com.spectrayan.spector.memory.hebbian;
 
+import com.spectrayan.spector.memory.PartitionManager;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
+import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 
 import java.lang.foreign.MemorySegment;
 
 /**
- * Arousal-modulated decay modulator backed by synaptic header data.
+ * Arousal-modulated decay modulator backed by synaptic header data across all partitions.
  *
  * <h3>Neuroscience Basis</h3>
  * <p>The amygdala modulates synaptic consolidation via noradrenergic signaling:
@@ -28,8 +32,8 @@ import java.lang.foreign.MemorySegment;
  * pathways between nodes.</p>
  *
  * <h3>Implementation</h3>
- * <p>Reads importance, arousal, and valence from the episodic partition's
- * synaptic headers. For each memory slot, computes a composite modifier:</p>
+ * <p>Reads importance, arousal, and valence from synaptic headers across frozen and active
+ * partitions. For each graph slot, computes a composite modifier:</p>
  * <pre>
  *   modifier = 1.0 + 0.3 * importance + 0.2 * arousal + 0.1 * abs(valence)
  * </pre>
@@ -46,18 +50,62 @@ public final class SynapticDecayModulator implements HebbianGraph.DecayModulator
     private final float[] modifiers;
 
     /**
-     * Creates a modulator by pre-reading synaptic headers from the episodic partition.
+     * Creates a partition-aware modulator by resolving synaptic headers across frozen and active partitions.
      *
-     * <p>Pre-reads all values into a float array for O(1) lookup during the decay loop.
-     * Cost: O(partitionCount) — typically &lt; 100K entries, &lt; 1ms.</p>
+     * @param partitionManager partition manager resolving colocated partition routers
+     * @param index            memory index mapping graph slots to memory IDs and locations
+     * @param capacity         HebbianGraph capacity (number of slots)
+     */
+    public SynapticDecayModulator(PartitionManager partitionManager, MemoryIndex index, int capacity) {
+        this.modifiers = new float[capacity];
+        java.util.Arrays.fill(modifiers, 1.0f);
+
+        if (partitionManager == null || index == null) return;
+
+        for (int s = 0; s < capacity; s++) {
+            try {
+                String id = index.idAt(s);
+                if (id == null) continue;
+
+                MemoryLocation loc = index.locate(id);
+                if (loc == null) continue;
+
+                CognitiveMemoryRouter router = partitionManager.routerFor(loc.colocatedPartition());
+                if (router == null) continue;
+
+                CognitiveMemoryRouter.CognitiveRecordBody body = router.readRecordBody(loc, false);
+                if (body == null || body.header() == null) continue;
+
+                CognitiveHeader header = body.header();
+                if (SynapticHeaderConstants.isTombstoned(header.flags())) continue;
+
+                float normArousal = (header.arousal() & 0xFF) / 255.0f;  // unsigned [0,1]
+                float normValence = Math.abs(header.valence()) / 127.0f; // absolute [0,1]
+
+                float modifier = 1.0f
+                        + 0.3f * header.importance()  // ACT-R base-level activation
+                        + 0.2f * normArousal          // Amygdala noradrenergic modulation
+                        + 0.1f * normValence;         // Emotional valence (polarity-independent)
+
+                modifiers[s] = modifier;
+            } catch (RuntimeException e) {
+                // Skip corrupted entries — default modifier remains 1.0f
+                modifiers[s] = 1.0f;
+            }
+        }
+    }
+
+    /**
+     * Creates a modulator by pre-reading synaptic headers from a single cognitive router (legacy/fallback).
      *
-     * @param cognitiveRouter the current cognitive memory router (provides access to episodic store)
+     * @param cognitiveRouter the current cognitive memory router
      * @param capacity        HebbianGraph capacity (number of slots)
      */
     public SynapticDecayModulator(CognitiveMemoryRouter cognitiveRouter, int capacity) {
         this.modifiers = new float[capacity];
         java.util.Arrays.fill(modifiers, 1.0f);
 
+        if (cognitiveRouter == null) return;
         var episodic = cognitiveRouter.episodic();
         if (episodic == null) return;
 
@@ -75,19 +123,16 @@ public final class SynapticDecayModulator implements HebbianGraph.DecayModulator
                 byte arousal = layout.readArousal(segment, offset);
                 byte valence = layout.readValence(segment, offset);
 
-                // Normalize: importance is [0,1], arousal/valence are signed bytes [-128,127]
-                float normArousal = (arousal & 0xFF) / 255.0f;  // unsigned [0,1]
-                float normValence = Math.abs(valence) / 127.0f; // absolute [0,1]
+                float normArousal = (arousal & 0xFF) / 255.0f;
+                float normValence = Math.abs(valence) / 127.0f;
 
-                // Composite: baseline 1.0 + weighted signals
                 float modifier = 1.0f
-                        + 0.3f * importance     // ACT-R base-level activation
-                        + 0.2f * normArousal    // Amygdala noradrenergic modulation
-                        + 0.1f * normValence;   // Emotional valence (polarity-independent)
+                        + 0.3f * importance
+                        + 0.2f * normArousal
+                        + 0.1f * normValence;
 
                 modifiers[i] = modifier;
             } catch (RuntimeException e) {
-                // Skip corrupted entries — use default modifier
                 modifiers[i] = 1.0f;
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
@@ -14,6 +14,10 @@ package com.spectrayan.spector.memory.hippocampus;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
 import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
+import com.spectrayan.spector.memory.PartitionManager;
+import com.spectrayan.spector.memory.cortex.EpisodicLogMemory;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.kernel.layout.EpisodicFieldAccessor;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.cortex.CentroidRouter;
@@ -189,6 +193,171 @@ public final class ReflectDaemon {
      * @param ingestionTarget the cognitive ingestion target to promote into
      * @return report summarizing what was done
      */
+    /**
+     * Runs a single synchronous reflection cycle across all frozen and active partitions (#446).
+     *
+     * @param partitionManager the partition manager providing frozen and active partition handles
+     * @param ingestionTarget the cognitive ingestion target to promote into (active partition)
+     * @param index memory index for text lookup
+     * @return report summarizing what was done
+     */
+    public ReflectReport runCycle(PartitionManager partitionManager,
+                                   CognitiveIngestionTarget ingestionTarget,
+                                   MemoryIndex index) {
+        if (partitionManager == null) {
+            return ReflectReport.EMPTY;
+        }
+
+        if (!running.compareAndSet(false, true)) {
+            log.warn("Reflection cycle already in progress  --  skipping");
+            return ReflectReport.EMPTY;
+        }
+
+        Instant start = Instant.now();
+        int totalTombstoned = 0;
+        int totalCompacted = 0;
+        int totalConsolidated = 0;
+
+        try {
+            var handles = partitionManager.snapshot();
+
+            // 1. Reflect log-structured episodic conversation turns across all partitions (ADR-0006)
+            for (var handle : handles) {
+                if (handle.router() != null && handle.router().isEpisodicLogMode()) {
+                    var logStore = handle.router().episodicLog();
+                    if (logStore != null) {
+                        int consolidatedTurns = reflectEpisodicLog(logStore, ingestionTarget);
+                        totalConsolidated += consolidatedTurns;
+                    }
+                }
+            }
+
+            // 2. Reflect legacy fixed-stride episodic partitions across all partition handles if present
+            List<EpisodicPartition> allLegacyPartitions = new ArrayList<>();
+            for (var handle : handles) {
+                if (handle.router() != null && !handle.router().isEpisodicLogMode()) {
+                    var episodicStore = handle.router().episodic();
+                    if (episodicStore != null) {
+                        allLegacyPartitions.addAll(episodicStore.partitions());
+                    }
+                }
+            }
+
+            if (!allLegacyPartitions.isEmpty()) {
+                long nowMs = System.currentTimeMillis();
+                for (EpisodicPartition partition : allLegacyPartitions) {
+                    totalTombstoned += compactor.pruneDecayed(partition, policy.decayPruneThreshold(), nowMs);
+                    int promoted = centroidRouter != null
+                            ? clusterAndSynthesize(partition, ingestionTarget, offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null)
+                            : promoteHighestImportance(partition, ingestionTarget, offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null);
+                    totalConsolidated += promoted;
+                }
+            }
+
+            Duration elapsed = Duration.between(start, Instant.now());
+            log.info("Reflection complete across {} partitions: consolidated={}, tombstoned={}, compacted={}, duration={}ms",
+                    handles.size(), totalConsolidated, totalTombstoned, totalCompacted, elapsed.toMillis());
+
+            return new ReflectReport(totalConsolidated, totalTombstoned, totalCompacted, 0, elapsed);
+        } finally {
+            running.set(false);
+        }
+    }
+
+    private int reflectEpisodicLog(EpisodicLogMemory logStore, CognitiveIngestionTarget ingestionTarget) {
+        if (logStore == null || ingestionTarget == null) return 0;
+        List<Long> unconsolidatedOffsets = logStore.unconsolidatedTurnOffsets();
+        if (unconsolidatedOffsets.isEmpty()) return 0;
+
+        List<EpisodicFieldAccessor.EpisodicRecord> turns = logStore.readTurns(unconsolidatedOffsets, true);
+        if (turns.isEmpty()) return 0;
+
+        // Group unconsolidated turns by sessionId
+        Map<Long, List<EpisodicFieldAccessor.EpisodicRecord>> sessionTurns = new HashMap<>();
+        Map<EpisodicFieldAccessor.EpisodicRecord, Long> turnToOffset = new HashMap<>();
+        for (int i = 0; i < turns.size(); i++) {
+            var turn = turns.get(i);
+            long offset = unconsolidatedOffsets.get(i);
+            sessionTurns.computeIfAbsent(turn.sessionId(), k -> new ArrayList<>()).add(turn);
+            turnToOffset.put(turn, offset);
+        }
+
+        int totalPromoted = 0;
+        for (Map.Entry<Long, List<EpisodicFieldAccessor.EpisodicRecord>> entry : sessionTurns.entrySet()) {
+            List<EpisodicFieldAccessor.EpisodicRecord> sessionList = entry.getValue();
+            if (sessionList.isEmpty()) continue;
+
+            List<String> turnTexts = new ArrayList<>();
+            for (var turn : sessionList) {
+                String text = extractTurnText(turn);
+                if (text != null && !text.isBlank()) {
+                    turnTexts.add(turn.role() + ": " + text);
+                }
+            }
+
+            if (turnTexts.isEmpty()) continue;
+
+            PromotedFact promoted = null;
+            if (textGenerator != null && embeddingProvider != null) {
+                promoted = synthesizeWithLlm(turnTexts, 0L, 1.0f);
+            }
+
+            if (promoted == null && !turnTexts.isEmpty()) {
+                String joinedText = String.join("\n", turnTexts);
+                if (joinedText.length() > 500) {
+                    joinedText = joinedText.substring(0, 500);
+                }
+                float[] vec = embeddingProvider != null ? embeddingProvider.embed(joinedText).vector() : new float[ingestionTarget.quantizer().dimensions()];
+                CognitiveHeader header = new CognitiveHeader(
+                        System.currentTimeMillis(),
+                        0L,
+                        1.0f,
+                        1.0f,
+                        1,
+                        (short) 0,
+                        (byte) 0,
+                        SynapticHeaderConstants.withMemoryType(SynapticHeaderConstants.FLAG_CONSOLIDATED, MemoryType.SEMANTIC.ordinal()),
+                        (byte) 0,
+                        1.0f
+                );
+                promoted = new PromotedFact(joinedText, vec, header);
+            }
+
+            if (promoted != null && promoted.header() != null) {
+                String newId = "rem-log-" + new com.spectrayan.spector.memory.id.TsidGenerator().generate();
+                ingestionTarget.ingestCognitiveWithHeader(
+                        newId,
+                        promoted.text(),
+                        promoted.vector(),
+                        MemoryType.SEMANTIC,
+                        new String[]{"conversation-reflection", "session-" + Long.toHexString(entry.getKey())},
+                        MemorySource.REFLECTED,
+                        promoted.header()
+                );
+                totalPromoted++;
+
+                // Mark all source turns in this session consolidated
+                for (var turn : sessionList) {
+                    Long off = turnToOffset.get(turn);
+                    if (off != null) {
+                        logStore.markConsolidated(off);
+                    }
+                }
+            }
+        }
+
+        return totalPromoted;
+    }
+
+    private String extractTurnText(EpisodicFieldAccessor.EpisodicRecord turn) {
+        if (turn.body() == null || turn.body().length == 0) return "";
+        try {
+            return new String(turn.body(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
     public ReflectReport runCycle(EpisodicRecordMemory episodicStore,
                                    CognitiveIngestionTarget ingestionTarget) {
         return runCycle(episodicStore, ingestionTarget, null);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -526,13 +526,16 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         graphSlotHighWater.set(Math.max(0, highWater));
     }
 
-    // NOTE (issue #443): this remains keyed on graphSlot (the former misnamed field), not
-    // the colocated partition. Re-pointing it at colocatedPartition is a consolidation
-    // follow-up (see ADR-0002 D5) and is intentionally out of scope for #443.
-    public Map<String, String> textsByPartition(int graphSlot) {
+    /**
+     * Returns a map of memory IDs to texts for all memories colocated in the given partition sequence.
+     *
+     * @param partitionSeq the partition sequence number
+     * @return map of id -> text for records in that partition
+     */
+    public Map<String, String> textsByPartition(int partitionSeq) {
         Map<String, String> result = new java.util.HashMap<>();
         for (Map.Entry<String, MemoryLocation> entry : locations.entrySet()) {
-            if (entry.getValue().graphSlot() == graphSlot) {
+            if (entry.getValue().colocatedPartition() == partitionSeq) {
                 String text = text(entry.getKey());
                 if (text != null && !text.isEmpty()) {
                     result.put(entry.getKey(), text);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
@@ -91,6 +91,7 @@ public final class CheckpointDaemon {
     static final int CKPT_SIZE = 16;
 
     private final CognitiveMemoryRouter cognitiveRouter;
+    private volatile java.util.function.Supplier<CognitiveMemoryRouter> routerSupplier;
     private final MemoryWal wal;
     private final Path checkpointMetaPath;
     private final MemoryIndex index;   // nullable — only set for DISK mode
@@ -110,6 +111,13 @@ public final class CheckpointDaemon {
     // ── Event Bus (replaces CheckpointListener) ──
     private volatile EventBus<SpectorLifecycleEvent> eventBus;
     private volatile Map<String, String> eventContext = Map.of();
+
+    /**
+     * Sets the active router supplier to dynamically resolve active partition stores across rolls (#446).
+     */
+    public void setRouterSupplier(java.util.function.Supplier<CognitiveMemoryRouter> supplier) {
+        this.routerSupplier = supplier;
+    }
 
 
 
@@ -186,8 +194,11 @@ public final class CheckpointDaemon {
     public void checkpoint() {
         long start = System.nanoTime();
 
-        // Step 1: Force all persistent cognitive memory store segments
-        cognitiveRouter.forceAll();
+        // Step 1: Force all persistent active cognitive memory store segments (skipping frozen stores)
+        CognitiveMemoryRouter router = (routerSupplier != null) ? routerSupplier.get() : this.cognitiveRouter;
+        if (router != null) {
+            router.forceAll();
+        }
 
         // Step 2: Save MemoryIndex (ID→offset, text, tags, source)
         // This is critical for crash recovery — without it, tier store

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionConsolidationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionConsolidationTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveRecord;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.EmbeddingResult;
+import com.spectrayan.spector.provider.generation.GenerationOptions;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+import com.spectrayan.spector.provider.model.LlmRequest;
+import com.spectrayan.spector.provider.model.LlmResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verification test suite for Issue #446: Multi-Partition Consolidation, Reflection, and Decay.
+ */
+@DisplayName("Issue #446 — Multi-Partition Consolidation, Reflection, and Decay")
+class PartitionConsolidationTest {
+
+    private static final int DIMENSIONS = 32;
+    private SpectorMemory memory;
+    private TestEmbeddingProvider embeddingProvider;
+    private MockLlmProvider llmProvider;
+
+    private SpectorMemory build(Path dir, int semanticCap) {
+        embeddingProvider = new TestEmbeddingProvider(DIMENSIONS);
+        llmProvider = new MockLlmProvider();
+
+        return DefaultSpectorMemory.builder()
+                .dimensions(DIMENSIONS)
+                .embeddingProvider(embeddingProvider)
+                .LlmProvider(llmProvider)
+                .persistenceMode(MemoryPersistenceMode.DISK)
+                .persistence(dir)
+                .workingCapacity(32)
+                .episodicPartitionCapacity(16)
+                .semanticCapacity(semanticCap)
+                .proceduralCapacity(32)
+                .surpriseWarmup(1)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (memory != null) {
+            memory.close();
+            memory = null;
+        }
+    }
+
+    @Test
+    @DisplayName("Batch consolidation detects and merges duplicate memories straddling frozen and active partitions")
+    void crossPartitionDuplicateConsolidation(@TempDir Path dir) {
+        memory = build(dir, /*semanticCap*/ 2);
+
+        float[] vector = new float[DIMENSIONS];
+        vector[0] = 1.0f;
+
+        String text0 = "The primary database host is db-primary.internal";
+        String text1 = "Authentication service token TTL is 3600 seconds";
+        String text2 = "The primary database host is db-primary.internal replica";
+
+        embeddingProvider.register(text0, vector);
+        embeddingProvider.register(text2, vector);
+
+        // Partition 000 (capacity 2): fill semantic store
+        memory.remember("sem-0", text0, MemoryType.SEMANTIC, MemorySource.USER_STATED, "infra");
+        memory.remember("sem-1", text1, MemoryType.SEMANTIC, MemorySource.USER_STATED, "infra");
+
+        // Overflow semantic tier (cap 2) -> triggers roll to active Partition
+        memory.remember("sem-2", text2, MemoryType.SEMANTIC, MemorySource.USER_STATED, "infra");
+
+        CognitiveRecord rec0Before = memory.inspect("sem-0");
+        CognitiveRecord rec2Before = memory.inspect("sem-2");
+        assertThat(rec0Before).isNotNull();
+        assertThat(rec2Before).isNotNull();
+        assertThat(rec0Before.partitionIndex()).isEqualTo(0);
+        assertThat(rec2Before.partitionIndex()).isGreaterThan(0);
+        assertThat(rec0Before.isTombstoned()).isFalse();
+        assertThat(rec2Before.isTombstoned()).isFalse();
+
+        // Run batch consolidation across frozen partition 000 and active partition
+        memory.consolidate();
+
+        // Both original memories across partitions should be tombstoned and de-indexed
+        assertThat(memory.inspect("sem-0")).isNull();
+        assertThat(memory.inspect("sem-2")).isNull();
+
+        // Merged memory should be recallable
+        List<CognitiveResult> results = memory.recall(text0, RecallOptions.builder().topK(10).build());
+        assertThat(results).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("CADP contradiction resolution marks loser contradicted in frozen partition in-place")
+    void crossPartitionCadpContradictionResolution(@TempDir Path dir) throws Exception {
+        memory = build(dir, /*semanticCap*/ 2);
+
+        float[] vector = new float[DIMENSIONS];
+        vector[5] = 1.0f;
+
+        String textOld = "The api gateway port is 8080";
+        String textOther = "Redis cache TTL is 300 seconds";
+        String textNew = "The api gateway port is 9090";
+
+        embeddingProvider.register(textOld, vector);
+        embeddingProvider.register(textNew, vector);
+
+        llmProvider.registerResponse(" 8080", "YES");
+        llmProvider.registerResponse(" 9090", "YES");
+
+        // Partition 000: initial facts
+        memory.remember("port-old", textOld, MemoryType.SEMANTIC, MemorySource.USER_STATED, "config");
+        memory.remember("cache-ttl", textOther, MemoryType.SEMANTIC, MemorySource.USER_STATED, "config");
+
+        Thread.sleep(10);
+
+        // Overflow to active Partition with contradictory statement
+        memory.remember("port-new", textNew, MemoryType.SEMANTIC, MemorySource.USER_STATED, "config");
+
+        CognitiveRecord oldRec = memory.inspect("port-old");
+        CognitiveRecord newRec = memory.inspect("port-new");
+        assertThat(oldRec).isNotNull();
+        assertThat(newRec).isNotNull();
+        assertThat(oldRec.partitionIndex()).isEqualTo(0);
+        assertThat(newRec.partitionIndex()).isGreaterThan(0);
+
+        // Run consolidation to trigger CADP
+        memory.consolidate();
+
+        CognitiveRecord oldRecAfter = memory.inspect("port-old");
+        CognitiveRecord newRecAfter = memory.inspect("port-new");
+
+        // Older memory in frozen partition should be marked contradicted in-place
+        assertThat(oldRecAfter).isNotNull();
+        assertThat(oldRecAfter.isContradicted())
+                .as("Older memory in frozen partition must be marked contradicted")
+                .isTrue();
+        assertThat(newRecAfter).isNotNull();
+        assertThat(newRecAfter.isContradicted())
+                .as("Newer memory in active partition must not be marked contradicted")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Reflection cycle executes across multi-partition deployment without errors")
+    void crossPartitionReflectionCycle(@TempDir Path dir) {
+        memory = build(dir, /*semanticCap*/ 2);
+
+        memory.remember("sem-0", "Microservice A communicates via gRPC",
+                MemoryType.SEMANTIC, MemorySource.USER_STATED, "arch");
+        memory.remember("sem-1", "Microservice B communicates via REST",
+                MemoryType.SEMANTIC, MemorySource.USER_STATED, "arch");
+
+        // Roll partition
+        memory.remember("sem-2", "Microservice C communicates via Kafka",
+                MemoryType.SEMANTIC, MemorySource.USER_STATED, "arch");
+
+        // Run reflection orchestrator
+        ReflectReport report = memory.reflect();
+
+        assertThat(report).isNotNull();
+        assertThat(report.duration()).isNotNull();
+    }
+
+    static class TestEmbeddingProvider implements EmbeddingProvider {
+        private final int dims;
+        private final Map<String, float[]> presetVectors = new HashMap<>();
+
+        TestEmbeddingProvider(int dims) {
+            this.dims = dims;
+        }
+
+        void register(String text, float[] vector) {
+            presetVectors.put(text, vector);
+        }
+
+        @Override
+        public EmbeddingResult embed(String text) {
+            float[] vec = presetVectors.get(text);
+            if (vec == null) {
+                vec = new float[dims];
+                Random rand = new Random(text.hashCode());
+                float normSq = 0;
+                for (int i = 0; i < dims; i++) {
+                    vec[i] = (rand.nextFloat() - 0.5f);
+                    normSq += vec[i] * vec[i];
+                }
+                float norm = (float) Math.sqrt(normSq);
+                for (int i = 0; i < dims; i++) {
+                    vec[i] /= norm;
+                }
+            }
+            return new EmbeddingResult(vec, 10, "test-embedder");
+        }
+
+        @Override
+        public int dimensions() {
+            return dims;
+        }
+
+        @Override
+        public String modelName() {
+            return "test-embedder";
+        }
+    }
+
+    static class MockLlmProvider implements LlmProvider {
+        private final Map<String, String> responses = new HashMap<>();
+
+        void registerResponse(String keyword, String reply) {
+            responses.put(keyword, reply);
+        }
+
+        @Override
+        public LlmResponse generate(LlmRequest request, GenerationOptions options) {
+            String prompt = request.messages().isEmpty() ? "" : request.messages().get(0).text();
+            if (prompt.contains("Merge these")) {
+                return new LlmResponse("The primary database host is db-primary.internal replica", 10, 10, "mock-llm");
+            }
+            String foundReply = "NO";
+            for (Map.Entry<String, String> entry : responses.entrySet()) {
+                if (prompt.contains(entry.getKey())) {
+                    foundReply = entry.getValue();
+                    break;
+                }
+            }
+            return new LlmResponse(foundReply, 10, 10, "mock-llm");
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        public String modelName() {
+            return "mock-llm";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #446.

Extends batch consolidation, duplicate detection, CADP contradiction resolution, Hebbian synaptic decay, temporal chain pruning, and conversation turn reflection across frozen and active partition handles.

### Key Architectural Changes
1. **Multi-Partition Duplicate & Contradiction Detection**:
   - `DuplicateDetector.findDuplicatesAcrossPartitions`: iterates all open semantic partition stores (frozen + active) from `PartitionRegistry.snapshot()`.
   - `BatchConsolidator.consolidate`: multi-partition overload scanning all candidate pairs across partition handles.
2. **Partition-Safe In-Place Mutations**:
   - `CadpContradictionResolver`: resolves `loser.partitionIndex()` and routes `markContradicted` off-heap directly to the loser's physical partition segment.
   - `AbstractConsolidator`: partition-aware `tombstoneRecord` and `mergeDuplicate` updating flags on source partition segment and ingesting fused memory into the active partition.
3. **Multi-Partition Hebbian & Temporal Modulations**:
   - `SynapticDecayModulator`: resolves graph slot -> memory index location -> `partitionManager.routerFor(partitionSeq)` -> `readRecordBody(loc, false)` to read importance and arousal across all tiers and partitions without cross-partition indexing anomalies.
   - `ReflectionOrchestrator.pruneTemporalChain`: importance queries resolved across partitions via `PartitionManager`.
4. **Episodic Store Evolution & Conversation Turn Reflection (ADR-0006)**:
   - Deprecated legacy fixed-stride `EpisodicRecordMemory` (`@Deprecated(since = "1.3.0", forRemoval = true)`).
   - Added `unconsolidatedTurnOffsets()` linear scanner to `EpisodicLogMemory`.
   - Added multi-partition conversation turn reflection to `ReflectDaemon.runCycle`, synthesizing semantic facts from unconsolidated turns across partition handles into the active partition and marking source turns consolidated in-place.
5. **Checkpoint & Index Partition Colocation**:
   - Updated `IndexRecordMemory.textsByPartition(int partitionSeq)` to filter by `colocatedPartition == partitionSeq`.
   - `CheckpointDaemon` dynamic active router resolution skipping `force()` writes to read-only frozen stores.
6. **Testing**:
   - Added comprehensive integration test suite `PartitionConsolidationTest.java` verifying cross-partition duplicate merging, CADP contradiction resolution on frozen partition slices, and multi-partition reflection.

## Verification
- `mvn test -Dtest=PartitionConsolidationTest` passed with 0 failures, 0 errors.
- `mvn test -pl :spector-memory` passed (1,250 tests, 0 failures, 0 errors).
- Clean full reactor compile across all 27 modules.