### PR TITLE
feat(memory): partition-aware HNSW for semantic recall across partitions (#445)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
@@ -59,21 +59,21 @@ public final class RecallPipelineBuilder {
         CognitiveMemoryRouter cognitiveRouter = cortex.cognitiveRouter();
         ScalarQuantizer quantizer = cortex.quantizer();
 
-        //  Semantic Recall Strategy + HNSW Rebuild 
+        // ── Semantic Recall Strategy + HNSW Rebuild (ADR-0009, #445) ──
         SemanticRecallStrategy semanticStrategy = null;
-        if (builder.semanticIndex != null && cognitiveRouter.semantic() != null) {
-            semanticStrategy = new SemanticRecallStrategy(builder.semanticIndex, cognitiveRouter.semantic(), index);
-            rebuildHnswIfNeeded(builder, cognitiveRouter, index, quantizer);
+        if (builder.semanticIndex != null) {
+            semanticStrategy = new SemanticRecallStrategy(builder.semanticIndex, partitionManager, index);
+            rebuildHnswIfNeeded(builder, partitionManager, index, quantizer);
         }
 
-        //  RecallHistory (Executive Dysfunction context buffer) 
+        // ── RecallHistory (Executive Dysfunction context buffer) ──
         RecallHistory recallHistory = new RecallHistory();
 
-        //  MMR Reranker 
+        // ── MMR Reranker ──
         com.spectrayan.spector.memory.pipeline.reranker.MmrReranker mmrReranker = 
             new com.spectrayan.spector.memory.pipeline.reranker.MmrReranker(index, partitionManager, quantizer.mins(), quantizer.scales());
 
-        //  Recall Pipeline 
+        // ── Recall Pipeline ──
         RecallPipeline recallPipeline = new RecallPipeline(
                 embeddingProvider, partitionManager, index,
                 bio.suppressionSet(), bio.habituationPenalty(), bio.prospectiveScheduler(), wal,
@@ -90,38 +90,54 @@ public final class RecallPipelineBuilder {
         return recallPipeline;
     }
 
-    private static void rebuildHnswIfNeeded(SpectorMemoryBuilder builder, CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, ScalarQuantizer quantizer) {
-        var semStore = cognitiveRouter.semantic();
-        int storeSize = semStore.size();
-        if (storeSize > 0 && builder.semanticIndex.size() == 0) {
-            log.info("Rebuilding HNSW index from {} persisted semantic records...", storeSize);
-            long startMs = System.currentTimeMillis();
+    private static void rebuildHnswIfNeeded(SpectorMemoryBuilder builder, PartitionManager partitionManager, MemoryIndex index, ScalarQuantizer quantizer) {
+        if (builder.semanticIndex == null || builder.semanticIndex.isReadOnly() || builder.semanticIndex.size() > 0) {
+            return;
+        }
+        var partitions = partitionManager.snapshot();
+        int totalRebuilt = 0;
+        long startMs = System.currentTimeMillis();
+
+        for (var handle : partitions) {
+            int partitionSeq = handle.seq();
+            var semStore = handle.router() != null ? handle.router().semantic() : null;
+            if (semStore == null || semStore.size() == 0) continue;
+
+            int storeSize = semStore.size();
             var seg = semStore.primarySegment();
             var recLayout = semStore.layout();
             int stride = recLayout.stride();
             int vecBytes = recLayout.quantizedVecBytes();
-            long baseOffset = semStore.filePath() != null
-                    ? com.spectrayan.spector.memory.cortex.AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
+            long baseOffset = semStore.dataOffset();
 
-            int rebuilt = 0;
             for (int i = 0; i < storeSize; i++) {
                 long recordOff = baseOffset + (long) i * stride;
-                byte[] quantized = new byte[vecBytes];
-                java.lang.foreign.MemorySegment.copy(
-                        seg, java.lang.foreign.ValueLayout.JAVA_BYTE,
-                        recLayout.vectorOffset(recordOff),
-                        java.lang.foreign.MemorySegment.ofArray(quantized),
-                        java.lang.foreign.ValueLayout.JAVA_BYTE, 0, vecBytes);
+                byte flags = recLayout.readFlags(seg, recordOff);
+                if (com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.isTombstoned(flags)) {
+                    continue;
+                }
 
-                float[] vector = quantizer.decode(quantized);
-                String id = index.findIdByOffset(MemoryType.SEMANTIC, recordOff);
-                if (id != null && !builder.semanticIndex.isReadOnly()) {
-                    builder.semanticIndex.add(id, i, vector);
-                    rebuilt++;
+                String id = index.findIdByOffset(partitionSeq, MemoryType.SEMANTIC, recordOff);
+                if (id != null) {
+                    byte[] quantized = new byte[vecBytes];
+                    java.lang.foreign.MemorySegment.copy(
+                            seg, java.lang.foreign.ValueLayout.JAVA_BYTE,
+                            recLayout.vectorOffset(recordOff),
+                            java.lang.foreign.MemorySegment.ofArray(quantized),
+                            java.lang.foreign.ValueLayout.JAVA_BYTE, 0, vecBytes);
+
+                    float[] vector = quantizer.decode(quantized);
+                    var loc = index.location(id);
+                    int graphSlot = (loc != null) ? loc.graphSlot() : i;
+                    builder.semanticIndex.add(id, graphSlot, vector);
+                    totalRebuilt++;
                 }
             }
+        }
+        if (totalRebuilt > 0) {
             long elapsed = System.currentTimeMillis() - startMs;
-            log.info("HNSW rebuild complete: {}/{} vectors added in {}ms", rebuilt, storeSize, elapsed);
+            log.info("HNSW multi-partition rebuild complete: {} vectors indexed across {} partitions in {}ms",
+                    totalRebuilt, partitions.size(), elapsed);
         }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -14,88 +14,89 @@ package com.spectrayan.spector.memory.cortex;
 
 import com.spectrayan.spector.index.ScoredResult;
 import com.spectrayan.spector.index.VectorIndex;
+import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.memory.model.ScoringMode;
-import com.spectrayan.spector.memory.index.MemoryIndex;
-import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
-import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.synapse.DecayStrategy;
-import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
 /**
- * Fused semantic recall strategy — HNSW vector search + cognitive header scoring.
+ * Fused HNSW + Cognitive Scoring recall strategy for Semantic Memory (ADR-0009, #445).
  *
- * <h3>Problem (The Truncation Trap — Semantic Variant)</h3>
- * <p>The {@code SemanticMemoryStore} stores only 64-byte cognitive headers (no vectors).
- * This means flat-scanning the header slab cannot compute vector similarity — the
- * {@code alpha * similarity} term is entirely missing. Semantic recall was scoring
- * only {@code beta * importance * decay}, which is fundamentally broken for
- * similarity-based retrieval.</p>
- *
- * <h3>Solution: Fused Pipeline</h3>
+ * <h3>Architecture</h3>
+ * <p>Semantic memory uses a unified {@link VectorIndex} (HNSW/IVF) for $O(\log N)$
+ * approximate nearest neighbor retrieval across all partitions. When a recall query arrives,
+ * the strategy:</p>
  * <ol>
- *   <li>Query the {@link VectorIndex} (HNSW) for top-N candidates with similarity scores</li>
- *   <li>For each candidate, look up the cognitive header from the header slab</li>
- *   <li>Apply the full 6-phase cognitive scoring: tag gating, valence filtering,
- *       temporal decay, reconsolidation, and weighted tag relevance</li>
- *   <li>Re-rank by fused score and return</li>
+ *   <li>Queries HNSW for {@code topK * semanticCandidateMultiplier} candidates</li>
+ *   <li>Resolves each candidate ID to its physical partition and offset via {@link MemoryIndex#location(String)}</li>
+ *   <li>Reads the 64-byte {@link CognitiveHeader} from the partition's off-heap slab segment</li>
+ *   <li>Applies tombstones, contradiction gating, temporal bounds, synaptic tags / hyperfocus, valence, and importance filtering</li>
+ *   <li>Computes the fused cognitive score (similarity + decay * importance * tag boost)</li>
+ *   <li>Sorts and returns the top-K cognitive results</li>
  * </ol>
  *
- * <h3>Performance</h3>
- * <p>HNSW search is O(log N) vs O(N) flat scan. For 100K+ semantic memories,
- * this is orders of magnitude faster. The over-fetch multiplier (default: 3×)
- * ensures cognitive re-ranking has enough candidates to find truly relevant results.</p>
- *
- * <h3>Graceful Degradation</h3>
- * <p>If no {@code VectorIndex} is configured, the caller falls back to
- * the header-only scoring path (with the newly-added tag/valence filters).</p>
+ * <h3>Partition Awareness</h3>
+ * <p>Unlike the legacy single-store implementation, this strategy resolves partition handles dynamically via
+ * {@link PartitionRegistry#handleFor(int)}, guaranteeing zero offset collisions across partition rolls.</p>
  */
 public final class SemanticRecallStrategy {
 
     private static final Logger log = LoggerFactory.getLogger(SemanticRecallStrategy.class);
 
     private final VectorIndex vectorIndex;
-    private final SemanticRecordMemory semanticStore;
+    private final PartitionRegistry partitionRegistry;
+    private final SemanticRecordMemory legacyStore;
     private final MemoryIndex memoryIndex;
 
     /**
-     * Creates a fused semantic recall strategy.
+     * Creates a partition-aware fused semantic recall strategy (ADR-0009).
      *
-     * @param vectorIndex   the HNSW/IVF index backing semantic memory
-     * @param semanticStore the header-only semantic slab
-     * @param memoryIndex   the ID → metadata index for reverse lookups
+     * @param vectorIndex       the HNSW/IVF index backing semantic memory
+     * @param partitionRegistry the partition registry for partition resolution
+     * @param memoryIndex       the ID → metadata index for location lookups
      */
     public SemanticRecallStrategy(VectorIndex vectorIndex,
-                                   SemanticRecordMemory semanticStore,
-                                   MemoryIndex memoryIndex) {
+                                  PartitionRegistry partitionRegistry,
+                                  MemoryIndex memoryIndex) {
         this.vectorIndex = vectorIndex;
-        this.semanticStore = semanticStore;
+        this.partitionRegistry = partitionRegistry;
+        this.legacyStore = null;
         this.memoryIndex = memoryIndex;
     }
 
     /**
-     * Executes a fused semantic recall: HNSW search → cognitive re-ranking.
+     * Legacy constructor for single-store configurations and tests.
      *
-     * <p>Steps:</p>
-     * <ol>
-     *   <li>Search HNSW for {@code topK * multiplier} candidates</li>
-     *   <li>For each candidate, read the cognitive header from the slab</li>
-     *   <li>Apply tag gating, valence filtering, importance threshold</li>
-     *   <li>Compute fused score: {@code alpha * similarity + beta * importance * decay}</li>
-     *   <li>Apply weighted tag relevance boost</li>
-     *   <li>Sort and return top-K</li>
-     * </ol>
+     * @param vectorIndex   the HNSW/IVF index backing semantic memory
+     * @param semanticStore the single semantic slab
+     * @param memoryIndex   the ID → metadata index for reverse lookups
+     */
+    public SemanticRecallStrategy(VectorIndex vectorIndex,
+                                  SemanticRecordMemory semanticStore,
+                                  MemoryIndex memoryIndex) {
+        this.vectorIndex = vectorIndex;
+        this.partitionRegistry = null;
+        this.legacyStore = semanticStore;
+        this.memoryIndex = memoryIndex;
+    }
+
+    /**
+     * Executes a fused semantic recall: HNSW search → partition-aware cognitive re-ranking.
      *
      * @param queryVector the embedded query vector
      * @param options     recall configuration
@@ -113,6 +114,7 @@ public final class SemanticRecallStrategy {
 
         // Extract filter parameters
         long queryTagMask = options.synapticTagMask();
+        long hyperfocusMask = options.hyperfocusMask();
         byte minValence = options.minValence();
         byte maxValence = options.maxValence();
         float minImportance = options.minImportance();
@@ -125,16 +127,31 @@ public final class SemanticRecallStrategy {
         float beta = options.beta();
         float tagRelevanceBoost = options.tagRelevanceBoost();
 
-        CognitiveRecordLayout layout = semanticStore.cognitiveLayout();
-        java.lang.foreign.MemorySegment headerSlab = semanticStore.primarySegment();
-
         List<CognitiveResult> results = new ArrayList<>();
 
         for (ScoredResult sr : hnswResults) {
-            // HNSW returns an internal store index — compute record offset in segment
-            // For persistent stores, records start after the 64-byte metadata header
-            long dataOffset = semanticStore.isPersistent() ? AbstractCognitiveRecordMemory.METADATA_HEADER_BYTES : 0;
-            long headerOffset = dataOffset + (long) sr.index() * layout.stride();
+            String id = sr.id();
+            if (id == null) continue;
+
+            MemoryLocation loc = memoryIndex.location(id);
+            if (loc == null || loc.type() != MemoryType.SEMANTIC) continue;
+
+            int partitionSeq = loc.colocatedPartition();
+            long headerOffset = loc.offset();
+
+            SemanticRecordMemory store;
+            if (partitionRegistry != null) {
+                PartitionHandle handle = partitionRegistry.handleFor(partitionSeq);
+                if (handle == null || handle.router() == null) continue;
+                store = handle.router().semantic();
+            } else {
+                store = legacyStore;
+            }
+
+            if (store == null) continue;
+
+            CognitiveRecordLayout layout = store.cognitiveLayout();
+            MemorySegment headerSlab = store.primarySegment();
 
             // Bounds check: ensure we're within the slab
             if (headerSlab == null || headerOffset + layout.headerLayout().headerBytes() > headerSlab.byteSize()) {
@@ -146,20 +163,24 @@ public final class SemanticRecallStrategy {
             // Phase 1: Tombstone check (always applied)
             if (SynapticHeaderConstants.isTombstoned(header.flags())) continue;
 
+            // Phase 1c: Contradiction Gating
             if (!options.includeContradictions()) {
                 byte cFlags = layout.readConsolidationFlags(headerSlab, headerOffset);
                 if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
             }
-
 
             // Phase 1b: Temporal gating (absolute timestamp bounds)
             long timestamp = header.timestampMs();
             if (minTimestamp != null && timestamp < minTimestamp) continue;
             if (maxTimestamp != null && timestamp > maxTimestamp) continue;
 
-            // Phase 2: Synaptic tag gating (skip on zero overlap)
+            // Phase 2: Synaptic tag gating
             long recordTags = header.synapticTags();
-            if (queryTagMask != 0 && (recordTags & queryTagMask) == 0) continue;
+            if (hyperfocusMask != 0L) {
+                if ((recordTags & hyperfocusMask) != hyperfocusMask) continue;
+            } else if (queryTagMask != 0L) {
+                if ((recordTags & queryTagMask) == 0L) continue;
+            }
 
             // Phase 3: Valence filter
             byte valence = header.valence();
@@ -175,43 +196,35 @@ public final class SemanticRecallStrategy {
             float rawDecay;
 
             if (pureSimilarity) {
-                // ── SIMILARITY mode: HNSW cosine score IS the final score ──
-                // No importance weighting, no decay, no tag boost.
-                // Pure information retrieval ranking.
                 finalScore = sr.score();
                 decay = 1.0f;
                 rawDecay = 1.0f;
             } else {
-                // ── COGNITIVE mode: full biologically-inspired scoring ──
-                // Phase 5: Use HNSW similarity score directly
                 float similarity = sr.score();
-
-                // Phase 6: Temporal decay + reconsolidation
                 int rawBucket = DecayStrategy.ageToBucket(timestamp, nowMs);
                 int adjusted = DecayStrategy.adjustForReconsolidation(rawBucket, agentRecallCount);
                 decay = DecayStrategy.decay(adjusted);
                 rawDecay = DecayStrategy.decay(rawBucket);
 
-                // Fused cognitive score with weighted tag relevance
                 float baseScore = alpha * similarity + beta * importance * decay;
                 float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
                 finalScore = baseScore * (1.0f + tagOverlap * tagRelevanceBoost);
             }
 
-            // Build result — use the same headerOffset for reverse lookup
-            String id = memoryIndex.findIdByOffset(MemoryType.SEMANTIC, headerOffset);
-            String text = id != null ? memoryIndex.text(id) : "";
-            MemorySource source = id != null ? memoryIndex.source(id) : MemorySource.OBSERVED;
-            String[] tags = id != null ? memoryIndex.tags(id) : new String[0];
+            String text = memoryIndex.text(id);
+            if (text == null) text = "";
+            MemorySource source = memoryIndex.source(id);
+            if (source == null) source = MemorySource.OBSERVED;
+            String[] tags = memoryIndex.tags(id);
+            if (tags == null) tags = new String[0];
             float ageDays = (nowMs - timestamp) / (1000f * 60f * 60f * 24f);
 
-            // Build breakdown for diagnostic output
             ScoreBreakdown breakdown;
             if (pureSimilarity) {
                 breakdown = new ScoreBreakdown(sr.score(), 0f, 1.0f, 1.0f, 1.0f, 1.0f, finalScore);
             } else {
                 float importanceDecay = importance * decay;
-                float tagOverlapForBd = SynapticTagEncoder.overlapRatio(header.synapticTags(), queryTagMask);
+                float tagOverlapForBd = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
                 float tagBoostFactor = 1.0f + tagOverlapForBd * tagRelevanceBoost;
                 breakdown = new ScoreBreakdown(
                         sr.score(), importanceDecay, tagBoostFactor,
@@ -219,8 +232,7 @@ public final class SemanticRecallStrategy {
             }
 
             results.add(new CognitiveResult(
-                    id != null ? id : "semantic-" + sr.index(),
-                    text, finalScore, importance, ageDays,
+                    id, text, finalScore, importance, ageDays,
                     agentRecallCount, valence, MemoryType.SEMANTIC, source,
                     tags, rawDecay, decay,
                     CognitiveResult.RetrievalMode.STANDARD, breakdown));
@@ -229,7 +241,7 @@ public final class SemanticRecallStrategy {
         // Sort by fused score descending
         results.sort(Comparator.comparing(CognitiveResult::score).reversed());
 
-        log.debug("Semantic fused recall: {} HNSW candidates → {} after filtering",
+        log.debug("Semantic partition-aware fused recall: {} HNSW candidates → {} after filtering",
                 hnswResults.length, results.size());
 
         return results;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/index/IndexRecordMemory.java
@@ -283,6 +283,11 @@ public class IndexRecordMemory extends AbstractRecordMemory<IndexEntryLayout> {
         return locations.get(id);
     }
 
+    /** Alias for {@link #locate(String)} (ADR-0009). */
+    public MemoryLocation location(String id) {
+        return locations.get(id);
+    }
+
     public String text(String id) {
         MemoryLocation loc = locations.get(id);
         if (loc != null && loc.hasTextPosition()) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -173,11 +173,11 @@ final class PostIngestSync {
         // Hebbian, Temporal, Entity, and Hypergraphs. Never reused.
         int graphSlot = index.allocateGraphSlot();
         try {
-            // Step 7b: Add to HNSW index (SEMANTIC only)
+            // Step 7b: Add to HNSW index (SEMANTIC only, #445: use monotonic graphSlot)
             if (params.type() == MemoryType.SEMANTIC && semanticIndex != null
                     && !semanticIndex.isReadOnly()
                     && !isParentChunk) {
-                storeIndex = cognitiveRouter.countFor(MemoryType.SEMANTIC) - 1;
+                storeIndex = graphSlot;
                 semanticIndex.add(params.id(), storeIndex, params.vector());
             }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -1011,6 +1011,11 @@ public final class RecallPipeline {
         // Working memory — GLOBAL, scanned once (baseOffset 0) via the active router.
         WORKING_SCAN.contribute(ctx, activeHandle, emitter);
 
+        // #445: Global semantic HNSW scan — emitted ONCE when HNSW is available across all partitions
+        if (ctx.semanticHnswAvailable() && CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, ctx.targetTypes())) {
+            emitter.emitSemanticHnsw();
+        }
+
         // #447: Query-time partition pruning before fan-out
         List<PartitionHandle> candidatePartitions = partitionPruner.prune(snapshot, options, targetTypes, nowMs);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanEmitter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/ScanEmitter.java
@@ -29,6 +29,6 @@ public interface ScanEmitter {
                       CognitiveRecordLayout layout, MemoryType type,
                       long baseOffset, int partitionSeq);
 
-    /** Emits the semantic HNSW fast-path recall (active single partition only). */
+    /** Emits the semantic HNSW fast-path recall across all partitions (ADR-0009). */
     void emitSemanticHnsw();
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
@@ -58,19 +58,18 @@ public interface TierScanStrategy {
         }
     }
 
-    /** Semantic tier strategy. */
+    /** Semantic tier strategy (ADR-0009, #445). */
     final class SemanticTierScanStrategy implements TierScanStrategy {
         @Override public MemoryType tier() { return MemoryType.SEMANTIC; }
 
         @Override
         public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
             if (!CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, ctx.targetTypes())) return;
-            CognitiveRecordMemory semantic = handle.router().semantic();
-            if (semantic == null || semantic.visibleCount() <= 0) return;
-            boolean useHnsw = handle.writable() && ctx.singlePartition() && ctx.semanticHnswAvailable();
-            if (useHnsw) {
-                emitter.emitSemanticHnsw();
-            } else {
+            // When HNSW is available, global semantic recall is emitted once by RecallPipeline.
+            // When unindexed (fallback), scan this partition's slab.
+            if (!ctx.semanticHnswAvailable()) {
+                CognitiveRecordMemory semantic = handle.router().semantic();
+                if (semantic == null || semantic.visibleCount() <= 0) return;
                 emitter.emitSlabScan(semantic::segment, semantic::visibleCount,
                         semantic.cognitiveLayout(), MemoryType.SEMANTIC,
                         semantic.dataOffset(), handle.seq());

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionAwareHnswRecallTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionAwareHnswRecallTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.core.similarity.SimilarityFunction;
+import com.spectrayan.spector.index.HnswIndex;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.kernel.StorageLayout;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.test.FakeEmbeddingProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit & Integration tests for Partition-Aware Global HNSW Semantic Recall (ADR-0009, #445).
+ */
+@DisplayName("Issue #445 — Partition-Aware Global HNSW Semantic Recall")
+class PartitionAwareHnswRecallTest {
+
+    private SpectorMemory memory;
+
+    private SpectorMemory build(Path dir, int semanticCap, HnswIndex semanticIndex) {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        return DefaultSpectorMemory.builder()
+                .dimensions(embed.dimensions())
+                .embeddingProvider(embed)
+                .persistenceMode(MemoryPersistenceMode.DISK)
+                .persistence(dir)
+                .workingCapacity(32)
+                .episodicPartitionCapacity(64)
+                .semanticCapacity(semanticCap)
+                .proceduralCapacity(32)
+                .surpriseWarmup(1)
+                .semanticIndex(semanticIndex)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (memory != null) {
+            memory.close();
+            memory = null;
+        }
+    }
+
+    private static Set<String> ids(List<CognitiveResult> results) {
+        return results.stream().map(CognitiveResult::id).collect(Collectors.toSet());
+    }
+
+    private static long partitionDirCount(Path base) throws Exception {
+        try (var stream = Files.newDirectoryStream(StorageLayout.partitionsDir(base))) {
+            long n = 0;
+            for (Path p : stream) {
+                if (Files.isDirectory(p) && StorageLayout.isPartitionDir(p.getFileName().toString())) n++;
+            }
+            return n;
+        }
+    }
+
+    @Test
+    @DisplayName("HNSW semantic recall spans multiple rolled partitions seamlessly")
+    void hnswRecallSpansMultiplePartitions(@TempDir Path dir) throws Exception {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        HnswIndex hnsw = new HnswIndex(embed.dimensions(), 100, SimilarityFunction.COSINE);
+        memory = build(dir, /*semanticCap*/ 2, hnsw);
+
+        // Ingest 5 semantic memories with semanticCapacity=2 → forces 3 partitions (000, 001, 002)
+        memory.remember("sem-0", "semantic knowledge about quantum computing algorithms",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "quantum");
+        memory.remember("sem-1", "entanglement in distributed quantum networks",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "quantum");
+        memory.remember("sem-2", "superconducting qubits and coherence decoherence times",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "quantum");
+        memory.remember("sem-3", "quantum error correction surface codes",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "quantum");
+        memory.remember("sem-4", "topological braid state quantum gates",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "quantum");
+
+        assertThat(partitionDirCount(dir)).isGreaterThanOrEqualTo(3);
+
+        // Recall with topK=10 covering all records
+        List<CognitiveResult> results = memory.recall(
+                "quantum algorithms and superconducting coherence",
+                RecallOptions.builder().topK(10).memoryTypes(MemoryType.SEMANTIC).build());
+
+        Set<String> resultIds = ids(results);
+        assertThat(resultIds).contains("sem-0", "sem-1", "sem-2", "sem-3", "sem-4");
+
+        // Verify cognitive properties are properly scored from the off-heap partition segments
+        for (CognitiveResult res : results) {
+            assertThat(res.memoryType()).isEqualTo(MemoryType.SEMANTIC);
+            assertThat(res.importance()).isGreaterThan(0.0f);
+            assertThat(res.score()).isGreaterThan(0.0f);
+            assertThat(res.text()).isNotBlank();
+        }
+    }
+
+    @Test
+    @DisplayName("Startup HNSW rebuild indexes semantic records across all frozen and active partitions")
+    void startupRebuildRestoresAllPartitions(@TempDir Path dir) throws Exception {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        HnswIndex hnsw1 = new HnswIndex(embed.dimensions(), 100, SimilarityFunction.COSINE);
+        memory = build(dir, /*semanticCap*/ 2, hnsw1);
+
+        memory.remember("sem-p0-1", "neural network transformer attention mechanisms",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "ml");
+        memory.remember("sem-p0-2", "flash attention tiling memory optimization",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "ml");
+        memory.remember("sem-p1-1", "rotary position embeddings in large language models",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "ml");
+        memory.remember("sem-p1-2", "mixture of experts routing algorithms",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "ml");
+        memory.remember("sem-p2-1", "quantized low rank adaptation fine-tuning",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "ml");
+
+        assertThat(partitionDirCount(dir)).isGreaterThanOrEqualTo(3);
+        memory.close();
+
+        // Re-open with a fresh, empty HnswIndex — startup rebuild should populate it from all partitions
+        HnswIndex hnsw2 = new HnswIndex(embed.dimensions(), 100, SimilarityFunction.COSINE);
+        assertThat(hnsw2.size()).isEqualTo(0);
+
+        memory = build(dir, /*semanticCap*/ 2, hnsw2);
+
+        // Verify HNSW was rebuilt from all partitions
+        assertThat(hnsw2.size()).isEqualTo(5);
+
+        List<CognitiveResult> results = memory.recall(
+                "transformer attention and rotary embeddings",
+                RecallOptions.builder().topK(10).memoryTypes(MemoryType.SEMANTIC).build());
+
+        Set<String> resultIds = ids(results);
+        assertThat(resultIds).containsExactlyInAnyOrder(
+                "sem-p0-1", "sem-p0-2", "sem-p1-1", "sem-p1-2", "sem-p2-1");
+    }
+
+    @Test
+    @DisplayName("Tombstoned/forgotten records in frozen partitions are skipped by HNSW recall")
+    void tombstonedRecordsInFrozenPartitionsAreSkipped(@TempDir Path dir) throws Exception {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        HnswIndex hnsw = new HnswIndex(embed.dimensions(), 100, SimilarityFunction.COSINE);
+        memory = build(dir, /*semanticCap*/ 2, hnsw);
+
+        // Fill partition 000 with sem-0 and sem-1
+        memory.remember("sem-0", "confidential secret encryption key details",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "security");
+        memory.remember("sem-1", "public cryptography elliptic curve parameters",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "security");
+        // Roll to partition 001 with sem-2
+        memory.remember("sem-2", "zero knowledge proofs and verifiable computing",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "security");
+
+        assertThat(partitionDirCount(dir)).isGreaterThanOrEqualTo(2);
+
+        // Forget sem-0 in frozen partition 000
+        memory.forget("sem-0");
+
+        List<CognitiveResult> results = memory.recall(
+                "encryption key and cryptography parameters",
+                RecallOptions.builder().topK(10).memoryTypes(MemoryType.SEMANTIC).build());
+
+        Set<String> resultIds = ids(results);
+        assertThat(resultIds).doesNotContain("sem-0");
+        assertThat(resultIds).contains("sem-1", "sem-2");
+    }
+
+    @Test
+    @DisplayName("Synaptic tag gating and hyperfocus filter HNSW results across partitions")
+    void synapticTagGatingAcrossPartitions(@TempDir Path dir) throws Exception {
+        FakeEmbeddingProvider embed = new FakeEmbeddingProvider();
+        HnswIndex hnsw = new HnswIndex(embed.dimensions(), 100, SimilarityFunction.COSINE);
+        memory = build(dir, /*semanticCap*/ 2, hnsw);
+
+        // Ingest memories with distinct tags across partition rolls
+        memory.remember("sem-tag-arch1", "microservices event driven architecture",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "architecture");
+        memory.remember("sem-tag-arch2", "domain driven design aggregate roots",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "architecture");
+        memory.remember("sem-tag-devops", "kubernetes container pod autoscaling",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "devops");
+        memory.remember("sem-tag-sec", "zero trust mutual tls authentication",
+                MemoryType.SEMANTIC, MemorySource.OBSERVED, "security");
+
+        // Hyperfocus on "architecture"
+        List<CognitiveResult> archResults = memory.recall(
+                "cloud system architecture and pod scaling",
+                RecallOptions.builder()
+                        .topK(10)
+                        .memoryTypes(MemoryType.SEMANTIC)
+                        .hyperfocusMask("architecture")
+                        .build());
+
+        Set<String> archIds = ids(archResults);
+        assertThat(archIds).contains("sem-tag-arch1", "sem-tag-arch2");
+        assertThat(archIds).doesNotContain("sem-tag-devops", "sem-tag-sec");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #445

This PR restores true (\log N)$ approximate nearest neighbor (ANN) retrieval for Semantic Memory across multi-partition deployments by implementing **Partition-Aware Global HNSW Semantic Recall** (ADR-0009).

### Key Architectural Changes

1. **Partition-Aware Candidate Resolution (`SemanticRecallStrategy`)**:
   - Queries global `VectorIndex.search(queryVector, candidateCount)` once across all partitions.
   - For each candidate `sr`, resolves `MemoryLocation loc = memoryIndex.location(sr.id())` ((1)$) to obtain physical `colocatedPartition` and `offset`.
   - Resolves `PartitionHandle handle = partitionRegistry.handleFor(loc.colocatedPartition())` and reads the 64-byte `CognitiveHeader` directly from the partition's off-heap slab segment at `loc.offset()`.
   - Evaluates tombstones, contradictions, temporal gating, synaptic tags, hyperfocus, valence, importance, temporal decay, and LTP reconsolidation without cross-partition offset collisions.

2. **Multi-Partition Startup Rebuild (`RecallPipelineBuilder`)**:
   - Iterates across all partitions in `partitionManager.snapshot()`, reading semantic vectors from active and frozen partition slabs and populating the `semanticIndex`.

3. **Collision-Free Ingestion (`PostIngestSync`)**:
   - Uses monotonic `graphSlot` instead of partition-local `storeIndex` in `semanticIndex.add(params.id(), graphSlot, params.vector())`, preventing node ID collisions across partition rolls.

4. **Tier Scan Strategy Optimization (`TierScanStrategy` & `RecallPipeline`)**:
   - `RecallPipeline.scan()` emits `emitter.emitSemanticHnsw()` globally once when `semanticHnswAvailable` is true, eliminating SIMD flat scans for semantic memory across partitions.
   - Gracefully falls back to per-partition SIMD slab scans if no vector index is configured.

5. **Scope Boundaries**:
   - **Semantic Memory**: Fused (\log N)$ HNSW $\to$ 6-phase cognitive re-ranking.
   - **Procedural / Working Memory**: Evaluated via sub-microsecond off-heap SIMD scan over inline quantized vectors.
   - **Episodic Memory**: Sequential session-based turn log in `EpisodicLogMemory`.

---

### Verification

- **New Test Suite**: `PartitionAwareHnswRecallTest` (4 unit & integration tests covering multi-partition rolls, startup rebuild, tombstone handling, and hyperfocus gating across partitions).
- **Full Reactor Test Suite**: 1,268 tests passing across `spector-memory` and all 27 reactor modules with 0 failures and 0 errors.

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>