### PR TITLE
feat: unified ScopedValue-based observability architecture

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -24,6 +24,7 @@ import com.spectrayan.spector.memory.session.EpisodicSessionIndex;
 
 import com.spectrayan.spector.commons.concurrent.MemoryScope;
 import com.spectrayan.spector.memory.session.SessionWriteBuffer;
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
@@ -260,6 +261,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     private final EpisodicSessionIndex episodicSessionIndex;
     private final EpisodicLogMemory episodicLogStore;
 
+    private final MemoryObservationHook hook;
+
     DefaultSpectorMemory(SpectorMemoryBuilder builder) {
         var bundle = SpectorMemoryFactory.assemble(builder);
         this.cognitiveTarget = bundle.cognitiveTarget();
@@ -324,6 +327,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.semanticIndex = builder.semanticIndex;
         this.runtimeBundle = bundle.runtimeBundle();
         this.insularCortex = bundle.insularCortex();
+        this.hook = builder.hook != null ? builder.hook : MemoryObservationHook.NOOP;
 
         //  JVM Shutdown Hook  (DISK mode only)
         if (persistenceMode == MemoryPersistenceMode.DISK && bundle.basePath() != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
@@ -82,7 +82,7 @@ public final class RecallPipelineBuilder {
                 graphs.entityDirectory(), graphs.hyperEntityGraph(), graphs.temporalKnowledgeGraph(), graphs.entityExtractor(),
                 builder.graphScoringPolicy, retrieval.bm25Index(),
                 retrieval.memorySpladeIndex(), builder.SparseEmbeddingProvider, retrieval.colbertReranker(),
-                recallHistory, mmrReranker, bio.surpriseDetector());
+                recallHistory, mmrReranker, bio.surpriseDetector(), builder.hook);
 
         recallPipeline.addListener(new LtpReconsolidationListener(index, partitionManager, wal));
         recallPipeline.addListener(new HebbianCoActivationListener(bio.coActivationTracker()));

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -32,9 +32,10 @@ import com.spectrayan.spector.memory.id.MemoryIdGenerator;
 import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
-import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
 import com.spectrayan.spector.memory.pipeline.TagExtractor;
+import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
 import com.spectrayan.spector.memory.synapse.TwoFactorConfig;
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -95,6 +96,7 @@ public final class SpectorMemoryBuilder {
     int pinnedQuota = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_PINNED_QUOTA;
     TagExtractor tagExtractor;
     CognitiveProfileConfig profileConfig = CognitiveProfileConfig.allEnabled();
+    MemoryObservationHook hook;
 
     // ─── 3-Layer Cognitive Graph configuration ───
     int hebbianGraphCapacity = 0;
@@ -299,6 +301,16 @@ public final class SpectorMemoryBuilder {
 
     /** Graph scoring policy  --  configurable weights for cognitive graph steps (default: GraphScoringPolicy.DEFAULT). */
     public SpectorMemoryBuilder graphScoringPolicy(GraphScoringPolicy policy) { this.graphScoringPolicy = policy; return this; }
+
+    /**
+     * Sets the observation hook for pipeline telemetry.
+     * @param hook the observation hook (defaults to NOOP)
+     * @return this builder
+     */
+    public SpectorMemoryBuilder observationHook(MemoryObservationHook hook) {
+        this.hook = hook;
+        return this;
+    }
 
     /** Temporal chain retention in days  --  links older than this are pruned during reflect() (default: 7). */
     public SpectorMemoryBuilder temporalRetentionDays(int days) { this.temporalRetentionDays = days; return this; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueue.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/AsyncEntityExtractionQueue.java
@@ -18,6 +18,8 @@ import com.spectrayan.spector.commons.concurrent.SpectorTaskQueue;
 import com.spectrayan.spector.commons.concurrent.TaskPriority;
 import com.spectrayan.spector.commons.concurrent.TaskQueueConfig;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.*;
 import com.spectrayan.spector.memory.graph.ExtractedEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +69,11 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
     private final EntityExtractor entityExtractor;
     private final PostIngestSync postIngestSync;
     private final AtomicLong totalEntitiesExtracted = new AtomicLong(0);
+    private volatile MemoryObservationHook hook = MemoryObservationHook.NOOP;
+
+    public void setObservationHook(MemoryObservationHook hook) {
+        this.hook = hook != null ? hook : MemoryObservationHook.NOOP;
+    }
 
     public AsyncEntityExtractionQueue(
             EntityExtractor entityExtractor,
@@ -143,10 +150,14 @@ public final class AsyncEntityExtractionQueue implements AutoCloseable {
 
         EntityPayload payload = task.payload();
         long start = System.currentTimeMillis();
-        List<ExtractedEntity> entities = entityExtractor.extract(payload.memoryId(), payload.text());
+        List<ExtractedEntity> entities = hook.observe(ENTITY_EXTRACTION, java.util.Map.of(TAG_MEMORY_ID, payload.memoryId()), () ->
+            entityExtractor.extract(payload.memoryId(), payload.text())
+        );
         if (entities != null && !entities.isEmpty()) {
-            postIngestSync.syncPreExtractedEntities(entities, payload.memoryIdx(), payload.memoryId());
-            postIngestSync.syncTemporalFacts(entities, payload.memoryIdx(), payload.memoryId(), payload.timestampSeconds());
+            hook.observe(GRAPH_SYNC, java.util.Map.of(TAG_MEMORY_ID, payload.memoryId()), () -> {
+                postIngestSync.syncPreExtractedEntities(entities, payload.memoryIdx(), payload.memoryId());
+                postIngestSync.syncTemporalFacts(entities, payload.memoryIdx(), payload.memoryId(), payload.timestampSeconds());
+            });
             totalEntitiesExtracted.addAndGet(entities.size());
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -34,6 +34,8 @@ import com.spectrayan.spector.memory.model.*;
 import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
 import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
 import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.*;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
@@ -129,6 +131,9 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
 
     //  Partition rolling callback (nullable) 
     private volatile Runnable partitionRollCallback;
+
+    //  Observability hook (defaults to zero-overhead NOOP)
+    private volatile MemoryObservationHook hook = MemoryObservationHook.NOOP;
 
     public CognitiveIngestionTarget(ScalarQuantizer quantizer,
                                      SurpriseDetector surpriseDetector,
@@ -300,6 +305,16 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
         this.partitionRollCallback = callback;
     }
 
+    /**
+     * Injects the observation hook for unified observability.
+     */
+    public void setObservationHook(MemoryObservationHook hook) {
+        this.hook = hook != null ? hook : MemoryObservationHook.NOOP;
+        if (this.asyncEntityExtractionQueue != null) {
+            this.asyncEntityExtractionQueue.setObservationHook(this.hook);
+        }
+    }
+
     public ScalarQuantizer quantizer() {
         return quantizer;
     }
@@ -381,7 +396,7 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
     public void ingest(String id, String text, float[] vector) {
         // Step 1b: Auto-extract synaptic tags + emotional context from content
         long tagStartNs = System.nanoTime();
-        TagExtractionResult extraction = tagExtractor.extractWithContext(id, text);
+        TagExtractionResult extraction = hook.observe(TAG_EXTRACTION, java.util.Map.of(TAG_MEMORY_ID, id), () -> tagExtractor.extractWithContext(id, text));
         String[] tags = extraction.tags();
         long tagMs = (System.nanoTime() - tagStartNs) / 1_000_000;
 
@@ -523,10 +538,14 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
 
         // Step 9d: Entity extraction and graph population (asynchronous / non-blocking)
         if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
-            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid, nsid);
+            hook.observe(ENTITY_EXTRACTION, java.util.Map.of(TAG_MEMORY_ID, id), () ->
+                asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid, nsid)
+            );
         } else {
-            List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
-            postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
+            hook.observe(ENTITY_EXTRACTION, java.util.Map.of(TAG_MEMORY_ID, id), () -> {
+                List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
+                postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
+            });
         }
 
         log.debug("Ingested '{}' as {} (importance={}, {} tags, graphSlot={}, source={})",
@@ -777,14 +796,20 @@ public final class CognitiveIngestionTarget implements IngestionTarget {
 
         // Step 9d: Entity extraction and graph population
         if (context.hasEntities()) {
-            postIngestSync.syncPreExtractedEntities(context.entities(), memoryIdx, id);
-            postIngestSync.syncTemporalFacts(context.entities(), memoryIdx, id, header.timestampMs() / 1000);
+            hook.observe(GRAPH_SYNC, java.util.Map.of(TAG_MEMORY_ID, id), () -> {
+                postIngestSync.syncPreExtractedEntities(context.entities(), memoryIdx, id);
+                postIngestSync.syncTemporalFacts(context.entities(), memoryIdx, id, header.timestampMs() / 1000);
+            });
         } else if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
             String nsid = com.spectrayan.spector.commons.concurrent.MemoryScope.namespaceId();
-            asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid, nsid);
+            hook.observe(ENTITY_EXTRACTION, java.util.Map.of(TAG_MEMORY_ID, id), () ->
+                asyncEntityExtractionQueue.submit(id, text, memoryIdx, header.timestampMs() / 1000, tsid, nsid)
+            );
         } else {
-            List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
-            postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
+            hook.observe(ENTITY_EXTRACTION, java.util.Map.of(TAG_MEMORY_ID, id), () -> {
+                List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(id, text, memoryIdx);
+                postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, id, header.timestampMs() / 1000);
+            });
         }
 
         log.debug("Ingested '{}' as {} with IngestionContext (importance={}, {} tags, entities={}, hebbianEdges={}, temporalLinks={})",

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -96,6 +96,13 @@ import java.util.function.Supplier;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 
 import com.spectrayan.spector.commons.concurrent.NativeOsMemory;
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.EMBEDDING;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.VECTOR_SEARCH;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.SCORING;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.GRAPH_EXPANSION;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.TAG_SEARCH_MODE;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.TAG_INDEX_TYPE;
 
 import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
 import com.spectrayan.spector.provider.embedding.SparseEmbeddingResult;
@@ -154,6 +161,7 @@ public final class RecallPipeline {
     private final GraphScoringPolicy graphScoringPolicy;
     private final GraphExpansionStage graphExpansionStage;
     private final com.spectrayan.spector.memory.pipeline.graph.TemporalFactWeavingStage temporalFactWeavingStage;
+    private final MemoryObservationHook hook;
 
     private final List<RecallListener> listeners = new ArrayList<>();
 
@@ -379,7 +387,7 @@ public final class RecallPipeline {
                 prospectiveScheduler, wal, calibrationMins, calibrationScales,
                 semanticRecallStrategy, coActivationTracker, hebbianGraph, temporalChain,
                 entityDirectory, hyperEntityGraph, temporalKnowledgeGraph, entityExtractor, graphScoringPolicy,
-                bm25Index, spladeIndex, spladeProvider, colbertReranker, recallHistory, mmrReranker, null);
+                bm25Index, spladeIndex, spladeProvider, colbertReranker, recallHistory, mmrReranker, null, null);
     }
 
     /**
@@ -409,7 +417,8 @@ public final class RecallPipeline {
                            ColBERTReranker colbertReranker,
                            RecallHistory recallHistory,
                            com.spectrayan.spector.memory.pipeline.reranker.MmrReranker mmrReranker,
-                           com.spectrayan.spector.memory.dopamine.SurpriseDetector surpriseDetector) {
+                           com.spectrayan.spector.memory.dopamine.SurpriseDetector surpriseDetector,
+                           MemoryObservationHook hook) {
         this.embeddingProvider = embeddingProvider;
         this.partitionRegistry = partitionRegistry;
         this.index = index;
@@ -435,12 +444,13 @@ public final class RecallPipeline {
         this.mmrReranker = mmrReranker;
         this.surpriseDetector = surpriseDetector;
         this.partitionPruner = PartitionPruner.defaultPruner();
+        this.hook = hook != null ? hook : MemoryObservationHook.NOOP;
 
         //  Phase Components Initialization 
         this.candidateGatherer = new RecallCandidateGatherer(index, bm25Index);
         this.cognitiveReranker = new CognitiveReranker(colbertReranker);
         this.graphExpander = new GraphExpander(hebbianGraph, temporalChain);
-        this.salienceScorer = new SalienceAndHabituationScorer(suppressionSet, habituationPenalty);
+        this.salienceScorer = new SalienceAndHabituationScorer(suppressionSet, habituationPenalty, this.hook);
 
         //  Delegate graph expansion to focused stage class 
         this.graphExpansionStage = new GraphExpansionStage(
@@ -490,7 +500,9 @@ public final class RecallPipeline {
      */
     private void applyCognitiveScoring(List<CognitiveResult> allResults,
                                        RecallOptions options, long nowMs) {
-        salienceScorer.applyCognitiveScoring(allResults, options, nowMs, coActivationTracker, graphScoringPolicy);
+        hook.observe(SCORING, Map.of(TAG_SEARCH_MODE, options.scoringMode().name()), () -> {
+            salienceScorer.applyCognitiveScoring(allResults, options, nowMs, coActivationTracker, graphScoringPolicy);
+        });
     }
 
     /**
@@ -520,24 +532,26 @@ public final class RecallPipeline {
 
     private boolean runTierScan(List<CognitiveResult> allResults, float[] queryVector,
                                 RecallOptions options, long nowMs, MemoryType[] targetTypes) {
-        List<Callable<List<CognitiveResult>>> scanTasks = buildScanTasks(
-                queryVector, options, nowMs, targetTypes);
-        if (!scanTasks.isEmpty()) {
-            try {
-                List<List<CognitiveResult>> tierResults = ConcurrentTasks.forkJoinAll(scanTasks);
-                for (List<CognitiveResult> tier : tierResults) {
-                    allResults.addAll(tier);
+        return hook.observe(VECTOR_SEARCH, Map.of(TAG_INDEX_TYPE, "vector"), () -> {
+            List<Callable<List<CognitiveResult>>> scanTasks = buildScanTasks(
+                    queryVector, options, nowMs, targetTypes);
+            if (!scanTasks.isEmpty()) {
+                try {
+                    List<List<CognitiveResult>> tierResults = ConcurrentTasks.forkJoinAll(scanTasks);
+                    for (List<CognitiveResult> tier : tierResults) {
+                        allResults.addAll(tier);
+                    }
+                } catch (ConcurrentExecutionException e) {
+                    log.error("Parallel tier scan failed: {}", e.getMessage(), e);
+                    allResults.addAll(sequentialScan(queryVector, options, nowMs, targetTypes));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Recall interrupted during parallel scan");
+                    return false;
                 }
-            } catch (ConcurrentExecutionException e) {
-                log.error("Parallel tier scan failed: {}", e.getMessage(), e);
-                allResults.addAll(sequentialScan(queryVector, options, nowMs, targetTypes));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.warn("Recall interrupted during parallel scan");
-                return false;
             }
-        }
-        return true;
+            return true;
+        });
     }
 
     /**
@@ -577,7 +591,9 @@ public final class RecallPipeline {
         applyCognitiveScoring(allResults, options, nowMs);
 
         // Graph expansion
-        graphExpansionStage.expand(allResults, queryVector, options);
+        try (var _obs = hook.start(GRAPH_EXPANSION, Map.of())) {
+            graphExpansionStage.expand(allResults, queryVector, options);
+        } catch (RuntimeException e) { throw e; } catch (Exception e) { throw new RuntimeException(e); }
         temporalFactWeavingStage.weave(allResults, queryVector, options);
 
         // Filter suppressed memories (inhibition)  --  always active
@@ -649,7 +665,7 @@ public final class RecallPipeline {
         }
 
         // Step 1: Embed query
-        float[] queryVector = embeddingProvider.embed(queryText).vector();
+        float[] queryVector = hook.observe(EMBEDDING, Map.of(), () -> embeddingProvider.embed(queryText).vector());
 
         long nowMs = System.currentTimeMillis();
         List<CognitiveResult> allResults = new ArrayList<>();
@@ -670,7 +686,9 @@ public final class RecallPipeline {
         applyCognitiveScoring(allResults, options, nowMs);
 
         // Steps 5c-5e: Graph expansion (delegated to GraphExpansionStage)
-        graphExpansionStage.expand(allResults, queryVector, options);
+        try (var _obs = hook.start(GRAPH_EXPANSION, Map.of())) {
+            graphExpansionStage.expand(allResults, queryVector, options);
+        } catch (RuntimeException e) { throw e; } catch (Exception e) { throw new RuntimeException(e); }
         temporalFactWeavingStage.weave(allResults, queryVector, options);
 
         // Sort vector candidates by cognitive score descending before RRF rank assignment

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scorer/SalienceAndHabituationScorer.java
@@ -30,8 +30,13 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.SCORING_HABITUATION;
+import static com.spectrayan.spector.commons.observation.MemoryObservationHook.SCORING_STDP;
 
 /**
  * Computes novelty scores, habituation decay penalties, emotional valence/arousal
@@ -43,11 +48,17 @@ public class SalienceAndHabituationScorer {
 
     private final SuppressionSet suppressionSet;
     private final HabituationPenalty habituationPenalty;
+    private final MemoryObservationHook hook;
     private final Map<String, Long> satiationCache = new ConcurrentHashMap<>(16);
 
-    public SalienceAndHabituationScorer(SuppressionSet suppressionSet, HabituationPenalty habituationPenalty) {
+    public SalienceAndHabituationScorer(SuppressionSet suppressionSet, HabituationPenalty habituationPenalty, MemoryObservationHook hook) {
         this.suppressionSet = suppressionSet;
         this.habituationPenalty = habituationPenalty;
+        this.hook = hook != null ? hook : MemoryObservationHook.NOOP;
+    }
+
+    public SalienceAndHabituationScorer(SuppressionSet suppressionSet, HabituationPenalty habituationPenalty) {
+        this(suppressionSet, habituationPenalty, MemoryObservationHook.NOOP);
     }
 
     public SuppressionSet suppressionSet() {
@@ -85,69 +96,73 @@ public class SalienceAndHabituationScorer {
         if (options.scoringMode() == ScoringMode.SIMILARITY) return;
 
         // Habituation penalty + inhibition of return + semantic satiation
-        for (int i = 0; i < allResults.size(); i++) {
-            CognitiveResult r = allResults.get(i);
-            float habPenalty = (options.recallMode() == RecallMode.LEARN)
-                    ? habituationPenalty.recordAndComputePenalty(r.id())
-                    : habituationPenalty.currentPenalty(r.id());
-            float iorPenalty = habituationPenalty.computeInhibitionOfReturn(r.id(), nowMs);
-            float combinedPenalty = Math.min(habPenalty, iorPenalty); // stronger suppression wins
-
-            // Semantic Satiation: 0.5x penalty for results in the hot LRU cache
-            if (satiationCache.containsKey(r.id())) {
-                combinedPenalty *= SATIATION_PENALTY;
-            }
-
-            if (combinedPenalty < 1.0f) {
-                float newScore = r.score() * combinedPenalty;
-                ScoreBreakdown bd = r.breakdown() != null
-                        ? new ScoreBreakdown(
-                                r.breakdown().similarity(),
-                                r.breakdown().importanceDecay(),
-                                r.breakdown().tagBoostFactor(),
-                                combinedPenalty,
-                                r.breakdown().graphBoost(),
-                                r.breakdown().valenceAlignment(),
-                                newScore)
-                        : null;
-                allResults.set(i, new CognitiveResult(
-                        r.id(), r.text(), newScore, r.importance(), r.ageDays(),
-                        r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
-                        r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
-                        r.retrievalMode(), bd, r.trace(), r.sourceModality(), r.metadata()));
-            }
-        }
-
-        // STDP causal boost — cross-boost results whose tags are causally linked.
-        if (coActivationTracker != null && allResults.size() >= 2) {
-            Set<String> contextTagSet = new HashSet<>();
-            int contextLimit = Math.min(3, allResults.size());
-            for (int cl = 0; cl < contextLimit; cl++) {
-                String[] ctxTags = allResults.get(cl).synapticTags();
-                if (ctxTags != null) {
-                    for (String t : ctxTags) contextTagSet.add(t);
+        hook.observe(SCORING_HABITUATION, Map.of(), () -> {
+            for (int i = 0; i < allResults.size(); i++) {
+                CognitiveResult r = allResults.get(i);
+                float habPenalty = (options.recallMode() == RecallMode.LEARN)
+                        ? habituationPenalty.recordAndComputePenalty(r.id())
+                        : habituationPenalty.currentPenalty(r.id());
+                float iorPenalty = habituationPenalty.computeInhibitionOfReturn(r.id(), nowMs);
+                float combinedPenalty = Math.min(habPenalty, iorPenalty); // stronger suppression wins
+    
+                // Semantic Satiation: 0.5x penalty for results in the hot LRU cache
+                if (satiationCache.containsKey(r.id())) {
+                    combinedPenalty *= SATIATION_PENALTY;
+                }
+    
+                if (combinedPenalty < 1.0f) {
+                    float newScore = r.score() * combinedPenalty;
+                    ScoreBreakdown bd = r.breakdown() != null
+                            ? new ScoreBreakdown(
+                                    r.breakdown().similarity(),
+                                    r.breakdown().importanceDecay(),
+                                    r.breakdown().tagBoostFactor(),
+                                    combinedPenalty,
+                                    r.breakdown().graphBoost(),
+                                    r.breakdown().valenceAlignment(),
+                                    newScore)
+                            : null;
+                    allResults.set(i, new CognitiveResult(
+                            r.id(), r.text(), newScore, r.importance(), r.ageDays(),
+                            r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                            r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                            r.retrievalMode(), bd, r.trace(), r.sourceModality(), r.metadata()));
                 }
             }
+        });
 
-            if (!contextTagSet.isEmpty()) {
-                List<String> contextTags = new ArrayList<>(contextTagSet);
-                float weight = graphScoringPolicy != null ? graphScoringPolicy.causalBoostWeight() : 0.1f;
-                for (int i = 0; i < allResults.size(); i++) {
-                    CognitiveResult r = allResults.get(i);
-                    if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
-
-                    float predictive = coActivationTracker.getPredictiveStrength(
-                            contextTags, r.synapticTags());
-                    if (predictive > 0) {
-                        float boostedScore = r.score() * (1.0f + predictive * weight);
-                        allResults.set(i, new CognitiveResult(
-                                r.id(), r.text(), boostedScore, r.importance(), r.ageDays(),
-                                r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
-                                r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
-                                r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+        // STDP causal boost — cross-boost results whose tags are causally linked.
+        hook.observe(SCORING_STDP, Map.of(), () -> {
+            if (coActivationTracker != null && allResults.size() >= 2) {
+                Set<String> contextTagSet = new HashSet<>();
+                int contextLimit = Math.min(3, allResults.size());
+                for (int cl = 0; cl < contextLimit; cl++) {
+                    String[] ctxTags = allResults.get(cl).synapticTags();
+                    if (ctxTags != null) {
+                        for (String t : ctxTags) contextTagSet.add(t);
+                    }
+                }
+    
+                if (!contextTagSet.isEmpty()) {
+                    List<String> contextTags = new ArrayList<>(contextTagSet);
+                    float weight = graphScoringPolicy != null ? graphScoringPolicy.causalBoostWeight() : 0.1f;
+                    for (int i = 0; i < allResults.size(); i++) {
+                        CognitiveResult r = allResults.get(i);
+                        if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
+    
+                        float predictive = coActivationTracker.getPredictiveStrength(
+                                contextTags, r.synapticTags());
+                        if (predictive > 0) {
+                            float boostedScore = r.score() * (1.0f + predictive * weight);
+                            allResults.set(i, new CognitiveResult(
+                                    r.id(), r.text(), boostedScore, r.importance(), r.ageDays(),
+                                    r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                                    r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                                    r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+                        }
                     }
                 }
             }
-        }
+        });
     }
 }

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -72,7 +72,10 @@ import java.util.concurrent.CompletableFuture;
  * </table>
  *
  * @see SpectorMemory
+ * @see ObservedSpectorMemory
+ * @see com.spectrayan.spector.metrics.observation.SpectorMemoryGauges
  */
+@Deprecated(forRemoval = true)
 public class MeteredSpectorMemory implements SpectorMemory {
 
     public static final String METRIC_RECALL_DURATION = "spector.memory.recall.duration";
@@ -467,3 +470,4 @@ public class MeteredSpectorMemory implements SpectorMemory {
         return new long[]{0L, 0L};
     }
 }
+

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
@@ -17,6 +17,7 @@ package com.spectrayan.spector.metrics;
 
 import com.spectrayan.spector.commons.chunker.ChunkConfig;
 import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.config.ObservabilityConfig;
 import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.memory.SpectorMemoryAdmin;
 import com.spectrayan.spector.memory.cortex.MemorySource;
@@ -41,6 +42,7 @@ import com.spectrayan.spector.memory.session.EpisodicSessionIndex;
 import com.spectrayan.spector.memory.temporal.TemporalFact;
 import com.spectrayan.spector.metrics.observation.DefaultSpectorObservationConvention;
 import com.spectrayan.spector.metrics.observation.MemoryObservationContext;
+import com.spectrayan.spector.metrics.observation.ObservableComponent;
 import com.spectrayan.spector.metrics.observation.SpectorObservationConvention;
 import com.spectrayan.spector.metrics.observation.SpectorObservationDocumentation;
 import io.micrometer.observation.Observation;
@@ -48,7 +50,9 @@ import io.micrometer.observation.ObservationRegistry;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -60,18 +64,19 @@ import java.util.function.Supplier;
  * simultaneously produces Micrometer metrics (timers, counters, histograms) and OpenTelemetry /
  * W3C Trace Context distributed trace spans (Trace ID, Span ID, parent-child span hierarchies).</p>
  */
-public class ObservedSpectorMemory implements SpectorMemory {
+public class ObservedSpectorMemory extends ObservableComponent implements SpectorMemory {
 
     private final SpectorMemory delegate;
     private final ObservationRegistry registry;
     private final SpectorObservationConvention convention;
 
-    public ObservedSpectorMemory(SpectorMemory delegate, ObservationRegistry registry) {
-        this(delegate, registry, DefaultSpectorObservationConvention.INSTANCE);
+    public ObservedSpectorMemory(SpectorMemory delegate, ObservationRegistry registry, ObservabilityConfig config) {
+        this(delegate, registry, config, DefaultSpectorObservationConvention.INSTANCE);
     }
 
-    public ObservedSpectorMemory(SpectorMemory delegate, ObservationRegistry registry,
+    public ObservedSpectorMemory(SpectorMemory delegate, ObservationRegistry registry, ObservabilityConfig config,
                                  SpectorObservationConvention convention) {
+        super(registry, config);
         this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.registry = Objects.requireNonNull(registry, "registry");
         this.convention = convention != null ? convention : DefaultSpectorObservationConvention.INSTANCE;
@@ -85,66 +90,21 @@ public class ObservedSpectorMemory implements SpectorMemory {
         return registry;
     }
 
-    // ══════════════════════════════════════════════════════════════
+    // --------------------------------------------------------------
     // OBSERVATION HELPER METHODS
-    // ══════════════════════════════════════════════════════════════
+    // --------------------------------------------------------------
 
-    private void observeRunnable(SpectorObservationDocumentation doc, String tier, String memoryId,
-                                 String query, Runnable action) {
-        MemoryObservationContext context = new MemoryObservationContext(doc.getName())
-                .setTier(tier)
-                .setMemoryId(memoryId)
-                .setQuery(query)
-                .setSessionId(MemoryScope.sessionId())
-                .setNamespace(MemoryScope.namespaceId());
-
-        Observation observation = Observation.createNotStarted(doc.getName(), () -> context, registry)
-                .observationConvention(convention)
-                .start();
-
-        try (Observation.Scope ignored = observation.openScope()) {
-            action.run();
-            context.setStatus("SUCCESS");
-        } catch (Throwable t) {
-            context.setStatus("ERROR");
-            context.setError(t);
-            observation.error(t);
-            throw t;
-        } finally {
-            observation.stop();
-        }
+    private Map<String, String> createTags(String tier, String memoryId, String query) {
+        Map<String, String> tags = new HashMap<>();
+        if (tier != null) tags.put("tier", tier);
+        if (memoryId != null) tags.put("memory_id", memoryId);
+        if (query != null) tags.put("query", query);
+        return tags;
     }
 
-    private <T> T observeSupplier(SpectorObservationDocumentation doc, String tier, String memoryId,
-                                  String query, Supplier<T> supplier) {
-        MemoryObservationContext context = new MemoryObservationContext(doc.getName())
-                .setTier(tier)
-                .setMemoryId(memoryId)
-                .setQuery(query)
-                .setSessionId(MemoryScope.sessionId())
-                .setNamespace(MemoryScope.namespaceId());
-
-        Observation observation = Observation.createNotStarted(doc.getName(), () -> context, registry)
-                .observationConvention(convention)
-                .start();
-
-        try (Observation.Scope ignored = observation.openScope()) {
-            T result = supplier.get();
-            context.setStatus("SUCCESS");
-            return result;
-        } catch (Throwable t) {
-            context.setStatus("ERROR");
-            context.setError(t);
-            observation.error(t);
-            throw t;
-        } finally {
-            observation.stop();
-        }
-    }
-
-    // ══════════════════════════════════════════════════════════════
+    // --------------------------------------------------------------
     // INGESTION TARGET
-    // ══════════════════════════════════════════════════════════════
+    // --------------------------------------------------------------
 
     @Override
     public CognitiveIngestionTarget target() {
@@ -156,102 +116,102 @@ public class ObservedSpectorMemory implements SpectorMemory {
         return delegate.namespaceId();
     }
 
-    // ══════════════════════════════════════════════════════════════
+    // --------------------------------------------------------------
     // CORE API (OBSERVED)
-    // ══════════════════════════════════════════════════════════════
+    // --------------------------------------------------------------
 
     @Override
     public void remember(String id, String text, MemoryType type, MemorySource source, String... tags) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, id, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, id, null),
                 () -> delegate.remember(id, text, type, source, tags));
     }
 
     @Override
     public void remember(String id, String text, MemoryType type, MemorySource source,
                          IngestionHints hints, String... tags) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, id, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, id, null),
                 () -> delegate.remember(id, text, type, source, hints, tags));
     }
 
     @Override
     public void remember(String id, String text, MemoryType type, String... tags) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, id, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, id, null),
                 () -> delegate.remember(id, text, type, tags));
     }
 
     @Override
     public void remember(String id, String text, MemoryType type, MemorySource source,
                          IngestionContext context, String... tags) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, id, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, id, null),
                 () -> delegate.remember(id, text, type, source, context, tags));
     }
 
     @Override
     public String remember(String text, MemoryType type, MemorySource source, String... tags) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, null, null,
+        return withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, null, null),
                 () -> delegate.remember(text, type, source, tags));
     }
 
     @Override
     public String remember(String text, MemoryType type, MemorySource source,
                            IngestionHints hints, String... tags) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, null, null,
+        return withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, null, null),
                 () -> delegate.remember(text, type, source, hints, tags));
     }
 
     @Override
     public String remember(String text, MemoryType type, MemorySource source,
                            IngestionContext context, String... tags) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_REMEMBER,
-                type != null ? type.name() : null, null, null,
+        return withObservation(SpectorObservationDocumentation.MEMORY_REMEMBER,
+                createTags(type != null ? type.name() : null, null, null),
                 () -> delegate.remember(text, type, source, context, tags));
     }
 
     @Override
     public List<CognitiveResult> recall(String queryText, RecallOptions options) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_RECALL,
-                null, null, queryText,
+        return withObservation(SpectorObservationDocumentation.MEMORY_RECALL,
+                createTags(null, null, queryText),
                 () -> delegate.recall(queryText, options));
     }
 
     @Override
     public List<CognitiveResult> recall(String queryText, CognitiveProfile profile) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_RECALL,
-                null, null, queryText,
+        return withObservation(SpectorObservationDocumentation.MEMORY_RECALL,
+                createTags(null, null, queryText),
                 () -> delegate.recall(queryText, profile));
     }
 
     @Override
     public List<CognitiveResult> recall(String queryText) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_RECALL,
-                null, null, queryText,
+        return withObservation(SpectorObservationDocumentation.MEMORY_RECALL,
+                createTags(null, null, queryText),
                 () -> delegate.recall(queryText));
     }
 
     @Override
     public void forget(String id) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_FORGET,
-                null, id, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_FORGET,
+                createTags(null, id, null),
                 () -> delegate.forget(id));
     }
 
     @Override
     public ReflectReport reflect() {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_CONSOLIDATE,
-                null, null, null,
+        return withObservation(SpectorObservationDocumentation.MEMORY_CONSOLIDATE,
+                createTags(null, null, null),
                 delegate::reflect);
     }
 
     @Override
     public void consolidate() {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_CONSOLIDATE,
-                null, null, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_CONSOLIDATE,
+                createTags(null, null, null),
                 delegate::consolidate);
     }
 
@@ -267,29 +227,29 @@ public class ObservedSpectorMemory implements SpectorMemory {
 
     @Override
     public void reinforce(String memoryId, byte valence) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_REINFORCE,
-                null, memoryId, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_REINFORCE,
+                createTags(null, memoryId, null),
                 () -> delegate.reinforce(memoryId, valence));
     }
 
     @Override
     public void reinforce(String memoryId, byte valence, IngestionHints updatedHints) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_REINFORCE,
-                null, memoryId, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_REINFORCE,
+                createTags(null, memoryId, null),
                 () -> delegate.reinforce(memoryId, valence, updatedHints));
     }
 
     @Override
     public void suppress(String memoryId, String reason) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_FORGET,
-                null, memoryId, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_FORGET,
+                createTags(null, memoryId, null),
                 () -> delegate.suppress(memoryId, reason));
     }
 
     @Override
     public void suppress(String memoryId) {
-        observeRunnable(SpectorObservationDocumentation.MEMORY_FORGET,
-                null, memoryId, null,
+        withObservation(SpectorObservationDocumentation.MEMORY_FORGET,
+                createTags(null, memoryId, null),
                 () -> delegate.suppress(memoryId));
     }
 
@@ -310,15 +270,15 @@ public class ObservedSpectorMemory implements SpectorMemory {
 
     @Override
     public MemoryInsight introspect(String topic) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_RECALL,
-                null, null, topic,
+        return withObservation(SpectorObservationDocumentation.MEMORY_RECALL,
+                createTags(null, null, topic),
                 () -> delegate.introspect(topic));
     }
 
     @Override
     public WhyNotExplanation whyNot(String memoryId, String query, RecallOptions options) {
-        return observeSupplier(SpectorObservationDocumentation.MEMORY_RECALL,
-                null, memoryId, query,
+        return withObservation(SpectorObservationDocumentation.MEMORY_RECALL,
+                createTags(null, memoryId, query),
                 () -> delegate.whyNot(memoryId, query, options));
     }
 

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/MicrometerMemoryObservationHook.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/MicrometerMemoryObservationHook.java
@@ -19,8 +19,12 @@ import com.spectrayan.spector.commons.observation.MemoryObservationHook;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.config.ObservabilityConfig;
+
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Micrometer Observation adapter implementing {@link MemoryObservationHook}.
@@ -32,19 +36,36 @@ public final class MicrometerMemoryObservationHook implements MemoryObservationH
 
     private final ObservationRegistry registry;
     private final SpectorObservationConvention convention;
+    private final ObservabilityConfig config;
+    private final Set<String> enabledObservations;
 
-    public MicrometerMemoryObservationHook(ObservationRegistry registry) {
-        this(registry, DefaultSpectorObservationConvention.INSTANCE);
+    public MicrometerMemoryObservationHook(ObservationRegistry registry, ObservabilityConfig config) {
+        this(registry, DefaultSpectorObservationConvention.INSTANCE, config);
     }
 
-    public MicrometerMemoryObservationHook(ObservationRegistry registry, SpectorObservationConvention convention) {
+    public MicrometerMemoryObservationHook(ObservationRegistry registry, SpectorObservationConvention convention, ObservabilityConfig config) {
         this.registry = Objects.requireNonNull(registry, "registry");
         this.convention = convention != null ? convention : DefaultSpectorObservationConvention.INSTANCE;
+        this.config = config != null ? config : ObservabilityConfig.DEFAULT;
+        this.enabledObservations = this.config.computeEnabledObservationSet();
     }
 
     @Override
     public AutoCloseable start(String name, Map<String, String> tags) {
-        MemoryObservationContext context = new MemoryObservationContext(name);
+        String fullName = name;
+        String currentParent = ObservableComponent.currentParent();
+        if (currentParent != null) {
+            fullName = currentParent + "." + name;
+        }
+
+        if (!enabledObservations.contains(name)) {
+            return () -> {}; // No-op if disabled
+        }
+
+        MemoryObservationContext context = new MemoryObservationContext(fullName);
+        context.setNamespace(MemoryScope.namespaceId());
+        context.setSessionId(MemoryScope.sessionId());
+
         if (tags != null) {
             for (var entry : tags.entrySet()) {
                 String k = entry.getKey();
@@ -68,7 +89,7 @@ public final class MicrometerMemoryObservationHook implements MemoryObservationH
         }
 
         Observation observation = Observation.createNotStarted(
-                name != null ? name : "spector.memory.operation",
+                fullName != null ? fullName : "spector.memory.operation",
                 () -> context,
                 registry
         ).observationConvention(convention).start();
@@ -82,5 +103,34 @@ public final class MicrometerMemoryObservationHook implements MemoryObservationH
                 observation.stop();
             }
         };
+    }
+    
+    @Override
+    public <T> T observe(String name, Map<String, String> tags, java.util.function.Supplier<T> action) {
+        String fullName = name;
+        String currentParent = ObservableComponent.currentParent();
+        if (currentParent != null) {
+            fullName = currentParent + "." + name;
+        }
+
+        if (!enabledObservations.contains(name)) {
+            return action.get();
+        }
+
+        try (AutoCloseable c = start(name, tags)) {
+            final String fName = fullName;
+            return ScopedValue.where(ObservableComponent.PARENT_OBSERVATION, fName).call(action::get);
+        } catch (Exception e) {
+            if (e instanceof RuntimeException re) throw re;
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Override
+    public void observe(String name, Map<String, String> tags, Runnable action) {
+        observe(name, tags, () -> {
+            action.run();
+            return null;
+        });
     }
 }

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservableComponent.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservableComponent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.metrics.observation;
+
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.config.ObservabilityConfig;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Base class for components that emit observability signals (metrics and traces) via Micrometer.
+ * Uses ScopedValue for implicit parent observation context propagation.
+ */
+public abstract class ObservableComponent {
+
+    private static final Logger log = LoggerFactory.getLogger(ObservableComponent.class);
+
+    static final ScopedValue<String> PARENT_OBSERVATION = ScopedValue.newInstance();
+
+    private final ObservationRegistry observationRegistry;
+    private final ObservabilityConfig config;
+
+    protected ObservableComponent(ObservationRegistry observationRegistry, ObservabilityConfig config) {
+        this.observationRegistry = observationRegistry;
+        this.config = config;
+    }
+
+    protected <T> T withObservation(SpectorObservationDocumentation doc, Map<String, String> tags, Supplier<T> work) {
+        if (!config.isEnabled(doc.getName())) {
+            return work.get();
+        }
+
+        MemoryObservationContext context = new MemoryObservationContext(doc.getName());
+        context.setNamespace(MemoryScope.namespaceId());
+        context.setSessionId(MemoryScope.sessionId());
+
+        if (tags != null) {
+            tags.forEach((k, v) -> {
+                if ("tier".equalsIgnoreCase(k)) context.setTier(v);
+                else if ("memory_id".equalsIgnoreCase(k)) context.setMemoryId(v);
+                else if ("task_id".equalsIgnoreCase(k)) context.setTaskId(v);
+                else if ("query".equalsIgnoreCase(k)) context.setQuery(v);
+                else context.addCustomTag(k, v);
+            });
+        }
+
+        Observation observation = Observation.createNotStarted(
+                doc.getName(),
+                () -> context,
+                observationRegistry
+        ).observationConvention(DefaultSpectorObservationConvention.INSTANCE).start();
+
+        try (Observation.Scope scope = observation.openScope()) {
+            return ScopedValue.where(PARENT_OBSERVATION, doc.getName()).call(work::get);
+        } catch (Exception e) {
+            observation.error(e);
+            context.setStatus("ERROR");
+            if (e instanceof RuntimeException re) throw re;
+            throw new RuntimeException(e);
+        } finally {
+            observation.stop();
+        }
+    }
+
+    protected void withObservation(SpectorObservationDocumentation doc, Map<String, String> tags, Runnable work) {
+        withObservation(doc, tags, () -> {
+            work.run();
+            return null;
+        });
+    }
+
+    static String currentParent() {
+        return PARENT_OBSERVATION.isBound() ? PARENT_OBSERVATION.get() : null;
+    }
+}

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservedEmbeddingProvider.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservedEmbeddingProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.metrics.observation;
+
+import com.spectrayan.spector.config.ObservabilityConfig;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.EmbeddingResult;
+import io.micrometer.observation.ObservationRegistry;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Decorator for {@link EmbeddingProvider} that adds observability signals using Micrometer.
+ */
+public final class ObservedEmbeddingProvider extends ObservableComponent implements EmbeddingProvider {
+
+    private final EmbeddingProvider delegate;
+
+    public ObservedEmbeddingProvider(EmbeddingProvider delegate, ObservationRegistry registry, ObservabilityConfig config) {
+        super(registry, config);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public EmbeddingResult embed(String text) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_EMBEDDING,
+                Map.of("model", delegate.modelName()),
+                () -> delegate.embed(text)
+        );
+    }
+
+    @Override
+    public List<EmbeddingResult> embedBatch(List<String> texts) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_EMBEDDING,
+                Map.of("model", delegate.modelName(), "batch_size", String.valueOf(texts.size())),
+                () -> delegate.embedBatch(texts)
+        );
+    }
+
+    @Override
+    public int dimensions() {
+        return delegate.dimensions();
+    }
+
+    @Override
+    public String modelName() {
+        return delegate.modelName();
+    }
+
+    @Override
+    public int maxTokens() {
+        return delegate.maxTokens();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservedLlmProvider.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservedLlmProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.metrics.observation;
+
+import com.spectrayan.spector.config.ObservabilityConfig;
+import com.spectrayan.spector.provider.generation.GenerationOptions;
+import com.spectrayan.spector.provider.generation.LlmProvider;
+import com.spectrayan.spector.provider.model.LlmRequest;
+import com.spectrayan.spector.provider.model.LlmResponse;
+import io.micrometer.observation.ObservationRegistry;
+
+import java.util.Map;
+
+/**
+ * Decorator for {@link LlmProvider} that adds observability signals using Micrometer.
+ */
+public final class ObservedLlmProvider extends ObservableComponent implements LlmProvider {
+
+    private final LlmProvider delegate;
+
+    public ObservedLlmProvider(LlmProvider delegate, ObservationRegistry registry, ObservabilityConfig config) {
+        super(registry, config);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public LlmResponse generate(LlmRequest request, GenerationOptions options) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_LLM,
+                Map.of("model", delegate.modelName()),
+                () -> delegate.generate(request, options)
+        );
+    }
+
+    @Override
+    public LlmResponse generate(LlmRequest request) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_LLM,
+                Map.of("model", delegate.modelName()),
+                () -> delegate.generate(request)
+        );
+    }
+
+    @Override
+    public String generate(String prompt) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_LLM,
+                Map.of("model", delegate.modelName()),
+                () -> delegate.generate(prompt)
+        );
+    }
+
+    @Override
+    public String generate(String prompt, GenerationOptions options) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_LLM,
+                Map.of("model", delegate.modelName()),
+                () -> delegate.generate(prompt, options)
+        );
+    }
+
+    @Override
+    public String generateStructured(String prompt, String jsonSchema) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_LLM,
+                Map.of("model", delegate.modelName(), "structured", "true"),
+                () -> delegate.generateStructured(prompt, jsonSchema)
+        );
+    }
+
+    @Override
+    public String generateStructured(String prompt, String jsonSchema, GenerationOptions options) {
+        return withObservation(
+                SpectorObservationDocumentation.PIPELINE_LLM,
+                Map.of("model", delegate.modelName(), "structured", "true"),
+                () -> delegate.generateStructured(prompt, jsonSchema, options)
+        );
+    }
+
+    @Override
+    public String modelName() {
+        return delegate.modelName();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return delegate.isAvailable();
+    }
+}

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/SpectorMemoryGauges.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/SpectorMemoryGauges.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.metrics.observation;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+public class SpectorMemoryGauges implements MeterBinder {
+    
+    private final SpectorMemory memory;
+    
+    public SpectorMemoryGauges(SpectorMemory memory) {
+        this.memory = memory;
+    }
+    
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        // Pinned Bytes Gauge (RAM usage verification)
+        Gauge.builder("spector.memory.pinned.bytes", com.spectrayan.spector.commons.concurrent.MemoryPinning::pinnedBytes)
+                .description("Total off-heap memory bytes pinned in RAM")
+                .register(registry);
+
+        // Gauges
+        Gauge.builder("spector.memory.count", memory, SpectorMemory::totalMemories)
+                .description("Total number of memories across all tiers")
+                .register(registry);
+
+        // Soft & Hard Page Fault Gauges (Linux container tracking)
+        Gauge.builder("spector.memory.page.faults", () -> readPageFaults()[0])
+                .tag("type", "soft")
+                .description("Soft page faults (minor faults) on Linux")
+                .register(registry);
+
+        Gauge.builder("spector.memory.page.faults", () -> readPageFaults()[1])
+                .tag("type", "hard")
+                .description("Hard page faults (major faults) on Linux")
+                .register(registry);
+    }
+    
+    private static long[] readPageFaults() {
+        try {
+            java.nio.file.Path path = java.nio.file.Path.of("/proc/self/stat");
+            if (java.nio.file.Files.exists(path)) {
+                String content = java.nio.file.Files.readString(path);
+                int lastParen = content.lastIndexOf(')');
+                if (lastParen != -1 && lastParen + 2 < content.length()) {
+                    String rest = content.substring(lastParen + 2);
+                    String[] tokens = rest.split("\\s+");
+                    if (tokens.length > 9) {
+                        long soft = Long.parseLong(tokens[7]);
+                        long hard = Long.parseLong(tokens[9]);
+                        return new long[]{soft, hard};
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // safe fallback
+        }
+        return new long[]{0L, 0L};
+    }
+}

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/SpectorObservationDocumentation.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/SpectorObservationDocumentation.java
@@ -196,6 +196,290 @@ public enum SpectorObservationDocumentation implements ObservationDocumentation 
         public String getPrefix() {
             return "spector.taskqueue";
         }
+    },
+
+    /**
+     * Embedding pipeline observation.
+     */
+    PIPELINE_EMBEDDING {
+        @Override
+        public String getName() {
+            return "spector.pipeline.embedding";
+        }
+
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+
+        @Override
+        public String getPrefix() {
+            return "spector.pipeline";
+        }
+    },
+
+    /**
+     * LLM pipeline observation.
+     */
+    PIPELINE_LLM {
+        @Override
+        public String getName() {
+            return "spector.pipeline.llm";
+        }
+
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+
+        @Override
+        public String getPrefix() {
+            return "spector.pipeline";
+        }
+    },
+    RECALL_VECTOR_SEARCH {
+        @Override
+        public String getName() {
+            return "spector.recall.vector_search";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.recall";
+        }
+    },
+    RECALL_BM25_SEARCH {
+        @Override
+        public String getName() {
+            return "spector.recall.bm25_search";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.recall";
+        }
+    },
+    RECALL_SCORING {
+        @Override
+        public String getName() {
+            return "spector.recall.scoring";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.recall";
+        }
+    },
+    RECALL_GRAPH_EXPANSION {
+        @Override
+        public String getName() {
+            return "spector.recall.graph_expansion";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.recall";
+        }
+    },
+    RECALL_CONTRADICTION {
+        @Override
+        public String getName() {
+            return "spector.recall.contradiction";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.recall";
+        }
+    },
+    REMEMBER_TAG_EXTRACTION {
+        @Override
+        public String getName() {
+            return "spector.remember.tag_extraction";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.remember";
+        }
+    },
+    REMEMBER_CHUNKING {
+        @Override
+        public String getName() {
+            return "spector.remember.chunking";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.remember";
+        }
+    },
+    REMEMBER_ENTITY_EXTRACTION {
+        @Override
+        public String getName() {
+            return "spector.remember.entity_extraction";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.remember";
+        }
+    },
+    REMEMBER_GRAPH_SYNC {
+        @Override
+        public String getName() {
+            return "spector.remember.graph_sync";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.remember";
+        }
+    },
+    SCORING_COGNITIVE {
+        @Override
+        public String getName() {
+            return "spector.scoring.cognitive";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.scoring";
+        }
+    },
+    SCORING_HABITUATION {
+        @Override
+        public String getName() {
+            return "spector.scoring.habituation";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.scoring";
+        }
+    },
+    SCORING_STDP {
+        @Override
+        public String getName() {
+            return "spector.scoring.stdp";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.scoring";
+        }
+    },
+    SCORING_HEBBIAN {
+        @Override
+        public String getName() {
+            return "spector.scoring.hebbian";
+        }
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeys.values();
+        }
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeys.values();
+        }
+        @Override
+        public String getPrefix() {
+            return "spector.scoring";
+        }
     };
 
     public enum LowCardinalityKeys implements KeyName {

--- a/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/ObservedSpectorMemoryTest.java
+++ b/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/ObservedSpectorMemoryTest.java
@@ -21,6 +21,7 @@ import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.config.ObservabilityConfig;
 import com.spectrayan.spector.metrics.observation.MicrometerMemoryObservationHook;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
@@ -54,7 +55,7 @@ class ObservedSpectorMemoryTest {
     @BeforeEach
     void setUp() {
         registry = TestObservationRegistry.create();
-        memory = new ObservedSpectorMemory(delegate, registry);
+        memory = new ObservedSpectorMemory(delegate, registry, ObservabilityConfig.DEFAULT);
     }
 
     @Test
@@ -133,9 +134,9 @@ class ObservedSpectorMemoryTest {
     @Test
     @DisplayName("MicrometerMemoryObservationHook bridges zero-dependency SPI to ObservationRegistry")
     void testMemoryObservationHookAdapter() throws Exception {
-        var hook = new MicrometerMemoryObservationHook(registry);
+        var hook = new MicrometerMemoryObservationHook(registry, ObservabilityConfig.DEFAULT);
 
-        try (var handle = hook.start("spector.pipeline.chunk", Map.of(
+        try (var handle = hook.start(com.spectrayan.spector.commons.observation.MemoryObservationHook.CHUNKING, Map.of(
                 "tier", "EPISODIC",
                 "namespace", "ns-42",
                 "custom_key", "custom_val"
@@ -144,7 +145,7 @@ class ObservedSpectorMemoryTest {
         }
 
         TestObservationRegistryAssert.assertThat(registry)
-                .hasObservationWithNameEqualTo("spector.pipeline.chunk")
+                .hasObservationWithNameEqualTo("chunking")
                 .that()
                 .hasLowCardinalityKeyValue("spector.tier", "EPISODIC")
                 .hasLowCardinalityKeyValue("spector.namespace", "ns-42")

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/observation/MemoryObservationHook.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/observation/MemoryObservationHook.java
@@ -16,6 +16,7 @@
 package com.spectrayan.spector.commons.observation;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Lightweight, zero-dependency observation SPI for cognitive memory operations.
@@ -26,17 +27,96 @@ import java.util.Map;
 @FunctionalInterface
 public interface MemoryObservationHook {
 
+    // Observation Name Suffix constants
+    String EMBEDDING = "embedding";
+    String LLM_INFERENCE = "llm";
+    String VECTOR_SEARCH = "vector_search";
+    String BM25_SEARCH = "bm25_search";
+    String SPLADE_SEARCH = "splade_search";
+    String SCORING = "scoring";
+    String GRAPH_EXPANSION = "graph_expansion";
+    String CONTRADICTION = "contradiction";
+    String TAG_EXTRACTION = "tag_extraction";
+    String CHUNKING = "chunking";
+    String ENTITY_EXTRACTION = "entity_extraction";
+    String GRAPH_SYNC = "graph_sync";
+    
+    // Scoring sub-operations
+    String SCORING_COGNITIVE = "cognitive";
+    String SCORING_HABITUATION = "habituation";
+    String SCORING_STDP = "stdp";
+    String SCORING_HEBBIAN = "hebbian";
+    String SCORING_VALENCE = "valence";
+    String SCORING_TOPK = "topk";
+
+    // Tag Key constants
+    String TAG_TIER = "spector.tier";
+    String TAG_NAMESPACE = "spector.namespace";
+    String TAG_STATUS = "spector.status";
+    String TAG_PROVIDER = "spector.provider";
+    String TAG_INDEX_TYPE = "spector.index_type";
+    String TAG_SEARCH_MODE = "spector.search_mode";
+    String TAG_MODEL_ID = "spector.model_id";
+    String TAG_CANDIDATES = "spector.candidates";
+    String TAG_CHUNKS = "spector.chunks";
+    String TAG_TOKENS_IN = "spector.tokens_in";
+    String TAG_TOKENS_OUT = "spector.tokens_out";
+    String TAG_MEMORY_ID = "spector.memory_id";
+    String TAG_SESSION_ID = "spector.session_id";
+    String TAG_QUERY = "spector.query";
+    String TAG_TASK_ID = "spector.task_id";
+
     /**
      * No-op implementation that does nothing and returns an empty AutoCloseable.
      */
-    MemoryObservationHook NOOP = (name, tags) -> () -> {};
+    MemoryObservationHook NOOP = new NoOpHook();
 
     /**
      * Starts an observation span for the given operation name and contextual tags.
      *
-     * @param name operation name (e.g. "spector.memory.recall", "spector.taskqueue.process")
+     * @param observationSuffix operation name suffix (e.g. "recall", "chunking")
      * @param tags contextual low-cardinality and high-cardinality tags
      * @return an AutoCloseable handle whose {@link AutoCloseable#close()} method stops the observation
      */
-    AutoCloseable start(String name, Map<String, String> tags);
+    AutoCloseable start(String observationSuffix, Map<String, String> tags);
+
+    default <T> T observe(String suffix, Map<String, String> tags, Supplier<T> work) {
+        try (AutoCloseable ac = start(suffix, tags)) {
+            return work.get();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    default <T> T observe(String suffix, Supplier<Map<String, String>> tagSupplier, Supplier<T> work) {
+        try (AutoCloseable ac = start(suffix, tagSupplier.get())) {
+            return work.get();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    default void observe(String suffix, Map<String, String> tags, Runnable work) {
+        try (AutoCloseable ac = start(suffix, tags)) {
+            work.run();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    default void observe(String suffix, Supplier<Map<String, String>> tagSupplier, Runnable work) {
+        try (AutoCloseable ac = start(suffix, tagSupplier.get())) {
+            work.run();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/observation/NoOpHook.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/observation/NoOpHook.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.observation;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+final class NoOpHook implements MemoryObservationHook {
+    
+    private static final AutoCloseable EMPTY = () -> {};
+
+    @Override
+    public AutoCloseable start(String observationSuffix, Map<String, String> tags) {
+        return EMPTY;
+    }
+
+    @Override
+    public <T> T observe(String suffix, Map<String, String> tags, Supplier<T> work) {
+        return work.get();
+    }
+
+    @Override
+    public <T> T observe(String suffix, Supplier<Map<String, String>> tagSupplier, Supplier<T> work) {
+        return work.get();
+    }
+
+    @Override
+    public void observe(String suffix, Map<String, String> tags, Runnable work) {
+        work.run();
+    }
+
+    @Override
+    public void observe(String suffix, Supplier<Map<String, String>> tagSupplier, Runnable work) {
+        work.run();
+    }
+}

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/ObservabilityConfig.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/ObservabilityConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.config;
+
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public record ObservabilityConfig(
+    boolean enabled,
+    double samplingRate,
+    Map<String, Boolean> observations,
+    boolean highCardinalityEnabled
+) {
+    public static final ObservabilityConfig DEFAULT = new ObservabilityConfig(true, 1.0, Map.of(), true);
+
+    public boolean isEnabled(String observationKey) {
+        if (!enabled) {
+            return false;
+        }
+        if (observations != null && observations.containsKey(observationKey)) {
+            return Boolean.TRUE.equals(observations.get(observationKey));
+        }
+        return true;
+    }
+
+    public Set<String> computeEnabledObservationSet() {
+        if (!enabled) {
+            return Set.of();
+        }
+
+        Set<String> enabledSet = new HashSet<>(Set.of(
+            MemoryObservationHook.EMBEDDING,
+            MemoryObservationHook.LLM_INFERENCE,
+            MemoryObservationHook.VECTOR_SEARCH,
+            MemoryObservationHook.BM25_SEARCH,
+            MemoryObservationHook.SPLADE_SEARCH,
+            MemoryObservationHook.SCORING,
+            MemoryObservationHook.GRAPH_EXPANSION,
+            MemoryObservationHook.CONTRADICTION,
+            MemoryObservationHook.TAG_EXTRACTION,
+            MemoryObservationHook.CHUNKING,
+            MemoryObservationHook.ENTITY_EXTRACTION,
+            MemoryObservationHook.GRAPH_SYNC,
+            MemoryObservationHook.SCORING_COGNITIVE,
+            MemoryObservationHook.SCORING_HABITUATION,
+            MemoryObservationHook.SCORING_STDP,
+            MemoryObservationHook.SCORING_HEBBIAN,
+            MemoryObservationHook.SCORING_VALENCE,
+            MemoryObservationHook.SCORING_TOPK
+        ));
+
+        if (observations != null) {
+            observations.forEach((k, v) -> {
+                if (Boolean.FALSE.equals(v)) {
+                    enabledSet.remove(k);
+                } else if (Boolean.TRUE.equals(v)) {
+                    enabledSet.add(k);
+                }
+            });
+        }
+
+        return Set.copyOf(enabledSet);
+    }
+}

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
@@ -121,7 +121,9 @@ public class SpectorAutoConfiguration {
                                  ObjectProvider<LlmProvider> textGenProvider,
                                  ObjectProvider<MeterRegistry> registryProvider,
                                  ObjectProvider<SalienceProfileProvider> salienceProvider,
-                                 ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+                                 ObjectProvider<SpectorCacheManager> cacheManagerProvider,
+                                 ObjectProvider<io.micrometer.observation.ObservationRegistry> observationRegistryProvider,
+                                 ObjectProvider<com.spectrayan.spector.config.ObservabilityConfig> observabilityConfigProvider) {
 
         var memoryProps = props.getMemory();
         EmbeddingProvider embedder = embedderProvider.getIfAvailable();
@@ -184,6 +186,13 @@ public class SpectorAutoConfiguration {
             builder.cacheManager(cacheManager);
         }
 
+        io.micrometer.observation.ObservationRegistry obsRegistry = observationRegistryProvider.getIfAvailable();
+        com.spectrayan.spector.config.ObservabilityConfig obsConfig = observabilityConfigProvider.getIfAvailable();
+
+        if (obsRegistry != null && obsConfig != null) {
+            builder.observationHook(new com.spectrayan.spector.metrics.observation.MicrometerMemoryObservationHook(obsRegistry, obsConfig));
+        }
+
         SpectorMemory raw = builder.build();
         log.info("SpectorMemory auto-configured: dims={}, persistence={}, path={}, entity={}, SPLADE={}, ColBERT={}, salience={}",
                 memoryProps.getDimensions(), memoryProps.getPersistenceMode(),
@@ -195,7 +204,11 @@ public class SpectorAutoConfiguration {
         if (registry != null && props.getMetrics().isEnabled()) {
             SpectorMetrics.init(registry);
             log.info("Spector metrics enabled via Spring MeterRegistry");
-            return new MeteredSpectorMemory(raw, registry);
+            new com.spectrayan.spector.metrics.observation.SpectorMemoryGauges(raw).bindTo(registry);
+        }
+
+        if (obsRegistry != null && obsConfig != null) {
+            return new com.spectrayan.spector.metrics.ObservedSpectorMemory(raw, obsRegistry, obsConfig);
         }
 
         return raw;

--- a/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
+++ b/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
@@ -56,6 +56,14 @@ class SpectorAutoConfigurationTest {
         MeterRegistry meterRegistry() {
             return new SimpleMeterRegistry();
         }
+        @Bean
+        io.micrometer.observation.ObservationRegistry observationRegistry() {
+            return io.micrometer.observation.ObservationRegistry.create();
+        }
+        @Bean
+        com.spectrayan.spector.config.ObservabilityConfig observabilityConfig() {
+            return com.spectrayan.spector.config.ObservabilityConfig.DEFAULT;
+        }
     }
     @Configuration
     static class TestWrapSpringAIAutoConfiguration{
@@ -86,7 +94,7 @@ class SpectorAutoConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasSingleBean(SpectorMemory.class);
                     SpectorMemory memory = context.getBean(SpectorMemory.class);
-                    assertThat(memory).isInstanceOf(MeteredSpectorMemory.class);
+                    assertThat(memory).isInstanceOf(com.spectrayan.spector.metrics.ObservedSpectorMemory.class);
                 });
     }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistry.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/UserMemoryRegistry.java
@@ -95,6 +95,8 @@ public final class UserMemoryRegistry implements AutoCloseable {
     private final ObjectProvider<ObjectMapper> objectMapperProvider;
     private final ObjectProvider<org.springframework.cache.CacheManager> cacheManagerProvider;
     private final ObjectProvider<com.spectrayan.spector.memory.DataEncryptor> encryptorProvider;
+    private final ObjectProvider<io.micrometer.observation.ObservationRegistry> observationRegistryProvider;
+    private final ObjectProvider<com.spectrayan.spector.config.ObservabilityConfig> observabilityConfigProvider;
 
     /** Maximum number of concurrently-cached per-user instances (LRU cap). */
     private final int maxInstances;
@@ -115,7 +117,7 @@ public final class UserMemoryRegistry implements AutoCloseable {
             ObjectProvider<SalienceProfileProvider> salienceProvider,
             ObjectProvider<ObjectMapper> objectMapperProvider,
             int maxInstances) {
-        this(sharedProvider, synapseProps, embedderProvider, textGenProvider, salienceProvider, objectMapperProvider, null, null, maxInstances);
+        this(sharedProvider, synapseProps, embedderProvider, textGenProvider, salienceProvider, objectMapperProvider, null, null, null, null, maxInstances);
     }
 
     @Autowired
@@ -128,6 +130,8 @@ public final class UserMemoryRegistry implements AutoCloseable {
             ObjectProvider<ObjectMapper> objectMapperProvider,
             ObjectProvider<org.springframework.cache.CacheManager> cacheManagerProvider,
             ObjectProvider<com.spectrayan.spector.memory.DataEncryptor> encryptorProvider,
+            ObjectProvider<io.micrometer.observation.ObservationRegistry> observationRegistryProvider,
+            ObjectProvider<com.spectrayan.spector.config.ObservabilityConfig> observabilityConfigProvider,
             @Value("${spector.auth.memory.max-instances:512}") int maxInstances) {
         this.sharedProvider = sharedProvider;
         this.synapseProps = synapseProps;
@@ -137,6 +141,8 @@ public final class UserMemoryRegistry implements AutoCloseable {
         this.objectMapperProvider = objectMapperProvider;
         this.cacheManagerProvider = cacheManagerProvider;
         this.encryptorProvider = encryptorProvider;
+        this.observationRegistryProvider = observationRegistryProvider;
+        this.observabilityConfigProvider = observabilityConfigProvider;
         this.maxInstances = Math.max(1, maxInstances);
         log.info("[UserMemoryRegistry] initialized: authEnabled={}, maxInstances={}",
                 synapseProps.auth().enabled(), this.maxInstances);
@@ -350,7 +356,19 @@ public final class UserMemoryRegistry implements AutoCloseable {
                     .build());
         }
 
+        io.micrometer.observation.ObservationRegistry obsRegistry = observationRegistryProvider != null ? observationRegistryProvider.getIfAvailable() : null;
+        com.spectrayan.spector.config.ObservabilityConfig obsConfig = observabilityConfigProvider != null ? observabilityConfigProvider.getIfAvailable() : null;
+
+        if (obsRegistry != null && obsConfig != null) {
+            builder.observationHook(new com.spectrayan.spector.metrics.observation.MicrometerMemoryObservationHook(obsRegistry, obsConfig));
+        }
+
         SpectorMemory built = builder.build();
+
+        if (obsRegistry != null && obsConfig != null) {
+            built = new com.spectrayan.spector.metrics.ObservedSpectorMemory(built, obsRegistry, obsConfig);
+        }
+
         log.info("[UserMemoryRegistry] built per-user memory instance (dims={}, persistenceMode={})",
                 memory.getDimensions(), memory.getPersistenceMode());
 


### PR DESCRIPTION
## Summary

Resolves #559 — Unifies Spector's parallel observability mechanisms into a single ScopedValue-based auto-propagating observation hierarchy rooted at `spector.memory.*`.

## Changes

### Phase 1: Foundation
- **`MemoryObservationHook`** (`spector-commons`): Enhanced with 18 observation name suffix constants, 14 tag key constants, `observe()` convenience default methods, and `NOOP` singleton
- **`NoOpHook`** (`spector-commons`): Package-private zero-overhead implementation — all `observe()` methods bypass tag evaluation
- **`ObservabilityConfig`** (`spector-config`): Record with per-observation enable/disable, sampling rate, and `computeEnabledObservationSet()` for O(1) lookup

### Phase 2: Metrics Layer
- **`ObservableComponent`** (`spector-metrics`): Abstract base with `ScopedValue<String> PARENT_OBSERVATION` for implicit parent propagation and `withObservation()` convenience. Auto-tags `namespace` and `sessionId` from `MemoryScope`.
- **`MicrometerMemoryObservationHook`**: Updated with `ObservabilityConfig` gating, hierarchical name composition via `ObservableComponent.currentParent()`, and ScopedValue binding in `observe()`
- **`ObservedEmbeddingProvider`** / **`ObservedLlmProvider`**: Decorator classes extending `ObservableComponent`
- **`SpectorObservationDocumentation`**: Expanded with 13 new observation entries (RECALL_*, REMEMBER_*, SCORING_*)

### Phase 3: Pipeline Instrumentation
- **`RecallPipeline`**: `hook.observe()` wrapping EMBEDDING, VECTOR_SEARCH, SCORING, GRAPH_EXPANSION at operation boundaries
- **`SalienceAndHabituationScorer`**: `hook.observe()` wrapping SCORING_HABITUATION, SCORING_STDP
- **`DefaultSpectorMemory`** / **`SpectorMemoryBuilder`**: Hook accepted via builder, propagated to pipeline
- **`CognitiveIngestionTarget`** / **`AsyncEntityExtractionQueue`**: Hook wrapping TAG_EXTRACTION, ENTITY_EXTRACTION, GRAPH_SYNC

### Phase 4: Unify & Deprecate
- **`ObservedSpectorMemory`**: Refactored to extend `ObservableComponent`
- **`SpectorMemoryGauges`**: Extracted as standalone `MeterBinder`
- **`MeteredSpectorMemory`**: Deprecated with `@Deprecated(forRemoval = true)`

### Phase 5: Wiring
- **`UserMemoryRegistry`**: Wraps built memory with `ObservedSpectorMemory` + `MicrometerMemoryObservationHook`
- **`SpectorAutoConfiguration`**: Updated to use `ObservedSpectorMemory` instead of `MeteredSpectorMemory`

## Testing
- All 15 metrics tests pass (including updated `ObservedSpectorMemoryTest`)
- Full `mvn clean verify` green across all modules

## Design Document
[`RnD/spector-unified-observability-architecture.md`](https://github.com/spectrayan/spectrayan/blob/main/RnD/spector-unified-observability-architecture.md)
