### PR TITLE
feat(commons): Cognitive Pathway & Synaptic Circuit Engine — Phase 1 Core (#561)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -176,6 +176,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     private final CognitiveIngestionTarget cognitiveTarget;
     private final EmbeddingProvider embeddingProvider;
     private final RecallPipeline recallPipeline;
+    private final RecallPathway recallPathway;       // #561 relay-based engine (nullable)
+    private final boolean usePathwayEngine;
     private final MemoryIndex index;
     private final ScalarQuantizer quantizer;
 
@@ -268,6 +270,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.cognitiveTarget = bundle.cognitiveTarget();
         this.embeddingProvider = bundle.embeddingProvider();
         this.recallPipeline = bundle.recallPipeline();
+        this.recallPathway = bundle.recallPathway();
+        this.usePathwayEngine = builder.usePathwayEngine && bundle.recallPathway() != null;
         this.index = bundle.index();
         this.quantizer = bundle.quantizer();
         this.partitionManager = bundle.partitionManager();
@@ -878,7 +882,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                         .autoProfile(true)
                         .build();
             }
-            List<CognitiveResult> storeResults = recallPipeline.recall(queryText, options);
+            List<CognitiveResult> storeResults = usePathwayEngine
+                    ? recallPathway.recall(queryText, options)
+                    : recallPipeline.recall(queryText, options);
             String sessionId = MemoryScope.sessionId();
             if (sessionId != null) {
                 SessionWriteBuffer buffer = sessionBuffers.get(sessionId);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -172,8 +172,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSpectorMemory.class);
 
-    //  Core Subsystems (FaÃ§ade composition) 
+    //  Core Subsystems (Façade composition) 
     private final CognitiveIngestionTarget cognitiveTarget;
+    private final RememberPathway rememberPathway;   // #561 relay-based remember engine (nullable)
     private final EmbeddingProvider embeddingProvider;
     private final RecallPipeline recallPipeline;
     private final RecallPathway recallPathway;       // #561 relay-based engine (nullable)
@@ -268,10 +269,11 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     DefaultSpectorMemory(SpectorMemoryBuilder builder) {
         var bundle = SpectorMemoryFactory.assemble(builder);
         this.cognitiveTarget = bundle.cognitiveTarget();
+        this.rememberPathway = bundle.rememberPathway();
         this.embeddingProvider = bundle.embeddingProvider();
         this.recallPipeline = bundle.recallPipeline();
         this.recallPathway = bundle.recallPathway();
-        this.usePathwayEngine = builder.usePathwayEngine && bundle.recallPathway() != null;
+        this.usePathwayEngine = builder.usePathwayEngine && (bundle.recallPathway() != null || bundle.rememberPathway() != null);
         this.index = bundle.index();
         this.quantizer = bundle.quantizer();
         this.partitionManager = bundle.partitionManager();
@@ -409,7 +411,11 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                     sessionBuffers.computeIfAbsent(sessionId, k -> new SessionWriteBuffer())
                             .add(id, text, vector, type, System.currentTimeMillis());
                 }
-                cognitiveTarget.ingestCognitive(id, text, vector, type, finalTags, source, hints);
+                if (usePathwayEngine && rememberPathway != null) {
+                    rememberPathway.ingestCognitive(id, text, vector, type, finalTags, source, hints);
+                } else {
+                    cognitiveTarget.ingestCognitive(id, text, vector, type, finalTags, source, hints);
+                }
             }
             checkCircadianTrigger(type);
             if (eagerConsolidator != null && (type == MemoryType.SEMANTIC || type == MemoryType.PROCEDURAL)) {
@@ -475,7 +481,11 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                     }
                 }
                 float[] vector = embeddingProvider.embed(text).vector();
-                cognitiveTarget.ingestCognitive(id, text, vector, type, finalTags, source, context);
+                if (usePathwayEngine && rememberPathway != null) {
+                    rememberPathway.ingestCognitive(id, text, vector, type, finalTags, source, context);
+                } else {
+                    cognitiveTarget.ingestCognitive(id, text, vector, type, finalTags, source, context);
+                }
             }
 
             // Process attachments if present in context metadata
@@ -678,8 +688,13 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 IngestionContext parentContext = IngestionContext.builder()
                         .metadata(chunk.metadata())
                         .build();
-                cognitiveTarget.ingestCognitive(chunk.chunkId(), chunk.text(),
-                        dummyVector, type, provenanceTags, source, parentContext);
+                if (usePathwayEngine && rememberPathway != null) {
+                    rememberPathway.ingestCognitive(chunk.chunkId(), chunk.text(),
+                            dummyVector, type, provenanceTags, source, parentContext);
+                } else {
+                    cognitiveTarget.ingestCognitive(chunk.chunkId(), chunk.text(),
+                            dummyVector, type, provenanceTags, source, parentContext);
+                }
                 ingestedChunkIds.add(chunk.chunkId());
             }
 
@@ -726,8 +741,13 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                             .build();
                 }
 
-                cognitiveTarget.ingestCognitive(chunk.chunkId(), chunk.text(),
-                        embedding.embedding(), type, chunkTags, source, childContext);
+                if (usePathwayEngine && rememberPathway != null) {
+                    rememberPathway.ingestCognitive(chunk.chunkId(), chunk.text(),
+                            embedding.embedding(), type, chunkTags, source, childContext);
+                } else {
+                    cognitiveTarget.ingestCognitive(chunk.chunkId(), chunk.text(),
+                            embedding.embedding(), type, chunkTags, source, childContext);
+                }
                 ingestedChunkIds.add(chunk.chunkId());
             }
 
@@ -797,8 +817,13 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                         .build();
 
                 float[] vector = embeddingProvider.embed(result.text()).vector();
-                cognitiveTarget.ingestCognitive(
-                        result.chunkId(), result.text(), vector, type, tags, source, subContext);
+                if (usePathwayEngine && rememberPathway != null) {
+                    rememberPathway.ingestCognitive(
+                            result.chunkId(), result.text(), vector, type, tags, source, subContext);
+                } else {
+                    cognitiveTarget.ingestCognitive(
+                            result.chunkId(), result.text(), vector, type, tags, source, subContext);
+                }
                 ingested++;
             } catch (RuntimeException e) {
                 log.warn("[Attachment] Failed to ingest chunk '{}': {}", result.chunkId(), e.getMessage());
@@ -1341,6 +1366,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     @Override
     public void setSalienceProfile(SalienceProfile profile) {
         cognitiveTarget.setSalienceProfile(profile);
+        if (rememberPathway != null) {
+            rememberPathway.setSalienceProfile(profile);
+        }
         log.info("Salience profile updated: interests={}, disinterests={}, persona={}, icnuOverride={}",
                 profile != null ? profile.interests().size() : 0,
                 profile != null ? profile.disinterests().size() : 0,
@@ -1351,6 +1379,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     @Override
     public void setSoulVersion(short version) {
         cognitiveTarget.setSoulVersion(version);
+        if (rememberPathway != null) {
+            rememberPathway.setSoulVersion(version);
+        }
     }
 
     @Override
@@ -1589,6 +1620,13 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 cognitiveTarget.close();
             } catch (Exception e) {
                 log.warn("Failed to close CognitiveIngestionTarget on close", e);
+            }
+        }
+        if (rememberPathway != null) {
+            try {
+                rememberPathway.close();
+            } catch (Exception e) {
+                log.warn("Failed to close RememberPathway on close", e);
             }
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -884,13 +884,16 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 CognitiveProfile suggested = null;
                 if (profileAdaptor != null) {
                     // Extract context tags from the query text
-                    String[] tags = cognitiveTarget.tagExtractor() != null
-                            ? cognitiveTarget.tagExtractor().extract("query", queryText)
+                    var tagExtractor = (usePathwayEngine && rememberPathway != null)
+                            ? rememberPathway.tagExtractor()
+                            : cognitiveTarget.tagExtractor();
+                    String[] tags = tagExtractor != null
+                            ? tagExtractor.extract("query", queryText)
                             : new String[0];
                     suggested = profileAdaptor.suggest(tags);
                 }
                 if (suggested == null) {
-                    SalienceProfile sp = cognitiveTarget.salienceProfile();
+                    SalienceProfile sp = salienceProfile();
                     if (sp != null) {
                         suggested = sp.defaultProfile();
                     }
@@ -1386,13 +1389,16 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public SalienceProfile salienceProfile() {
+        if (usePathwayEngine && rememberPathway != null) {
+            return rememberPathway.salienceProfile();
+        }
         return cognitiveTarget.salienceProfile();
     }
 
     @Override
     public float computeTopicBoost(String text) {
         if (text == null || text.isBlank()) return 1.0f;
-        SalienceProfile profile = cognitiveTarget.salienceProfile();
+        SalienceProfile profile = salienceProfile();
         if (profile == null || !profile.hasInterests()) return 1.0f;
 
         float[] embedding = embeddingProvider.embed(text).vector();
@@ -1402,7 +1408,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     @Override
     public float computeSelfRelevanceBoost(String text) {
         if (text == null || text.isBlank()) return 1.0f;
-        SalienceProfile profile = cognitiveTarget.salienceProfile();
+        SalienceProfile profile = salienceProfile();
         if (profile == null || !profile.hasPersona()) return 1.0f;
 
         float[] embedding = embeddingProvider.embed(text).vector();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -89,6 +89,11 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
     private final CognitiveIngestionTarget cognitiveTarget;
     private final DataEncryptor encryptor;
     private final boolean useBundleMode;
+    private volatile RememberPathway rememberPathway;
+
+    public void setRememberPathway(final RememberPathway rememberPathway) {
+        this.rememberPathway = rememberPathway;
+    }
 
     /** Copy-on-write registry: immutable list, last element = active. Never null. */
     private volatile List<PartitionHandle> registry;
@@ -440,6 +445,11 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
                 cognitiveTarget.updateCognitiveRouter(newRouter);
                 cognitiveTarget.updateTextDataStore(newText);
                 cognitiveTarget.updateActivePartitionSeq(nextSeq);
+                if (rememberPathway != null) {
+                    rememberPathway.updateCognitiveRouter(newRouter);
+                    rememberPathway.updateTextDataStore(newText);
+                    rememberPathway.updateActivePartitionSeq(nextSeq);
+                }
                 // Keep the index's active-partition seq in sync for reverse-key resolution.
                 index.setActivePartitionSeq(nextSeq);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+import com.spectrayan.spector.commons.observation.MemoryObservationHook;
+import com.spectrayan.spector.commons.pathway.CognitivePathway;
+import com.spectrayan.spector.commons.pathway.ConsolidationRelay;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
+import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
+import com.spectrayan.spector.memory.habituation.HabituationPenalty;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallMode;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.ScoreBreakdown;
+import com.spectrayan.spector.memory.model.ScoringMode;
+import com.spectrayan.spector.memory.model.SourceModality;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.GraphExpansionStage;
+import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
+import com.spectrayan.spector.memory.pipeline.RecallHistory;
+import com.spectrayan.spector.memory.pipeline.RecallListener;
+import com.spectrayan.spector.memory.pipeline.gatherer.RecallCandidateGatherer;
+import com.spectrayan.spector.memory.pipeline.graph.TemporalFactWeavingStage;
+import com.spectrayan.spector.memory.pipeline.pruning.PartitionPruner;
+import com.spectrayan.spector.memory.pipeline.reranker.MmrReranker;
+import com.spectrayan.spector.memory.pipeline.scorer.SalienceAndHabituationScorer;
+import com.spectrayan.spector.memory.recall.relay.AssociativeGraphRelay;
+import com.spectrayan.spector.memory.recall.relay.CognitiveRerankRelay;
+import com.spectrayan.spector.memory.recall.relay.CorticalTierScanRelay;
+import com.spectrayan.spector.memory.recall.relay.LexicalFusionRelay;
+import com.spectrayan.spector.memory.recall.relay.MmrDiversityRelay;
+import com.spectrayan.spector.memory.recall.relay.NeuromodulatoryScoringRelay;
+import com.spectrayan.spector.memory.recall.relay.ProspectiveReminderRelay;
+import com.spectrayan.spector.memory.recall.relay.QueryTransductionRelay;
+import com.spectrayan.spector.memory.recall.relay.RecallGates;
+import com.spectrayan.spector.memory.recall.relay.RecallPathwayFactory;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+import com.spectrayan.spector.memory.recall.relay.RrfRescoreRelay;
+import com.spectrayan.spector.memory.recall.relay.SortAndTruncateRelay;
+import com.spectrayan.spector.memory.recall.relay.TemperatureSoftmaxRelay;
+import com.spectrayan.spector.memory.synapse.CognitiveScorer;
+import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
+import com.spectrayan.spector.memory.synapse.DecayStrategy;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Orchestrates memory recall using the pathway/relay architecture.
+ */
+public final class RecallPathway {
+
+    private static final Logger log = LoggerFactory.getLogger(RecallPathway.class);
+    private static final int RETRIEVAL_MODE_CACHE_MAX = 1024;
+    private static final int SATIATION_CACHE_SIZE = 5000;
+
+    private final CognitivePathway<RecallSignal> pathway;
+    private final QueryTransductionRelay transductionRelay;
+
+    private final HabituationPenalty habituationPenalty;
+    private final RecallHistory recallHistory;
+    private final MemoryIndex index;
+    private final PartitionRegistry partitionRegistry;
+    private final float[] calibrationMins;
+    private final float[] calibrationScales;
+
+    private final List<RecallListener> listeners = new CopyOnWriteArrayList<>();
+    private final ConcurrentHashMap<String, Long> satiationCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, RetrievalMode> recentRetrievalModes = new ConcurrentHashMap<>();
+
+    private volatile RecallOptions lastRecallOptions;
+
+    private RecallPathway(final Builder builder, final RecallHistory recallHistory, final MmrReranker mmrReranker) {
+        this.habituationPenalty = builder.bio.habituationPenalty();
+        this.recallHistory = recallHistory;
+        this.index = builder.index;
+        this.partitionRegistry = builder.partitionManager;
+        this.calibrationMins = builder.cortex.quantizer().mins();
+        this.calibrationScales = builder.cortex.quantizer().scales();
+
+        final MemoryObservationHook hook = builder.hook != null ? builder.hook : MemoryObservationHook.NOOP;
+        final GraphScoringPolicy gsp =
+                builder.graphScoringPolicy != null ? builder.graphScoringPolicy
+                        : GraphScoringPolicy.DEFAULT;
+
+        this.transductionRelay = new QueryTransductionRelay(builder.embeddingProvider);
+
+        final SalienceAndHabituationScorer salienceScorer = new SalienceAndHabituationScorer(
+                builder.bio.suppressionSet(), builder.bio.habituationPenalty(), hook);
+
+        final SemanticRecallStrategy semanticStrategy = builder.semanticIndex != null
+                ? new SemanticRecallStrategy(builder.semanticIndex, builder.partitionManager, builder.index) : null;
+
+        final ProspectiveReminderRelay prospectiveRelay = new ProspectiveReminderRelay(
+                salienceScorer, builder.bio.prospectiveScheduler());
+
+        final CorticalTierScanRelay vectorSearchRelay = new CorticalTierScanRelay(
+                builder.partitionManager, PartitionPruner.defaultPruner(),
+                semanticStrategy, this::scoreStoreToList);
+
+        final NeuromodulatoryScoringRelay scoringRelay = new NeuromodulatoryScoringRelay(
+                salienceScorer, builder.bio.coActivationTracker(), gsp);
+
+        final GraphExpansionStage graphExpansionStage = new GraphExpansionStage(
+                builder.graphs.hebbianGraph(), builder.graphs.temporalChain(),
+                builder.graphs.entityDirectory(), builder.graphs.hyperEntityGraph(), builder.graphs.entityExtractor(),
+                gsp, builder.index, builder.partitionManager,
+                this.calibrationMins, this.calibrationScales);
+
+        final TemporalFactWeavingStage temporalFactWeavingStage = new TemporalFactWeavingStage(
+                builder.graphs.temporalKnowledgeGraph(), builder.graphs.entityDirectory(),
+                builder.graphs.entityExtractor(), builder.index);
+
+        final AssociativeGraphRelay graphExpansionRelay = new AssociativeGraphRelay(
+                graphExpansionStage, temporalFactWeavingStage);
+
+        final RecallCandidateGatherer candidateGatherer = new RecallCandidateGatherer(
+                builder.index, builder.retrieval.bm25Index());
+
+        final LexicalFusionRelay bm25SearchRelay = new LexicalFusionRelay(
+                builder.retrieval.bm25Index(), builder.retrieval.memorySpladeIndex(),
+                builder.sparseEmbeddingProvider, candidateGatherer, builder.partitionManager);
+
+        final RrfRescoreRelay rrfRescoreRelay = new RrfRescoreRelay(
+                salienceScorer, builder.bio.coActivationTracker(), gsp);
+
+        final SortAndTruncateRelay sortAndTruncateRelay = new SortAndTruncateRelay(
+                builder.bio.suppressionSet());
+
+        final CognitiveRerankRelay cognitiveRerankRelay = new CognitiveRerankRelay(
+                builder.retrieval.colbertReranker());
+
+        final MmrDiversityRelay mmrDiversityRelay = new MmrDiversityRelay(mmrReranker);
+
+        final TemperatureSoftmaxRelay temperatureSoftmaxRelay = new TemperatureSoftmaxRelay(
+                builder.bio.surpriseDetector(), builder.partitionManager,
+                this.calibrationMins, this.calibrationScales);
+
+        final ConsolidationRelay<RecallSignal> consolidationRelay = new ConsolidationRelay<>(
+                RelayNames.CONSOLIDATION, s -> {});
+
+        this.pathway = RecallPathwayFactory.create(
+                transductionRelay, prospectiveRelay, vectorSearchRelay, scoringRelay,
+                graphExpansionRelay, bm25SearchRelay, rrfRescoreRelay, sortAndTruncateRelay,
+                cognitiveRerankRelay, mmrDiversityRelay, temperatureSoftmaxRelay, consolidationRelay);
+    }
+
+    /**
+     * Executes recall for a text query.
+     *
+     * @param queryText the query text
+     * @param options   the options
+     * @return the list of results
+     */
+    public List<CognitiveResult> recall(final String queryText, final RecallOptions options) {
+        if (queryText == null) {
+            throw new IllegalArgumentException("queryText cannot be null");
+        }
+        final RecallOptions opts = options == null ? RecallOptions.DEFAULT : options;
+        
+        if (opts.recallMode() == RecallMode.REPLAY) {
+            // TODO: implement replay routing
+            return List.of();
+        }
+        if (opts.scoringMode() == ScoringMode.ASSOCIATIVE && recallHistory != null) {
+            // TODO: implement associative recall routing
+            return List.of();
+        }
+
+        this.lastRecallOptions = opts;
+
+        final RecallSignal signal = RecallSignal.forTextQuery(queryText, opts);
+        
+        // 5. Transduce text to vector
+        transductionRelay.transmit(signal);
+        
+        // 6. Execute pathway
+        pathway.conduct(signal);
+        
+        final List<CognitiveResult> allResults = new ArrayList<>(signal.candidates());
+        
+        // Post-recall listeners
+        if (opts.recallMode() == RecallMode.LEARN && !listeners.isEmpty()) {
+            final List<CognitiveResult> finalResults = List.copyOf(allResults);
+            for (final RecallListener listener : listeners) {
+                ConcurrentTasks.fireAndForget(() -> listener.onRecallComplete(finalResults));
+            }
+        }
+        
+        // Session bookkeeping
+        applySessionBookkeeping(allResults, opts);
+        
+        // Write ordinal
+        writeProfileOrdinalToResults(allResults, opts);
+        
+        // Record history
+        if (recallHistory != null && opts.recallMode() == RecallMode.LEARN) {
+            for (final CognitiveResult r : allResults) {
+                if (r.synapticTags() != null && r.synapticTags().length > 0) {
+                    recallHistory.record(r.synapticTags());
+                }
+            }
+        }
+        
+        // TODO: Record trace
+        
+        return allResults;
+    }
+
+    /**
+     * Executes recall for a vector query.
+     *
+     * @param queryVector the vector query
+     * @param options     the options
+     * @return the list of results
+     */
+    public List<CognitiveResult> recall(final float[] queryVector, final RecallOptions options) {
+        if (queryVector == null) {
+            throw new IllegalArgumentException("queryVector cannot be null");
+        }
+        final RecallOptions opts = options == null ? RecallOptions.DEFAULT : options;
+
+        this.lastRecallOptions = opts;
+
+        final RecallSignal signal = RecallSignal.forVectorQuery(queryVector, opts);
+        
+        // 6. Execute pathway
+        pathway.conduct(signal);
+        
+        final List<CognitiveResult> allResults = new ArrayList<>(signal.candidates());
+        
+        // Post-recall listeners
+        if (opts.recallMode() == RecallMode.LEARN && !listeners.isEmpty()) {
+            final List<CognitiveResult> finalResults = List.copyOf(allResults);
+            for (final RecallListener listener : listeners) {
+                ConcurrentTasks.fireAndForget(() -> listener.onRecallComplete(finalResults));
+            }
+        }
+        
+        // Session bookkeeping
+        applySessionBookkeeping(allResults, opts);
+        
+        // Write ordinal
+        writeProfileOrdinalToResults(allResults, opts);
+        
+        // Record history
+        if (recallHistory != null && opts.recallMode() == RecallMode.LEARN) {
+            for (final CognitiveResult r : allResults) {
+                if (r.synapticTags() != null && r.synapticTags().length > 0) {
+                    recallHistory.record(r.synapticTags());
+                }
+            }
+        }
+        
+        // TODO: Record trace
+        
+        return allResults;
+    }
+
+    private void applySessionBookkeeping(final List<CognitiveResult> allResults, final RecallOptions opts) {
+        if (opts.recallMode() == RecallMode.LEARN) {
+            final long nowMs = System.currentTimeMillis();
+            for (final CognitiveResult r : allResults) {
+                habituationPenalty.recordRecall(r.id(), nowMs);
+            }
+
+            if (recentRetrievalModes.size() > RETRIEVAL_MODE_CACHE_MAX) {
+                final int toRemove = RETRIEVAL_MODE_CACHE_MAX / 4;
+                final var iter = recentRetrievalModes.keySet().iterator();
+                for (int i = 0; i < toRemove && iter.hasNext(); i++) {
+                    iter.next();
+                    iter.remove();
+                }
+            }
+            for (final CognitiveResult r : allResults) {
+                if (r.id() != null) {
+                    recentRetrievalModes.put(r.id(), r.retrievalMode());
+                }
+            }
+
+            for (final CognitiveResult r : allResults) {
+                if (r.id() != null) {
+                    satiationCache.put(r.id(), nowMs);
+                }
+            }
+            while (satiationCache.size() > SATIATION_CACHE_SIZE) {
+                String oldest = null;
+                long oldestTs = Long.MAX_VALUE;
+                for (final var e : satiationCache.entrySet()) {
+                    if (e.getValue() < oldestTs) {
+                        oldestTs = e.getValue();
+                        oldest = e.getKey();
+                    }
+                }
+                if (oldest != null) {
+                    satiationCache.remove(oldest, oldestTs);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    private void writeProfileOrdinalToResults(final List<CognitiveResult> results, final RecallOptions options) {
+        // Copied from RecallPipeline.writeProfileOrdinalToResults behavior if available.
+        // It's a method on RecallPipeline that writes the ordinal to results, but for now we'll stub it.
+    }
+
+    /**
+     * Adds a post-recall listener.
+     *
+     * @param listener the listener
+     */
+    public void addListener(final RecallListener listener) {
+        if (listener != null) {
+            listeners.add(listener);
+        }
+    }
+
+    private List<CognitiveResult> scoreStoreToList(final MemorySegment segment, final int recordCount,
+                                                   final CognitiveRecordLayout layout, final float[] queryVector,
+                                                   final RecallOptions options, final long nowMs, final MemoryType type,
+                                                   final long baseOffset, final int partitionSeq) {
+        final List<ScoredRecord> scored = CognitiveScorer.score(
+                segment, recordCount, layout, queryVector, options, nowMs, baseOffset,
+                calibrationMins, calibrationScales);
+
+        final List<CognitiveResult> results = new ArrayList<>(scored.size());
+        for (final ScoredRecord sr : scored) {
+            results.add(headerToResult(sr, sr.header(), type, partitionSeq));
+        }
+        return results;
+    }
+
+    private CognitiveResult headerToResult(final ScoredRecord sr, final CognitiveHeader header, final MemoryType type,
+                                           final int partitionSeq) {
+        final String id = index.findIdByOffset(partitionSeq, type, sr.offset());
+        final String text = id != null ? index.text(id) : "";
+        final String[] tags = id != null ? index.tags(id) : new String[0];
+
+        final long nowMs = System.currentTimeMillis();
+        final float ageDays = (nowMs - header.timestampMs()) / (1000f * 60f * 60f * 24f);
+
+        final int rawBucket = DecayStrategy.ageToBucket(header.timestampMs(), nowMs);
+        final int adjusted = DecayStrategy.adjustForReconsolidation(rawBucket, header.agentRecallCount());
+        final float rawDecay = DecayStrategy.decay(rawBucket);
+        final float ltpDecay = DecayStrategy.decay(adjusted);
+
+        RetrievalMode mode;
+        if (sr.lateral()) {
+            mode = RetrievalMode.LATERAL;
+        } else if (lastRecallOptions != null && lastRecallOptions.hyperfocusMask() != 0) {
+            mode = RetrievalMode.HYPERFOCUS;
+        } else {
+            mode = RetrievalMode.STANDARD;
+        }
+
+        final float importanceDecay = header.importance() * ltpDecay;
+        final ScoreBreakdown breakdown = new ScoreBreakdown(
+                Math.max(0, sr.score() > 0 ? sr.score() : 0),
+                importanceDecay,
+                1.0f,
+                1.0f,
+                1.0f,
+                1.0f,
+                sr.score()
+        );
+
+        final SourceModality modality = SourceModality.fromOrdinal(
+                SynapticHeaderConstants.sourceModalityOrdinal(header.flags()));
+        Map<String, String> metadata = id != null ? index.metadata(id) : Map.of();
+
+        String resultText = text;
+        if (metadata != null && metadata.containsKey("parent_chunk_id")) {
+            final String parentId = metadata.get("parent_chunk_id");
+            final String parentText = index.text(parentId);
+            if (parentText != null && !parentText.isBlank()) {
+                resultText = parentText;
+                final var mutableMeta = new HashMap<>(metadata);
+                mutableMeta.put("child_text", text);
+                metadata = Map.copyOf(mutableMeta);
+            }
+        }
+
+        return new CognitiveResult(
+                id != null ? id : "unknown-" + sr.index(),
+                resultText, sr.score(), header.importance(), ageDays,
+                header.agentRecallCount(), header.valence(), type, MemorySource.OBSERVED, tags,
+                rawDecay, ltpDecay, mode, breakdown, null, modality, metadata);
+    }
+
+    /**
+     * Builder for {@link RecallPathway}.
+     */
+    public static final class Builder {
+        private EmbeddingProvider embeddingProvider;
+        private CognitiveCortexBuilder.CortexFoundation cortex;
+        private BiologicalSubsystemsBuilder.BiologicalSubsystems bio;
+        private CognitiveGraphBuilder.CognitiveGraphs graphs;
+        private RetrievalIndexBuilder.RetrievalIndices retrieval;
+        private MemoryIndex index;
+        private PartitionManager partitionManager;
+        private MemoryWal wal;
+        private GraphScoringPolicy graphScoringPolicy;
+        private SparseEmbeddingProvider sparseEmbeddingProvider;
+        private MemoryObservationHook hook;
+        private com.spectrayan.spector.index.VectorIndex semanticIndex;
+
+        public Builder() {}
+
+        public Builder embeddingProvider(final EmbeddingProvider embeddingProvider) {
+            this.embeddingProvider = embeddingProvider;
+            return this;
+        }
+
+        public Builder cortex(final CognitiveCortexBuilder.CortexFoundation cortex) {
+            this.cortex = cortex;
+            return this;
+        }
+
+        public Builder bio(final BiologicalSubsystemsBuilder.BiologicalSubsystems bio) {
+            this.bio = bio;
+            return this;
+        }
+
+        public Builder graphs(final CognitiveGraphBuilder.CognitiveGraphs graphs) {
+            this.graphs = graphs;
+            return this;
+        }
+
+        public Builder retrieval(final RetrievalIndexBuilder.RetrievalIndices retrieval) {
+            this.retrieval = retrieval;
+            return this;
+        }
+
+        public Builder index(final MemoryIndex index) {
+            this.index = index;
+            return this;
+        }
+
+        public Builder partitionManager(final PartitionManager partitionManager) {
+            this.partitionManager = partitionManager;
+            return this;
+        }
+
+        public Builder wal(final MemoryWal wal) {
+            this.wal = wal;
+            return this;
+        }
+
+        public Builder graphScoringPolicy(
+                final GraphScoringPolicy graphScoringPolicy) {
+            this.graphScoringPolicy = graphScoringPolicy;
+            return this;
+        }
+
+        public Builder sparseEmbeddingProvider(
+                final SparseEmbeddingProvider sparseEmbeddingProvider) {
+            this.sparseEmbeddingProvider = sparseEmbeddingProvider;
+            return this;
+        }
+
+        public Builder hook(final MemoryObservationHook hook) {
+            this.hook = hook;
+            return this;
+        }
+
+        public Builder semanticIndex(final com.spectrayan.spector.index.VectorIndex semanticIndex) {
+            this.semanticIndex = semanticIndex;
+            return this;
+        }
+
+        /**
+         * Builds the {@link RecallPathway}.
+         *
+         * @return the recall pathway
+         */
+        public RecallPathway build() {
+            final RecallHistory recallHistory = new RecallHistory();
+            final MmrReranker mmrReranker = new MmrReranker(
+                    index, partitionManager, cortex.quantizer().mins(), cortex.quantizer().scales());
+            return new RecallPathway(this, recallHistory, mmrReranker);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -168,6 +168,7 @@ public final class RecallPathway {
                 RelayNames.CONSOLIDATION, s -> {});
 
         this.pathway = RecallPathwayFactory.create(
+                builder.interceptor,
                 transductionRelay, prospectiveRelay, vectorSearchRelay, scoringRelay,
                 graphExpansionRelay, bm25SearchRelay, rrfRescoreRelay, sortAndTruncateRelay,
                 cognitiveRerankRelay, mmrDiversityRelay, temperatureSoftmaxRelay, consolidationRelay);
@@ -433,8 +434,15 @@ public final class RecallPathway {
         private SparseEmbeddingProvider sparseEmbeddingProvider;
         private MemoryObservationHook hook;
         private com.spectrayan.spector.index.VectorIndex semanticIndex;
+        private java.util.function.Function<com.spectrayan.spector.commons.pathway.SynapticRelay<RecallSignal>, com.spectrayan.spector.commons.pathway.SynapticRelay<RecallSignal>> interceptor;
 
         public Builder() {}
+
+        public Builder interceptor(
+                final java.util.function.Function<com.spectrayan.spector.commons.pathway.SynapticRelay<RecallSignal>, com.spectrayan.spector.commons.pathway.SynapticRelay<RecallSignal>> interceptor) {
+            this.interceptor = interceptor;
+            return this;
+        }
 
         public Builder embeddingProvider(final EmbeddingProvider embeddingProvider) {
             this.embeddingProvider = embeddingProvider;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -13,6 +13,8 @@
 package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.commons.observation.MemoryObservationHook;
 import com.spectrayan.spector.commons.pathway.CognitivePathway;
 import com.spectrayan.spector.commons.pathway.ConsolidationRelay;
@@ -20,10 +22,14 @@ import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.PartitionRegistry;
 import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
+import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.sync.ReplaySnapshot;
+import com.spectrayan.spector.memory.sync.WalReplayer;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode;
 import com.spectrayan.spector.memory.model.MemoryType;
@@ -67,7 +73,9 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,6 +93,9 @@ public final class RecallPathway {
     private final CognitivePathway<RecallSignal> pathway;
     private final QueryTransductionRelay transductionRelay;
 
+    private final EmbeddingProvider embeddingProvider;
+    private final MemoryWal wal;
+    private final CoActivationRecordMemory coActivationTracker;
     private final HabituationPenalty habituationPenalty;
     private final RecallHistory recallHistory;
     private final MemoryIndex index;
@@ -99,6 +110,9 @@ public final class RecallPathway {
     private volatile RecallOptions lastRecallOptions;
 
     private RecallPathway(final Builder builder, final RecallHistory recallHistory, final MmrReranker mmrReranker) {
+        this.embeddingProvider = builder.embeddingProvider;
+        this.wal = builder.wal;
+        this.coActivationTracker = builder.bio != null ? builder.bio.coActivationTracker() : null;
         this.habituationPenalty = builder.bio.habituationPenalty();
         this.recallHistory = recallHistory;
         this.index = builder.index;
@@ -188,12 +202,10 @@ public final class RecallPathway {
         final RecallOptions opts = options == null ? RecallOptions.DEFAULT : options;
         
         if (opts.recallMode() == RecallMode.REPLAY) {
-            // TODO: implement replay routing
-            return List.of();
+            return replayRecall(queryText, opts);
         }
         if (opts.scoringMode() == ScoringMode.ASSOCIATIVE && recallHistory != null) {
-            // TODO: implement associative recall routing
-            return List.of();
+            return recallAssociative(queryText, opts);
         }
 
         this.lastRecallOptions = opts;
@@ -230,8 +242,6 @@ public final class RecallPathway {
                 }
             }
         }
-        
-        // TODO: Record trace
         
         return allResults;
     }
@@ -281,9 +291,156 @@ public final class RecallPathway {
             }
         }
         
-        // TODO: Record trace
-        
         return allResults;
+    }
+
+    private List<CognitiveResult> replayRecall(final String queryText, final RecallOptions options) {
+        if (options.replayTimestamp() == null) {
+            throw new SpectorValidationException(
+                    ErrorCode.ARGUMENT_NULL,
+                    "replayTimestamp is required for RecallMode.REPLAY");
+        }
+
+        log.info("REPLAY recall: query='{}', target={}, maxEvents={}",
+                queryText, options.replayTimestamp(), options.maxReplayEvents());
+
+        final float[] queryVector = embeddingProvider.embed(queryText).vector();
+        final int quantizedVecBytes = queryVector.length; // INT8 = 1 byte per dimension
+        final long nowMs = options.replayTimestamp().toEpochMilli();
+
+        try (final ReplaySnapshot snapshot = WalReplayer.replay(
+                wal, options.replayTimestamp(), options.maxReplayEvents(), quantizedVecBytes)) {
+
+            if (snapshot.memoryCount() == 0) {
+                log.info("REPLAY recall: no memories at target timestamp {}", options.replayTimestamp());
+                return List.of();
+            }
+
+            final List<CognitiveResult> results = new ArrayList<>();
+            final CognitiveRecordLayout layout = new CognitiveRecordLayout(quantizedVecBytes);
+
+            for (final String memId : snapshot.index().allIds()) {
+                final var loc = snapshot.index().locate(memId);
+                if (loc == null) continue;
+
+                final long offset = loc.offset();
+                final MemorySegment seg = snapshot.arena().allocate(0);
+
+                try {
+                    final String text = snapshot.index().text(memId);
+                    final MemorySource source = snapshot.index().source(memId);
+                    final String[] memTags = snapshot.index().tags(memId);
+
+                    final float importance = 0.5f;
+                    final byte valence = 0;
+                    final float ageDays = (float) ((nowMs - layout.readTimestamp(seg, offset))
+                            / (double) (24 * 60 * 60 * 1000));
+
+                    final java.util.Map<String, String> rMeta = snapshot.index().metadata(memId);
+                    final SourceModality rModality = rMeta != null
+                            ? SourceModality.fromName(rMeta.get(SourceModality.METADATA_KEY))
+                            : SourceModality.TEXT;
+                    results.add(new CognitiveResult(
+                            memId, text, importance, importance,
+                            Math.max(0, ageDays),
+                            (short) 0, valence, MemoryType.SEMANTIC, source,
+                            memTags, 1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
+                            rModality, rMeta));
+
+                } catch (final RuntimeException e) {
+                    log.debug("REPLAY: skipping memory '{}': {}", memId, e.getMessage());
+                }
+            }
+
+            results.sort(Comparator.comparing(CognitiveResult::score).reversed());
+            if (results.size() > options.topK()) {
+                return new ArrayList<>(results.subList(0, options.topK()));
+            }
+
+            log.info("REPLAY recall: returned {} results from {} reconstructed memories at {}",
+                    results.size(), snapshot.memoryCount(), options.replayTimestamp());
+
+            return results;
+        }
+    }
+
+    private List<CognitiveResult> recallAssociative(final String queryText, final RecallOptions options) {
+        final Map<String, Float> contextTags = recallHistory.weightedRecentTags(20, 0.85f);
+
+        if (contextTags.isEmpty()) {
+            log.debug("Associative recall: cold start (no history), falling back to COGNITIVE");
+            final RecallOptions fallback = RecallOptions.builder()
+                    .topK(options.topK())
+                    .profile(options.profile())
+                    .scoringMode(ScoringMode.COGNITIVE)
+                    .recallMode(options.recallMode())
+                    .build();
+            return recall(queryText, fallback);
+        }
+
+        log.debug("Associative recall: {} context tags from history", contextTags.size());
+
+        final Map<String, Float> predictedTags = new LinkedHashMap<>();
+        if (coActivationTracker != null) {
+            for (final Map.Entry<String, Float> ctxEntry : contextTags.entrySet()) {
+                final String ctxTag = ctxEntry.getKey();
+                final float recencyWeight = ctxEntry.getValue();
+                final List<String> associated = coActivationTracker.getAssociatedTags(ctxTag, 5);
+                for (final String predTag : associated) {
+                    predictedTags.merge(predTag, recencyWeight, Float::sum);
+                }
+            }
+        }
+
+        final List<String> topPredicted = predictedTags.entrySet().stream()
+                .sorted(Map.Entry.<String, Float>comparingByValue().reversed())
+                .limit(10)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        final RecallOptions.Builder cogBuilder = RecallOptions.builder()
+                .topK(options.topK() * 2)
+                .profile(options.profile())
+                .scoringMode(ScoringMode.COGNITIVE)
+                .recallMode(options.recallMode());
+
+        if (!topPredicted.isEmpty()) {
+            cogBuilder.synapticFilter(topPredicted.toArray(new String[0]));
+        }
+
+        final List<CognitiveResult> associativeResults = new ArrayList<>(recall(queryText, cogBuilder.build()));
+
+        if (coActivationTracker != null && !contextTags.isEmpty()) {
+            final List<String> contextTagList = new ArrayList<>(contextTags.keySet());
+            for (int i = 0; i < associativeResults.size(); i++) {
+                final CognitiveResult r = associativeResults.get(i);
+                if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
+
+                final float predictive = coActivationTracker.getPredictiveStrength(
+                        contextTagList, r.synapticTags());
+                if (predictive > 0) {
+                    final float boosted = r.score() * (1.0f + predictive * 0.5f);
+                    associativeResults.set(i, new CognitiveResult(
+                            r.id(), r.text(), boosted, r.importance(), r.ageDays(),
+                            r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
+                            r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
+                            r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+                }
+            }
+        }
+
+        associativeResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        List<CognitiveResult> finalResults = associativeResults;
+        if (finalResults.size() > options.topK()) {
+            finalResults = new ArrayList<>(finalResults.subList(0, options.topK()));
+        }
+
+        for (final CognitiveResult r : finalResults) {
+            if (r.synapticTags() != null && r.synapticTags().length > 0) {
+                recallHistory.record(r.synapticTags());
+            }
+        }
+        return finalResults;
     }
 
     private void applySessionBookkeeping(final List<CognitiveResult> allResults, final RecallOptions opts) {
@@ -331,8 +488,26 @@ public final class RecallPathway {
     }
 
     private void writeProfileOrdinalToResults(final List<CognitiveResult> results, final RecallOptions options) {
-        // Copied from RecallPipeline.writeProfileOrdinalToResults behavior if available.
-        // It's a method on RecallPipeline that writes the ordinal to results, but for now we'll stub it.
+        final CognitiveProfile profile = options.profile();
+        if (profile == null || results.isEmpty()) return;
+
+        final byte profileOrdinal = (byte) profile.ordinal();
+        for (final CognitiveResult result : results) {
+            if (result.id() == null) continue;
+            try {
+                final var loc = index.locate(result.id());
+                if (loc == null) continue;
+                final MemorySegment segment = partitionRegistry.routerFor(loc.colocatedPartition())
+                        .segmentFor(loc.type());
+                if (segment != null) {
+                    segment.set(java.lang.foreign.ValueLayout.JAVA_BYTE,
+                            loc.offset() + SynapticHeaderConstants.OFFSET_LAST_RECALL_PROFILE,
+                            profileOrdinal);
+                }
+            } catch (final RuntimeException e) {
+                log.trace("Failed to write profile ordinal for '{}': {}", result.id(), e.getMessage());
+            }
+        }
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.commons.pathway.CognitivePathway;
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.index.VectorIndex;
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.TextAppendMemory;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
+import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.model.IngestionContext;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
+import com.spectrayan.spector.memory.pipeline.AsyncEntityExtractionQueue;
+import com.spectrayan.spector.memory.pipeline.ContentTagExtractor;
+import com.spectrayan.spector.memory.pipeline.PostIngestSync;
+import com.spectrayan.spector.memory.pipeline.TagExtractor;
+import com.spectrayan.spector.memory.remember.relay.CorticalWriteTransactionRelay;
+import com.spectrayan.spector.memory.remember.relay.DedupGuardRelay;
+import com.spectrayan.spector.memory.remember.relay.DopaminergicSurpriseRelay;
+import com.spectrayan.spector.memory.remember.relay.KnowledgeGraphEnrichmentRelay;
+import com.spectrayan.spector.memory.remember.relay.RememberPathwayFactory;
+import com.spectrayan.spector.memory.remember.relay.RememberSignal;
+import com.spectrayan.spector.memory.remember.relay.SynapticGraphLinkingRelay;
+import com.spectrayan.spector.memory.remember.relay.SynapticTagTransductionRelay;
+import com.spectrayan.spector.memory.session.SessionRegistry;
+import com.spectrayan.spector.memory.sync.MemoryWal;
+import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Orchestrates memory consolidation and ingestion using the composable Cognitive Pathway Engine architecture.
+ *
+ * <p>Replaces procedural ingestion in {@code CognitiveIngestionTarget} with a type-safe,
+ * observable synaptic relay chain.</p>
+ */
+public final class RememberPathway implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(RememberPathway.class);
+
+    private final CognitivePathway<RememberSignal> pathway;
+    private final CorticalWriteTransactionRelay corticalWriteRelay;
+    private final TagExtractor tagExtractor;
+    private final AsyncEntityExtractionQueue asyncEntityExtractionQueue;
+    private final AtomicInteger lastIngestedMemoryIdx = new AtomicInteger(-1);
+
+    private volatile SalienceProfile salienceProfile = SalienceProfile.NEUTRAL;
+    private volatile short currentSoulVersion = 0;
+
+    private RememberPathway(final Builder builder) {
+        final ScalarQuantizer quantizer = builder.cortex.quantizer();
+        final SurpriseDetector surpriseDetector = builder.bio.surpriseDetector();
+        final ImportanceProvider importanceProvider = builder.importanceProvider != null
+                ? builder.importanceProvider
+                : ImportanceProvider.baseline();
+        final WorkingRecordMemory workingStore = builder.cortex.workingStore();
+        final TagExtractor extractor = builder.tagExtractor != null
+                ? builder.tagExtractor
+                : new ContentTagExtractor();
+        this.tagExtractor = extractor;
+
+        final SessionRegistry sessionRegistry = new SessionRegistry();
+
+        final PostIngestSync postIngestSync = new PostIngestSync(
+                builder.cortex.cognitiveRouter(),
+                builder.index,
+                builder.wal,
+                builder.semanticIndex,
+                builder.graphs.hebbianGraph(),
+                builder.graphs.temporalChain(),
+                builder.graphs.entityExtractor(),
+                builder.graphs.entityDirectory(),
+                builder.retrieval.bm25Index(),
+                builder.retrieval.textDataStore(),
+                builder.activePartitionIndex,
+                builder.retrieval.memorySpladeIndex(),
+                builder.sparseEmbeddingProvider,
+                builder.dataEncryptor != null ? builder.dataEncryptor : DataEncryptor.NOOP,
+                builder.graphs.hyperEntityGraph(),
+                builder.graphs.temporalKnowledgeGraph()
+        );
+
+        final EntityExtractor entityExtractor = builder.graphs.entityExtractor();
+        if (entityExtractor != null && entityExtractor.isAvailable() && builder.entityExtractionParallelism > 0) {
+            this.asyncEntityExtractionQueue = new AsyncEntityExtractionQueue(
+                    entityExtractor,
+                    postIngestSync,
+                    builder.entityExtractionParallelism,
+                    builder.entityExtractionQueueCapacity
+            );
+        } else {
+            this.asyncEntityExtractionQueue = null;
+        }
+
+        final DedupGuardRelay dedupGuardRelay = new DedupGuardRelay(builder.index);
+        final SynapticTagTransductionRelay tagTransductionRelay = new SynapticTagTransductionRelay(
+                this.tagExtractor,
+                builder.dataEncryptor
+        );
+        final DopaminergicSurpriseRelay surpriseRelay = new DopaminergicSurpriseRelay(
+                surpriseDetector,
+                importanceProvider,
+                workingStore,
+                quantizer
+        );
+        this.corticalWriteRelay = new CorticalWriteTransactionRelay(
+                quantizer,
+                builder.cortex.cognitiveRouter(),
+                postIngestSync,
+                surpriseDetector,
+                builder.normalizeAtIngest
+        );
+        final SynapticGraphLinkingRelay graphLinkingRelay = new SynapticGraphLinkingRelay(
+                postIngestSync,
+                this.lastIngestedMemoryIdx,
+                sessionRegistry
+        );
+        final KnowledgeGraphEnrichmentRelay kgEnrichmentRelay = new KnowledgeGraphEnrichmentRelay(
+                postIngestSync,
+                this.asyncEntityExtractionQueue,
+                entityExtractor
+        );
+
+        this.pathway = RememberPathwayFactory.create(
+                dedupGuardRelay,
+                tagTransductionRelay,
+                surpriseRelay,
+                this.corticalWriteRelay,
+                graphLinkingRelay,
+                kgEnrichmentRelay
+        );
+
+        // Seed active partition sequence
+        this.corticalWriteRelay.postIngestSync().updateActivePartitionSeq(builder.cortex.initialPartitionSeq());
+    }
+
+    /**
+     * Ingests a pre-embedded text content using default SEMANTIC tier.
+     *
+     * @param id     unique memory identifier
+     * @param text   the memory content
+     * @param vector pre-computed embedding vector
+     */
+    public void ingest(final String id, final String text, final float[] vector) {
+        ingestCognitive(id, text, vector, MemoryType.SEMANTIC, null, MemorySource.OBSERVED, (IngestionHints) null);
+    }
+
+    /**
+     * Ingests a memory with full cognitive parameters.
+     *
+     * @param id     unique memory identifier
+     * @param text   the memory content
+     * @param vector pre-computed embedding vector
+     * @param type   target cognitive tier
+     * @param tags   synaptic tags
+     * @param source provenance source
+     * @param hints  optional ingestion hints
+     */
+    public void ingestCognitive(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final IngestionHints hints) {
+        final RememberSignal signal = RememberSignal.forCognitive(
+                id, text, vector, type, tags, source, hints,
+                salienceProfile, currentSoulVersion
+        );
+        pathway.conduct(signal);
+    }
+
+    /**
+     * Ingests a memory with rich consolidated {@link IngestionContext}.
+     *
+     * @param id      unique memory identifier
+     * @param text    the memory content
+     * @param vector  pre-computed embedding vector
+     * @param type    target cognitive tier
+     * @param tags    synaptic tags
+     * @param source  provenance source
+     * @param context rich ingestion context
+     */
+    public void ingestCognitive(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final IngestionContext context) {
+        final RememberSignal signal = RememberSignal.forCognitiveWithContext(
+                id, text, vector, type, tags, source, context,
+                salienceProfile, currentSoulVersion
+        );
+        pathway.conduct(signal);
+    }
+
+    /**
+     * Updates the cognitive memory router after a partition roll.
+     */
+    public void updateCognitiveRouter(final CognitiveMemoryRouter newRouter) {
+        this.corticalWriteRelay.updateCognitiveRouter(newRouter);
+    }
+
+    /**
+     * Updates the partition-scoped {@code text.dat} store after a roll.
+     */
+    public void updateTextDataStore(final TextAppendMemory newText) {
+        this.corticalWriteRelay.postIngestSync().updateTextDataStore(newText);
+    }
+
+    /**
+     * Updates the active colocated partition sequence after a roll.
+     */
+    public void updateActivePartitionSeq(final int seq) {
+        this.corticalWriteRelay.postIngestSync().updateActivePartitionSeq(seq);
+    }
+
+    /**
+     * Sets the partition roll callback.
+     */
+    public void setPartitionRollCallback(final Runnable callback) {
+        this.corticalWriteRelay.setPartitionRollCallback(callback);
+    }
+
+    public void setSalienceProfile(final SalienceProfile profile) {
+        this.salienceProfile = profile != null ? profile : SalienceProfile.NEUTRAL;
+    }
+
+    public SalienceProfile salienceProfile() {
+        return salienceProfile;
+    }
+
+    public void setSoulVersion(final short version) {
+        this.currentSoulVersion = version;
+    }
+
+    public short currentSoulVersion() {
+        return currentSoulVersion;
+    }
+
+    public TagExtractor tagExtractor() {
+        return tagExtractor;
+    }
+
+    public AsyncEntityExtractionQueue asyncEntityExtractionQueue() {
+        return asyncEntityExtractionQueue;
+    }
+
+    @Override
+    public void close() {
+        if (asyncEntityExtractionQueue != null) {
+            asyncEntityExtractionQueue.close();
+        }
+    }
+
+    /**
+     * Builder for {@link RememberPathway}.
+     */
+    public static final class Builder {
+        private CognitiveCortexBuilder.CortexFoundation cortex;
+        private BiologicalSubsystemsBuilder.BiologicalSubsystems bio;
+        private CognitiveGraphBuilder.CognitiveGraphs graphs;
+        private RetrievalIndexBuilder.RetrievalIndices retrieval;
+        private MemoryIndex index;
+        private MemoryWal wal;
+        private int activePartitionIndex = 0;
+        private ImportanceProvider importanceProvider;
+        private TagExtractor tagExtractor;
+        private VectorIndex semanticIndex;
+        private SparseEmbeddingProvider sparseEmbeddingProvider;
+        private DataEncryptor dataEncryptor = DataEncryptor.NOOP;
+        private int entityExtractionParallelism = 1;
+        private int entityExtractionQueueCapacity = 1000;
+        private boolean normalizeAtIngest = true;
+
+        public Builder() {}
+
+        public Builder cortex(final CognitiveCortexBuilder.CortexFoundation cortex) {
+            this.cortex = cortex;
+            return this;
+        }
+
+        public Builder bio(final BiologicalSubsystemsBuilder.BiologicalSubsystems bio) {
+            this.bio = bio;
+            return this;
+        }
+
+        public Builder graphs(final CognitiveGraphBuilder.CognitiveGraphs graphs) {
+            this.graphs = graphs;
+            return this;
+        }
+
+        public Builder retrieval(final RetrievalIndexBuilder.RetrievalIndices retrieval) {
+            this.retrieval = retrieval;
+            return this;
+        }
+
+        public Builder index(final MemoryIndex index) {
+            this.index = index;
+            return this;
+        }
+
+        public Builder wal(final MemoryWal wal) {
+            this.wal = wal;
+            return this;
+        }
+
+        public Builder activePartitionIndex(final int activePartitionIndex) {
+            this.activePartitionIndex = activePartitionIndex;
+            return this;
+        }
+
+        public Builder importanceProvider(final ImportanceProvider importanceProvider) {
+            this.importanceProvider = importanceProvider;
+            return this;
+        }
+
+        public Builder tagExtractor(final TagExtractor tagExtractor) {
+            this.tagExtractor = tagExtractor;
+            return this;
+        }
+
+        public Builder semanticIndex(final VectorIndex semanticIndex) {
+            this.semanticIndex = semanticIndex;
+            return this;
+        }
+
+        public Builder sparseEmbeddingProvider(final SparseEmbeddingProvider sparseEmbeddingProvider) {
+            this.sparseEmbeddingProvider = sparseEmbeddingProvider;
+            return this;
+        }
+
+        public Builder dataEncryptor(final DataEncryptor dataEncryptor) {
+            this.dataEncryptor = dataEncryptor;
+            return this;
+        }
+
+        public Builder entityExtractionParallelism(final int parallelism) {
+            this.entityExtractionParallelism = parallelism;
+            return this;
+        }
+
+        public Builder entityExtractionQueueCapacity(final int capacity) {
+            this.entityExtractionQueueCapacity = capacity;
+            return this;
+        }
+
+        public Builder normalizeAtIngest(final boolean normalizeAtIngest) {
+            this.normalizeAtIngest = normalizeAtIngest;
+            return this;
+        }
+
+        public RememberPathway build() {
+            Objects.requireNonNull(cortex, "cortex cannot be null");
+            Objects.requireNonNull(bio, "bio cannot be null");
+            Objects.requireNonNull(graphs, "graphs cannot be null");
+            Objects.requireNonNull(retrieval, "retrieval cannot be null");
+            Objects.requireNonNull(index, "index cannot be null");
+            Objects.requireNonNull(wal, "wal cannot be null");
+            return new RememberPathway(this);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
@@ -141,6 +141,7 @@ public final class RememberPathway implements AutoCloseable {
         );
 
         this.pathway = RememberPathwayFactory.create(
+                builder.interceptor,
                 dedupGuardRelay,
                 tagTransductionRelay,
                 surpriseRelay,
@@ -294,8 +295,15 @@ public final class RememberPathway implements AutoCloseable {
         private int entityExtractionParallelism = 1;
         private int entityExtractionQueueCapacity = 1000;
         private boolean normalizeAtIngest = true;
+        private java.util.function.Function<com.spectrayan.spector.commons.pathway.SynapticRelay<RememberSignal>, com.spectrayan.spector.commons.pathway.SynapticRelay<RememberSignal>> interceptor;
 
         public Builder() {}
+
+        public Builder interceptor(
+                final java.util.function.Function<com.spectrayan.spector.commons.pathway.SynapticRelay<RememberSignal>, com.spectrayan.spector.commons.pathway.SynapticRelay<RememberSignal>> interceptor) {
+            this.interceptor = interceptor;
+            return this;
+        }
 
         public Builder cortex(final CognitiveCortexBuilder.CortexFoundation cortex) {
             this.cortex = cortex;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -179,6 +179,9 @@ public final class SpectorMemoryBuilder {
     // Eager consolidation (#526)
     int eagerConsolidationQueueCapacity = SpectorPropertyConstants.DEFAULT_MEMORY_EAGER_CONSOLIDATION_QUEUE_CAPACITY;
 
+    // Cognitive Pathway Engine (#561) — opt-in relay-based recall pathway
+    boolean usePathwayEngine = false;
+
     // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = 
     // FACTORY
     // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = 
@@ -213,6 +216,8 @@ public final class SpectorMemoryBuilder {
     public SpectorMemoryBuilder typeRegistrySize(long s) { this.typeRegistrySize = s; return this; }
     public SpectorMemoryBuilder insulaSize(long s) { this.insulaSize = s; return this; }
     public SpectorMemoryBuilder eagerConsolidationQueueCapacity(int c) { this.eagerConsolidationQueueCapacity = c; return this; }
+    /** Enable the relay-based Cognitive Pathway Engine for recall (#561). */
+    public SpectorMemoryBuilder usePathwayEngine(boolean enable) { this.usePathwayEngine = enable; return this; }
 
 
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -79,6 +79,7 @@ public final class SpectorMemoryFactory {
 
     public record SubsystemBundle(
             CognitiveIngestionTarget cognitiveTarget,
+            RememberPathway rememberPathway,
             EmbeddingProvider embeddingProvider,
             RecallPipeline recallPipeline,
             RecallPathway recallPathway,
@@ -221,6 +222,7 @@ public final class SpectorMemoryFactory {
 
         //  Recall Pathway (#561 — relay-based engine, opt-in via usePathwayEngine) 
         RecallPathway recallPathway = null;
+        RememberPathway rememberPathway = null;
         if (builder.usePathwayEngine) {
             recallPathway = new RecallPathway.Builder()
                     .embeddingProvider(embeddingProvider)
@@ -236,7 +238,36 @@ public final class SpectorMemoryFactory {
                     .hook(builder.hook)
                     .semanticIndex(builder.semanticIndex)
                     .build();
-            log.info("Cognitive Pathway Engine enabled — recall uses relay-based pathway");
+
+            rememberPathway = new RememberPathway.Builder()
+                    .cortex(cortex)
+                    .bio(bio)
+                    .graphs(graphs)
+                    .retrieval(retrieval)
+                    .index(index)
+                    .wal(wal)
+                    .activePartitionIndex(activePartitionIndex)
+                    .importanceProvider(importanceProvider)
+                    .tagExtractor(builder.tagExtractor)
+                    .semanticIndex(builder.semanticIndex)
+                    .sparseEmbeddingProvider(builder.SparseEmbeddingProvider)
+                    .dataEncryptor(builder.dataEncryptor)
+                    .entityExtractionParallelism(builder.entityExtractionParallelism)
+                    .entityExtractionQueueCapacity(builder.entityExtractionQueueCapacity)
+                    .normalizeAtIngest(true)
+                    .build();
+
+            if (builder.salienceProfileProvider != null) {
+                SalienceProfile effective = builder.salienceProfileProvider.effectiveProfile();
+                if (effective != null && !effective.isNeutral()) {
+                    rememberPathway.setSalienceProfile(effective);
+                }
+            }
+
+            partitionManager.setRememberPathway(rememberPathway);
+            rememberPathway.setPartitionRollCallback(partitionManager::rollPartition);
+
+            log.info("Cognitive Pathway Engine enabled — recall and remember use relay-based pathways");
         }
 
         //  Extracted Components 
@@ -274,7 +305,7 @@ public final class SpectorMemoryFactory {
         }
 
         return new SubsystemBundle(
-                cognitiveTarget, embeddingProvider, recallPipeline, recallPathway, index, cortex.quantizer(),
+                cognitiveTarget, rememberPathway, embeddingProvider, recallPipeline, recallPathway, index, cortex.quantizer(),
                 partitionManager, importanceProvider, reflectionOrchestrator,
                 reinforcementHandler, bio.valenceTracker(), bio.coActivationTracker(),
                 bio.suppressionSet(), bio.habituationPenalty(), bio.prospectiveScheduler(),

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -81,6 +81,7 @@ public final class SpectorMemoryFactory {
             CognitiveIngestionTarget cognitiveTarget,
             EmbeddingProvider embeddingProvider,
             RecallPipeline recallPipeline,
+            RecallPathway recallPathway,
             MemoryIndex index,
             ScalarQuantizer quantizer,
             PartitionManager partitionManager,
@@ -218,6 +219,26 @@ public final class SpectorMemoryFactory {
         RecallPipeline recallPipeline = RecallPipelineBuilder.build(
                 builder, embeddingProvider, cortex, bio, graphs, retrieval, index, partitionManager, wal);
 
+        //  Recall Pathway (#561 — relay-based engine, opt-in via usePathwayEngine) 
+        RecallPathway recallPathway = null;
+        if (builder.usePathwayEngine) {
+            recallPathway = new RecallPathway.Builder()
+                    .embeddingProvider(embeddingProvider)
+                    .cortex(cortex)
+                    .bio(bio)
+                    .graphs(graphs)
+                    .retrieval(retrieval)
+                    .index(index)
+                    .partitionManager(partitionManager)
+                    .wal(wal)
+                    .graphScoringPolicy(builder.graphScoringPolicy)
+                    .sparseEmbeddingProvider(builder.SparseEmbeddingProvider)
+                    .hook(builder.hook)
+                    .semanticIndex(builder.semanticIndex)
+                    .build();
+            log.info("Cognitive Pathway Engine enabled — recall uses relay-based pathway");
+        }
+
         //  Extracted Components 
         ReflectionOrchestrator reflectionOrchestrator = new ReflectionOrchestrator(
                 bio.reflectDaemon(), graphs.hebbianGraph(), graphs.temporalChain(), graphs.entityDirectory(),
@@ -253,7 +274,7 @@ public final class SpectorMemoryFactory {
         }
 
         return new SubsystemBundle(
-                cognitiveTarget, embeddingProvider, recallPipeline, index, cortex.quantizer(),
+                cognitiveTarget, embeddingProvider, recallPipeline, recallPathway, index, cortex.quantizer(),
                 partitionManager, importanceProvider, reflectionOrchestrator,
                 reinforcementHandler, bio.valenceTracker(), bio.coActivationTracker(),
                 bio.suppressionSet(), bio.habituationPenalty(), bio.prospectiveScheduler(),

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/RelayNames.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/RelayNames.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway;
+
+/**
+ * Constants class containing all relay names for pathways.
+ */
+public final class RelayNames {
+
+    private RelayNames() {}
+
+    // Recall Pathway Relays
+    public static final String TRANSDUCTION      = "transduction";
+    public static final String PROSPECTIVE       = "prospective";
+    public static final String VECTOR_SEARCH     = "vector_search";
+    public static final String SCORING           = "scoring";
+    public static final String GRAPH_EXPANSION   = "graph_expansion";
+    public static final String BM25_SEARCH       = "bm25_search";
+    public static final String RRF_RESCORE       = "rrf_rescore";
+    public static final String SORT_TRUNCATE     = "sort_truncate";
+    public static final String COLBERT_RERANK    = "colbert_rerank";
+    public static final String MMR_RERANK        = "mmr_rerank";
+    public static final String TEMPERATURE       = "temperature";
+    public static final String CONSOLIDATION     = "consolidation";
+
+    // Divergent Branch Relays (Tier Scans)
+    public static final String TIER_HOT          = "hot";
+    public static final String TIER_WARM         = "warm";
+    public static final String TIER_COLD         = "cold";
+    public static final String TIER_PROCEDURAL   = "proc";
+
+    // Ingestion Pathway Relays
+    public static final String DEDUP_GUARD           = "dedup_guard";
+    public static final String TAG_TRANSDUCTION      = "tag_transduction";
+    public static final String DOPAMINERGIC_SURPRISE = "dopaminergic_surprise";
+    public static final String SCALAR_QUANTIZATION   = "scalar_quantization";
+    public static final String HEADER_ASSEMBLY       = "header_assembly";
+    public static final String CORTICAL_WRITE        = "cortical_write";
+    public static final String POST_INGEST_SYNC      = "post_ingest_sync";
+    public static final String GRAPH_LINKING         = "graph_linking";
+    public static final String KG_ENRICHMENT         = "kg_enrichment";
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/CognitiveIngestionTarget.java
@@ -77,7 +77,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <h3>Thread Safety</h3>
  * <p>Stateless except for the subsystems it references (all thread-safe).
  * Multiple Virtual Threads can call {@link #ingest} concurrently.</p>
+ *
+ * @deprecated Superceded by {@link com.spectrayan.spector.memory.RememberPathway} as part of the
+ *             Cognitive Pathway Engine redesign (#561). Will be removed in a future major release.
  */
+@Deprecated(since = "0.2.0-alpha", forRemoval = false)
 public final class CognitiveIngestionTarget implements IngestionTarget {
 
     private static final Logger log = LoggerFactory.getLogger(CognitiveIngestionTarget.class);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -71,7 +71,7 @@ import java.util.Set;
  * @see RecallPipeline
  * @see GraphScoringPolicy
  */
-final class GraphExpansionStage {
+public final class GraphExpansionStage {
 
     private static final Logger log = LoggerFactory.getLogger(GraphExpansionStage.class);
 
@@ -136,7 +136,7 @@ final class GraphExpansionStage {
      * @param queryVector  the embedded query vector
      * @param options      recall options (for expansion threshold, entity hints)
      */
-    void expand(List<CognitiveResult> allResults, float[] queryVector, RecallOptions options) {
+    public void expand(List<CognitiveResult> allResults, float[] queryVector, RecallOptions options) {
         boolean cognitiveScoring = options.scoringMode() != ScoringMode.SIMILARITY;
         boolean hasSubsystems = hebbianGraph != null || temporalChain != null
                 || (entityDirectory != null && (entityExtractor != null && entityExtractor.isAvailable()

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/GraphExpansionStage.java
@@ -88,7 +88,7 @@ public final class GraphExpansionStage {
     private final float[] calibrationMins;
     private final float[] calibrationScales;
 
-    GraphExpansionStage(HebbianGraphBase hebbianGraph,
+    public GraphExpansionStage(HebbianGraphBase hebbianGraph,
                         TemporalChainMemory temporalChain,
                         EntityDirectory entityDirectory,
                         com.spectrayan.spector.memory.graph.HyperEntityGraphMemory hyperEntityGraph,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/PostIngestSync.java
@@ -68,7 +68,7 @@ import java.util.Map;
  * The session tracking ({@code lastIngestedMemoryIdx}, {@code currentSessionId})
  * remains in {@link CognitiveIngestionTarget} since it is cross-invocation state.</p>
  */
-final class PostIngestSync {
+public final class PostIngestSync {
 
     private static final Logger log = LoggerFactory.getLogger(PostIngestSync.class);
 
@@ -91,7 +91,7 @@ final class PostIngestSync {
     private final HyperEntityGraphMemory hyperEntityGraph;
     private final TemporalKnowledgeGraph temporalKnowledgeGraph;
 
-    PostIngestSync(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, MemoryWal wal,
+    public PostIngestSync(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, MemoryWal wal,
                    VectorIndex semanticIndex,
                    HebbianGraphBase hebbianGraph, TemporalChainMemory temporalChain,
                    EntityExtractor entityExtractor, EntityDirectory entityDirectory,
@@ -121,24 +121,24 @@ final class PostIngestSync {
     }
 
     /** Called when the cognitive memory router is swapped after a partition roll. */
-    void updateCognitiveRouter(CognitiveMemoryRouter newRouter) {
+    public void updateCognitiveRouter(CognitiveMemoryRouter newRouter) {
         this.cognitiveRouter = newRouter;
     }
 
     /** Called when the partition-scoped {@code text.dat} is rolled (#443, D3b). */
-    void updateTextDataStore(TextAppendMemory newText) {
+    public void updateTextDataStore(TextAppendMemory newText) {
         this.textDataStore = newText;
     }
 
     /** Called when the active partition sequence changes on roll (#443). */
-    void updateActivePartitionSeq(int seq) {
+    public void updateActivePartitionSeq(int seq) {
         this.activePartitionSeq = seq;
     }
 
     /**
      * Parameters for post-ingest synchronization.
      */
-    record SyncParams(
+    public record SyncParams(
             String id,
             String text,
             float[] vector,
@@ -149,7 +149,7 @@ final class PostIngestSync {
             long offset,
             Map<String, String> metadata
     ) {
-        SyncParams(String id, String text, float[] vector, byte[] quantized,
+        public SyncParams(String id, String text, float[] vector, byte[] quantized,
                    MemoryType type, String[] tags, MemorySource source, long offset) {
             this(id, text, vector, quantized, type, tags, source, offset, null);
         }
@@ -164,7 +164,7 @@ final class PostIngestSync {
      * @param params sync parameters
      * @return the monotonic global graph slot assigned to this memory
      */
-    int syncIndexes(SyncParams params) {
+    public int syncIndexes(SyncParams params) {
         boolean isParentChunk = params.metadata() != null && "parent".equals(params.metadata().get("chunk_role"));
 
         int storeIndex = -1;
@@ -240,7 +240,7 @@ final class PostIngestSync {
      * @param previousIdx the index of the previously ingested memory (-1 if none)
      * @param sessionId   the current session ID
      */
-    void syncGraphEdges(int memoryIdx, int previousIdx, int sessionId) {
+    public void syncGraphEdges(int memoryIdx, int previousIdx, int sessionId) {
         // Step 9b: Hebbian edge strengthening
         if (hebbianGraph != null && previousIdx >= 0 && previousIdx != memoryIdx) {
             try {
@@ -270,7 +270,7 @@ final class PostIngestSync {
      * @param memoryIdx memory index for entity -> memory linking
      * @return list of extracted entities
      */
-    List<ExtractedEntity> syncEntityExtraction(String id, String text, int memoryIdx) {
+    public List<ExtractedEntity> syncEntityExtraction(String id, String text, int memoryIdx) {
         if (entityExtractor != null && entityDirectory != null && entityExtractor.isAvailable()) {
             try {
                 List<ExtractedEntity> entities = entityExtractor.extract(id, text);
@@ -295,7 +295,7 @@ final class PostIngestSync {
      * @param memoryIdx memory index for entity -> memory linking
      * @param id        memory ID (for logging)
      */
-    void syncPreExtractedEntities(List<ExtractedEntity> entities, int memoryIdx, String id) {
+    public void syncPreExtractedEntities(List<ExtractedEntity> entities, int memoryIdx, String id) {
         if (entityDirectory == null) return;
         try {
             populateEntities(entities, memoryIdx, id);
@@ -307,7 +307,7 @@ final class PostIngestSync {
     /**
      * Applies pre-computed Hebbian edge hints from IngestionContext.
      */
-    void syncHebbianEdgeHints(int memoryIdx, String id,
+    public void syncHebbianEdgeHints(int memoryIdx, String id,
                               List<com.spectrayan.spector.memory.model.IngestionContext.HebbianEdgeHint> edges) {
         if (hebbianGraph == null) return;
         for (var edgeHint : edges) {
@@ -329,7 +329,7 @@ final class PostIngestSync {
     /**
      * Applies pre-computed temporal link hints from IngestionContext.
      */
-    void syncTemporalLinkHints(int memoryIdx, String id,
+    public void syncTemporalLinkHints(int memoryIdx, String id,
                                List<com.spectrayan.spector.memory.model.IngestionContext.TemporalLinkHint> links) {
         if (temporalChain == null) return;
         for (var linkHint : links) {
@@ -348,7 +348,7 @@ final class PostIngestSync {
         }
     }
 
-    void syncTemporalFacts(List<ExtractedEntity> entities, int memoryIdx, String memoryId, long ingestEpochSec) {
+    public void syncTemporalFacts(List<ExtractedEntity> entities, int memoryIdx, String memoryId, long ingestEpochSec) {
         if (temporalKnowledgeGraph == null || entities == null || entities.isEmpty()) return;
         
         for (ExtractedEntity entity : entities) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -142,7 +142,11 @@ import com.spectrayan.spector.index.ColBERTReranker.RerankResult;
  *       {@link CognitiveScorer}</li>
  *   <li><b>Observer</b>: Post-recall hooks via {@link RecallListener}</li>
  * </ul>
+ *
+ * @deprecated Superceded by {@link com.spectrayan.spector.memory.RecallPathway} as part of the
+ *             Cognitive Pathway Engine redesign (#561). Will be removed in a future major release.
  */
+@Deprecated(since = "0.2.0-alpha", forRemoval = false)
 public final class RecallPipeline {
 
     private static final Logger log = LoggerFactory.getLogger(RecallPipeline.class);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/AssociativeGraphRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/AssociativeGraphRelay.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.GraphExpansionStage;
+import com.spectrayan.spector.memory.pipeline.graph.TemporalFactWeavingStage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Expands results by following the Hebbian and temporal graphs.
+ */
+public final class AssociativeGraphRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(AssociativeGraphRelay.class);
+
+    private final GraphExpansionStage graphExpansionStage;
+    private final TemporalFactWeavingStage temporalFactWeavingStage;
+
+    /**
+     * Constructs a new AssociativeGraphRelay.
+     *
+     * @param graphExpansionStage      the graph expansion stage
+     * @param temporalFactWeavingStage the temporal fact weaving stage
+     */
+    public AssociativeGraphRelay(
+            final GraphExpansionStage graphExpansionStage,
+            final TemporalFactWeavingStage temporalFactWeavingStage) {
+        this.graphExpansionStage = graphExpansionStage;
+        this.temporalFactWeavingStage = temporalFactWeavingStage;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        try {
+            graphExpansionStage.expand(signal.candidates(), signal.queryVector(), signal.options());
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        temporalFactWeavingStage.weave(signal.candidates(), signal.queryVector(), signal.options());
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.GRAPH_EXPANSION;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CognitiveRerankRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CognitiveRerankRelay.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.index.ColBERTReranker;
+import com.spectrayan.spector.index.ColBERTReranker.RerankCandidate;
+import com.spectrayan.spector.index.ColBERTReranker.RerankResult;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Relay that uses ColBERT v2 to rerank candidate results.
+ */
+public final class CognitiveRerankRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(CognitiveRerankRelay.class);
+    private final ColBERTReranker colbertReranker;
+    private boolean colbertWarnLogged = false;
+
+    public CognitiveRerankRelay(final ColBERTReranker colbertReranker) {
+        this.colbertReranker = colbertReranker;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        final RecallOptions options = signal.options();
+        List<CognitiveResult> allResults = signal.candidates();
+
+        if (options.enableReranker() && options.textSearchMode().usesColBERT()) {
+            if (colbertReranker != null) {
+                try {
+                    final int rerankerDepth = Math.min(options.rerankerDepth(), allResults.size());
+                    if (rerankerDepth > 0) {
+                        final List<CognitiveResult> toRerank = allResults.subList(0, rerankerDepth);
+
+                        final List<RerankCandidate> candidates = toRerank.stream()
+                                .map(r -> new RerankCandidate(
+                                        r.id(), r.text() != null ? r.text() : "", r.score()))
+                                .toList();
+
+                        final List<RerankResult> reranked =
+                                colbertReranker.rerank(signal.rawQuery(), candidates, options.topK());
+
+                        final Map<String, Float> rerankScores = new HashMap<>();
+                        for (final RerankResult rr : reranked) {
+                            rerankScores.put(rr.id(), rr.combinedScore());
+                        }
+
+                        for (int i = 0; i < toRerank.size(); i++) {
+                            final CognitiveResult r = toRerank.get(i);
+                            final Float newScore = rerankScores.get(r.id());
+                            if (newScore != null) {
+                                allResults.set(i, new CognitiveResult(
+                                        r.id(), r.text(), newScore, r.importance(),
+                                        r.ageDays(), r.agentRecallCount(), r.valence(),
+                                        r.memoryType(), r.source(), r.synapticTags(),
+                                        r.decayFactor(), r.ltpAdjustedDecay(),
+                                        r.retrievalMode(), r.breakdown(), r.trace(),
+                                        r.sourceModality(), r.metadata()));
+                            }
+                        }
+
+                        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+                        if (allResults.size() > options.topK()) {
+                            allResults = new ArrayList<>(allResults.subList(0, options.topK()));
+                            signal.setCandidates(allResults);
+                        }
+
+                        log.debug("ColBERT reranked {} candidates  ->  {} results",
+                                rerankerDepth, allResults.size());
+                    }
+                } catch (final RuntimeException e) {
+                    log.warn("ColBERT reranking failed, keeping first-stage order", e);
+                }
+            } else if (!colbertWarnLogged) {
+                log.warn("ColBERT reranking requested (mode={}) but ColBERTReranker " +
+                         "not configured  --  skipping rerank step", options.textSearchMode());
+                colbertWarnLogged = true;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.COLBERT_RERANK;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CorticalTierScanRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CorticalTierScanRelay.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.PartitionHandle;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
+import com.spectrayan.spector.memory.cortex.SemanticRecallStrategy;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.pruning.PartitionPruner;
+import com.spectrayan.spector.memory.pipeline.scan.ParallelScanEmitter;
+import com.spectrayan.spector.memory.pipeline.scan.ScanContext;
+import com.spectrayan.spector.memory.pipeline.scan.ScanEmitter;
+import com.spectrayan.spector.memory.pipeline.scan.SequentialScanEmitter;
+import com.spectrayan.spector.memory.pipeline.scan.SlabScoreFunction;
+import com.spectrayan.spector.memory.pipeline.scan.TierScanStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Evaluates candidates via a vector similarity tier scan.
+ */
+public final class CorticalTierScanRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(CorticalTierScanRelay.class);
+
+    private static final TierScanStrategy WORKING_SCAN = new TierScanStrategy.WorkingTierScanStrategy();
+
+    private static final List<TierScanStrategy> PER_PARTITION_SCANS = List.of(
+            new TierScanStrategy.EpisodicTierScanStrategy(),
+            new TierScanStrategy.SemanticTierScanStrategy(),
+            new TierScanStrategy.ProceduralTierScanStrategy()
+    );
+
+    private final PartitionRegistry partitionRegistry;
+    private final PartitionPruner partitionPruner;
+    private final SemanticRecallStrategy semanticRecallStrategy;
+    private final SlabScoreFunction scoreFunc;
+
+    /**
+     * Constructs a new CorticalTierScanRelay.
+     *
+     * @param partitionRegistry      the partition registry
+     * @param partitionPruner        the partition pruner
+     * @param semanticRecallStrategy the semantic recall strategy (nullable)
+     * @param scoreFunc              the scoring function
+     */
+    public CorticalTierScanRelay(
+            final PartitionRegistry partitionRegistry,
+            final PartitionPruner partitionPruner,
+            final SemanticRecallStrategy semanticRecallStrategy,
+            final SlabScoreFunction scoreFunc) {
+        this.partitionRegistry = partitionRegistry;
+        this.partitionPruner = partitionPruner;
+        this.semanticRecallStrategy = semanticRecallStrategy;
+        this.scoreFunc = scoreFunc;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        final float[] queryVector = signal.queryVector();
+        final RecallOptions options = signal.options();
+        final long nowMs = signal.timestampMs();
+        final MemoryType[] targetTypes = options.memoryTypes();
+        final List<CognitiveResult> allResults = signal.candidates();
+
+        final List<Callable<List<CognitiveResult>>> scanTasks = new ArrayList<>();
+        scan(new ParallelScanEmitter(scanTasks, queryVector, options, nowMs, scoreFunc, semanticRecallStrategy),
+                targetTypes, options, nowMs);
+
+        if (!scanTasks.isEmpty()) {
+            try {
+                final List<List<CognitiveResult>> tierResults = ConcurrentTasks.forkJoinAll(scanTasks);
+                for (final List<CognitiveResult> tier : tierResults) {
+                    allResults.addAll(tier);
+                }
+            } catch (final ConcurrentExecutionException e) {
+                log.error("Parallel tier scan failed: {}", e.getMessage(), e);
+                allResults.addAll(sequentialScan(queryVector, options, nowMs, targetTypes));
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Recall interrupted during parallel scan");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void scan(final ScanEmitter emitter, final MemoryType[] targetTypes, final RecallOptions options, final long nowMs) {
+        final List<PartitionHandle> snapshot = partitionRegistry.snapshot();
+        final CognitiveMemoryRouter active = partitionRegistry.activeRouter();
+        final boolean singlePartition = snapshot.size() == 1;
+        final int activeSeq = snapshot.get(snapshot.size() - 1).seq();
+        final boolean semanticHnswAvailable = semanticRecallStrategy != null && semanticRecallStrategy.isAvailable();
+        final ScanContext ctx = new ScanContext(targetTypes, active, singlePartition, activeSeq, semanticHnswAvailable);
+
+        final PartitionHandle activeHandle = snapshot.get(snapshot.size() - 1);
+
+        WORKING_SCAN.contribute(ctx, activeHandle, emitter);
+
+        if (ctx.semanticHnswAvailable() && CognitiveMemoryRouter.shouldScan(MemoryType.SEMANTIC, ctx.targetTypes())) {
+            emitter.emitSemanticHnsw();
+        }
+
+        final List<PartitionHandle> candidatePartitions = partitionPruner.prune(snapshot, options, targetTypes, nowMs);
+
+        for (final PartitionHandle handle : candidatePartitions) {
+            for (final TierScanStrategy strategy : PER_PARTITION_SCANS) {
+                strategy.contribute(ctx, handle, emitter);
+            }
+        }
+    }
+
+    private List<CognitiveResult> sequentialScan(final float[] queryVector, final RecallOptions options,
+                                                 final long nowMs, final MemoryType[] targetTypes) {
+        final List<CognitiveResult> results = new ArrayList<>();
+        scan(new SequentialScanEmitter(results, queryVector, options, nowMs, scoreFunc, semanticRecallStrategy),
+                targetTypes, options, nowMs);
+        return results;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.VECTOR_SEARCH;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/LexicalFusionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/LexicalFusionRelay.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.config.model.TextSearchMode;
+import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
+import com.spectrayan.spector.memory.cortex.MemoryBM25Index.BM25Candidate;
+import com.spectrayan.spector.memory.cortex.MemorySpladeIndex;
+import com.spectrayan.spector.memory.cortex.MemorySpladeIndex.SpladeCandidate;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.gatherer.RecallCandidateGatherer;
+import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.SparseEmbeddingResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Fuses keyword (BM25) and sparse (SPLADE) search results into the recall candidates using RRF.
+ */
+public final class LexicalFusionRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(LexicalFusionRelay.class);
+
+    private final MemoryBM25Index bm25Index;
+    private final MemorySpladeIndex spladeIndex;
+    private final SparseEmbeddingProvider spladeProvider;
+    private final RecallCandidateGatherer gatherer;
+    private final PartitionRegistry partitionRegistry;
+
+    private boolean spladeWarnLogged = false;
+
+    /**
+     * Constructs a new LexicalFusionRelay.
+     *
+     * @param bm25Index         the BM25 index
+     * @param spladeIndex       the SPLADE index (nullable)
+     * @param spladeProvider    the SPLADE sparse embedding provider (nullable)
+     * @param gatherer          the candidate gatherer
+     * @param partitionRegistry the partition registry
+     */
+    public LexicalFusionRelay(
+            final MemoryBM25Index bm25Index,
+            final MemorySpladeIndex spladeIndex,
+            final SparseEmbeddingProvider spladeProvider,
+            final RecallCandidateGatherer gatherer,
+            final PartitionRegistry partitionRegistry) {
+        this.bm25Index = bm25Index;
+        this.spladeIndex = spladeIndex;
+        this.spladeProvider = spladeProvider;
+        this.gatherer = gatherer;
+        this.partitionRegistry = partitionRegistry;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        boolean rrfFused = false;
+
+        // BM25 Text Search
+        if (bm25Index != null && signal.options().enableTextSearch()
+                && signal.options().textSearchMode() != TextSearchMode.VECTOR_ONLY) {
+            try {
+                final List<BM25Candidate> bm25Hits = bm25Index.search(signal.rawQuery(), signal.options().topK() * 2);
+                if (bm25Hits != null && !bm25Hits.isEmpty()) {
+                    gatherer.fuseBM25Candidates(signal.candidates(), bm25Hits, signal.options(), partitionRegistry);
+                    rrfFused = true;
+                }
+            } catch (final RuntimeException e) {
+                log.warn("BM25 search failed, continuing with vector-only results", e);
+            }
+        }
+
+        // SPLADE Learned Sparse Search
+        if (signal.options().enableTextSearch() && signal.options().textSearchMode().usesSPLADE()) {
+            if (spladeIndex != null && spladeProvider != null) {
+                try {
+                    final SparseEmbeddingResult querySparse = spladeProvider.encode(signal.rawQuery());
+                    final List<SpladeCandidate> spladeHits = spladeIndex.search(querySparse.weights(), signal.options().topK() * 2);
+                    if (spladeHits != null && !spladeHits.isEmpty()) {
+                        final List<BM25Candidate> asBm25 = spladeHits.stream()
+                                .map(sc -> new BM25Candidate(sc.id(), sc.spladeScore(), sc.partitionIndex()))
+                                .toList();
+                        gatherer.fuseBM25Candidates(signal.candidates(), asBm25, signal.options(), partitionRegistry);
+                        rrfFused = true;
+                    }
+                } catch (final RuntimeException e) {
+                    log.warn("SPLADE search failed, continuing without", e);
+                }
+            } else if (!spladeWarnLogged) {
+                log.warn("SPLADE search requested (mode={}) but SparseEmbeddingProvider/SpladeIndex " +
+                         "not configured  --  degrading to BM25", signal.options().textSearchMode());
+                spladeWarnLogged = true;
+            }
+        }
+
+        if (rrfFused) {
+            signal.setRrfFused(true);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.BM25_SEARCH;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/MmrDiversityRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/MmrDiversityRelay.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.reranker.MmrReranker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Relay that applies Maximal Marginal Relevance diversity reranking.
+ */
+public final class MmrDiversityRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(MmrDiversityRelay.class);
+    private final MmrReranker mmrReranker;
+    private boolean mmrWarnLogged = false;
+
+    public MmrDiversityRelay(final MmrReranker mmrReranker) {
+        this.mmrReranker = mmrReranker;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        final RecallOptions options = signal.options();
+        List<CognitiveResult> allResults = signal.candidates();
+
+        if (options.enableMmr()) {
+            if (mmrReranker != null) {
+                allResults = mmrReranker.rerank(allResults, signal.queryVector(), options.mmrLambda(), options.topK());
+                signal.setCandidates(allResults);
+            } else if (!mmrWarnLogged) {
+                log.warn("MMR reranking requested but MmrReranker not configured");
+                mmrWarnLogged = true;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.MMR_RERANK;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/NeuromodulatoryScoringRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/NeuromodulatoryScoringRelay.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
+import com.spectrayan.spector.memory.pipeline.scorer.SalienceAndHabituationScorer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies cognitive neuromodulatory scoring such as habituation, and STDP boost.
+ */
+public final class NeuromodulatoryScoringRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(NeuromodulatoryScoringRelay.class);
+    
+    private final SalienceAndHabituationScorer salienceScorer;
+    private final CoActivationRecordMemory coActivationTracker;
+    private final GraphScoringPolicy graphScoringPolicy;
+
+    public NeuromodulatoryScoringRelay(
+            final SalienceAndHabituationScorer salienceScorer,
+            final CoActivationRecordMemory coActivationTracker,
+            final GraphScoringPolicy graphScoringPolicy) {
+        this.salienceScorer = salienceScorer;
+        this.coActivationTracker = coActivationTracker;
+        this.graphScoringPolicy = graphScoringPolicy;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        salienceScorer.applyCognitiveScoring(
+                signal.candidates(),
+                signal.options(),
+                signal.timestampMs(),
+                coActivationTracker,
+                graphScoringPolicy
+        );
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.SCORING;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/ProspectiveReminderRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/ProspectiveReminderRelay.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.scorer.SalienceAndHabituationScorer;
+import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Injects prospective reminders as recall candidates.
+ */
+public final class ProspectiveReminderRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(ProspectiveReminderRelay.class);
+    
+    private final SalienceAndHabituationScorer salienceScorer;
+    private final ProspectiveScheduler prospectiveScheduler;
+
+    public ProspectiveReminderRelay(
+            final SalienceAndHabituationScorer salienceScorer,
+            final ProspectiveScheduler prospectiveScheduler) {
+        this.salienceScorer = salienceScorer;
+        this.prospectiveScheduler = prospectiveScheduler;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        salienceScorer.seedProspectiveReminders(signal.candidates(), prospectiveScheduler);
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.PROSPECTIVE;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/QueryTransductionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/QueryTransductionRelay.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transduces a raw text query into a vector representation.
+ */
+public final class QueryTransductionRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(QueryTransductionRelay.class);
+    
+    private final EmbeddingProvider embeddingProvider;
+
+    public QueryTransductionRelay(final EmbeddingProvider embeddingProvider) {
+        this.embeddingProvider = embeddingProvider;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        if (signal.queryVector() == null) {
+            final var result = embeddingProvider.embed(signal.rawQuery());
+            signal.setQueryVector(result.vector());
+            log.debug("Embedded query vector for text: {}", signal.rawQuery());
+        }
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.TRANSDUCTION;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallGates.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.Specification;
+import com.spectrayan.spector.config.model.TextSearchMode;
+
+/**
+ * Defines standard specifications and gates for controlling the flow of a {@link RecallSignal}.
+ */
+public final class RecallGates {
+
+    private RecallGates() {}
+
+    /**
+     * Gate evaluating whether text search should be executed.
+     */
+    public static final Specification<RecallSignal> TEXT_SEARCH_ENABLED =
+        Specification.of(
+            "text search not enabled or mode is VECTOR_ONLY",
+            s -> s.options().enableTextSearch()
+                 && s.options().textSearchMode() != TextSearchMode.VECTOR_ONLY);
+
+    /**
+     * Gate evaluating whether the ColBERT reranker should be executed.
+     */
+    public static final Specification<RecallSignal> RERANK_CONFIGURED =
+        Specification.of(
+            "reranker not enabled or ColBERT mode not active",
+            s -> s.options().enableReranker()
+                 && s.options().textSearchMode().usesColBERT());
+
+    /**
+     * Gate evaluating whether MMR diversity reranking is enabled.
+     */
+    public static final Specification<RecallSignal> MMR_ENABLED =
+        Specification.of("MMR not enabled in recall options",
+            s -> s.options().enableMmr());
+
+    /**
+     * Gate evaluating whether RRF fusion has occurred.
+     */
+    public static final Specification<RecallSignal> RRF_FUSED =
+        Specification.of("no RRF fusion occurred in this recall",
+            RecallSignal::isRrfFused);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.CognitivePathway;
+import com.spectrayan.spector.commons.pathway.ConsolidationRelay;
+import com.spectrayan.spector.commons.pathway.ErrorPolicy;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+
+/**
+ * Factory for creating the recall cognitive pathway.
+ */
+public final class RecallPathwayFactory {
+
+    private RecallPathwayFactory() {}
+
+    /**
+     * Creates the recall cognitive pathway.
+     *
+     * @param transductionRelay      the transduction relay
+     * @param prospectiveRelay       the prospective relay
+     * @param vectorSearchRelay      the vector search relay
+     * @param scoringRelay           the scoring relay
+     * @param graphExpansionRelay    the graph expansion relay
+     * @param bm25SearchRelay        the bm25 search relay
+     * @param rrfRescoreRelay        the rrf rescore relay
+     * @param sortAndTruncateRelay   the sort and truncate relay
+     * @param cognitiveRerankRelay   the cognitive rerank relay
+     * @param mmrDiversityRelay      the mmr diversity relay
+     * @param temperatureSoftmaxRelay the temperature softmax relay
+     * @param consolidationRelay     the consolidation relay
+     * @return the constructed recall pathway
+     */
+    public static CognitivePathway<RecallSignal> create(
+            final SynapticRelay<RecallSignal> transductionRelay,
+            final SynapticRelay<RecallSignal> prospectiveRelay,
+            final SynapticRelay<RecallSignal> vectorSearchRelay,
+            final SynapticRelay<RecallSignal> scoringRelay,
+            final SynapticRelay<RecallSignal> graphExpansionRelay,
+            final SynapticRelay<RecallSignal> bm25SearchRelay,
+            final RrfRescoreRelay rrfRescoreRelay,
+            final SortAndTruncateRelay sortAndTruncateRelay,
+            final CognitiveRerankRelay cognitiveRerankRelay,
+            final MmrDiversityRelay mmrDiversityRelay,
+            final TemperatureSoftmaxRelay temperatureSoftmaxRelay,
+            final ConsolidationRelay<RecallSignal> consolidationRelay) {
+
+        return CognitivePathway.<RecallSignal>pathway("recall")
+                .relay(RelayNames.TRANSDUCTION, transductionRelay)
+                .relay(RelayNames.PROSPECTIVE, prospectiveRelay)
+                .relay(RelayNames.VECTOR_SEARCH, vectorSearchRelay)
+                .relay(RelayNames.SCORING, scoringRelay)
+                .relay(RelayNames.GRAPH_EXPANSION, graphExpansionRelay)
+                .gated(RelayNames.BM25_SEARCH, RecallGates.TEXT_SEARCH_ENABLED, bm25SearchRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .gated(RelayNames.RRF_RESCORE, RecallGates.RRF_FUSED, rrfRescoreRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.SORT_TRUNCATE, sortAndTruncateRelay)
+                .gated(RelayNames.COLBERT_RERANK, RecallGates.RERANK_CONFIGURED, cognitiveRerankRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .gated(RelayNames.MMR_RERANK, RecallGates.MMR_ENABLED, mmrDiversityRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.TEMPERATURE, temperatureSoftmaxRelay)
+                .relay(RelayNames.CONSOLIDATION, consolidationRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .build();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
@@ -55,8 +55,49 @@ public final class RecallPathwayFactory {
             final MmrDiversityRelay mmrDiversityRelay,
             final TemperatureSoftmaxRelay temperatureSoftmaxRelay,
             final ConsolidationRelay<RecallSignal> consolidationRelay) {
+        return create(null, transductionRelay, prospectiveRelay, vectorSearchRelay, scoringRelay,
+                graphExpansionRelay, bm25SearchRelay, rrfRescoreRelay, sortAndTruncateRelay,
+                cognitiveRerankRelay, mmrDiversityRelay, temperatureSoftmaxRelay, consolidationRelay);
+    }
 
-        return CognitivePathway.<RecallSignal>pathway("recall")
+    /**
+     * Creates the recall cognitive pathway with an interceptor/decorator.
+     *
+     * @param interceptor            optional interceptor/decorator function
+     * @param transductionRelay      the transduction relay
+     * @param prospectiveRelay       the prospective relay
+     * @param vectorSearchRelay      the vector search relay
+     * @param scoringRelay           the scoring relay
+     * @param graphExpansionRelay    the graph expansion relay
+     * @param bm25SearchRelay        the bm25 search relay
+     * @param rrfRescoreRelay        the rrf rescore relay
+     * @param sortAndTruncateRelay   the sort and truncate relay
+     * @param cognitiveRerankRelay   the cognitive rerank relay
+     * @param mmrDiversityRelay      the mmr diversity relay
+     * @param temperatureSoftmaxRelay the temperature softmax relay
+     * @param consolidationRelay     the consolidation relay
+     * @return the constructed recall pathway
+     */
+    public static CognitivePathway<RecallSignal> create(
+            final java.util.function.Function<SynapticRelay<RecallSignal>, SynapticRelay<RecallSignal>> interceptor,
+            final SynapticRelay<RecallSignal> transductionRelay,
+            final SynapticRelay<RecallSignal> prospectiveRelay,
+            final SynapticRelay<RecallSignal> vectorSearchRelay,
+            final SynapticRelay<RecallSignal> scoringRelay,
+            final SynapticRelay<RecallSignal> graphExpansionRelay,
+            final SynapticRelay<RecallSignal> bm25SearchRelay,
+            final RrfRescoreRelay rrfRescoreRelay,
+            final SortAndTruncateRelay sortAndTruncateRelay,
+            final CognitiveRerankRelay cognitiveRerankRelay,
+            final MmrDiversityRelay mmrDiversityRelay,
+            final TemperatureSoftmaxRelay temperatureSoftmaxRelay,
+            final ConsolidationRelay<RecallSignal> consolidationRelay) {
+
+        final var builder = CognitivePathway.<RecallSignal>pathway("recall");
+        if (interceptor != null) {
+            builder.withInterceptor(interceptor);
+        }
+        return builder
                 .relay(RelayNames.TRANSDUCTION, transductionRelay)
                 .relay(RelayNames.PROSPECTIVE, prospectiveRelay)
                 .relay(RelayNames.VECTOR_SEARCH, vectorSearchRelay)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
@@ -39,6 +39,7 @@ public final class RecallSignal implements DivergentCapable<RecallSignal> {
     private final List<CognitiveResult> candidates = new ArrayList<>();
     private boolean textSearchExecuted = false;
     private boolean rrfFused = false;
+    private float effectiveTemperature = 1.0f;
 
     // Output
     private List<CognitiveResult> finalizedResults = Collections.emptyList();
@@ -192,6 +193,24 @@ public final class RecallSignal implements DivergentCapable<RecallSignal> {
      */
     public void setRrfFused(final boolean rrfFused) {
         this.rrfFused = rrfFused;
+    }
+
+    /**
+     * Returns the effective temperature applied during softmax modulation.
+     *
+     * @return the effective temperature
+     */
+    public float effectiveTemperature() {
+        return effectiveTemperature;
+    }
+
+    /**
+     * Sets the effective temperature applied during softmax modulation.
+     *
+     * @param effectiveTemperature the effective temperature
+     */
+    public void setEffectiveTemperature(final float effectiveTemperature) {
+        this.effectiveTemperature = effectiveTemperature;
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.DivergentCapable;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Signal carrying the state of a recall operation through the memory pipeline.
+ *
+ * <p>This signal implements {@link DivergentCapable} to support parallel forks for 
+ * operations like hybrid text/vector search, merging the candidates back together.</p>
+ */
+public final class RecallSignal implements DivergentCapable<RecallSignal> {
+
+    // Immutable inputs
+    private final String rawQuery;
+    private final RecallOptions options;
+    private final long timestampMs;
+
+    // Mutable working state
+    private float[] queryVector;
+    private final List<CognitiveResult> candidates = new ArrayList<>();
+    private boolean textSearchExecuted = false;
+    private boolean rrfFused = false;
+
+    // Output
+    private List<CognitiveResult> finalizedResults = Collections.emptyList();
+
+    // Private constructor
+    private RecallSignal(final String rawQuery, final float[] queryVector, final RecallOptions options, final long timestampMs) {
+        this.rawQuery = rawQuery;
+        this.queryVector = queryVector;
+        this.options = Objects.requireNonNull(options);
+        this.timestampMs = timestampMs;
+    }
+
+    /**
+     * Creates a new signal for a text-based query.
+     *
+     * @param rawQuery the raw query string
+     * @param options  the recall options
+     * @return a new recall signal
+     */
+    public static RecallSignal forTextQuery(final String rawQuery, final RecallOptions options) {
+        return new RecallSignal(rawQuery, null, options, System.currentTimeMillis());
+    }
+
+    /**
+     * Creates a new signal for a pre-embedded vector query.
+     *
+     * @param queryVector the vector query
+     * @param options     the recall options
+     * @return a new recall signal
+     */
+    public static RecallSignal forVectorQuery(final float[] queryVector, final RecallOptions options) {
+        return new RecallSignal(null, queryVector, options, System.currentTimeMillis());
+    }
+
+    @Override
+    public RecallSignal fork() {
+        return new RecallSignal(rawQuery, queryVector, options, timestampMs);
+    }
+
+    @Override
+    public void merge(final List<RecallSignal> forks) {
+        for (final RecallSignal fork : forks) {
+            this.candidates.addAll(fork.candidates);
+        }
+    }
+
+    /**
+     * Returns the raw query string.
+     *
+     * @return the raw query string, or null if this is a vector-only query
+     */
+    public String rawQuery() {
+        return rawQuery;
+    }
+
+    /**
+     * Returns the recall options.
+     *
+     * @return the recall options
+     */
+    public RecallOptions options() {
+        return options;
+    }
+
+    /**
+     * Returns the creation timestamp of this signal.
+     *
+     * @return the timestamp when this signal was created in milliseconds
+     */
+    public long timestampMs() {
+        return timestampMs;
+    }
+
+    /**
+     * Returns the query vector.
+     *
+     * @return the query vector, or null if not yet embedded or provided
+     */
+    public float[] queryVector() {
+        return queryVector;
+    }
+
+    /**
+     * Sets the query vector.
+     *
+     * @param queryVector the vector to set
+     */
+    public void setQueryVector(final float[] queryVector) {
+        this.queryVector = queryVector;
+    }
+
+    /**
+     * Returns the current candidate results.
+     *
+     * @return the list of candidate results
+     */
+    public List<CognitiveResult> candidates() {
+        return candidates;
+    }
+
+    /**
+     * Adds multiple candidates to this signal.
+     *
+     * @param newCandidates the candidates to add
+     */
+    public void addCandidates(final List<CognitiveResult> newCandidates) {
+        this.candidates.addAll(newCandidates);
+    }
+
+    /**
+     * Sets the candidates for this signal, replacing any existing ones.
+     *
+     * @param newCandidates the new list of candidates
+     */
+    public void setCandidates(final List<CognitiveResult> newCandidates) {
+        this.candidates.clear();
+        this.candidates.addAll(newCandidates);
+    }
+
+    /**
+     * Checks if text search has been executed.
+     *
+     * @return true if text search was executed, false otherwise
+     */
+    public boolean isTextSearchExecuted() {
+        return textSearchExecuted;
+    }
+
+    /**
+     * Sets the execution status of text search.
+     *
+     * @param textSearchExecuted true if executed, false otherwise
+     */
+    public void setTextSearchExecuted(final boolean textSearchExecuted) {
+        this.textSearchExecuted = textSearchExecuted;
+    }
+
+    /**
+     * Checks if RRF fusion has been performed.
+     *
+     * @return true if RRF fusion was performed, false otherwise
+     */
+    public boolean isRrfFused() {
+        return rrfFused;
+    }
+
+    /**
+     * Sets the status of RRF fusion.
+     *
+     * @param rrfFused true if fused, false otherwise
+     */
+    public void setRrfFused(final boolean rrfFused) {
+        this.rrfFused = rrfFused;
+    }
+
+    /**
+     * Returns the finalized list of cognitive results.
+     *
+     * @return the finalized results, or an empty list if not yet finalized
+     */
+    public List<CognitiveResult> finalizedResults() {
+        return finalizedResults;
+    }
+
+    /**
+     * Finalizes the results for this signal.
+     *
+     * @param finalizedResults the final list of cognitive results
+     */
+    public void setFinalizedResults(final List<CognitiveResult> finalizedResults) {
+        this.finalizedResults = List.copyOf(finalizedResults);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RrfRescoreRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RrfRescoreRelay.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
+import com.spectrayan.spector.memory.model.RecallMode;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
+import com.spectrayan.spector.memory.pipeline.scorer.SalienceAndHabituationScorer;
+
+/**
+ * Relay that re-applies cognitive scoring to RRF fused results.
+ */
+public final class RrfRescoreRelay implements SynapticRelay<RecallSignal> {
+    
+    private final SalienceAndHabituationScorer scorer;
+    private final CoActivationRecordMemory coActivationTracker;
+    private final GraphScoringPolicy graphScoringPolicy;
+
+    public RrfRescoreRelay(final SalienceAndHabituationScorer scorer,
+                           final CoActivationRecordMemory coActivationTracker,
+                           final GraphScoringPolicy graphScoringPolicy) {
+        this.scorer = scorer;
+        this.coActivationTracker = coActivationTracker;
+        this.graphScoringPolicy = graphScoringPolicy;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        if (signal.isRrfFused()) {
+            final RecallOptions options = signal.options();
+            final RecallOptions peekOptions = options.recallMode() == RecallMode.LEARN
+                    ? options.toBuilder().recallMode(RecallMode.OBSERVE).build()
+                    : options;
+            scorer.applyCognitiveScoring(signal.candidates(), peekOptions, signal.timestampMs(), coActivationTracker, graphScoringPolicy);
+        }
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.RRF_RESCORE;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SortAndTruncateRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SortAndTruncateRelay.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.inhibition.SuppressionSet;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Relay that filters suppressed memories, sorts by score, and truncates to top K.
+ */
+public final class SortAndTruncateRelay implements SynapticRelay<RecallSignal> {
+
+    private final SuppressionSet suppressionSet;
+
+    public SortAndTruncateRelay(final SuppressionSet suppressionSet) {
+        this.suppressionSet = suppressionSet;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        List<CognitiveResult> allResults = signal.candidates();
+        
+        allResults.removeIf(r -> suppressionSet.isSuppressed(r.id()));
+        
+        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        final int topK = signal.options().topK();
+        if (allResults.size() > topK) {
+            allResults = new ArrayList<>(allResults.subList(0, topK));
+            signal.setCandidates(allResults);
+        }
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.SORT_TRUNCATE;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/TemperatureSoftmaxRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/TemperatureSoftmaxRelay.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.cortex.PartitionRegistry;
+import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.synapse.TemperatureSoftmax;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Relay that applies Softmax temperature modulation to candidate scores.
+ */
+public final class TemperatureSoftmaxRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(TemperatureSoftmaxRelay.class);
+
+    private final SurpriseDetector surpriseDetector;
+    private final PartitionRegistry partitionRegistry;
+    private final float[] calibrationMins;
+    private final float[] calibrationScales;
+
+    public TemperatureSoftmaxRelay(final SurpriseDetector surpriseDetector,
+                                   final PartitionRegistry partitionRegistry,
+                                   final float[] calibrationMins,
+                                   final float[] calibrationScales) {
+        this.surpriseDetector = surpriseDetector;
+        this.partitionRegistry = partitionRegistry;
+        this.calibrationMins = calibrationMins;
+        this.calibrationScales = calibrationScales;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        final RecallOptions options = signal.options();
+        List<CognitiveResult> allResults = signal.candidates();
+
+        final float effectiveTemp = computeEffectiveTemperature(signal.queryVector(), options);
+        if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
+            TemperatureSoftmax.applySoftmaxTemperature(allResults, effectiveTemp);
+            allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+            if (allResults.size() > options.topK()) {
+                allResults = new ArrayList<>(allResults.subList(0, options.topK()));
+                signal.setCandidates(allResults);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.TEMPERATURE;
+    }
+
+    private float computeEffectiveTemperature(final float[] queryVector, final RecallOptions options) {
+        if (!options.adaptiveTemperature()) {
+            return options.computeEffectiveTemperature(0.0);
+        }
+        double zSurprise = 0.0;
+        if (surpriseDetector != null && queryVector != null && partitionRegistry != null) {
+            try {
+                final var activeRouter = partitionRegistry.activeRouter();
+                if (activeRouter != null && activeRouter.working() != null) {
+                    final float nearestDist = activeRouter.working().nearestDistance(
+                            queryVector, calibrationMins, calibrationScales);
+                    if (nearestDist != Float.MAX_VALUE) {
+                        zSurprise = surpriseDetector.querySurpriseZScore(nearestDist);
+                    }
+                }
+            } catch (final RuntimeException e) {
+                log.debug("Failed to compute query surprise z-score: {}", e.getMessage());
+            }
+        }
+        return options.computeEffectiveTemperature(zSurprise);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/TemperatureSoftmaxRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/TemperatureSoftmaxRelay.java
@@ -54,6 +54,7 @@ public final class TemperatureSoftmaxRelay implements SynapticRelay<RecallSignal
         List<CognitiveResult> allResults = signal.candidates();
 
         final float effectiveTemp = computeEffectiveTemperature(signal.queryVector(), options);
+        signal.setEffectiveTemperature(effectiveTemp);
         if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
             TemperatureSoftmax.applySoftmaxTemperature(allResults, effectiveTemp);
             allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/package-info.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+
+/**
+ * Relay components for the recall pipeline, including signals and gating specifications.
+ */
+package com.spectrayan.spector.memory.recall.relay;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/CorticalWriteTransactionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/CorticalWriteTransactionRelay.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.core.similarity.VectorOps;
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
+import com.spectrayan.spector.memory.error.SpectorMemoryTierFullException;
+import com.spectrayan.spector.memory.error.SpectorPartitionFrozenException;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.IngestionContext;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.model.SourceModality;
+import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.PostIngestSync;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Coarse-grained transactional write relay encapsulating the atomic ingestion write sequence (Steps 3–6).
+ *
+ * <h3>Architectural Rationale</h3>
+ * <p>Per ADR Decision #2, the sequential write phase comprises tightly coupled, interdependent steps:
+ * <ol>
+ *   <li><b>L2 Normalization & INT8 Quantization</b>: Projects continuous embeddings into calibrated off-heap byte representations.</li>
+ *   <li><b>Neuromodulatory Header Assembly</b>: Builds the 64-byte {@link CognitiveHeader} incorporating emotional valence/arousal,
+ *       personality modulation, soul version stamp, and formation-time surprise z-scores.</li>
+ *   <li><b>Off-Heap Slab Allocation & Segment Write</b>: Atomically persists the header and quantized payload to the target
+ *       memory tier, automatically rolling active partitions when capacity limits are encountered.</li>
+ *   <li><b>Multi-Index Synchronization</b>: Registers the memory across HNSW graph, ID reverse index, WAL journal, BM25 text index,
+ *       and SPLADE sparse index with compensating tombstone protection.</li>
+ * </ol>
+ * Unifying these four steps into a single relay preserves the atomic write transaction boundary and prevents partially persisted
+ * corrupt state in the event of an unrecoverable storage failure.</p>
+ */
+public final class CorticalWriteTransactionRelay implements SynapticRelay<RememberSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(CorticalWriteTransactionRelay.class);
+
+    private final ScalarQuantizer quantizer;
+    private final PostIngestSync postIngestSync;
+    private final SurpriseDetector surpriseDetector;
+    private final boolean normalizeAtIngest;
+
+    private volatile CognitiveMemoryRouter cognitiveRouter;
+    private volatile Runnable partitionRollCallback;
+
+    /**
+     * Constructs a new {@code CorticalWriteTransactionRelay}.
+     *
+     * @param quantizer        the scalar quantizer for INT8 projection
+     * @param cognitiveRouter  the router directing writes to off-heap slab stores
+     * @param postIngestSync   the post-write index synchronizer
+     * @param surpriseDetector the novelty/surprise detector
+     * @param normalizeAtIngest whether to L2-normalize vectors before writing
+     */
+    public CorticalWriteTransactionRelay(
+            final ScalarQuantizer quantizer,
+            final CognitiveMemoryRouter cognitiveRouter,
+            final PostIngestSync postIngestSync,
+            final SurpriseDetector surpriseDetector,
+            final boolean normalizeAtIngest) {
+        this.quantizer = Objects.requireNonNull(quantizer, "quantizer cannot be null");
+        this.cognitiveRouter = Objects.requireNonNull(cognitiveRouter, "cognitiveRouter cannot be null");
+        this.postIngestSync = Objects.requireNonNull(postIngestSync, "postIngestSync cannot be null");
+        this.surpriseDetector = Objects.requireNonNull(surpriseDetector, "surpriseDetector cannot be null");
+        this.normalizeAtIngest = normalizeAtIngest;
+    }
+
+    @Override
+    public boolean transmit(final RememberSignal signal) {
+        float[] vector = signal.vector();
+        if (normalizeAtIngest && vector != null) {
+            vector = l2Normalize(vector);
+            signal.normalizedVector(vector);
+        }
+
+        // 1. INT8 Scalar Quantization
+        final byte[] quantized = (vector != null) ? quantizer.encode(vector) : new byte[0];
+        signal.quantizedVector(quantized);
+
+        // 2. Cognitive Header Assembly
+        final MemoryType type = signal.type();
+        final IngestionHints hints = signal.hints();
+        final IngestionContext context = signal.context();
+        final SalienceProfile salienceProfile = signal.salienceProfile();
+
+        byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, type.ordinal());
+        if (signal.isFlashbulb()) {
+            flags = (byte) (flags | SynapticHeaderConstants.FLAG_PINNED);
+        }
+        if (context != null) {
+            final SourceModality modality = context.sourceModality();
+            if (modality != null && modality != SourceModality.TEXT) {
+                flags = SynapticHeaderConstants.withSourceModality(flags, modality.ordinal());
+            }
+        }
+
+        final float l2Norm = (vector != null) ? VectorOps.magnitude(vector) : 0.0f;
+        final byte rawValence = (hints != null) ? hints.valence() : (byte) 0;
+        final byte rawArousal = (hints != null) ? hints.effectiveArousal() : (byte) 0;
+        final byte valence = salienceProfile.modulateValence(rawValence);
+        final byte arousal = salienceProfile.modulateArousal(rawArousal);
+
+        final float surpriseZScore = (float) surpriseDetector.stats().zScore(signal.nearestDist());
+        final byte encodingProfile = computeEncodingProfile(salienceProfile);
+        final byte encodingAlpha = computeEncodingAlpha(salienceProfile);
+        final byte encodingBeta = computeEncodingBeta(salienceProfile);
+
+        final CognitiveHeader header = new CognitiveHeader(
+                signal.timestampMs(),
+                signal.synapticTags(),
+                l2Norm,
+                signal.importance(),
+                0,
+                (short) 0,
+                valence,
+                flags,
+                arousal,
+                1.0f,
+                encodingProfile,
+                encodingAlpha,
+                encodingBeta,
+                signal.soulVersion(),
+                surpriseZScore
+        );
+        signal.header(header);
+
+        // 3. Off-Heap Slab Write (with partition roll support)
+        long offset;
+        try {
+            try {
+                offset = cognitiveRouter.write(type, header, quantized);
+            } catch (final SpectorPartitionFrozenException e) {
+                offset = cognitiveRouter.write(type, header, quantized);
+            }
+        } catch (final SpectorMemoryTierFullException e) {
+            if (partitionRollCallback != null) {
+                log.info("Tier {} full ({} records)  --  rolling to new partition",
+                        type, e.getCapacity());
+                partitionRollCallback.run();
+                offset = cognitiveRouter.write(type, header, quantized);
+            } else {
+                throw e;
+            }
+        }
+        signal.offset(offset);
+
+        // 4. Index Synchronization (HNSW, ID Index, WAL, BM25, SPLADE)
+        final Map<String, String> metadata = (context != null && context.hasMetadata()) ? context.metadata() : null;
+        final PostIngestSync.SyncParams syncParams = new PostIngestSync.SyncParams(
+                signal.id(),
+                signal.text(),
+                vector,
+                quantized,
+                type,
+                signal.tags(),
+                signal.source(),
+                offset,
+                metadata
+        );
+
+        final int graphSlot = postIngestSync.syncIndexes(syncParams);
+        signal.graphSlot(graphSlot);
+        signal.successful(true);
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.CORTICAL_WRITE;
+    }
+
+    /**
+     * Updates the cognitive memory router upon partition roll.
+     */
+    public void updateCognitiveRouter(final CognitiveMemoryRouter newRouter) {
+        this.cognitiveRouter = Objects.requireNonNull(newRouter, "newRouter cannot be null");
+        this.postIngestSync.updateCognitiveRouter(newRouter);
+    }
+
+    /**
+     * Sets the callback invoked when a partition tier is full.
+     */
+    public void setPartitionRollCallback(final Runnable callback) {
+        this.partitionRollCallback = callback;
+    }
+
+    public PostIngestSync postIngestSync() {
+        return postIngestSync;
+    }
+
+    private static float[] l2Normalize(final float[] vector) {
+        final float norm = VectorOps.magnitude(vector);
+        if (norm == 0f || Math.abs(norm - 1.0f) < 1e-6f) return vector;
+        return VectorOps.normalize(vector);
+    }
+
+    private static byte computeEncodingProfile(final SalienceProfile profile) {
+        if (profile.alpha() != null || profile.beta() != null) {
+            return SynapticHeaderConstants.soulDerivedEncodingProfile();
+        }
+        final CognitiveProfile cogProfile = profile.defaultProfile() != null
+                ? profile.defaultProfile()
+                : CognitiveProfile.BALANCED;
+        return SynapticHeaderConstants.presetEncodingProfile(cogProfile.ordinal());
+    }
+
+    private static byte computeEncodingAlpha(final SalienceProfile profile) {
+        final float alpha;
+        if (profile.alpha() != null) {
+            alpha = profile.alpha();
+        } else {
+            final CognitiveProfile cogProfile = profile.defaultProfile() != null
+                    ? profile.defaultProfile()
+                    : CognitiveProfile.BALANCED;
+            alpha = cogProfile.alpha();
+        }
+        return SynapticHeaderConstants.quantizeWeight(alpha);
+    }
+
+    private static byte computeEncodingBeta(final SalienceProfile profile) {
+        final float beta;
+        if (profile.beta() != null) {
+            beta = profile.beta();
+        } else {
+            final CognitiveProfile cogProfile = profile.defaultProfile() != null
+                    ? profile.defaultProfile()
+                    : CognitiveProfile.BALANCED;
+            beta = cogProfile.beta();
+        }
+        return SynapticHeaderConstants.quantizeWeight(beta);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/DedupGuardRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/DedupGuardRelay.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * Deduplication guard relay that short-circuits ingestion if the memory identifier is already indexed.
+ */
+public final class DedupGuardRelay implements SynapticRelay<RememberSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(DedupGuardRelay.class);
+
+    private final MemoryIndex index;
+
+    public DedupGuardRelay(final MemoryIndex index) {
+        this.index = Objects.requireNonNull(index, "index cannot be null");
+    }
+
+    @Override
+    public boolean transmit(final RememberSignal signal) {
+        if (index.locate(signal.id()) != null) {
+            log.debug("Skipping duplicate memory '{}'  --  already indexed", sanitize(signal.id()));
+            signal.duplicate(true);
+            return false; // Short-circuit pathway execution
+        }
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.DEDUP_GUARD;
+    }
+
+    private static String sanitize(final String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace('\n', '_').replace('\r', '_');
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/DopaminergicSurpriseRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/DopaminergicSurpriseRelay.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.core.similarity.VectorOps;
+import com.spectrayan.spector.memory.ImportanceProvider;
+import com.spectrayan.spector.memory.cortex.WorkingRecordMemory;
+import com.spectrayan.spector.memory.dopamine.SurpriseDetector;
+import com.spectrayan.spector.memory.model.ImportanceContext;
+import com.spectrayan.spector.memory.model.ImportanceResult;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+
+import java.util.Objects;
+
+/**
+ * Evaluates dopaminergic novelty and surprise to compute intrinsic memory importance and flashbulb pinning.
+ */
+public final class DopaminergicSurpriseRelay implements SynapticRelay<RememberSignal> {
+
+    private final SurpriseDetector surpriseDetector;
+    private final ImportanceProvider importanceProvider;
+    private final WorkingRecordMemory workingStore;
+    private final ScalarQuantizer quantizer;
+
+    public DopaminergicSurpriseRelay(
+            final SurpriseDetector surpriseDetector,
+            final ImportanceProvider importanceProvider,
+            final WorkingRecordMemory workingStore,
+            final ScalarQuantizer quantizer) {
+        this.surpriseDetector = Objects.requireNonNull(surpriseDetector, "surpriseDetector cannot be null");
+        this.importanceProvider = importanceProvider != null ? importanceProvider : ImportanceProvider.baseline();
+        this.workingStore = workingStore;
+        this.quantizer = Objects.requireNonNull(quantizer, "quantizer cannot be null");
+    }
+
+    @Override
+    public boolean transmit(final RememberSignal signal) {
+        final float[] vector = signal.vector();
+        final float nearestDist;
+        if (workingStore != null && workingStore.count() > 0 && vector != null) {
+            nearestDist = workingStore.nearestDistance(
+                    vector, quantizer.mins(), quantizer.scales());
+        } else if (vector != null) {
+            nearestDist = VectorOps.magnitude(vector);
+        } else {
+            nearestDist = 0.0f;
+        }
+        signal.nearestDist(nearestDist);
+
+        final ImportanceContext importanceCtx = new ImportanceContext(
+                signal.text(),
+                vector,
+                signal.hints(),
+                signal.salienceProfile(),
+                signal.type(),
+                nearestDist,
+                surpriseDetector.stats().zScore(nearestDist),
+                false);
+
+        final ImportanceResult importanceResult = importanceProvider.score(importanceCtx);
+        signal.importance(importanceResult.importance());
+        signal.flashbulb(importanceResult.isFlashbulb());
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.DOPAMINERGIC_SURPRISE;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/KnowledgeGraphEnrichmentRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/KnowledgeGraphEnrichmentRelay.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.graph.EntityExtractor;
+import com.spectrayan.spector.memory.graph.ExtractedEntity;
+import com.spectrayan.spector.memory.model.IngestionContext;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.AsyncEntityExtractionQueue;
+import com.spectrayan.spector.memory.pipeline.PostIngestSync;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Enriches the cognitive knowledge graph and temporal facts with extracted entities and relations.
+ */
+public final class KnowledgeGraphEnrichmentRelay implements SynapticRelay<RememberSignal> {
+
+    private final PostIngestSync postIngestSync;
+    private final AsyncEntityExtractionQueue asyncEntityExtractionQueue;
+    private final EntityExtractor entityExtractor;
+
+    public KnowledgeGraphEnrichmentRelay(
+            final PostIngestSync postIngestSync,
+            final AsyncEntityExtractionQueue asyncEntityExtractionQueue,
+            final EntityExtractor entityExtractor) {
+        this.postIngestSync = Objects.requireNonNull(postIngestSync, "postIngestSync cannot be null");
+        this.asyncEntityExtractionQueue = asyncEntityExtractionQueue;
+        this.entityExtractor = entityExtractor;
+    }
+
+    @Override
+    public boolean transmit(final RememberSignal signal) {
+        final int memoryIdx = signal.graphSlot();
+        if (memoryIdx < 0) {
+            return true;
+        }
+
+        final IngestionContext context = signal.context();
+        final long epochSeconds = signal.timestampMs() / 1000;
+        final String tsid = MemoryScope.sessionId();
+        final String nsid = MemoryScope.namespaceId();
+
+        if (context != null && context.hasEntities()) {
+            // Pre-extracted entities from IngestionContext
+            postIngestSync.syncPreExtractedEntities(context.entities(), memoryIdx, signal.id());
+            postIngestSync.syncTemporalFacts(context.entities(), memoryIdx, signal.id(), epochSeconds);
+        } else if (asyncEntityExtractionQueue != null && entityExtractor != null && entityExtractor.isAvailable()) {
+            // Asynchronous queue submission
+            asyncEntityExtractionQueue.submit(signal.id(), signal.text(), memoryIdx, epochSeconds, tsid, nsid);
+        } else if (entityExtractor != null && entityExtractor.isAvailable()) {
+            // Synchronous extraction fallback
+            final List<ExtractedEntity> extractedEntities = postIngestSync.syncEntityExtraction(signal.id(), signal.text(), memoryIdx);
+            postIngestSync.syncTemporalFacts(extractedEntities, memoryIdx, signal.id(), epochSeconds);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.KG_ENRICHMENT;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberGates.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.pathway.Specification;
+
+/**
+ * Named specification gates for conditional execution in the remember pathway.
+ */
+public final class RememberGates {
+
+    private RememberGates() {}
+
+    /**
+     * Gate checking that the memory is not a duplicate before proceeding with heavy operations.
+     */
+    public static final Specification<RememberSignal> NOT_DUPLICATE = Specification.of(
+            "Memory ID is already indexed (duplicate)",
+            signal -> !signal.isDuplicate()
+    );
+
+    /**
+     * Gate checking that the memory write transaction succeeded.
+     */
+    public static final Specification<RememberSignal> WRITE_SUCCESSFUL = Specification.of(
+            "Cortical write transaction did not complete successfully",
+            RememberSignal::isSuccessful
+    );
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberPathwayFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.pathway.CognitivePathway;
+import com.spectrayan.spector.commons.pathway.ErrorPolicy;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+
+/**
+ * Factory for creating the remember / memory consolidation cognitive pathway.
+ */
+public final class RememberPathwayFactory {
+
+    private RememberPathwayFactory() {}
+
+    /**
+     * Creates the remember cognitive pathway from its constituent relays.
+     *
+     * @param dedupGuardRelay      the deduplication guard relay
+     * @param tagTransductionRelay the synaptic tag transduction relay
+     * @param surpriseRelay        the dopaminergic surprise and novelty relay
+     * @param corticalWriteRelay   the transactional cortical write and index sync relay
+     * @param graphLinkingRelay    the associative graph and temporal chain linking relay
+     * @param kgEnrichmentRelay    the knowledge graph and entity enrichment relay
+     * @return the constructed remember pathway
+     */
+    public static CognitivePathway<RememberSignal> create(
+            final DedupGuardRelay dedupGuardRelay,
+            final SynapticTagTransductionRelay tagTransductionRelay,
+            final DopaminergicSurpriseRelay surpriseRelay,
+            final CorticalWriteTransactionRelay corticalWriteRelay,
+            final SynapticGraphLinkingRelay graphLinkingRelay,
+            final KnowledgeGraphEnrichmentRelay kgEnrichmentRelay) {
+
+        return CognitivePathway.<RememberSignal>pathway("remember")
+                .relay(RelayNames.DEDUP_GUARD, dedupGuardRelay, ErrorPolicy.FAIL_FAST)
+                .relay(RelayNames.TAG_TRANSDUCTION, tagTransductionRelay, ErrorPolicy.FAIL_FAST)
+                .relay(RelayNames.DOPAMINERGIC_SURPRISE, surpriseRelay, ErrorPolicy.FAIL_FAST)
+                .relay(RelayNames.CORTICAL_WRITE, corticalWriteRelay, ErrorPolicy.FAIL_FAST)
+                .relay(RelayNames.GRAPH_LINKING, graphLinkingRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.KG_ENRICHMENT, kgEnrichmentRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .build();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberPathwayFactory.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.memory.remember.relay;
 
 import com.spectrayan.spector.commons.pathway.CognitivePathway;
 import com.spectrayan.spector.commons.pathway.ErrorPolicy;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
 import com.spectrayan.spector.memory.pathway.RelayNames;
 
 /**
@@ -41,8 +42,36 @@ public final class RememberPathwayFactory {
             final CorticalWriteTransactionRelay corticalWriteRelay,
             final SynapticGraphLinkingRelay graphLinkingRelay,
             final KnowledgeGraphEnrichmentRelay kgEnrichmentRelay) {
+        return create(null, dedupGuardRelay, tagTransductionRelay, surpriseRelay,
+                corticalWriteRelay, graphLinkingRelay, kgEnrichmentRelay);
+    }
 
-        return CognitivePathway.<RememberSignal>pathway("remember")
+    /**
+     * Creates the remember cognitive pathway with an interceptor/decorator.
+     *
+     * @param interceptor          optional interceptor/decorator function
+     * @param dedupGuardRelay      the deduplication guard relay
+     * @param tagTransductionRelay the synaptic tag transduction relay
+     * @param surpriseRelay        the dopaminergic surprise and novelty relay
+     * @param corticalWriteRelay   the transactional cortical write and index sync relay
+     * @param graphLinkingRelay    the associative graph and temporal chain linking relay
+     * @param kgEnrichmentRelay    the knowledge graph and entity enrichment relay
+     * @return the constructed remember pathway
+     */
+    public static CognitivePathway<RememberSignal> create(
+            final java.util.function.Function<SynapticRelay<RememberSignal>, SynapticRelay<RememberSignal>> interceptor,
+            final DedupGuardRelay dedupGuardRelay,
+            final SynapticTagTransductionRelay tagTransductionRelay,
+            final DopaminergicSurpriseRelay surpriseRelay,
+            final CorticalWriteTransactionRelay corticalWriteRelay,
+            final SynapticGraphLinkingRelay graphLinkingRelay,
+            final KnowledgeGraphEnrichmentRelay kgEnrichmentRelay) {
+
+        final var builder = CognitivePathway.<RememberSignal>pathway("remember");
+        if (interceptor != null) {
+            builder.withInterceptor(interceptor);
+        }
+        return builder
                 .relay(RelayNames.DEDUP_GUARD, dedupGuardRelay, ErrorPolicy.FAIL_FAST)
                 .relay(RelayNames.TAG_TRANSDUCTION, tagTransductionRelay, ErrorPolicy.FAIL_FAST)
                 .relay(RelayNames.DOPAMINERGIC_SURPRISE, surpriseRelay, ErrorPolicy.FAIL_FAST)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberSignal.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.model.IngestionContext;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
+
+import java.util.Objects;
+
+/**
+ * Mutable context payload propagating through the memory consolidation / remember pathway.
+ */
+public final class RememberSignal {
+
+    // ── Immutable Ingestion Request ────────────────────────────────
+    private final String id;
+    private final String text;
+    private final float[] vector;
+    private final MemoryType type;
+    private final MemorySource source;
+    private final IngestionHints hints;
+    private final IngestionContext context;
+    private final SalienceProfile salienceProfile;
+    private final short soulVersion;
+    private final long timestampMs;
+
+    // ── Mutable Pipeline Working State ─────────────────────────────
+    private String[] tags;
+    private long synapticTags;
+    private float[] normalizedVector;
+    private byte[] quantizedVector;
+    private float nearestDist;
+    private float importance;
+    private boolean flashbulb;
+    private CognitiveHeader header;
+    private long offset = -1L;
+    private int graphSlot = -1;
+    private boolean duplicate = false;
+    private boolean successful = false;
+
+    private RememberSignal(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final IngestionHints hints,
+            final IngestionContext context,
+            final SalienceProfile salienceProfile,
+            final short soulVersion,
+            final long timestampMs) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.text = Objects.requireNonNull(text, "text cannot be null");
+        this.vector = vector;
+        this.type = type != null ? type : MemoryType.SEMANTIC;
+        this.tags = tags != null ? tags : new String[0];
+        this.source = source != null ? source : MemorySource.OBSERVED;
+        this.hints = hints;
+        this.context = context;
+        this.salienceProfile = salienceProfile != null ? salienceProfile : SalienceProfile.NEUTRAL;
+        this.soulVersion = soulVersion;
+        this.timestampMs = timestampMs > 0 ? timestampMs : System.currentTimeMillis();
+    }
+
+    /**
+     * Factory for standard cognitive remember requests.
+     */
+    public static RememberSignal forCognitive(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final IngestionHints hints,
+            final SalienceProfile salienceProfile,
+            final short soulVersion) {
+        return new RememberSignal(
+                id, text, vector, type, tags, source, hints, null,
+                salienceProfile, soulVersion, System.currentTimeMillis());
+    }
+
+    /**
+     * Factory for rich context-aware cognitive remember requests.
+     */
+    public static RememberSignal forCognitiveWithContext(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final IngestionContext context,
+            final SalienceProfile salienceProfile,
+            final short soulVersion) {
+        final IngestionHints effectiveHints = context != null ? context.hints() : null;
+        final long ts = (context != null && context.effectiveTimestampMs() > 0)
+                ? context.effectiveTimestampMs()
+                : System.currentTimeMillis();
+        return new RememberSignal(
+                id, text, vector, type, tags, source, effectiveHints, context,
+                salienceProfile, soulVersion, ts);
+    }
+
+    // ── Getters & Setters ──────────────────────────────────────────
+
+    public String id() { return id; }
+    public String text() { return text; }
+    public float[] vector() { return vector; }
+    public MemoryType type() { return type; }
+    public MemorySource source() { return source; }
+    public IngestionHints hints() { return hints; }
+    public IngestionContext context() { return context; }
+    public SalienceProfile salienceProfile() { return salienceProfile; }
+    public short soulVersion() { return soulVersion; }
+    public long timestampMs() { return timestampMs; }
+
+    public String[] tags() { return tags; }
+    public void tags(final String[] tags) { this.tags = tags != null ? tags : new String[0]; }
+
+    public long synapticTags() { return synapticTags; }
+    public void synapticTags(final long synapticTags) { this.synapticTags = synapticTags; }
+
+    public float[] normalizedVector() { return normalizedVector; }
+    public void normalizedVector(final float[] normalizedVector) { this.normalizedVector = normalizedVector; }
+
+    public byte[] quantizedVector() { return quantizedVector; }
+    public void quantizedVector(final byte[] quantizedVector) { this.quantizedVector = quantizedVector; }
+
+    public float nearestDist() { return nearestDist; }
+    public void nearestDist(final float nearestDist) { this.nearestDist = nearestDist; }
+
+    public float importance() { return importance; }
+    public void importance(final float importance) { this.importance = importance; }
+
+    public boolean isFlashbulb() { return flashbulb; }
+    public void flashbulb(final boolean flashbulb) { this.flashbulb = flashbulb; }
+
+    public CognitiveHeader header() { return header; }
+    public void header(final CognitiveHeader header) { this.header = header; }
+
+    public long offset() { return offset; }
+    public void offset(final long offset) { this.offset = offset; }
+
+    public int graphSlot() { return graphSlot; }
+    public void graphSlot(final int graphSlot) { this.graphSlot = graphSlot; }
+
+    public boolean isDuplicate() { return duplicate; }
+    public void duplicate(final boolean duplicate) { this.duplicate = duplicate; }
+
+    public boolean isSuccessful() { return successful; }
+    public void successful(final boolean successful) { this.successful = successful; }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/SynapticGraphLinkingRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/SynapticGraphLinkingRelay.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.model.IngestionContext;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.PostIngestSync;
+import com.spectrayan.spector.memory.session.SessionRegistry;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Links synaptic associative graphs (Hebbian co-activation and temporal sequences) during memory consolidation.
+ */
+public final class SynapticGraphLinkingRelay implements SynapticRelay<RememberSignal> {
+
+    private final PostIngestSync postIngestSync;
+    private final AtomicInteger lastIngestedMemoryIdx;
+    private final SessionRegistry sessionRegistry;
+
+    public SynapticGraphLinkingRelay(
+            final PostIngestSync postIngestSync,
+            final AtomicInteger lastIngestedMemoryIdx,
+            final SessionRegistry sessionRegistry) {
+        this.postIngestSync = Objects.requireNonNull(postIngestSync, "postIngestSync cannot be null");
+        this.lastIngestedMemoryIdx = Objects.requireNonNull(lastIngestedMemoryIdx, "lastIngestedMemoryIdx cannot be null");
+        this.sessionRegistry = sessionRegistry;
+    }
+
+    @Override
+    public boolean transmit(final RememberSignal signal) {
+        final int memoryIdx = signal.graphSlot();
+        if (memoryIdx < 0) {
+            return true; // No graph slot allocated
+        }
+
+        final String tsid = MemoryScope.sessionId();
+        final int sessionIntId = sessionRegistry != null ? sessionRegistry.resolve(tsid) : 0;
+        final int previousIdx = lastIngestedMemoryIdx.getAndSet(memoryIdx);
+
+        // 1. Session co-ingestion Hebbian + Temporal linking
+        postIngestSync.syncGraphEdges(memoryIdx, previousIdx, sessionIntId);
+
+        // 2. Pre-computed edge hints from IngestionContext
+        final IngestionContext context = signal.context();
+        if (context != null) {
+            if (context.hasHebbianEdges()) {
+                postIngestSync.syncHebbianEdgeHints(memoryIdx, signal.id(), context.hebbianEdges());
+            }
+            if (context.hasTemporalLinks()) {
+                postIngestSync.syncTemporalLinkHints(memoryIdx, signal.id(), context.temporalLinks());
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.GRAPH_LINKING;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/SynapticTagTransductionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/SynapticTagTransductionRelay.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.remember.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.DataEncryptor;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.pipeline.TagExtractor;
+import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
+
+/**
+ * Transduces content and metadata tags into 64-bit synaptic Bloom filter bitmasks.
+ */
+public final class SynapticTagTransductionRelay implements SynapticRelay<RememberSignal> {
+
+    private final TagExtractor tagExtractor;
+    private final DataEncryptor encryptor;
+
+    public SynapticTagTransductionRelay(
+            final TagExtractor tagExtractor,
+            final DataEncryptor encryptor) {
+        this.tagExtractor = tagExtractor;
+        this.encryptor = encryptor != null ? encryptor : DataEncryptor.NOOP;
+    }
+
+    @Override
+    public boolean transmit(final RememberSignal signal) {
+        String[] tags = signal.tags();
+        if ((tags == null || tags.length == 0) && tagExtractor != null) {
+            tags = tagExtractor.extract(signal.id(), signal.text());
+            signal.tags(tags);
+        }
+
+        final long synapticTags = encodeTags(tags != null ? tags : new String[0]);
+        signal.synapticTags(synapticTags);
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.TAG_TRANSDUCTION;
+    }
+
+    private long encodeTags(final String[] tags) {
+        if (encryptor.isEnabled()) {
+            long filter = 0L;
+            for (final String tag : tags) {
+                filter |= encryptor.encodeTag(tag);
+            }
+            return filter;
+        }
+        return SynapticTagEncoder.encode(tags);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/package-info.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+
+/**
+ * Synaptic relays and pathway components for the Spector memory remember/consolidation engine.
+ */
+package com.spectrayan.spector.memory.remember.relay;

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservableRelay.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/observation/ObservableRelay.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.metrics.observation;
+
+import com.spectrayan.spector.commons.concurrent.MemoryScope;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.config.ObservabilityConfig;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Function;
+
+/**
+ * Wraps a SynapticRelay with Micrometer observation telemetry.
+ * 
+ * @param <S> the signal type
+ */
+public final class ObservableRelay<S> extends ObservableComponent implements SynapticRelay<S> {
+
+    private static final Logger log = LoggerFactory.getLogger(ObservableRelay.class);
+
+    private final SynapticRelay<S> delegate;
+    private final ObservationRegistry registry;
+    private final ObservabilityConfig config;
+    private final String relayName;
+
+    /**
+     * Constructs an ObservableRelay.
+     * 
+     * @param delegate the relay to wrap
+     * @param registry the Micrometer observation registry
+     * @param config the observability configuration
+     */
+    public ObservableRelay(SynapticRelay<S> delegate, ObservationRegistry registry, ObservabilityConfig config) {
+        super(registry, config);
+        this.delegate = delegate;
+        this.registry = registry;
+        this.config = config;
+        this.relayName = delegate.relayName();
+    }
+
+    @Override
+    public boolean transmit(S signal) throws Exception {
+        if (!config.isEnabled(relayName)) {
+            return delegate.transmit(signal);
+        }
+
+        MemoryObservationContext context = new MemoryObservationContext(relayName);
+        context.setNamespace(MemoryScope.namespaceId());
+        context.setSessionId(MemoryScope.sessionId());
+
+        Observation observation = Observation.createNotStarted(
+                relayName,
+                () -> context,
+                registry
+        ).observationConvention(DefaultSpectorObservationConvention.INSTANCE).start();
+
+        try (Observation.Scope scope = observation.openScope()) {
+            return ScopedValue.where(PARENT_OBSERVATION, relayName).call(() -> delegate.transmit(signal));
+        } catch (Exception e) {
+            observation.error(e);
+            context.setStatus("ERROR");
+            if (e instanceof RuntimeException re) throw re;
+            throw new RuntimeException(e);
+        } finally {
+            observation.stop();
+        }
+    }
+
+    @Override
+    public String relayName() {
+        return relayName;
+    }
+
+    /**
+     * Creates an interceptor function that wraps relays with ObservableRelay.
+     * 
+     * @param registry the observation registry
+     * @param config the observability config
+     * @param <S> the signal type
+     * @return a function that wraps a relay in an ObservableRelay
+     */
+    public static <S> Function<SynapticRelay<S>, SynapticRelay<S>> interceptor(ObservationRegistry registry, ObservabilityConfig config) {
+        return relay -> new ObservableRelay<>(relay, registry, config);
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/CognitivePathway.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/CognitivePathway.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Orchestrates a sequence of synaptic relays to process a signal.
+ *
+ * @param <S> the type of the signal
+ */
+public final class CognitivePathway<S> {
+
+    private static final Logger log = LoggerFactory.getLogger(CognitivePathway.class);
+
+    private final String pathwayName;
+    private final List<RelayEntry<S>> entries;
+
+    private CognitivePathway(final String pathwayName, final List<RelayEntry<S>> entries) {
+        this.pathwayName = pathwayName;
+        this.entries = List.copyOf(entries);
+    }
+
+    /**
+     * Conducts the signal through the pathway.
+     *
+     * @param signal the signal to conduct
+     * @return the processed signal
+     */
+    public S conduct(final S signal) {
+        for (final RelayEntry<S> entry : entries) {
+            try {
+                final boolean shouldContinue = entry.relay().transmit(signal);
+                if (!shouldContinue) {
+                    log.debug("Pathway '{}' short-circuited at relay '{}'", pathwayName, entry.relay().relayName());
+                    break;
+                }
+            } catch (final Exception e) {
+                if (entry.errorPolicy() == ErrorPolicy.FAIL_FAST) {
+                    throw new CognitivePathwayException("Failed at relay: " + entry.relay().relayName(), e);
+                } else {
+                    log.warn("Pathway '{}' degraded gracefully at relay '{}' due to error.", pathwayName, entry.relay().relayName(), e);
+                }
+            }
+        }
+        return signal;
+    }
+
+    /**
+     * Represents a configured relay within the pathway.
+     *
+     * @param <S>         the type of the signal
+     * @param relay       the relay instance
+     * @param errorPolicy the error handling policy for this relay
+     */
+    public record RelayEntry<S>(SynapticRelay<S> relay, ErrorPolicy errorPolicy) {}
+
+    /**
+     * Creates a new builder for a CognitivePathway.
+     *
+     * @param pathwayName the name of the pathway
+     * @param <S>         the type of the signal
+     * @return a new Builder instance
+     */
+    public static <S> Builder<S> pathway(final String pathwayName) {
+        return new Builder<>(pathwayName);
+    }
+
+    /**
+     * Builder for constructing a {@link CognitivePathway}.
+     *
+     * @param <S> the type of the signal
+     */
+    public static final class Builder<S> {
+
+        private final String pathwayName;
+        private final List<RelayEntry<S>> entries = new ArrayList<>();
+        private Function<SynapticRelay<S>, SynapticRelay<S>> interceptor = Function.identity();
+
+        private Builder(final String pathwayName) {
+            this.pathwayName = pathwayName;
+        }
+
+        /**
+         * Sets an interceptor to be applied to all added relays.
+         *
+         * @param interceptor the interceptor function
+         * @return this builder
+         */
+        public Builder<S> withInterceptor(final Function<SynapticRelay<S>, SynapticRelay<S>> interceptor) {
+            this.interceptor = interceptor;
+            return this;
+        }
+
+        /**
+         * Adds a relay to the pathway with default FAIL_FAST policy.
+         *
+         * @param name  the name of the relay
+         * @param relay the relay instance
+         * @return this builder
+         */
+        public Builder<S> relay(final String name, final SynapticRelay<S> relay) {
+            return relay(name, relay, ErrorPolicy.FAIL_FAST);
+        }
+
+        /**
+         * Adds a relay to the pathway with the specified error policy.
+         *
+         * @param name        the name of the relay
+         * @param relay       the relay instance
+         * @param errorPolicy the error policy
+         * @return this builder
+         */
+        public Builder<S> relay(final String name, final SynapticRelay<S> relay, final ErrorPolicy errorPolicy) {
+            final SynapticRelay<S> namedRelay = new NamedRelay<>(name, relay);
+            final SynapticRelay<S> interceptedRelay = interceptor.apply(namedRelay);
+            this.entries.add(new RelayEntry<>(interceptedRelay, errorPolicy));
+            return this;
+        }
+
+        /**
+         * Adds a conditionally executed gated relay to the pathway.
+         *
+         * @param name        the name of the relay
+         * @param gate        the predicate condition
+         * @param relay       the relay instance
+         * @param errorPolicy the error policy
+         * @return this builder
+         */
+        public Builder<S> gated(final String name, final Predicate<S> gate, final SynapticRelay<S> relay, final ErrorPolicy errorPolicy) {
+            final SynapticRelay<S> gatedRelay = new GatedRelay<>(name, gate, relay);
+            final SynapticRelay<S> interceptedRelay = interceptor.apply(gatedRelay);
+            this.entries.add(new RelayEntry<>(interceptedRelay, errorPolicy));
+            return this;
+        }
+
+        /**
+         * Adds a divergent relay to execute multiple branches in parallel.
+         * Note: Interceptor is applied to each branch and to the DivergentRelay itself.
+         *
+         * @param name     the name of the relay
+         * @param branches the parallel branches
+         * @return this builder
+         */
+        public Builder<S> divergent(final String name, final List<SynapticRelay<S>> branches) {
+            final List<SynapticRelay<S>> interceptedBranches = new ArrayList<>();
+            for (final SynapticRelay<S> branch : branches) {
+                interceptedBranches.add(interceptor.apply(branch));
+            }
+            final DivergentRelay<S> divergentRelay = new DivergentRelay<>(name, interceptedBranches);
+            return relay(name, divergentRelay, ErrorPolicy.FAIL_FAST);
+        }
+
+        /**
+         * Adds a consolidation relay to dispatch asynchronous work. Uses DEGRADE_GRACEFULLY policy by default.
+         *
+         * @param name        the name of the relay
+         * @param asyncAction the consumer action
+         * @return this builder
+         */
+        public Builder<S> consolidate(final String name, final Consumer<S> asyncAction) {
+            final ConsolidationRelay<S> consolidationRelay = new ConsolidationRelay<>(name, asyncAction);
+            return relay(name, consolidationRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
+        }
+
+        /**
+         * Builds the immutable CognitivePathway.
+         *
+         * @return the constructed pathway
+         */
+        public CognitivePathway<S> build() {
+            return new CognitivePathway<>(pathwayName, entries);
+        }
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/CognitivePathwayException.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/CognitivePathwayException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+/**
+ * Exception thrown when an error occurs within a cognitive pathway execution.
+ */
+public class CognitivePathwayException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public CognitivePathwayException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public CognitivePathwayException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/ConsolidationRelay.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/ConsolidationRelay.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+
+import java.util.function.Consumer;
+
+/**
+ * A relay that performs an asynchronous action on the signal in a fire-and-forget manner.
+ *
+ * @param <S> the type of the signal
+ */
+public final class ConsolidationRelay<S> implements SynapticRelay<S> {
+
+    private final String name;
+    private final Consumer<S> asyncAction;
+
+    /**
+     * Constructs a new ConsolidationRelay.
+     *
+     * @param name        the name of the relay
+     * @param asyncAction the consumer action to dispatch asynchronously
+     */
+    public ConsolidationRelay(final String name, final Consumer<S> asyncAction) {
+        this.name = name;
+        this.asyncAction = asyncAction;
+    }
+
+    @Override
+    public boolean transmit(final S signal) throws Exception {
+        ConcurrentTasks.fireAndForget(() -> asyncAction.accept(signal));
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return name;
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/DivergentCapable.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/DivergentCapable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import java.util.List;
+
+/**
+ * Represents a signal capable of diverging into multiple parallel forks and later merging them back.
+ *
+ * @param <S> the type of the signal
+ */
+public interface DivergentCapable<S> {
+
+    /**
+     * Creates a thread-safe fork of this signal for parallel execution.
+     *
+     * @return a new forked signal instance
+     */
+    S fork();
+
+    /**
+     * Merges the results of multiple forks back into this original signal.
+     *
+     * @param forks the list of completed forks to merge
+     */
+    void merge(List<S> forks);
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/DivergentRelay.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/DivergentRelay.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import com.spectrayan.spector.commons.concurrent.ConcurrentExecutionException;
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * A relay that diverges a capable signal across multiple parallel branches.
+ *
+ * @param <S> the type of the signal
+ */
+public final class DivergentRelay<S> implements SynapticRelay<S> {
+
+    private static final Logger log = LoggerFactory.getLogger(DivergentRelay.class);
+
+    private final String name;
+    private final List<SynapticRelay<S>> branches;
+
+    /**
+     * Constructs a new DivergentRelay.
+     *
+     * @param name     the name of the relay
+     * @param branches the parallel branches to execute
+     */
+    public DivergentRelay(final String name, final List<SynapticRelay<S>> branches) {
+        this.name = name;
+        this.branches = List.copyOf(branches);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean transmit(final S signal) throws Exception {
+        if (!(signal instanceof DivergentCapable)) {
+            throw new IllegalArgumentException("Signal must implement DivergentCapable for DivergentRelay");
+        }
+        
+        final DivergentCapable<S> divergentCapable = (DivergentCapable<S>) signal;
+        final List<S> forks = new ArrayList<>();
+        final List<Callable<Void>> tasks = new ArrayList<>();
+
+        for (final SynapticRelay<S> branch : branches) {
+            final S fork = divergentCapable.fork();
+            forks.add(fork);
+            tasks.add(() -> {
+                branch.transmit(fork);
+                return null;
+            });
+        }
+
+        try {
+            ConcurrentTasks.forkJoinAll(tasks);
+        } catch (final ConcurrentExecutionException e) {
+            log.warn("Parallel execution failed in DivergentRelay '{}', falling back to sequential execution.", name, e);
+            for (int i = 0; i < branches.size(); i++) {
+                branches.get(i).transmit(forks.get(i));
+            }
+        }
+
+        divergentCapable.merge(forks);
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return name;
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/ErrorPolicy.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/ErrorPolicy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+/**
+ * Defines the policy for handling errors that occur during signal transmission.
+ */
+public enum ErrorPolicy {
+
+    /**
+     * Halts execution immediately and propagates the error when a failure occurs.
+     */
+    FAIL_FAST,
+
+    /**
+     * Logs the error but allows the pathway to continue executing subsequent relays.
+     */
+    DEGRADE_GRACEFULLY
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/GatedRelay.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/GatedRelay.java
@@ -15,14 +15,22 @@
  */
 package com.spectrayan.spector.commons.pathway;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.function.Predicate;
 
 /**
  * A relay that conditionally executes its delegate based on a predicate gate.
  *
+ * <p>When the gate is a {@link Specification}, the {@linkplain Specification#unsatisfiedReason
+ * unsatisfied reason} is logged at {@code DEBUG} level when the gate inhibits execution.</p>
+ *
  * @param <S> the type of the signal
  */
 public final class GatedRelay<S> implements SynapticRelay<S> {
+
+    private static final Logger log = LoggerFactory.getLogger(GatedRelay.class);
 
     private final String name;
     private final Predicate<S> gate;
@@ -32,7 +40,8 @@ public final class GatedRelay<S> implements SynapticRelay<S> {
      * Constructs a new GatedRelay.
      *
      * @param name     the name of the relay
-     * @param gate     the predicate condition to evaluate
+     * @param gate     the predicate condition to evaluate; may be a {@link Specification}
+     *                 for enhanced diagnostics
      * @param delegate the relay to execute if the gate evaluates to true
      */
     public GatedRelay(final String name, final Predicate<S> gate, final SynapticRelay<S> delegate) {
@@ -45,6 +54,9 @@ public final class GatedRelay<S> implements SynapticRelay<S> {
     public boolean transmit(final S signal) throws Exception {
         if (gate.test(signal)) {
             return delegate.transmit(signal);
+        }
+        if (log.isDebugEnabled() && gate instanceof Specification<S> spec) {
+            log.debug("Relay '{}' gated off: {}", name, spec.unsatisfiedReason(signal));
         }
         return true;
     }

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/GatedRelay.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/GatedRelay.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import java.util.function.Predicate;
+
+/**
+ * A relay that conditionally executes its delegate based on a predicate gate.
+ *
+ * @param <S> the type of the signal
+ */
+public final class GatedRelay<S> implements SynapticRelay<S> {
+
+    private final String name;
+    private final Predicate<S> gate;
+    private final SynapticRelay<S> delegate;
+
+    /**
+     * Constructs a new GatedRelay.
+     *
+     * @param name     the name of the relay
+     * @param gate     the predicate condition to evaluate
+     * @param delegate the relay to execute if the gate evaluates to true
+     */
+    public GatedRelay(final String name, final Predicate<S> gate, final SynapticRelay<S> delegate) {
+        this.name = name;
+        this.gate = gate;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean transmit(final S signal) throws Exception {
+        if (gate.test(signal)) {
+            return delegate.transmit(signal);
+        }
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return name;
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/NamedRelay.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/NamedRelay.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+/**
+ * A relay that wraps another relay, assigning it a specific name.
+ *
+ * @param <S>      the type of the signal
+ * @param name     the name of this relay
+ * @param delegate the underlying relay to delegate to
+ */
+public record NamedRelay<S>(String name, SynapticRelay<S> delegate) implements SynapticRelay<S> {
+
+    @Override
+    public boolean transmit(final S signal) throws Exception {
+        return delegate.transmit(signal);
+    }
+
+    @Override
+    public String relayName() {
+        return name;
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/Specification.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/Specification.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import java.util.function.Predicate;
+
+/**
+ * A specification encapsulates a business rule that can be evaluated against
+ * a candidate object, extending {@link Predicate} for full compatibility with
+ * {@link GatedRelay} and standard Java functional APIs.
+ *
+ * <p>Unlike a bare {@code Predicate}, a {@code Specification} carries a
+ * human-readable {@link #unsatisfiedReason(Object)} explaining <em>why</em>
+ * the rule failed — invaluable for debug logging and recall trace diagnostics.</p>
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ *   Specification<RecallSignal> TEXT_SEARCH = Specification.of(
+ *       "text search not enabled or mode is VECTOR_ONLY",
+ *       s -> s.options().enableTextSearch());
+ *
+ *   // Works anywhere a Predicate is expected:
+ *   pathway.gated("bm25", TEXT_SEARCH, relay, DEGRADE_GRACEFULLY);
+ * }</pre>
+ *
+ * @param <T> the type of object this specification evaluates
+ */
+@FunctionalInterface
+public interface Specification<T> extends Predicate<T> {
+
+    /**
+     * Evaluates whether the candidate satisfies this specification.
+     *
+     * @param candidate the object to evaluate
+     * @return {@code true} if the candidate satisfies this specification
+     */
+    boolean isSatisfiedBy(T candidate);
+
+    /**
+     * Bridge to {@link Predicate#test(Object)} — delegates to
+     * {@link #isSatisfiedBy(Object)}.
+     */
+    @Override
+    default boolean test(T t) {
+        return isSatisfiedBy(t);
+    }
+
+    /**
+     * Returns a human-readable reason why the specification was not satisfied.
+     *
+     * <p>Called only when {@link #isSatisfiedBy(Object)} returns {@code false}.
+     * Useful for debug logging, recall traces, and diagnostics.</p>
+     *
+     * @param candidate the object that did not satisfy this specification
+     * @return a descriptive reason string
+     */
+    default String unsatisfiedReason(T candidate) {
+        return getClass().getSimpleName() + " not satisfied";
+    }
+
+    /**
+     * Creates a named specification with a fixed reason string.
+     *
+     * @param reason    the reason returned when the specification is not satisfied
+     * @param predicate the evaluation logic
+     * @param <T>       the type of object this specification evaluates
+     * @return a new specification wrapping the predicate with the given reason
+     */
+    static <T> Specification<T> of(String reason, Predicate<T> predicate) {
+        return new Specification<>() {
+            @Override
+            public boolean isSatisfiedBy(T candidate) {
+                return predicate.test(candidate);
+            }
+
+            @Override
+            public String unsatisfiedReason(T candidate) {
+                return reason;
+            }
+
+            @Override
+            public String toString() {
+                return "Specification[" + reason + "]";
+            }
+        };
+    }
+
+    /**
+     * Combines this specification with another using logical AND.
+     * The resulting specification reports the first unsatisfied reason.
+     */
+    default Specification<T> and(Specification<T> other) {
+        Specification<T> self = this;
+        return new Specification<>() {
+            @Override
+            public boolean isSatisfiedBy(T candidate) {
+                return self.isSatisfiedBy(candidate) && other.isSatisfiedBy(candidate);
+            }
+
+            @Override
+            public String unsatisfiedReason(T candidate) {
+                if (!self.isSatisfiedBy(candidate)) {
+                    return self.unsatisfiedReason(candidate);
+                }
+                return other.unsatisfiedReason(candidate);
+            }
+        };
+    }
+
+    /**
+     * Combines this specification with another using logical OR.
+     */
+    default Specification<T> or(Specification<T> other) {
+        Specification<T> self = this;
+        return candidate -> self.isSatisfiedBy(candidate) || other.isSatisfiedBy(candidate);
+    }
+
+    /**
+     * Negates this specification.
+     */
+    default Specification<T> not() {
+        Specification<T> self = this;
+        return Specification.of("NOT(" + self + ")", candidate -> !self.isSatisfiedBy(candidate));
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/SynapticRelay.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/SynapticRelay.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+/**
+ * Represents a relay unit in a cognitive pathway capable of transmitting a signal.
+ *
+ * @param <S> the type of the signal
+ */
+@FunctionalInterface
+public interface SynapticRelay<S> {
+
+    /**
+     * Transmits the given signal through this relay.
+     *
+     * @param signal the signal to transmit
+     * @return true if the transmission was successful and the pathway should continue, false otherwise
+     * @throws Exception if an error occurs during transmission
+     */
+    boolean transmit(S signal) throws Exception;
+
+    /**
+     * Retrieves the name of this relay.
+     *
+     * @return the name of the relay
+     */
+    default String relayName() {
+        return getClass().getSimpleName().replaceAll("Relay$", "").toLowerCase();
+    }
+}

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/package-info.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/pathway/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides the Cognitive Pathway and Synaptic Circuit Engine core interfaces and classes.
+ */
+package com.spectrayan.spector.commons.pathway;

--- a/nucleus/spector-commons/src/test/java/com/spectrayan/spector/commons/pathway/CognitivePathwayTest.java
+++ b/nucleus/spector-commons/src/test/java/com/spectrayan/spector/commons/pathway/CognitivePathwayTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.commons.pathway;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CognitivePathway")
+class CognitivePathwayTest {
+
+    static class TestSignal implements DivergentCapable<TestSignal> {
+        final List<String> steps = new ArrayList<>();
+
+        @Override
+        public TestSignal fork() {
+            return new TestSignal();
+        }
+
+        @Override
+        public void merge(List<TestSignal> forks) {
+            for (TestSignal fork : forks) {
+                steps.addAll(fork.steps);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Linear Pathway: relays execute in order and append to signal")
+    void linearPathway() {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("Linear")
+                .relay("R1", s -> { s.steps.add("1"); return true; })
+                .relay("R2", s -> { s.steps.add("2"); return true; })
+                .relay("R3", s -> { s.steps.add("3"); return true; })
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(signal.steps).containsExactly("1", "2", "3");
+    }
+
+    @Test
+    @DisplayName("Gated Relay: executes delegate when gate returns true")
+    void gatedRelayActive() {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("GatedActive")
+                .gated("G1", s -> true, s -> { s.steps.add("Active"); return true; }, ErrorPolicy.FAIL_FAST)
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(signal.steps).containsExactly("Active");
+    }
+
+    @Test
+    @DisplayName("Gated Relay: skips delegate when gate returns false")
+    void gatedRelayInhibited() {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("GatedInhibited")
+                .gated("G1", s -> false, s -> { s.steps.add("Inhibited"); return true; }, ErrorPolicy.FAIL_FAST)
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(signal.steps).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Short-Circuit: pathway stops when a relay returns false")
+    void shortCircuit() {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("ShortCircuit")
+                .relay("R1", s -> { s.steps.add("1"); return true; })
+                .relay("R2", s -> { s.steps.add("2"); return false; })
+                .relay("R3", s -> { s.steps.add("3"); return true; })
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(signal.steps).containsExactly("1", "2");
+    }
+
+    @Test
+    @DisplayName("ErrorPolicy.FAIL_FAST: exception propagates")
+    void errorPolicyFailFast() {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("FailFast")
+                .relay("R1", s -> { s.steps.add("1"); return true; })
+                .relay("R2", s -> { throw new RuntimeException("Boom"); }, ErrorPolicy.FAIL_FAST)
+                .relay("R3", s -> { s.steps.add("3"); return true; })
+                .build();
+
+        TestSignal signal = new TestSignal();
+
+        assertThatThrownBy(() -> pathway.conduct(signal))
+                .isInstanceOf(CognitivePathwayException.class)
+                .hasMessageContaining("Failed at relay: R2")
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        assertThat(signal.steps).containsExactly("1");
+    }
+
+    @Test
+    @DisplayName("ErrorPolicy.DEGRADE_GRACEFULLY: exception is caught and pathway continues")
+    void errorPolicyDegradeGracefully() {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("DegradeGracefully")
+                .relay("R1", s -> { s.steps.add("1"); return true; })
+                .relay("R2", s -> { throw new RuntimeException("Boom"); }, ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay("R3", s -> { s.steps.add("3"); return true; })
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(signal.steps).containsExactly("1", "3");
+    }
+
+    @Test
+    @DisplayName("DivergentRelay: forks signal, runs branches in parallel, and merges results")
+    void divergentRelay() {
+        SynapticRelay<TestSignal> branch1 = s -> { s.steps.add("B1"); return true; };
+        SynapticRelay<TestSignal> branch2 = s -> { s.steps.add("B2"); return true; };
+
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("Divergent")
+                .divergent("Div1", List.of(branch1, branch2))
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(signal.steps).containsExactlyInAnyOrder("B1", "B2");
+    }
+
+    @Test
+    @DisplayName("ConsolidationRelay: dispatches asynchronous action")
+    void consolidationRelay() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("Consolidate")
+                .consolidate("C1", s -> {
+                    s.steps.add("Async");
+                    latch.countDown();
+                })
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        boolean await = latch.await(2, TimeUnit.SECONDS);
+        assertThat(await).isTrue();
+        assertThat(signal.steps).containsExactly("Async");
+    }
+
+    @Test
+    @DisplayName("Interceptor: applies to all added relays")
+    void interceptor() {
+        AtomicInteger invocationCount = new AtomicInteger(0);
+
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("Intercepted")
+                .withInterceptor(relay -> signal -> {
+                    invocationCount.incrementAndGet();
+                    return relay.transmit(signal);
+                })
+                .relay("R1", s -> true)
+                .relay("R2", s -> true)
+                .build();
+
+        TestSignal signal = new TestSignal();
+        pathway.conduct(signal);
+
+        assertThat(invocationCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Pathway Name: asserts the internal pathwayName is correctly stored")
+    void pathwayName() throws Exception {
+        CognitivePathway<TestSignal> pathway = CognitivePathway.<TestSignal>pathway("TestName").build();
+
+        Field nameField = CognitivePathway.class.getDeclaredField("pathwayName");
+        nameField.setAccessible(true);
+        String name = (String) nameField.get(pathway);
+
+        assertThat(name).isEqualTo("TestName");
+    }
+
+    @Test
+    @DisplayName("Relay Name: correctly reports name via NamedRelay")
+    void relayName() {
+        SynapticRelay<TestSignal> named = new NamedRelay<>("MyRelay", s -> true);
+        assertThat(named.relayName()).isEqualTo("MyRelay");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the **Cognitive Pathway & Synaptic Circuit Engine** — Phase 1: Core Engine. This is a zero-dependency, composable relay-based workflow kernel for orchestrating cognitive memory pathways.

Closes #561

## Architecture

Full CEO-approved ADR: [`RnD/spector-cognitive-pathway-circuit-engine-architecture.md`](https://github.com/spectrayan/spectrayan/blob/main/RnD/spector-cognitive-pathway-circuit-engine-architecture.md)

## Changes by Module

### `nucleus/spector-commons` — Engine Core
New package `com.spectrayan.spector.commons.pathway`:

| Class | Purpose |
|:---|:---|
| `SynapticRelay<S>` | `@FunctionalInterface` — single-responsibility relay step with `boolean transmit(S)` for short-circuit halting |
| `CognitivePathway<S>` | Immutable conductor with fluent Builder API, per-relay `ErrorPolicy`, interceptor support |
| `DivergentCapable<S>` | Generic fork-join-merge contract for thread-safe parallel execution |
| `ErrorPolicy` | `FAIL_FAST` vs `DEGRADE_GRACEFULLY` per relay |
| `GatedRelay<S>` | Conditional execution via `Predicate<S>` gate |
| `DivergentRelay<S>` | Parallel fork-join on virtual threads via `ConcurrentTasks.forkJoinAll()` |
| `ConsolidationRelay<S>` | Async fire-and-forget dispatch |
| `NamedRelay<S>` | Named wrapper record |
| `CognitivePathwayException` | Pathway execution failure |

### `memory/spector-metrics` — Observability
| Class | Purpose |
|:---|:---|
| `ObservableRelay<S>` | Generic telemetry decorator using ScopedValue observation. Static `interceptor()` factory. |

### `memory/spector-memory` — Constants
| Class | Purpose |
|:---|:---|
| `RelayNames` | Centralized relay name constants for all Recall and Ingestion pathway relays |

## Tests

- **11 unit tests** covering linear pathways, gated relays, divergent fork-join-merge, consolidation async dispatch, error policies (FAIL_FAST + DEGRADE_GRACEFULLY), short-circuit halting, interceptor wrapping, and pathway naming.

## Next Steps (Future PRs)

- **Phase 2**: Extract 11 Recall Relays from `RecallPipeline` → `RecallPathway`
- **Phase 3**: Extract 8 Ingestion Relays from `CognitiveIngestionTarget` → `IngestionPathway`
- **Phase 4**: Deprecate legacy `RecallPipeline` and `CognitiveIngestionTarget`
