### PR TITLE
feat(memory): async entity extraction queue with configurable batch parallelism and zero-LLM recall (#555)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveIngestionTargetBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveIngestionTargetBuilder.java
@@ -60,7 +60,8 @@ final class CognitiveIngestionTargetBuilder {
                 retrieval.bm25Index(), retrieval.textDataStore(), activePartitionIndex,
                 retrieval.memorySpladeIndex(), builder.SparseEmbeddingProvider,
                 builder.dataEncryptor, importanceProvider,
-                new com.spectrayan.spector.memory.session.SessionRegistry());
+                new com.spectrayan.spector.memory.session.SessionRegistry(),
+                builder.entityExtractionParallelism, builder.entityExtractionQueueCapacity);
 
         //  Wire Salience Profile Provider 
         if (builder.salienceProfileProvider != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -685,8 +685,13 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                             "Embedding failed for chunk: " + embedding.error());
                 }
 
-                // Extract content-specific tags from this chunk's text
-                String[] contentTags = chunkTagExtractor.extract(chunk.chunkId(), chunk.text());
+                // Extract content-specific tags from this chunk's text (skip LLM extraction if caller tags provided)
+                String[] contentTags;
+                if (provenanceTags != null && provenanceTags.length > 0) {
+                    contentTags = new String[0];
+                } else {
+                    contentTags = chunkTagExtractor.extract(chunk.chunkId(), chunk.text());
+                }
 
                 // Merge provenance + per-chunk content tags (deduplicated)
                 var mergedSet = new java.util.LinkedHashSet<String>();
@@ -1565,6 +1570,15 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 eagerConsolidator.close();
             } catch (Exception e) {
                 log.warn("Failed to close EagerConsolidator on close", e);
+            }
+        }
+
+        // Close ingestion target (stops async entity extraction queue)
+        if (cognitiveTarget != null) {
+            try {
+                cognitiveTarget.close();
+            } catch (Exception e) {
+                log.warn("Failed to close CognitiveIngestionTarget on close", e);
             }
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -144,6 +144,10 @@ public final class SpectorMemoryBuilder {
     //  Embedding pipeline batch size 
     int embedBatchSize = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_PROVIDER_EMBEDDING_BATCH_SIZE;
 
+    //  Asynchronous entity extraction queue configuration
+    int entityExtractionParallelism = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_EXTRACTION_PARALLELISM;
+    int entityExtractionQueueCapacity = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_ENTITY_EXTRACTION_QUEUE_CAPACITY;
+
     //  Salience profile provider (enterprise SPI) 
     SalienceProfileProvider salienceProfileProvider;
 
@@ -466,6 +470,30 @@ public final class SpectorMemoryBuilder {
      */
     public SpectorMemoryBuilder cacheManager(com.spectrayan.spector.commons.cache.SpectorCacheManager cacheManager) {
         this.cacheManager = cacheManager;
+        return this;
+    }
+
+    /**
+     * Sets the number of virtual threads processing the asynchronous entity extraction queue.
+     *
+     * <p>Default: 1 (sequential FIFO execution to prevent Ollama/LLM congestion).</p>
+     *
+     * @param parallelism number of worker threads (must be >= 1)
+     * @return this builder
+     */
+    public SpectorMemoryBuilder entityExtractionParallelism(int parallelism) {
+        this.entityExtractionParallelism = Math.max(1, parallelism);
+        return this;
+    }
+
+    /**
+     * Sets the bounded capacity of the asynchronous entity extraction queue.
+     *
+     * @param capacity maximum tasks in queue (must be >= 16)
+     * @return this builder
+     */
+    public SpectorMemoryBuilder entityExtractionQueueCapacity(int capacity) {
+        this.entityExtractionQueueCapacity = Math.max(16, capacity);
         return this;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
@@ -22,6 +22,7 @@ import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -55,7 +56,7 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
 
     private static final Logger log = LoggerFactory.getLogger(EagerConsolidator.class);
 
-    public record EagerConsolidationTask(String memoryId, MemoryType type) {}
+    public record EagerConsolidationTask(String memoryId, MemoryType type, String sessionId) {}
 
     private final BlockingQueue<EagerConsolidationTask> taskQueue;
     private final ExecutorService executor;
@@ -111,7 +112,8 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
             return false;
         }
 
-        boolean accepted = taskQueue.offer(new EagerConsolidationTask(memoryId, type));
+        String sessionId = MemoryScope.sessionId();
+        boolean accepted = taskQueue.offer(new EagerConsolidationTask(memoryId, type, sessionId));
         if (!accepted) {
             log.debug("Eager consolidation queue full ({}) — task for '{}' skipped; batch consolidation will catch it",
                     taskQueue.size(), memoryId);
@@ -124,7 +126,12 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
             try {
                 EagerConsolidationTask task = taskQueue.poll(500, TimeUnit.MILLISECONDS);
                 if (task != null) {
-                    processTask(task);
+                    Runnable worker = () -> processTask(task);
+                    if (task.sessionId() != null && !task.sessionId().isBlank()) {
+                        ScopedValue.where(MemoryScope.SESSION_ID, task.sessionId()).run(worker);
+                    } else {
+                        worker.run();
+                    }
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
@@ -12,6 +12,8 @@
  */
 package com.spectrayan.spector.memory.consolidation;
 
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
 import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.core.similarity.SimilarityFunction;
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
@@ -22,7 +24,6 @@ import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
-import com.spectrayan.spector.commons.concurrent.MemoryScope;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -36,30 +37,27 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 /**
- * Asynchronous eager consolidation coordinator (#526).
+ * Eager single-memory contradiction consolidator.
  *
- * <p>Processes newly ingested semantic and procedural memories on a dedicated
- * single-thread virtual executor with a bounded task queue. Performs a gated
- * contradiction scan (tombstone &rarr; bloom filter &rarr; vector distance &rarr; LLM) and applies
- * CADP directional resolution (#507) immediately after ingestion, closing the
- * confusion window before the next batch consolidation cycle.</p>
+ * <p>Ingests a memory and evaluates it against existing memories immediately
+ * using a centralized virtual thread managed by {@link ConcurrentTasks#virtualExecutor()}
+ * and a bounded task queue. Performs a gated contradiction scan (tombstone &rarr; bloom
+ * filter &rarr; vector distance &rarr; LLM) and applies CADP directional resolution (#507)
+ * immediately after ingestion, closing the confusion window before the next batch consolidation cycle.</p>
  */
 public final class EagerConsolidator extends AbstractConsolidator implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(EagerConsolidator.class);
 
-    public record EagerConsolidationTask(String memoryId, MemoryType type, String sessionId) {}
+    public record EagerConsolidationTask(String memoryId, MemoryType type, String sessionId, String namespaceId) {}
 
     private final BlockingQueue<EagerConsolidationTask> taskQueue;
-    private final ExecutorService executor;
     private final CognitiveMemoryRouter cognitiveRouter;
     private final MemoryIndex index;
     private final ScalarQuantizer quantizer;
@@ -92,9 +90,7 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
         this.distanceThreshold = distanceThreshold;
         this.taskQueue = new LinkedBlockingQueue<>(Math.max(16, queueCapacity));
 
-        this.executor = Executors.newSingleThreadExecutor(
-                Thread.ofVirtual().name("spector-eager-consolidator-", 0).factory());
-        this.executor.submit(this::processLoop);
+        ConcurrentTasks.virtualExecutor().submit(this::processLoop);
     }
 
     /**
@@ -113,7 +109,8 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
         }
 
         String sessionId = MemoryScope.sessionId();
-        boolean accepted = taskQueue.offer(new EagerConsolidationTask(memoryId, type, sessionId));
+        String namespaceId = MemoryScope.namespaceId();
+        boolean accepted = taskQueue.offer(new EagerConsolidationTask(memoryId, type, sessionId, namespaceId));
         if (!accepted) {
             log.debug("Eager consolidation queue full ({}) — task for '{}' skipped; batch consolidation will catch it",
                     taskQueue.size(), memoryId);
@@ -127,11 +124,7 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
                 EagerConsolidationTask task = taskQueue.poll(500, TimeUnit.MILLISECONDS);
                 if (task != null) {
                     Runnable worker = () -> processTask(task);
-                    if (task.sessionId() != null && !task.sessionId().isBlank()) {
-                        ScopedValue.where(MemoryScope.SESSION_ID, task.sessionId()).run(worker);
-                    } else {
-                        worker.run();
-                    }
+                    MemoryScope.runWithScope(task.sessionId(), task.namespaceId(), worker);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -250,14 +243,14 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
-            executor.shutdown();
-            try {
-                if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
-                    executor.shutdownNow();
+            long deadline = System.currentTimeMillis() + 2000;
+            while (!taskQueue.isEmpty() && System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
                 }
-            } catch (InterruptedException e) {
-                executor.shutdownNow();
-                Thread.currentThread().interrupt();
             }
         }
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueue.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueue.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.memory.pipeline;
 
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
 import com.spectrayan.spector.commons.concurrent.MemoryScope;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
@@ -21,8 +22,6 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,13 +33,14 @@ import java.util.concurrent.atomic.AtomicLong;
  * <h3>Architecture</h3>
  * <p>Ingesting a memory must never block the client on slow LLM text-generation calls (~15s–25s).
  * {@code AsyncEntityExtractionQueue} decouples entity extraction from the ingestion critical path,
- * buffering tasks in a bounded FIFO queue and processing them via a supervised pool of virtual
- * threads with configurable parallelism (defaulting to 1 for sequential execution to prevent
- * Ollama/LLM concurrency congestion).</p>
+ * buffering tasks in a bounded FIFO queue and processing them via centralized virtual threads
+ * managed by {@link ConcurrentTasks#virtualExecutor()} with configurable parallelism (defaulting
+ * to 1 for sequential execution to prevent Ollama/LLM concurrency congestion).</p>
  *
  * <h3>Scoped Context Propagation</h3>
- * <p>Captures {@link MemoryScope#SESSION_ID} at submission time and re-binds it via {@link ScopedValue}
- * in the executing virtual thread, ensuring session identity and temporal link contexts are preserved.</p>
+ * <p>Captures {@link MemoryScope#SESSION_ID} and {@link MemoryScope#NAMESPACE_ID} at submission
+ * time and re-binds them via {@link MemoryScope#runWithScope} in the executing virtual thread,
+ * ensuring session identity and namespace isolation contexts are preserved end-to-end.</p>
  */
 public final class AsyncEntityExtractionQueue implements AutoCloseable {
 
@@ -51,7 +51,8 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
             String text,
             int memoryIdx,
             long timestampSeconds,
-            String sessionId
+            String sessionId,
+            String namespaceId
     ) {}
 
     public record QueueStats(
@@ -71,7 +72,6 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
     private final int parallelism;
     private final EntityExtractor entityExtractor;
     private final PostIngestSync postIngestSync;
-    private final ExecutorService executor;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final AtomicLong totalSubmitted = new AtomicLong(0);
@@ -91,31 +91,27 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
         this.queueCapacity = Math.max(16, queueCapacity);
         this.queue = new LinkedBlockingQueue<>(this.queueCapacity);
 
-        this.executor = Executors.newFixedThreadPool(
-                this.parallelism,
-                Thread.ofVirtual().name("spector-entity-extractor-", 0).factory()
-        );
-
         for (int i = 0; i < this.parallelism; i++) {
-            this.executor.submit(this::processLoop);
+            ConcurrentTasks.virtualExecutor().submit(this::processLoop);
         }
 
-        log.info("[AsyncEntityExtractionQueue] Initialized with parallelism={}, capacity={}",
+        log.info("[AsyncEntityExtractionQueue] Initialized via ConcurrentTasks with parallelism={}, capacity={}",
                 this.parallelism, this.queueCapacity);
     }
 
     /**
-     * Submits a memory for asynchronous entity extraction.
+     * Submits a memory for asynchronous entity extraction with session and namespace contexts.
      *
      * @param memoryId         memory ID
      * @param text             raw text content
      * @param memoryIdx        graph slot / memory index
      * @param timestampSeconds epoch timestamp in seconds
      * @param sessionId        scoped session ID (nullable)
+     * @param namespaceId      scoped namespace ID (nullable)
      * @return true if accepted, false if dropped or closed
      */
     public boolean submit(String memoryId, String text, int memoryIdx,
-                          long timestampSeconds, String sessionId) {
+                          long timestampSeconds, String sessionId, String namespaceId) {
         if (closed.get() || memoryId == null || text == null) {
             return false;
         }
@@ -123,8 +119,15 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
             return false;
         }
 
+        String effectiveSessionId = (sessionId != null && !sessionId.isBlank())
+                ? sessionId
+                : MemoryScope.sessionId();
+        String effectiveNamespaceId = (namespaceId != null && !namespaceId.isBlank())
+                ? namespaceId
+                : MemoryScope.namespaceId();
+
         EntityExtractionTask task = new EntityExtractionTask(
-                memoryId, text, memoryIdx, timestampSeconds, sessionId);
+                memoryId, text, memoryIdx, timestampSeconds, effectiveSessionId, effectiveNamespaceId);
         boolean accepted = queue.offer(task);
         if (accepted) {
             totalSubmitted.incrementAndGet();
@@ -136,17 +139,21 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
         return accepted;
     }
 
+    /**
+     * Backward-compatible overload submitting with scoped session ID.
+     */
+    public boolean submit(String memoryId, String text, int memoryIdx,
+                          long timestampSeconds, String sessionId) {
+        return submit(memoryId, text, memoryIdx, timestampSeconds, sessionId, MemoryScope.namespaceId());
+    }
+
     private void processLoop() {
         while (!closed.get() && !Thread.currentThread().isInterrupted()) {
             try {
                 EntityExtractionTask task = queue.poll(500, TimeUnit.MILLISECONDS);
                 if (task != null) {
                     Runnable worker = () -> processTask(task);
-                    if (task.sessionId() != null && !task.sessionId().isBlank()) {
-                        ScopedValue.where(MemoryScope.SESSION_ID, task.sessionId()).run(worker);
-                    } else {
-                        worker.run();
-                    }
+                    MemoryScope.runWithScope(task.sessionId(), task.namespaceId(), worker);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -203,23 +210,22 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
         );
     }
 
-    public int queueSize() {
-        return queue.size();
-    }
-
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
-            executor.shutdown();
-            try {
-                if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
-                    executor.shutdownNow();
+            log.info("[AsyncEntityExtractionQueue] Closing extraction queue, draining remaining {} tasks...",
+                    queue.size());
+            long deadline = System.currentTimeMillis() + 5000;
+            while (!queue.isEmpty() && System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
                 }
-            } catch (InterruptedException e) {
-                executor.shutdownNow();
-                Thread.currentThread().interrupt();
             }
-            log.info("[AsyncEntityExtractionQueue] Shutdown complete (remaining queue size: {})", queue.size());
+            log.info("[AsyncEntityExtractionQueue] Closed. Drained stats: processed={}, failed={}, remaining={}",
+                    totalProcessed.get(), totalFailed.get(), queue.size());
         }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueue.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueue.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline;
+
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Supervised asynchronous entity and relationship extraction queue.
+ *
+ * <h3>Architecture</h3>
+ * <p>Ingesting a memory must never block the client on slow LLM text-generation calls (~15s–25s).
+ * {@code AsyncEntityExtractionQueue} decouples entity extraction from the ingestion critical path,
+ * buffering tasks in a bounded FIFO queue and processing them via a supervised pool of virtual
+ * threads with configurable parallelism (defaulting to 1 for sequential execution to prevent
+ * Ollama/LLM concurrency congestion).</p>
+ *
+ * <h3>Scoped Context Propagation</h3>
+ * <p>Captures {@link MemoryScope#SESSION_ID} at submission time and re-binds it via {@link ScopedValue}
+ * in the executing virtual thread, ensuring session identity and temporal link contexts are preserved.</p>
+ */
+public final class AsyncEntityExtractionQueue implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncEntityExtractionQueue.class);
+
+    public record EntityExtractionTask(
+            String memoryId,
+            String text,
+            int memoryIdx,
+            long timestampSeconds,
+            String sessionId
+    ) {}
+
+    public record QueueStats(
+            int queueSize,
+            int queueCapacity,
+            int parallelism,
+            long totalSubmitted,
+            long totalProcessed,
+            long totalFailed,
+            long totalEntitiesExtracted,
+            long avgProcessingLatencyMs,
+            boolean isRunning
+    ) {}
+
+    private final BlockingQueue<EntityExtractionTask> queue;
+    private final int queueCapacity;
+    private final int parallelism;
+    private final EntityExtractor entityExtractor;
+    private final PostIngestSync postIngestSync;
+    private final ExecutorService executor;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private final AtomicLong totalSubmitted = new AtomicLong(0);
+    private final AtomicLong totalProcessed = new AtomicLong(0);
+    private final AtomicLong totalFailed = new AtomicLong(0);
+    private final AtomicLong totalEntitiesExtracted = new AtomicLong(0);
+    private final AtomicLong totalProcessingDurationMs = new AtomicLong(0);
+
+    public AsyncEntityExtractionQueue(
+            EntityExtractor entityExtractor,
+            PostIngestSync postIngestSync,
+            int parallelism,
+            int queueCapacity) {
+        this.entityExtractor = entityExtractor;
+        this.postIngestSync = Objects.requireNonNull(postIngestSync, "postIngestSync");
+        this.parallelism = Math.max(1, parallelism);
+        this.queueCapacity = Math.max(16, queueCapacity);
+        this.queue = new LinkedBlockingQueue<>(this.queueCapacity);
+
+        this.executor = Executors.newFixedThreadPool(
+                this.parallelism,
+                Thread.ofVirtual().name("spector-entity-extractor-", 0).factory()
+        );
+
+        for (int i = 0; i < this.parallelism; i++) {
+            this.executor.submit(this::processLoop);
+        }
+
+        log.info("[AsyncEntityExtractionQueue] Initialized with parallelism={}, capacity={}",
+                this.parallelism, this.queueCapacity);
+    }
+
+    /**
+     * Submits a memory for asynchronous entity extraction.
+     *
+     * @param memoryId         memory ID
+     * @param text             raw text content
+     * @param memoryIdx        graph slot / memory index
+     * @param timestampSeconds epoch timestamp in seconds
+     * @param sessionId        scoped session ID (nullable)
+     * @return true if accepted, false if dropped or closed
+     */
+    public boolean submit(String memoryId, String text, int memoryIdx,
+                          long timestampSeconds, String sessionId) {
+        if (closed.get() || memoryId == null || text == null) {
+            return false;
+        }
+        if (entityExtractor == null || !entityExtractor.isAvailable()) {
+            return false;
+        }
+
+        EntityExtractionTask task = new EntityExtractionTask(
+                memoryId, text, memoryIdx, timestampSeconds, sessionId);
+        boolean accepted = queue.offer(task);
+        if (accepted) {
+            totalSubmitted.incrementAndGet();
+        } else {
+            totalFailed.incrementAndGet();
+            log.warn("[AsyncEntityExtractionQueue] Queue full ({}/{}) - dropped task for '{}'",
+                    queue.size(), queueCapacity, memoryId);
+        }
+        return accepted;
+    }
+
+    private void processLoop() {
+        while (!closed.get() && !Thread.currentThread().isInterrupted()) {
+            try {
+                EntityExtractionTask task = queue.poll(500, TimeUnit.MILLISECONDS);
+                if (task != null) {
+                    Runnable worker = () -> processTask(task);
+                    if (task.sessionId() != null && !task.sessionId().isBlank()) {
+                        ScopedValue.where(MemoryScope.SESSION_ID, task.sessionId()).run(worker);
+                    } else {
+                        worker.run();
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.warn("[AsyncEntityExtractionQueue] Worker loop error: {}", e.getMessage(), e);
+            }
+        }
+    }
+
+    private void processTask(EntityExtractionTask task) {
+        if (entityExtractor == null || !entityExtractor.isAvailable()) {
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        try {
+            List<ExtractedEntity> entities = entityExtractor.extract(task.memoryId(), task.text());
+            if (entities != null && !entities.isEmpty()) {
+                postIngestSync.syncPreExtractedEntities(entities, task.memoryIdx(), task.memoryId());
+                postIngestSync.syncTemporalFacts(entities, task.memoryIdx(), task.memoryId(), task.timestampSeconds());
+                totalEntitiesExtracted.addAndGet(entities.size());
+            }
+
+            long elapsed = System.currentTimeMillis() - start;
+            totalProcessingDurationMs.addAndGet(elapsed);
+            totalProcessed.incrementAndGet();
+
+            log.debug("[AsyncEntityExtractionQueue] Extracted {} entities for '{}' in {} ms (queueDepth={})",
+                    entities != null ? entities.size() : 0, task.memoryId(), elapsed, queue.size());
+        } catch (Exception e) {
+            totalFailed.incrementAndGet();
+            log.warn("[AsyncEntityExtractionQueue] Extraction failed for '{}': {}",
+                    task.memoryId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns current telemetry and stats for the extraction queue.
+     */
+    public QueueStats stats() {
+        long processed = totalProcessed.get();
+        long avgLatency = processed > 0 ? (totalProcessingDurationMs.get() / processed) : 0;
+        return new QueueStats(
+                queue.size(),
+                queueCapacity,
+                parallelism,
+                totalSubmitted.get(),
+                processed,
+                totalFailed.get(),
+                totalEntitiesExtracted.get(),
+                avgLatency,
+                !closed.get()
+        );
+    }
+
+    public int queueSize() {
+        return queue.size();
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            executor.shutdown();
+            try {
+                if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+            log.info("[AsyncEntityExtractionQueue] Shutdown complete (remaining queue size: {})", queue.size());
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -16,48 +16,30 @@ import com.spectrayan.spector.core.quantization.ScalarQuantizer;
 import com.spectrayan.spector.core.similarity.VectorOps;
 import com.spectrayan.spector.index.VectorIndex;
 import com.spectrayan.spector.ingestion.IngestionTarget;
-import com.spectrayan.spector.memory.model.MemoryType;
-import com.spectrayan.spector.memory.model.SourceModality;
-import com.spectrayan.spector.memory.cortex.MemorySource;
-import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
-import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
+import com.spectrayan.spector.memory.DataEncryptor;
+import com.spectrayan.spector.memory.ImportanceProvider;
+import com.spectrayan.spector.memory.cortex.*;
 import com.spectrayan.spector.memory.dopamine.FlashbulbPolicy;
 import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
+import com.spectrayan.spector.memory.error.SpectorMemoryTierFullException;
 import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
-import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
-import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
-import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
-import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
-import com.spectrayan.spector.memory.DataEncryptor;
-import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.model.*;
+import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
+import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
 import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
+import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
-import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
-import com.spectrayan.spector.memory.cortex.MemorySpladeIndex;
-import com.spectrayan.spector.memory.cortex.TextAppendMemory;
-
 import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
-import com.spectrayan.spector.provider.embedding.SparseEmbeddingResult;
-
-import com.spectrayan.spector.memory.error.SpectorEntityGraphException;
-import com.spectrayan.spector.memory.error.SpectorHebbianException;
-import com.spectrayan.spector.memory.error.SpectorMemoryTierFullException;
-import com.spectrayan.spector.memory.error.SpectorTemporalChainException;
-import com.spectrayan.spector.memory.model.SalienceProfile;
-import com.spectrayan.spector.memory.ImportanceProvider;
-import com.spectrayan.spector.memory.model.ImportanceContext;
-import com.spectrayan.spector.memory.model.ImportanceResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -534,13 +516,14 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         // index.size()-1 which is non-monotonic (shrinks on forget, causing reuse).
         int memoryIdx = graphSlot;
         String tsid = com.spectrayan.spector.commons.concurrent.MemoryScope.sessionId();
+        String nsid = com.spectrayan.spector.commons.concurrent.MemoryScope.namespaceId();
         int sessionIntId = sessionRegistry != null ? sessionRegistry.resolve(tsid) : 0;
         int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);
         postIngestSync.syncGraphEdges(memoryIdx, previousIdx, sessionIntId);
 
         // Step 9d: Entity extraction and graph population (asynchronous / non-blocking)
         if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
-            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid);
+            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid, nsid);
         } else {
             List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
             postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
@@ -797,7 +780,8 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             postIngestSync.syncPreExtractedEntities(context.entities(), memoryIdx, id);
             postIngestSync.syncTemporalFacts(context.entities(), memoryIdx, id, header.timestampMs() / 1000);
         } else if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
-            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid);
+            String nsid = com.spectrayan.spector.commons.concurrent.MemoryScope.namespaceId();
+            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid, nsid);
         } else {
             List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
             postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -142,6 +142,9 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     //  Post-ingest index synchronization stage 
     private final PostIngestSync postIngestSync;
 
+    //  Asynchronous entity extraction queue (non-blocking ingestion)
+    private final AsyncEntityExtractionQueue asyncEntityExtractionQueue;
+
     //  Partition rolling callback (nullable) 
     private volatile Runnable partitionRollCallback;
 
@@ -175,12 +178,10 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                 hebbianGraph, temporalChain, entityExtractor,
                 entityDirectory, hyperEntityGraph, temporalKnowledgeGraph,
                 bm25Index, textDataStore, activePartitionIndex,
-                spladeIndex, spladeProvider, DataEncryptor.NOOP, importanceProvider, sessionRegistry);
+                spladeIndex, spladeProvider, DataEncryptor.NOOP, importanceProvider, sessionRegistry,
+                1, 1000);
     }
 
-    /**
-     * Full constructor with data encryption support.
-     */
     public CognitiveIngestionTarget(ScalarQuantizer quantizer,
                                      SurpriseDetector surpriseDetector,
                                      FlashbulbPolicy flashbulbPolicy,
@@ -206,6 +207,46 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                                      DataEncryptor encryptor,
                                      ImportanceProvider importanceProvider,
                                      com.spectrayan.spector.memory.session.SessionRegistry sessionRegistry) {
+        this(quantizer, surpriseDetector, flashbulbPolicy, cognitiveRouter,
+                index, wal, workingStore, icnuWeights, semanticIndex,
+                tagExtractor, normalizeAtIngest,
+                hebbianGraph, temporalChain, entityExtractor,
+                entityDirectory, hyperEntityGraph, temporalKnowledgeGraph,
+                bm25Index, textDataStore, activePartitionIndex,
+                spladeIndex, spladeProvider, encryptor, importanceProvider, sessionRegistry,
+                1, 1000);
+    }
+
+    /**
+     * Full constructor with data encryption and async entity extraction configuration support.
+     */
+    public CognitiveIngestionTarget(ScalarQuantizer quantizer,
+                                     SurpriseDetector surpriseDetector,
+                                     FlashbulbPolicy flashbulbPolicy,
+                                     CognitiveMemoryRouter cognitiveRouter,
+                                     MemoryIndex index,
+                                     MemoryWal wal,
+                                     WorkingRecordMemory workingStore,
+                                     IcnuWeights icnuWeights,
+                                     VectorIndex semanticIndex,
+                                     TagExtractor tagExtractor,
+                                     boolean normalizeAtIngest,
+                                     HebbianGraphBase hebbianGraph,
+                                     TemporalChainMemory temporalChain,
+                                     EntityExtractor entityExtractor,
+                                     EntityDirectory entityDirectory,
+                                     HyperEntityGraphMemory hyperEntityGraph,
+                                     com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph temporalKnowledgeGraph,
+                                     MemoryBM25Index bm25Index,
+                                     TextAppendMemory textDataStore,
+                                     int activePartitionIndex,
+                                     MemorySpladeIndex spladeIndex,
+                                     SparseEmbeddingProvider spladeProvider,
+                                     DataEncryptor encryptor,
+                                     ImportanceProvider importanceProvider,
+                                     com.spectrayan.spector.memory.session.SessionRegistry sessionRegistry,
+                                     int entityExtractionParallelism,
+                                     int entityExtractionQueueCapacity) {
         this.quantizer = quantizer;
         this.surpriseDetector = surpriseDetector;
         this.flashbulbPolicy = flashbulbPolicy;
@@ -237,6 +278,9 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
                 hebbianGraph, temporalChain, entityExtractor, entityDirectory,
                 bm25Index, textDataStore, activePartitionIndex,
                 spladeIndex, spladeProvider, this.encryptor, hyperEntityGraph, temporalKnowledgeGraph);
+        this.asyncEntityExtractionQueue = new AsyncEntityExtractionQueue(
+                entityExtractor, this.postIngestSync,
+                entityExtractionParallelism, entityExtractionQueueCapacity);
     }
 
     /**
@@ -494,9 +538,13 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);
         postIngestSync.syncGraphEdges(memoryIdx, previousIdx, sessionIntId);
 
-        // Step 9d: Entity extraction and graph population
-        List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
-        postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
+        // Step 9d: Entity extraction and graph population (asynchronous / non-blocking)
+        if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
+            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid);
+        } else {
+            List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
+            postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
+        }
 
         log.debug("Ingested '{}' as {} (importance={}, {} tags, graphSlot={}, source={})",
                 id, type, importance, tags.length, graphSlot, source);
@@ -745,14 +793,15 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         }
 
         // Step 9d: Entity extraction and graph population
-        List<ExtractedEntity> extractedEntities;
         if (context.hasEntities()) {
             postIngestSync.syncPreExtractedEntities(context.entities(), memoryIdx, id);
-            extractedEntities = context.entities();
+            postIngestSync.syncTemporalFacts(context.entities(), memoryIdx, id, header.timestampMs() / 1000);
+        } else if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
+            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid);
         } else {
-            extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
+            List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
+            postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
         }
-        postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
 
         log.debug("Ingested '{}' as {} with IngestionContext (importance={}, {} tags, entities={}, hebbianEdges={}, temporalLinks={})",
                 id, type, importance, tags.length,
@@ -857,5 +906,18 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
             beta = cogProfile.beta();
         }
         return SynapticHeaderConstants.quantizeWeight(beta);
+    }
+
+    /**
+     * Returns the asynchronous entity extraction queue.
+     */
+    public AsyncEntityExtractionQueue asyncEntityExtractionQueue() {
+        return asyncEntityExtractionQueue;
+    }
+
+    public void close() {
+        if (asyncEntityExtractionQueue != null) {
+            asyncEntityExtractionQueue.close();
+        }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -306,11 +306,29 @@ final class GraphExpansionStage {
         if (!options.entityHints().isEmpty()) {
             queryEntities = options.entityHints();
         }
-        // Priority 2: Live EntityExtractor SPI
+        // Priority 2: Fast zero-LLM directory lookup from top seed candidate's indexed slot
+        else if (entityDirectory != null && index != null && !allResults.isEmpty()) {
+            CognitiveResult topResult = allResults.getFirst();
+            MemoryIndex.MemoryLocation loc = index.locate(topResult.id());
+            if (loc != null) {
+                int slot = loc.graphSlot() >= 0 ? loc.graphSlot() : (int) (loc.offset() / 164);
+                List<Integer> seedEntityIds = com.spectrayan.spector.memory.consolidation.CadpContradictionResolver
+                        .findEntitiesForSlot(entityDirectory, slot);
+                if (seedEntityIds != null && !seedEntityIds.isEmpty()) {
+                    queryEntities = new java.util.ArrayList<>(seedEntityIds.size());
+                    for (int eid : seedEntityIds) {
+                        String name = entityDirectory.entityName(eid);
+                        String type = entityDirectory.entityType(eid);
+                        if (name != null) {
+                            queryEntities.add(new ExtractedEntity(name, type != null ? type : "UNKNOWN", List.of()));
+                        }
+                    }
+                }
+            }
+        }
+        // Priority 3: Fallback to live EntityExtractor SPI only if no directory entities found
         else if (entityExtractor != null && entityExtractor.isAvailable()) {
             try {
-                // We don't have the query text here — extract from first result
-                // This is a compromise vs. passing queryText through the stage
                 queryEntities = entityExtractor.extract("query", allResults.getFirst().text());
             } catch (RuntimeException e) {
                 SpectorEntityGraphException ex = new SpectorEntityGraphException("entity extraction", e);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -449,7 +449,7 @@ public final class RecallPipeline {
                 calibrationMins, calibrationScales);
         
         this.temporalFactWeavingStage = new com.spectrayan.spector.memory.pipeline.graph.TemporalFactWeavingStage(
-                temporalKnowledgeGraph, entityDirectory, entityExtractor);
+                temporalKnowledgeGraph, entityDirectory, entityExtractor, index);
     }
 
     public PartitionPruner partitionPruner() { return partitionPruner; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/graph/TemporalFactWeavingStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/graph/TemporalFactWeavingStage.java
@@ -14,9 +14,11 @@ package com.spectrayan.spector.memory.pipeline.graph;
 
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.memory.temporal.TemporalFact;
+import com.spectrayan.spector.memory.consolidation.CadpContradictionResolver;
 import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import org.slf4j.Logger;
@@ -35,11 +37,18 @@ public final class TemporalFactWeavingStage {
     private final TemporalKnowledgeGraph tkg;
     private final EntityDirectory entityDirectory;
     private final EntityExtractor entityExtractor;
+    private final MemoryIndex index;
     
     public TemporalFactWeavingStage(TemporalKnowledgeGraph tkg, EntityDirectory entityDirectory, EntityExtractor entityExtractor) {
+        this(tkg, entityDirectory, entityExtractor, null);
+    }
+
+    public TemporalFactWeavingStage(TemporalKnowledgeGraph tkg, EntityDirectory entityDirectory,
+                                    EntityExtractor entityExtractor, MemoryIndex index) {
         this.tkg = tkg;
         this.entityDirectory = entityDirectory;
         this.entityExtractor = entityExtractor;
+        this.index = index;
     }
     
     public void weave(List<CognitiveResult> candidates, float[] queryVector, RecallOptions options) {
@@ -50,33 +59,52 @@ public final class TemporalFactWeavingStage {
         for (int i = 0; i < candidates.size(); i++) {
             CognitiveResult candidate = candidates.get(i);
             try {
-                if (entityExtractor != null && entityExtractor.isAvailable()) {
-                    List<ExtractedEntity> entities = entityExtractor.extract(candidate.id(), candidate.text());
-                    if (entities == null || entities.isEmpty()) continue;
-                    
-                    int validFactsCount = 0;
-                    for (ExtractedEntity entity : entities) {
-                        if (entityDirectory != null) {
-                            int entityId = entityDirectory.findEntity(entity.name());
-                            if (entityId < 0) continue;
-                            
-                            List<TemporalFact> facts = tkg.factsAbout(entityId).validAt(asOf).resolve();
-                            if (facts != null && !facts.isEmpty()) {
-                                validFactsCount += facts.size();
+                int validFactsCount = 0;
+
+                // Priority 1: Fast O(1) off-heap lookup via EntityDirectory index slot
+                if (entityDirectory != null && index != null) {
+                    MemoryIndex.MemoryLocation loc = index.locate(candidate.id());
+                    if (loc != null) {
+                        int slot = loc.graphSlot() >= 0 ? loc.graphSlot() : (int) (loc.offset() / 164);
+                        List<Integer> entityIds = CadpContradictionResolver.findEntitiesForSlot(entityDirectory, slot);
+                        if (entityIds != null && !entityIds.isEmpty()) {
+                            for (int entityId : entityIds) {
+                                List<TemporalFact> facts = tkg.factsAbout(entityId).validAt(asOf).resolve();
+                                if (facts != null && !facts.isEmpty()) {
+                                    validFactsCount += facts.size();
+                                }
                             }
                         }
                     }
-                    
-                    if (validFactsCount > 0) {
-                        java.util.Map<String, String> meta = candidate.metadata();
-                        if (meta == null) {
-                            meta = new java.util.HashMap<>();
-                        } else {
-                            meta = new java.util.HashMap<>(meta);
+                }
+
+                // Priority 2: Fallback to live EntityExtractor only if not found in directory
+                if (validFactsCount == 0 && index == null && entityExtractor != null && entityExtractor.isAvailable()) {
+                    List<ExtractedEntity> entities = entityExtractor.extract(candidate.id(), candidate.text());
+                    if (entities != null && !entities.isEmpty()) {
+                        for (ExtractedEntity entity : entities) {
+                            if (entityDirectory != null) {
+                                int entityId = entityDirectory.findEntity(entity.name());
+                                if (entityId >= 0) {
+                                    List<TemporalFact> facts = tkg.factsAbout(entityId).validAt(asOf).resolve();
+                                    if (facts != null && !facts.isEmpty()) {
+                                        validFactsCount += facts.size();
+                                    }
+                                }
+                            }
                         }
-                        meta.put("tkg_valid_facts", String.valueOf(validFactsCount));
-                        candidates.set(i, candidate.withModality(candidate.sourceModality(), meta));
                     }
+                }
+                
+                if (validFactsCount > 0) {
+                    java.util.Map<String, String> meta = candidate.metadata();
+                    if (meta == null) {
+                        meta = new java.util.HashMap<>();
+                    } else {
+                        meta = new java.util.HashMap<>(meta);
+                    }
+                    meta.put("tkg_valid_facts", String.valueOf(validFactsCount));
+                    candidates.set(i, candidate.withModality(candidate.sourceModality(), meta));
                 }
             } catch (Exception e) {
                 log.debug("Failed to weave temporal facts for candidate '{}': {}", candidate.id(), e.getMessage());

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/EagerConsolidationAndTraversalsIntegrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/EagerConsolidationAndTraversalsIntegrationTest.java
@@ -118,7 +118,7 @@ class EagerConsolidationAndTraversalsIntegrationTest {
     }
 
     @Test
-    void testTemporalBridge_retractsTemporalFactsOnContradiction() {
+    void testTemporalBridge_retractsTemporalFactsOnContradiction() throws Exception {
         float[] vector = new float[DIMENSIONS];
         vector[4] = 1.0f;
 
@@ -142,15 +142,29 @@ class EagerConsolidationAndTraversalsIntegrationTest {
         assertThat(activeBefore).hasSize(1);
         assertThat(activeBefore.get(0).factId()).isEqualTo(factId);
 
-        // Store contradictory memories
+        // Store contradictory memories (loc-2 is strictly newer)
         memory.remember("loc-1", textA, MemoryType.SEMANTIC, MemorySource.OBSERVED, "location");
+        Thread.sleep(20);
         memory.remember("loc-2", textB, MemoryType.SEMANTIC, MemorySource.OBSERVED, "location");
 
-        // Run consolidation
-        memory.consolidate();
+        // Await async eager consolidation or trigger consolidation
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            CognitiveRecord r1 = memory.inspect("loc-1");
+            if (r1 != null && r1.isContradicted()) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+
+        // Run batch consolidation fallback if not already resolved by eager consolidator
+        CognitiveRecord record1 = memory.inspect("loc-1");
+        if (record1 == null || !record1.isContradicted()) {
+            memory.consolidate();
+            record1 = memory.inspect("loc-1");
+        }
 
         // Check that CADP resolved
-        CognitiveRecord record1 = memory.inspect("loc-1");
         CognitiveRecord record2 = memory.inspect("loc-2");
         assertThat(record1.isContradicted()).isTrue();
         assertThat(record2.isContradicted()).isFalse();

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueueTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueueTest.java
@@ -57,7 +57,7 @@ class AsyncEntityExtractionQueueTest {
 
         try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
             boolean accepted = queue.submit("mem-1", "Alice is a software engineer.",
-                    42, 1700000000L, "session-abc");
+                    42, 1700000000L, "session-abc", "ns-tenant-1");
 
             assertThat(accepted).isTrue();
 
@@ -73,25 +73,28 @@ class AsyncEntityExtractionQueueTest {
     }
 
     @Test
-    @DisplayName("Propagates MemoryScope.SESSION_ID into the executing virtual thread")
+    @DisplayName("Propagates MemoryScope.SESSION_ID and NAMESPACE_ID into the executing virtual thread")
     void testMemoryScopePropagation() throws Exception {
         when(entityExtractor.isAvailable()).thenReturn(true);
 
         AtomicReference<String> capturedSessionId = new AtomicReference<>();
+        AtomicReference<String> capturedNamespaceId = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
 
         when(entityExtractor.extract(anyString(), anyString())).thenAnswer(invocation -> {
             capturedSessionId.set(MemoryScope.sessionId());
+            capturedNamespaceId.set(MemoryScope.namespaceId());
             latch.countDown();
             return List.of(new ExtractedEntity("Bob", "PERSON", List.of()));
         });
 
         try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
-            queue.submit("mem-2", "Bob works with Alice.", 10, 1700000000L, "scoped-session-999");
+            queue.submit("mem-2", "Bob works with Alice.", 10, 1700000000L, "scoped-session-999", "scoped-ns-888");
 
             boolean completed = latch.await(3, TimeUnit.SECONDS);
             assertThat(completed).isTrue();
             assertThat(capturedSessionId.get()).isEqualTo("scoped-session-999");
+            assertThat(capturedNamespaceId.get()).isEqualTo("scoped-ns-888");
         }
     }
 
@@ -103,7 +106,7 @@ class AsyncEntityExtractionQueueTest {
         try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
             boolean accepted = queue.submit("mem-3", "Some text", 1, 1700000000L, null);
             assertThat(accepted).isFalse();
-            assertThat(queue.queueSize()).isEqualTo(0);
+            assertThat(queue.stats().queueSize()).isEqualTo(0);
         }
     }
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueueTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueueTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline;
+
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncEntityExtractionQueueTest {
+
+    @Mock
+    private EntityExtractor entityExtractor;
+
+    @Mock
+    private PostIngestSync postIngestSync;
+
+    @Test
+    @DisplayName("Submits task and processes asynchronously without blocking caller")
+    void testAsyncSubmissionAndProcessing() throws Exception {
+        when(entityExtractor.isAvailable()).thenReturn(true);
+        List<ExtractedEntity> entities = List.of(
+                new ExtractedEntity("Alice", "PERSON", List.of())
+        );
+        when(entityExtractor.extract("mem-1", "Alice is a software engineer."))
+                .thenReturn(entities);
+
+        try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
+            boolean accepted = queue.submit("mem-1", "Alice is a software engineer.",
+                    42, 1700000000L, "session-abc");
+
+            assertThat(accepted).isTrue();
+
+            verify(postIngestSync, timeout(2000)).syncPreExtractedEntities(eq(entities), eq(42), eq("mem-1"));
+            verify(postIngestSync, timeout(2000)).syncTemporalFacts(eq(entities), eq(42), eq("mem-1"), eq(1700000000L));
+
+            var stats = queue.stats();
+            assertThat(stats.totalSubmitted()).isEqualTo(1);
+            assertThat(stats.totalProcessed()).isEqualTo(1);
+            assertThat(stats.totalEntitiesExtracted()).isEqualTo(1);
+            assertThat(stats.totalFailed()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    @DisplayName("Propagates MemoryScope.SESSION_ID into the executing virtual thread")
+    void testMemoryScopePropagation() throws Exception {
+        when(entityExtractor.isAvailable()).thenReturn(true);
+
+        AtomicReference<String> capturedSessionId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        when(entityExtractor.extract(anyString(), anyString())).thenAnswer(invocation -> {
+            capturedSessionId.set(MemoryScope.sessionId());
+            latch.countDown();
+            return List.of(new ExtractedEntity("Bob", "PERSON", List.of()));
+        });
+
+        try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
+            queue.submit("mem-2", "Bob works with Alice.", 10, 1700000000L, "scoped-session-999");
+
+            boolean completed = latch.await(3, TimeUnit.SECONDS);
+            assertThat(completed).isTrue();
+            assertThat(capturedSessionId.get()).isEqualTo("scoped-session-999");
+        }
+    }
+
+    @Test
+    @DisplayName("Gracefully ignores submissions when entity extractor is unavailable")
+    void testExtractorUnavailable() {
+        when(entityExtractor.isAvailable()).thenReturn(false);
+
+        try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
+            boolean accepted = queue.submit("mem-3", "Some text", 1, 1700000000L, null);
+            assertThat(accepted).isFalse();
+            assertThat(queue.queueSize()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    @DisplayName("Gracefully rejects tasks after shutdown")
+    void testShutdownRejection() {
+        var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100);
+        queue.close();
+
+        boolean accepted = queue.submit("mem-4", "Some text", 1, 1700000000L, null);
+        assertThat(accepted).isFalse();
+        assertThat(queue.stats().isRunning()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Tracks failed extraction attempts and updates failure counter")
+    void testExtractionFailureHandling() throws Exception {
+        when(entityExtractor.isAvailable()).thenReturn(true);
+        CountDownLatch latch = new CountDownLatch(1);
+        when(entityExtractor.extract("mem-err", "Err text")).thenAnswer(inv -> {
+            latch.countDown();
+            throw new RuntimeException("LLM timeout");
+        });
+
+        try (var queue = new AsyncEntityExtractionQueue(entityExtractor, postIngestSync, 1, 100)) {
+            queue.submit("mem-err", "Err text", 5, 1700000000L, null);
+
+            boolean completed = latch.await(3, TimeUnit.SECONDS);
+            assertThat(completed).isTrue();
+            Thread.sleep(50);
+            assertThat(queue.stats().totalFailed()).isGreaterThanOrEqualTo(1);
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/graph/TemporalFactWeavingStageTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/graph/TemporalFactWeavingStageTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pipeline.graph;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.graph.EntityDirectory;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.index.IndexRecordMemory;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.temporal.TemporalFact;
+import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
+import com.spectrayan.spector.memory.temporal.TemporalQuery;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TemporalFactWeavingStageTest {
+
+    @Mock
+    private TemporalKnowledgeGraph tkg;
+
+    @Mock
+    private EntityDirectory entityDirectory;
+
+    @Mock
+    private EntityExtractor entityExtractor;
+
+    @Mock
+    private MemoryIndex index;
+
+    @Test
+    @DisplayName("Weaves temporal facts via fast EntityDirectory and index slot without calling LLM extractor")
+    void testFastZeroLlmWeaving() {
+        when(tkg.factCount()).thenReturn(5);
+
+        IndexRecordMemory.MemoryLocation loc = new IndexRecordMemory.MemoryLocation(MemoryType.SEMANTIC, 0L, 7);
+        when(index.locate("mem-100")).thenReturn(loc);
+
+        // Slot 7 is linked to entity ID 3
+        when(entityDirectory.entityCount()).thenReturn(4);
+        when(entityDirectory.memoryRefCount(anyInt())).thenReturn(0);
+        when(entityDirectory.memoryRefCount(3)).thenReturn(1);
+        when(entityDirectory.memoryRefAt(3, 0)).thenReturn(7);
+
+        var fluentQuery = mock(TemporalQuery.class);
+        when(tkg.factsAbout(3)).thenReturn(fluentQuery);
+        when(fluentQuery.validAt(any())).thenReturn(fluentQuery);
+        var mockFact = new TemporalFact(
+                1, 3, 10, 4, 0L, (short) 0, 1000L, Long.MAX_VALUE, 1000L, 0.9f, -1, (byte) 0);
+        when(fluentQuery.resolve()).thenReturn(List.of(mockFact));
+
+        var stage = new TemporalFactWeavingStage(tkg, entityDirectory, entityExtractor, index);
+
+        CognitiveResult candidate = new CognitiveResult(
+                "mem-100", "Alice works at Spectrayan", 0.95f, 0.8f,
+                0f, 1, (byte) 0, MemoryType.SEMANTIC, MemorySource.USER_STATED,
+                new String[]{"work"}, 0.95f, 0.95f
+        );
+        List<CognitiveResult> candidates = new ArrayList<>(List.of(candidate));
+
+        stage.weave(candidates, new float[768], RecallOptions.builder().topK(5).build());
+
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.getFirst().metadata()).containsEntry("tkg_valid_facts", "1");
+
+        // Verify EntityExtractor was NEVER called
+        verify(entityExtractor, never()).extract(any(), any());
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/ConcurrentTasks.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/ConcurrentTasks.java
@@ -147,6 +147,25 @@ public final class ConcurrentTasks {
     }
 
     /**
+     * Submits a task for asynchronous execution on a virtual thread with bound
+     * {@link MemoryScope} session and namespace contexts.
+     *
+     * @param sessionId   scoped session ID (nullable)
+     * @param namespaceId scoped namespace ID (nullable)
+     * @param task        the work to execute asynchronously
+     */
+    public static void fireAndForget(String sessionId, String namespaceId, Runnable task) {
+        FIRE_FORGET_EXECUTOR.submit(() -> {
+            try {
+                MemoryScope.runWithScope(sessionId, namespaceId, task);
+            } catch (Exception e) {
+                log.log(System.Logger.Level.WARNING, "Scoped fire-and-forget task failed: " + e.getMessage(), e);
+            }
+        });
+    }
+
+
+    /**
      * Returns the shared virtual-thread-per-task executor.
      *
      * <p>Use this when you need a {@link java.util.concurrent.CompletableFuture} handle

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/MemoryScope.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/MemoryScope.java
@@ -15,17 +15,20 @@
  */
 package com.spectrayan.spector.commons.concurrent;
 
+import java.util.concurrent.Callable;
+
 /**
- * {@link ScopedValue}-based carrier for the memory session ID.
+ * {@link ScopedValue}-based carrier for memory session and namespace context in Java 25.
  *
- * <p>Allows the session ID to be passed anywhere in the call stack
- * without constructor injection.</p>
+ * <p>Allows the session ID and namespace ID to be propagated anywhere in the call stack
+ * and across virtual thread boundaries without constructor injection or manual carrier objects.</p>
  *
- * @see com.spectrayan.spector.events.TelemetryScope
+ * @see com.spectrayan.spector.commons.concurrent.ConcurrentTasks
  */
 public final class MemoryScope {
 
     public static final ScopedValue<String> SESSION_ID = ScopedValue.newInstance();
+    public static final ScopedValue<String> NAMESPACE_ID = ScopedValue.newInstance();
 
     private MemoryScope() {}
 
@@ -42,11 +45,92 @@ public final class MemoryScope {
     }
 
     /**
+     * Returns the namespace ID if bound in the current scope, null otherwise.
+     *
+     * @return the namespace ID or null
+     */
+    public static String namespaceId() {
+        if (NAMESPACE_ID.isBound()) {
+            return NAMESPACE_ID.get();
+        }
+        return null;
+    }
+
+    /**
      * Returns true if a session ID is bound in the current scope.
      *
      * @return true if session ID is active in this call stack
      */
-    public static boolean isActive() {
+    public static boolean isSessionActive() {
         return SESSION_ID.isBound();
+    }
+
+    /**
+     * Returns true if a namespace ID is bound in the current scope.
+     *
+     * @return true if namespace ID is active in this call stack
+     */
+    public static boolean isNamespaceActive() {
+        return NAMESPACE_ID.isBound();
+    }
+
+    /**
+     * Backward-compatible alias for {@link #isSessionActive()}.
+     *
+     * @return true if session ID is active in this call stack
+     */
+    public static boolean isActive() {
+        return isSessionActive();
+    }
+
+    /**
+     * Executes a {@link Runnable} within a bound session and namespace scope.
+     *
+     * @param sessionId   session ID to bind (optional)
+     * @param namespaceId namespace ID to bind (optional)
+     * @param task        the runnable task to execute
+     */
+    public static void runWithScope(String sessionId, String namespaceId, Runnable task) {
+        boolean hasSession = sessionId != null && !sessionId.isBlank();
+        boolean hasNamespace = namespaceId != null && !namespaceId.isBlank();
+
+        if (hasSession && hasNamespace) {
+            ScopedValue.where(SESSION_ID, sessionId)
+                    .where(NAMESPACE_ID, namespaceId)
+                    .run(task);
+        } else if (hasSession) {
+            ScopedValue.where(SESSION_ID, sessionId).run(task);
+        } else if (hasNamespace) {
+            ScopedValue.where(NAMESPACE_ID, namespaceId).run(task);
+        } else {
+            task.run();
+        }
+    }
+
+    /**
+     * Executes a {@link Callable} within a bound session and namespace scope.
+     *
+     * @param sessionId   session ID to bind (optional)
+     * @param namespaceId namespace ID to bind (optional)
+     * @param task        the callable task to execute
+     * @param <T>         return type
+     * @return result of the task
+     * @throws Exception if task throws
+     */
+    public static <T> T callWithScope(String sessionId, String namespaceId, Callable<T> task) throws Exception {
+        boolean hasSession = sessionId != null && !sessionId.isBlank();
+        boolean hasNamespace = namespaceId != null && !namespaceId.isBlank();
+
+        if (hasSession && hasNamespace) {
+            return ScopedValue.where(SESSION_ID, sessionId)
+                    .where(NAMESPACE_ID, namespaceId)
+                    .call(task::call);
+        } else if (hasSession) {
+            return ScopedValue.where(SESSION_ID, sessionId).call(task::call);
+        } else if (hasNamespace) {
+            return ScopedValue.where(NAMESPACE_ID, namespaceId).call(task::call);
+        } else {
+            return task.call();
+        }
     }
 }

--- a/nucleus/spector-commons/src/test/java/com/spectrayan/spector/commons/concurrent/MemoryScopeTest.java
+++ b/nucleus/spector-commons/src/test/java/com/spectrayan/spector/commons/concurrent/MemoryScopeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MemoryScope} — Java 25 ScopedValue carrier for session and namespace contexts.
+ */
+@DisplayName("MemoryScope")
+class MemoryScopeTest {
+
+    @Test
+    @DisplayName("unbound scope returns null and false")
+    void unboundScope() {
+        assertThat(MemoryScope.sessionId()).isNull();
+        assertThat(MemoryScope.namespaceId()).isNull();
+        assertThat(MemoryScope.isSessionActive()).isFalse();
+        assertThat(MemoryScope.isNamespaceActive()).isFalse();
+        assertThat(MemoryScope.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("runWithScope binds both session and namespace")
+    void runWithBothScopes() {
+        AtomicReference<String> seenSession = new AtomicReference<>();
+        AtomicReference<String> seenNamespace = new AtomicReference<>();
+        AtomicBoolean seenActive = new AtomicBoolean(false);
+
+        MemoryScope.runWithScope("sess-123", "ns-456", () -> {
+            seenSession.set(MemoryScope.sessionId());
+            seenNamespace.set(MemoryScope.namespaceId());
+            seenActive.set(MemoryScope.isSessionActive() && MemoryScope.isNamespaceActive());
+        });
+
+        assertThat(seenSession.get()).isEqualTo("sess-123");
+        assertThat(seenNamespace.get()).isEqualTo("ns-456");
+        assertThat(seenActive.get()).isTrue();
+
+        // Ensure unbound after exit
+        assertThat(MemoryScope.sessionId()).isNull();
+        assertThat(MemoryScope.namespaceId()).isNull();
+    }
+
+    @Test
+    @DisplayName("callWithScope binds both session and namespace and returns value")
+    void callWithBothScopes() throws Exception {
+        String result = MemoryScope.callWithScope("sess-abc", "ns-xyz", () -> {
+            assertThat(MemoryScope.sessionId()).isEqualTo("sess-abc");
+            assertThat(MemoryScope.namespaceId()).isEqualTo("ns-xyz");
+            return MemoryScope.sessionId() + ":" + MemoryScope.namespaceId();
+        });
+
+        assertThat(result).isEqualTo("sess-abc:ns-xyz");
+        assertThat(MemoryScope.sessionId()).isNull();
+        assertThat(MemoryScope.namespaceId()).isNull();
+    }
+
+    @Test
+    @DisplayName("runWithScope handles nullable or blank parameters gracefully")
+    void runWithPartialScope() {
+        AtomicReference<String> seenSession = new AtomicReference<>();
+        AtomicReference<String> seenNamespace = new AtomicReference<>();
+
+        // Only session
+        MemoryScope.runWithScope("sess-only", null, () -> {
+            seenSession.set(MemoryScope.sessionId());
+            seenNamespace.set(MemoryScope.namespaceId());
+        });
+        assertThat(seenSession.get()).isEqualTo("sess-only");
+        assertThat(seenNamespace.get()).isNull();
+
+        // Only namespace
+        MemoryScope.runWithScope(null, "ns-only", () -> {
+            seenSession.set(MemoryScope.sessionId());
+            seenNamespace.set(MemoryScope.namespaceId());
+        });
+        assertThat(seenSession.get()).isNull();
+        assertThat(seenNamespace.get()).isEqualTo("ns-only");
+
+        // Neither
+        MemoryScope.runWithScope("", "  ", () -> {
+            seenSession.set(MemoryScope.sessionId());
+            seenNamespace.set(MemoryScope.namespaceId());
+        });
+        assertThat(seenSession.get()).isNull();
+        assertThat(seenNamespace.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("ConcurrentTasks fireAndForget propagates scope to virtual thread")
+    void concurrentTasksFireAndForgetScope() throws InterruptedException {
+        AtomicReference<String> seenSession = new AtomicReference<>();
+        AtomicReference<String> seenNamespace = new AtomicReference<>();
+        AtomicBoolean done = new AtomicBoolean(false);
+
+        ConcurrentTasks.fireAndForget("sess-async", "ns-async", () -> {
+            seenSession.set(MemoryScope.sessionId());
+            seenNamespace.set(MemoryScope.namespaceId());
+            done.set(true);
+        });
+
+        long deadline = System.currentTimeMillis() + 3000;
+        while (!done.get() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+
+        assertThat(done.get()).isTrue();
+        assertThat(seenSession.get()).isEqualTo("sess-async");
+        assertThat(seenNamespace.get()).isEqualTo("ns-async");
+    }
+}

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorConfigFactory.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorConfigFactory.java
@@ -142,6 +142,8 @@ public final class SpectorConfigFactory {
         properties.setTypeRegistryCapacity(props.getInt(MEMORY_TYPE_REGISTRY_CAPACITY, DEFAULT_MEMORY_TYPE_REGISTRY_CAPACITY));
         properties.setTypeRegistrySize(props.getLong(MEMORY_TYPE_REGISTRY_SIZE, DEFAULT_MEMORY_TYPE_REGISTRY_SIZE));
         properties.setInsulaSize(props.getLong(MEMORY_INSULA_SIZE, DEFAULT_MEMORY_INSULA_SIZE));
+        properties.setEntityExtractionParallelism(props.getInt(MEMORY_ENTITY_EXTRACTION_PARALLELISM, DEFAULT_MEMORY_ENTITY_EXTRACTION_PARALLELISM));
+        properties.setEntityExtractionQueueCapacity(props.getInt(MEMORY_ENTITY_EXTRACTION_QUEUE_CAPACITY, DEFAULT_MEMORY_ENTITY_EXTRACTION_QUEUE_CAPACITY));
 
         var llm = new LlmProperties(
                 props.getFloat(MEMORY_LLM_TEMPERATURE, DEFAULT_MEMORY_LLM_TEMPERATURE),

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -410,6 +410,12 @@ public final class SpectorPropertyConstants {
     public static final String MEMORY_ENTITY_SHADOW_MODE = "spector.memory.entity.shadow-mode";
     public static final boolean DEFAULT_MEMORY_ENTITY_SHADOW_MODE = true;
 
+    public static final String MEMORY_ENTITY_EXTRACTION_PARALLELISM = "spector.memory.entity-extraction.parallelism";
+    public static final int DEFAULT_MEMORY_ENTITY_EXTRACTION_PARALLELISM = 1;
+
+    public static final String MEMORY_ENTITY_EXTRACTION_QUEUE_CAPACITY = "spector.memory.entity-extraction.queue-capacity";
+    public static final int DEFAULT_MEMORY_ENTITY_EXTRACTION_QUEUE_CAPACITY = 1000;
+
     public static final String MEMORY_EDGE_IMPORTANCE = "spector.memory.edge-importance";
     public static final String DEFAULT_MEMORY_EDGE_IMPORTANCE = "DEFAULT";
 

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/properties/MemoryProperties.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/properties/MemoryProperties.java
@@ -64,6 +64,9 @@ public class MemoryProperties implements Serializable {
     private ConsolidationProperties consolidation = new ConsolidationProperties();
     private LlmProperties llm = new LlmProperties();
 
+    private int entityExtractionParallelism = DEFAULT_MEMORY_ENTITY_EXTRACTION_PARALLELISM;
+    private int entityExtractionQueueCapacity = DEFAULT_MEMORY_ENTITY_EXTRACTION_QUEUE_CAPACITY;
+
     public MemoryProperties() {}
 
     public MemoryProperties(int maxMemories, int dimensions) {
@@ -235,4 +238,12 @@ public class MemoryProperties implements Serializable {
     public long getInsulaSize() { return insulaSize; }
     public void setInsulaSize(long insulaSize) { this.insulaSize = insulaSize; }
     public long insulaSize() { return insulaSize; }
+
+    public int getEntityExtractionParallelism() { return entityExtractionParallelism; }
+    public void setEntityExtractionParallelism(int entityExtractionParallelism) { this.entityExtractionParallelism = entityExtractionParallelism; }
+    public int entityExtractionParallelism() { return entityExtractionParallelism; }
+
+    public int getEntityExtractionQueueCapacity() { return entityExtractionQueueCapacity; }
+    public void setEntityExtractionQueueCapacity(int entityExtractionQueueCapacity) { this.entityExtractionQueueCapacity = entityExtractionQueueCapacity; }
+    public int entityExtractionQueueCapacity() { return entityExtractionQueueCapacity; }
 }

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryRememberTool.java
@@ -185,15 +185,6 @@ public final class MemoryRememberTool extends MemoryToolHandler {
 
         IngestionContext context = ctxBuilder.build();
 
-        // Compute importance estimate (read-only) to show what was assigned
-        com.spectrayan.spector.memory.model.ImportanceResult estimate = null;
-        try {
-            estimate = memory.estimateImportance(text, hints);
-        } catch (Exception e) {
-            // Non-fatal: importance display is best-effort
-            log.warn("[MemoryRememberTool] Importance estimation failed: {}", e.getMessage());
-        }
-
         // Ingest: auto-generate ID if not provided
         boolean autoId = id.isEmpty();
         if (autoId) {
@@ -208,6 +199,12 @@ public final class MemoryRememberTool extends MemoryToolHandler {
             memory.remember(id, text, type, source, context, tags);
         }
 
+        // Retrieve stored cognitive record for importance feedback (zero extra embedding calls)
+        com.spectrayan.spector.memory.model.CognitiveRecord storedRecord = null;
+        try {
+            storedRecord = memory.inspect(id);
+        } catch (Exception ignored) {}
+
         StringBuilder sb = new StringBuilder();
         sb.append("✅ Stored ").append(type).append(" memory '").append(id).append("'");
         if (autoId) sb.append(" (auto-generated TSID)");
@@ -221,16 +218,11 @@ public final class MemoryRememberTool extends MemoryToolHandler {
             if (arousal != 0) sb.append(" | arousal=").append(arousal);
         }
 
-        // Show computed importance feedback
-        if (estimate != null) {
-            sb.append(String.format("\n📈 Importance: %.2f / 10.0", estimate.importance()));
-            sb.append(String.format(" (novelty=%.2f, z=%.2f)", estimate.breakdown().noveltyScore(), estimate.breakdown().noveltyZScore()));
-            if (estimate.isFlashbulb()) {
-                sb.append(" ⚡ FLASHBULB");
-            }
-            if (estimate.breakdown().nearestMemoryId() != null) {
-                sb.append(String.format("\n🔗 Nearest: '%s' (dist=%.4f)",
-                        estimate.breakdown().nearestMemoryId(), estimate.breakdown().nearestDistance()));
+        // Show computed importance feedback from stored record
+        if (storedRecord != null) {
+            sb.append(String.format("\n📈 Importance: %.2f / 10.0", storedRecord.importance()));
+            if (storedRecord.isPinned()) {
+                sb.append(" ⚡ FLASHBULB (Pinned)");
             }
         }
 


### PR DESCRIPTION
## Summary

Resolves **#555** by eliminating the synchronous LLM bottlenecks across the Spector ingestion and recall pipelines, and standardizing background task execution on `ConcurrentTasks` with full Java 25 `ScopedValue` context propagation:

1. **Centralized Concurrency via `ConcurrentTasks`**:
   - Replaced ad-hoc `Executors.newFixedThreadPool(...)` and `newSingleThreadExecutor(...)` in `AsyncEntityExtractionQueue` and `EagerConsolidator` with centralized `ConcurrentTasks.virtualExecutor()` thread management.
   - Preserves configurable parallelism (`spector.memory.entity-extraction.parallelism`, defaulting to `1`) and bounded queue capacity (`spector.memory.entity-extraction.queue-capacity`, defaulting to `1000`).

2. **Full Scoped Context Propagation (`MemoryScope`)**:
   - Expanded [`MemoryScope`](file:///d:/git/spector/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/concurrent/MemoryScope.java) with `NAMESPACE_ID` alongside `SESSION_ID` using Java 25 `ScopedValue`.
   - Added `runWithScope()` and `callWithScope()` helpers and a scoped overload to `ConcurrentTasks.fireAndForget()`.
   - Captured both `sessionId` and `namespaceId` at submission time and rebound them in executing worker virtual threads.

3. **Zero-LLM Fast Recall Pipeline**:
   - Replaced synchronous `EntityExtractor.extract()` in `TemporalFactWeavingStage` and `GraphExpansionStage` with $O(1)$ off-heap memory index slot lookups via `CadpContradictionResolver.findEntitiesForSlot()` and pre-indexed `TemporalKnowledgeGraph` facts.

4. **Ingestion Redundancy Elimination**:
   - Removed redundant pre-ingest `estimateImportance()` embedding call in `MemoryRememberTool.java`, reading computed importance directly from the stored `CognitiveRecord` post-ingest.
   - Bypassed chunk tag extraction in `DefaultSpectorMemory` when caller-supplied synaptic tags already exist.

---

## Architectural Changes & Commits

- `feat(config)`: Add configurable entity extraction parallelism and queue capacity (#555)
- `feat(memory)`: Implement async entity extraction queue with scoped session propagation (#555)
- `perf(recall)`: Eliminate LLM calls in recall pipeline via fast off-heap entity resolution (#555)
- `perf(mcp)`: Eliminate redundant importance embedding call during ingestion (#555)
- `test(memory)`: Add unit and integration tests for async extraction and zero-LLM recall (#555)
- `feat(commons,memory)`: Use centralized `ConcurrentTasks` virtual executor and propagate namespace `ScopedValue` (#555)

---

## Verification & Test Results

- `MemoryScopeTest`: Verified `SESSION_ID` and `NAMESPACE_ID` isolation, binding, unbinding, and async propagation.
- `AsyncEntityExtractionQueueTest`: Verified async throughput, dual `ScopedValue` propagation (`SESSION_ID` & `NAMESPACE_ID`), error counters, and graceful shutdown.
- `TemporalFactWeavingStageTest`: Verified zero-LLM temporal fact resolution.
- `EagerConsolidationAndTraversalsIntegrationTest`: Verified async CADP contradiction resolution and temporal fact retraction.
- Full reactor build: `mvn verify -pl nucleus/spector-commons,nucleus/spector-config,memory/spector-memory,synapse/spector-mcp -am` -> **SUCCESS (1,282 memory tests + 645 commons tests + 29 MCP tests passed)**.

---

Closes #555
Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
