### PR TITLE
feat(memory): Active Inference Self-Model Engine — Phase 2: Free-Energy Guided Recall (#587)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/FreeEnergyCalculator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/FreeEnergyCalculator.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.similarity.FreeEnergyKernel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Calculates Variational Free Energy and situational Free-Energy Relevance Scores (FERS).
+ *
+ * <h3>Biological Analog: Variational Free Energy Reduction & Active Inference</h3>
+ * <p>Quantifies the degree to which a candidate memory or observation minimizes surprise and
+ * resolves ambiguity in the agent's generative self-model.</p>
+ */
+public final class FreeEnergyCalculator {
+
+    private static final Logger log = LoggerFactory.getLogger(FreeEnergyCalculator.class);
+
+    private final float defaultMemoryPrecision;
+
+    public FreeEnergyCalculator() {
+        this(2.0f);
+    }
+
+    public FreeEnergyCalculator(float defaultMemoryPrecision) {
+        if (defaultMemoryPrecision <= 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Memory precision must be positive");
+        }
+        this.defaultMemoryPrecision = defaultMemoryPrecision;
+    }
+
+    /**
+     * Calculates the Variational Free Energy F(q) of the current posterior state given prior and observation.
+     *
+     * @param posterior current posterior belief distribution q(s)
+     * @param selfModel generative self-model providing prior p(s) and observation likelihood p(o|s)
+     * @param observation current sensory observation vector o
+     * @return scalar Variational Free Energy
+     */
+    public float calculateFreeEnergy(MentalStatePosterior posterior, GenerativeSelfModel selfModel, float[] observation) {
+        if (posterior == null || selfModel == null || observation == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        if (posterior.dimensions() != selfModel.dimensions() || observation.length != selfModel.dimensions()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimensions mismatch between posterior, model, and observation");
+        }
+
+        return FreeEnergyKernel.variationalFreeEnergy(
+                posterior.mean(),
+                posterior.precision(),
+                selfModel.priorMean(),
+                selfModel.priorPrecision(),
+                observation,
+                selfModel.observationPrecision()
+        );
+    }
+
+    /**
+     * Calculates the Free-Energy reduction deltaF provided by conditioning on a candidate memory embedding:
+     * deltaF(mu_i) = F(q(s_t)) - F(q(s_t | mu_i))
+     *
+     * @param posterior current posterior belief distribution q(s)
+     * @param selfModel generative self-model providing prior and observation parameters
+     * @param observation current sensory observation vector o
+     * @param candidateEmbedding memory vector embedding e_mu
+     * @param memoryPrecision precision vector for the candidate memory (or null for default scalar precision)
+     * @return free energy reduction deltaF (positive indicates surprise/uncertainty reduction)
+     */
+    public float calculateFreeEnergyReduction(MentalStatePosterior posterior,
+                                              GenerativeSelfModel selfModel,
+                                              float[] observation,
+                                              float[] candidateEmbedding,
+                                              float[] memoryPrecision) {
+        if (posterior == null || selfModel == null || observation == null || candidateEmbedding == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        int dim = posterior.dimensions();
+        if (candidateEmbedding.length != dim) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Candidate embedding length must match posterior dimensions");
+        }
+
+        float[] prec = memoryPrecision;
+        if (prec == null) {
+            prec = new float[dim];
+            Arrays.fill(prec, defaultMemoryPrecision);
+        } else if (prec.length != dim) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Memory precision vector length must match posterior dimensions");
+        }
+
+        float baseFE = calculateFreeEnergy(posterior, selfModel, observation);
+
+        MentalStatePosterior conditionedPosterior = posterior.withEvidence(
+                candidateEmbedding,
+                prec,
+                posterior.timestampMs(),
+                posterior.version() + 1
+        );
+
+        float conditionedFE = calculateFreeEnergy(conditionedPosterior, selfModel, observation);
+        float deltaF = baseFE - conditionedFE;
+
+        if (log.isTraceEnabled()) {
+            log.trace("Free-energy calculation: baseFE={}, condFE={}, deltaF={}", baseFE, conditionedFE, deltaF);
+        }
+
+        return deltaF;
+    }
+
+    /**
+     * Fuses base semantic similarity, free-energy reduction, and affective resonance into the Free-Energy Relevance Score (FERS).
+     *
+     * @param baseSimilarity base semantic similarity score (e.g. from HNSW / VectorOps)
+     * @param deltaF free energy reduction deltaF
+     * @param affectiveResonance affective resonance score in [0, 1]
+     * @param alpha weight for base similarity
+     * @param beta weight for free-energy reduction
+     * @param gamma weight for affective resonance
+     * @return fused FERS score
+     */
+    public static float calculateFersScore(float baseSimilarity, float deltaF, float affectiveResonance,
+                                           float alpha, float beta, float gamma) {
+        float normalizedDeltaF = 1.0f / (1.0f + (float) Math.exp(-deltaF));
+        return (alpha * baseSimilarity) + (beta * normalizedDeltaF) + (gamma * affectiveResonance);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModel.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModel.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import java.util.Arrays;
+
+/**
+ * Encapsulates the generative prior distribution p(s|m) and observation precision model p(o|s)
+ * derived from the agent's persistent identity and cognitive profile.
+ *
+ * <h3>Biological Analog: Top-Down Generative Priors & Cortical Precision Allocations</h3>
+ * <p>Represents the internal generative model of the world and self. Modulates baseline expectations
+ * and attentional precision weighting according to personality and neurocognitive traits.</p>
+ */
+public record GenerativeSelfModel(
+        float[] priorMean,
+        float[] priorPrecision,
+        float[] observationPrecision,
+        AgentSoul soul,
+        CognitiveProfile profile
+) {
+
+    /**
+     * Compact constructor with defensive copies and validation.
+     */
+    public GenerativeSelfModel {
+        if (priorMean == null || priorPrecision == null || observationPrecision == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Model vectors must not be null");
+        }
+        if (priorMean.length != priorPrecision.length || priorMean.length != observationPrecision.length) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "All generative model vectors must have equal dimensions");
+        }
+        if (priorMean.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vector dimension must be greater than zero");
+        }
+
+        priorMean = Arrays.copyOf(priorMean, priorMean.length);
+        priorPrecision = Arrays.copyOf(priorPrecision, priorPrecision.length);
+        observationPrecision = Arrays.copyOf(observationPrecision, observationPrecision.length);
+    }
+
+    /**
+     * @return the dimensionality of the generative space
+     */
+    public int dimensions() {
+        return priorMean.length;
+    }
+
+    /**
+     * Creates an initial default posterior q(s_0) matching the prior p(s|m).
+     *
+     * @param timestampMs creation timestamp
+     * @return initialized posterior matching the prior distribution
+     */
+    public MentalStatePosterior createInitialPosterior(long timestampMs) {
+        return new MentalStatePosterior(priorMean, priorPrecision, timestampMs, 0);
+    }
+
+    /**
+     * Constructs a GenerativeSelfModel from an AgentSoul and CognitiveProfile.
+     *
+     * @param soul the agent persistent identity (may be null)
+     * @param profile the cognitive profile governing precision dynamics (may be null)
+     * @param dimensions target embedding dimension
+     * @return configured GenerativeSelfModel
+     */
+    public static GenerativeSelfModel fromSoulAndProfile(AgentSoul soul, CognitiveProfile profile, int dimensions) {
+        if (dimensions <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimensions must be positive");
+        }
+
+        float[] mean = new float[dimensions];
+        if (soul != null && soul.identityEmbedding() != null) {
+            float[] idEmb = soul.identityEmbedding();
+            int copyLen = Math.min(dimensions, idEmb.length);
+            System.arraycopy(idEmb, 0, mean, 0, copyLen);
+        }
+
+        float basePrecision = 2.5f;
+        if (profile != null) {
+            switch (profile) {
+                case HYPERFOCUS -> basePrecision = 8.0f;
+                case SYSTEMATIZER -> basePrecision = 6.0f;
+                case BALANCED -> basePrecision = 3.0f;
+                case DIVERGENT -> basePrecision = 1.0f;
+                case EXPLORING -> basePrecision = 1.5f;
+                case EXECUTIVE_DYSFUNCTION -> basePrecision = 0.8f;
+                case PARANOID_SENTINEL -> basePrecision = 10.0f;
+                case DEFAULT_MODE_NETWORK -> basePrecision = 2.0f;
+                default -> basePrecision = 2.5f;
+            }
+        }
+
+        float[] priorPrec = new float[dimensions];
+        Arrays.fill(priorPrec, basePrecision);
+
+        float[] obsPrec = new float[dimensions];
+        Arrays.fill(obsPrec, 4.0f);
+
+        return new GenerativeSelfModel(mean, priorPrec, obsPrec, soul, profile);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GenerativeSelfModel that)) return false;
+        return Arrays.equals(priorMean, that.priorMean) &&
+                Arrays.equals(priorPrecision, that.priorPrecision) &&
+                Arrays.equals(observationPrecision, that.observationPrecision) &&
+                profile == that.profile;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(priorMean);
+        result = 31 * result + Arrays.hashCode(priorPrecision);
+        result = 31 * result + Arrays.hashCode(observationPrecision);
+        result = 31 * result + (profile != null ? profile.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GenerativeSelfModel{" +
+                "dimensions=" + priorMean.length +
+                ", profile=" + profile +
+                '}';
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/MentalStatePosterior.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/MentalStatePosterior.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.similarity.FreeEnergyKernel;
+
+import java.util.Arrays;
+
+/**
+ * Immutable representation of the agent's approximate posterior belief distribution q(s_t)
+ * over continuous latent mental states.
+ *
+ * <h3>Biological Analog: Cortical Latent Belief Density</h3>
+ * <p>Represents a multivariate diagonal Gaussian distribution parameterized by mean expectations
+ * and precision (inverse variance) weightings across cognitive dimensions.</p>
+ */
+public record MentalStatePosterior(
+        float[] mean,
+        float[] precision,
+        long timestampMs,
+        int version
+) {
+
+    /**
+     * Compact constructor enforcing defensive copies, dimensionality alignment, and precision positivity.
+     */
+    public MentalStatePosterior {
+        if (mean == null || precision == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Mean and precision vectors must not be null");
+        }
+        if (mean.length != precision.length) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Mean and precision vectors must have equal dimensions");
+        }
+        if (mean.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vector dimension must be greater than zero");
+        }
+
+        mean = Arrays.copyOf(mean, mean.length);
+        precision = Arrays.copyOf(precision, precision.length);
+
+        for (int i = 0; i < mean.length; i++) {
+            if (Float.isNaN(mean[i]) || Float.isInfinite(mean[i])) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Mean vector contains NaN or Infinite value at index " + i);
+            }
+            if (Float.isNaN(precision[i]) || Float.isInfinite(precision[i]) || precision[i] <= 0.0f) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Precision vector must contain strictly positive non-NaN values at index " + i);
+            }
+        }
+    }
+
+    /**
+     * @return the dimensionality of the latent mental state distribution
+     */
+    public int dimensions() {
+        return mean.length;
+    }
+
+    /**
+     * Derives a new posterior conditioned on new sensory or memory evidence via precision-weighted Bayesian fusion.
+     *
+     * @param evidenceMean mean vector of incoming evidence
+     * @param evidencePrecision precision vector of incoming evidence
+     * @param timestamp epoch timestamp in milliseconds
+     * @param nextVersion incremented state version
+     * @return updated posterior distribution
+     */
+    public MentalStatePosterior withEvidence(float[] evidenceMean, float[] evidencePrecision, long timestamp, int nextVersion) {
+        int dim = dimensions();
+        float[] fusedMean = new float[dim];
+        float[] fusedPrecision = new float[dim];
+
+        FreeEnergyKernel.precisionWeightedFusion(mean, precision, evidenceMean, evidencePrecision, fusedMean, fusedPrecision);
+        return new MentalStatePosterior(fusedMean, fusedPrecision, timestamp, nextVersion);
+    }
+
+    /**
+     * Simulates temporal decay of beliefs back toward a baseline prior.
+     *
+     * @param priorMean prior mean vector
+     * @param priorPrecision prior precision vector
+     * @param decayFactor decay rate in [0, 1] (0 = no decay, 1 = immediate snap to prior)
+     * @param timestamp timestamp in milliseconds
+     * @param nextVersion incremented state version
+     * @return decayed posterior distribution
+     */
+    public MentalStatePosterior decayTowards(float[] priorMean, float[] priorPrecision, float decayFactor, long timestamp, int nextVersion) {
+        float factor = Math.max(0.0f, Math.min(1.0f, decayFactor));
+        int dim = dimensions();
+        float[] decayedMean = new float[dim];
+        float[] decayedPrecision = new float[dim];
+
+        for (int i = 0; i < dim; i++) {
+            decayedMean[i] = (1.0f - factor) * mean[i] + factor * priorMean[i];
+            decayedPrecision[i] = (1.0f - factor) * precision[i] + factor * priorPrecision[i];
+            if (decayedPrecision[i] <= 0.0f) {
+                decayedPrecision[i] = 1.0f;
+            }
+        }
+
+        return new MentalStatePosterior(decayedMean, decayedPrecision, timestamp, nextVersion);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MentalStatePosterior that)) return false;
+        return timestampMs == that.timestampMs &&
+                version == that.version &&
+                Arrays.equals(mean, that.mean) &&
+                Arrays.equals(precision, that.precision);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(timestampMs);
+        result = 31 * result + Integer.hashCode(version);
+        result = 31 * result + Arrays.hashCode(mean);
+        result = 31 * result + Arrays.hashCode(precision);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MentalStatePosterior{" +
+                "dim=" + mean.length +
+                ", version=" + version +
+                ", timestampMs=" + timestampMs +
+                '}';
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/MentalStateTracker.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/MentalStateTracker.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Thread-safe manager maintaining the continuous approximate posterior belief state q(s_t)
+ * across conversational turns and environmental observations.
+ *
+ * <h3>Biological Analog: Continuous Prefrontal & Insular Latent State Tracking</h3>
+ * <p>Maintains the active internal state representation, updating expectations with incoming
+ * observations via precision weighting and decaying unreinforced states back toward baseline priors.</p>
+ */
+public final class MentalStateTracker {
+
+    private static final Logger log = LoggerFactory.getLogger(MentalStateTracker.class);
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final GenerativeSelfModel selfModel;
+    private MentalStatePosterior currentPosterior;
+
+    /**
+     * Constructs a MentalStateTracker for a given GenerativeSelfModel.
+     *
+     * @param selfModel the generative self-model providing priors and observation parameters
+     */
+    public MentalStateTracker(GenerativeSelfModel selfModel) {
+        if (selfModel == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "GenerativeSelfModel must not be null");
+        }
+        this.selfModel = selfModel;
+        this.currentPosterior = selfModel.createInitialPosterior(System.currentTimeMillis());
+    }
+
+    /**
+     * Constructs a MentalStateTracker with an explicit initial posterior state.
+     *
+     * @param selfModel the generative self-model
+     * @param initialPosterior the initial posterior belief state
+     */
+    public MentalStateTracker(GenerativeSelfModel selfModel, MentalStatePosterior initialPosterior) {
+        if (selfModel == null || initialPosterior == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        if (selfModel.dimensions() != initialPosterior.dimensions()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "SelfModel and initial posterior dimension mismatch");
+        }
+        this.selfModel = selfModel;
+        this.currentPosterior = initialPosterior;
+    }
+
+    /**
+     * Updates the current posterior belief given an incoming sensory observation vector.
+     *
+     * @param observation sensory observation vector
+     * @param timestampMs current epoch timestamp in milliseconds
+     */
+    public void updateWithObservation(float[] observation, long timestampMs) {
+        updateWithObservation(observation, selfModel.observationPrecision(), timestampMs);
+    }
+
+    /**
+     * Updates the current posterior belief given an incoming observation with explicit precision weighting.
+     *
+     * @param observation sensory observation vector
+     * @param obsPrecision precision weighting vector for the observation
+     * @param timestampMs current epoch timestamp in milliseconds
+     */
+    public void updateWithObservation(float[] observation, float[] obsPrecision, long timestampMs) {
+        if (observation == null || obsPrecision == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Observation and precision vectors must not be null");
+        }
+        if (observation.length != selfModel.dimensions() || obsPrecision.length != selfModel.dimensions()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Observation dimension mismatch with model");
+        }
+
+        lock.lock();
+        try {
+            MentalStatePosterior oldPosterior = currentPosterior;
+            currentPosterior = currentPosterior.withEvidence(
+                    observation,
+                    obsPrecision,
+                    timestampMs,
+                    oldPosterior.version() + 1
+            );
+
+            if (log.isTraceEnabled()) {
+                log.trace("Updated posterior from version {} to {}", oldPosterior.version(), currentPosterior.version());
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Applies temporal decay to the posterior, gently shifting expectations back toward baseline prior p(s|m).
+     *
+     * @param currentTimestampMs current timestamp
+     * @param decayFactor decay factor in [0, 1]
+     */
+    public void decay(long currentTimestampMs, float decayFactor) {
+        lock.lock();
+        try {
+            currentPosterior = currentPosterior.decayTowards(
+                    selfModel.priorMean(),
+                    selfModel.priorPrecision(),
+                    decayFactor,
+                    currentTimestampMs,
+                    currentPosterior.version() + 1
+            );
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @return an immutable snapshot of the current posterior distribution
+     */
+    public MentalStatePosterior currentPosterior() {
+        lock.lock();
+        try {
+            return currentPosterior;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @return the underlying GenerativeSelfModel
+     */
+    public GenerativeSelfModel selfModel() {
+        return selfModel;
+    }
+
+    /**
+     * Resets the posterior belief state back to the prior baseline.
+     */
+    public void reset() {
+        lock.lock();
+        try {
+            currentPosterior = selfModel.createInitialPosterior(System.currentTimeMillis());
+            log.debug("Reset mental state posterior to generative prior baseline");
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/FreeEnergyGuidedRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/FreeEnergyGuidedRelay.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.aisme.fegr.FreeEnergyCalculator;
+import com.spectrayan.spector.memory.aisme.fegr.MentalStatePosterior;
+import com.spectrayan.spector.memory.aisme.fegr.MentalStateTracker;
+import com.spectrayan.spector.memory.aisme.homeostasis.AffectiveResonanceScorer;
+import com.spectrayan.spector.memory.aisme.homeostasis.HomeostaticCore;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * RecallPathway relay that enhances candidate retrieval scores using Free-Energy Relevance Scoring (FERS).
+ *
+ * <h3>Biological Analog: Variational Prediction-Error Guided Memory Selection</h3>
+ * <p>Scores candidate memories not only on semantic proximity, but on their mathematical capacity
+ * to reduce variational free energy and situational uncertainty in the agent's generative self-model.</p>
+ */
+public final class FreeEnergyGuidedRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(FreeEnergyGuidedRelay.class);
+
+    private final MentalStateTracker tracker;
+    private final FreeEnergyCalculator calculator;
+    private final HomeostaticCore homeostaticCore;
+    private final AffectiveResonanceScorer affectiveScorer;
+    private final Function<String, float[]> embeddingLookup;
+
+    private final float alpha;
+    private final float beta;
+    private final float gamma;
+
+    /**
+     * Constructs a FreeEnergyGuidedRelay with default scoring weights (alpha=0.5, beta=0.35, gamma=0.15).
+     *
+     * @param tracker the active mental state tracker (nullable)
+     * @param calculator the free energy calculation engine (nullable)
+     * @param homeostaticCore the homeostatic affective core (nullable)
+     * @param affectiveScorer affective resonance scorer (nullable)
+     * @param embeddingLookup function to resolve candidate memory vectors by id (nullable)
+     */
+    public FreeEnergyGuidedRelay(
+            MentalStateTracker tracker,
+            FreeEnergyCalculator calculator,
+            HomeostaticCore homeostaticCore,
+            AffectiveResonanceScorer affectiveScorer,
+            Function<String, float[]> embeddingLookup) {
+        this(tracker, calculator, homeostaticCore, affectiveScorer, embeddingLookup, 0.5f, 0.35f, 0.15f);
+    }
+
+    /**
+     * Constructs a FreeEnergyGuidedRelay with explicit scoring weights.
+     *
+     * @param tracker active mental state tracker
+     * @param calculator free energy calculator
+     * @param homeostaticCore homeostatic core
+     * @param affectiveScorer affective resonance scorer
+     * @param embeddingLookup embedding lookup function
+     * @param alpha semantic similarity weight
+     * @param beta free-energy reduction weight
+     * @param gamma affective resonance weight
+     */
+    public FreeEnergyGuidedRelay(
+            MentalStateTracker tracker,
+            FreeEnergyCalculator calculator,
+            HomeostaticCore homeostaticCore,
+            AffectiveResonanceScorer affectiveScorer,
+            Function<String, float[]> embeddingLookup,
+            float alpha,
+            float beta,
+            float gamma) {
+        this.tracker = tracker;
+        this.calculator = calculator;
+        this.homeostaticCore = homeostaticCore;
+        this.affectiveScorer = affectiveScorer;
+        this.embeddingLookup = embeddingLookup;
+        this.alpha = alpha;
+        this.beta = beta;
+        this.gamma = gamma;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        if (tracker == null || calculator == null || signal == null) {
+            return true;
+        }
+
+        List<CognitiveResult> candidates = signal.candidates();
+        if (candidates == null || candidates.isEmpty()) {
+            return true;
+        }
+
+        float[] observation = signal.queryVector();
+        if (observation == null || observation.length != tracker.selfModel().dimensions()) {
+            return true;
+        }
+
+        MentalStatePosterior posterior = tracker.currentPosterior();
+        InteroceptiveState interoceptiveState = (homeostaticCore != null) ? homeostaticCore.currentState() : null;
+
+        for (int i = 0; i < candidates.size(); i++) {
+            CognitiveResult r = candidates.get(i);
+            float baseSim = r.score();
+            float deltaF = 0.0f;
+
+            if (embeddingLookup != null) {
+                float[] candidateVec = embeddingLookup.apply(r.id());
+                if (candidateVec != null && candidateVec.length == posterior.dimensions()) {
+                    deltaF = calculator.calculateFreeEnergyReduction(
+                            posterior,
+                            tracker.selfModel(),
+                            observation,
+                            candidateVec,
+                            null
+                    );
+                }
+            }
+
+            float affectiveResonance = 0.5f;
+            if (affectiveScorer != null && interoceptiveState != null) {
+                affectiveResonance = affectiveScorer.score(interoceptiveState, r.valence(), 0.5f);
+            }
+
+            float fersScore = FreeEnergyCalculator.calculateFersScore(
+                    baseSim,
+                    deltaF,
+                    affectiveResonance,
+                    alpha,
+                    beta,
+                    gamma
+            );
+
+            candidates.set(i, new CognitiveResult(
+                    r.id(), r.text(), fersScore, r.importance(),
+                    r.ageDays(), r.agentRecallCount(), r.valence(),
+                    r.memoryType(), r.source(), r.synapticTags(),
+                    r.decayFactor(), r.ltpAdjustedDecay(),
+                    r.retrievalMode(), r.breakdown(), r.trace(),
+                    r.sourceModality(), r.metadata()
+            ));
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("FreeEnergyGuidedRelay processed {} candidates with alpha={}, beta={}, gamma={}",
+                    candidates.size(), alpha, beta, gamma);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return "free-energy-guided";
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/FreeEnergyCalculatorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/FreeEnergyCalculatorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FreeEnergyCalculator}.
+ */
+class FreeEnergyCalculatorTest {
+
+    private FreeEnergyCalculator calculator;
+    private GenerativeSelfModel selfModel;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new FreeEnergyCalculator(2.0f);
+        selfModel = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.BALANCED, 2);
+    }
+
+    @Test
+    void calculateFreeEnergy_producesPositiveScalar() {
+        MentalStatePosterior posterior = selfModel.createInitialPosterior(1000L);
+        float[] observation = {1.0f, -1.0f};
+
+        float fe = calculator.calculateFreeEnergy(posterior, selfModel, observation);
+        assertThat(fe).isGreaterThan(0.0f);
+    }
+
+    @Test
+    void calculateFreeEnergyReduction_candidateExplainingObservation_reducesFreeEnergy() {
+        MentalStatePosterior posterior = selfModel.createInitialPosterior(1000L);
+        float[] observation = {2.0f, 2.0f};
+
+        // Candidate matching the observation closely should reduce uncertainty/error
+        float[] candidateExplaining = {2.0f, 2.0f};
+        float deltaFExplaining = calculator.calculateFreeEnergyReduction(
+                posterior, selfModel, observation, candidateExplaining, null);
+
+        // Candidate pointing completely away
+        float[] candidateOpposite = {-5.0f, -5.0f};
+        float deltaFOpposite = calculator.calculateFreeEnergyReduction(
+                posterior, selfModel, observation, candidateOpposite, null);
+
+        // Explaining candidate should yield higher free-energy reduction
+        assertThat(deltaFExplaining).isGreaterThan(deltaFOpposite);
+    }
+
+    @Test
+    void calculateFersScore_combinesAllComponents() {
+        float baseSim = 0.8f;
+        float deltaF = 1.5f;
+        float affectiveResonance = 0.9f;
+
+        float fers = FreeEnergyCalculator.calculateFersScore(
+                baseSim, deltaF, affectiveResonance, 0.5f, 0.35f, 0.15f);
+
+        // base: 0.5 * 0.8 = 0.4
+        // deltaF sigmoid: 1 / (1 + exp(-1.5)) ≈ 0.81757 * 0.35 ≈ 0.28615
+        // affective: 0.15 * 0.9 = 0.135
+        // total ≈ 0.82115
+        assertThat(fers).isCloseTo(0.82115f, within(0.01f));
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModelTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModelTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GenerativeSelfModel}.
+ */
+class GenerativeSelfModelTest {
+
+    @Test
+    void fromSoulAndProfile_hyperfocus_highPrecision() {
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.HYPERFOCUS, 4);
+        assertThat(model.dimensions()).isEqualTo(4);
+        assertThat(model.priorPrecision()[0]).isEqualTo(8.0f);
+        assertThat(model.observationPrecision()[0]).isEqualTo(4.0f);
+    }
+
+    @Test
+    void fromSoulAndProfile_divergent_flexiblePrecision() {
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.DIVERGENT, 4);
+        assertThat(model.priorPrecision()[0]).isEqualTo(1.0f);
+    }
+
+    @Test
+    void fromSoulAndProfile_withSoulEmbedding_initializesPriorMean() {
+        float[] idEmb = {0.1f, 0.2f, 0.3f, 0.4f};
+        AgentSoul soul = AgentSoul.builder()
+                .id("test-soul")
+                .name("Persona")
+                .purposeEmbedding(idEmb)
+                .build();
+
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(soul, CognitiveProfile.BALANCED, 4);
+        assertThat(model.priorMean()).containsExactly(0.1f, 0.2f, 0.3f, 0.4f);
+        assertThat(model.priorPrecision()[0]).isEqualTo(3.0f);
+    }
+
+    @Test
+    void createInitialPosterior_matchesPriorParameters() {
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.BALANCED, 3);
+        MentalStatePosterior initial = model.createInitialPosterior(12345L);
+
+        assertThat(initial.dimensions()).isEqualTo(3);
+        assertThat(initial.timestampMs()).isEqualTo(12345L);
+        assertThat(initial.version()).isEqualTo(0);
+        assertThat(initial.mean()).containsExactly(model.priorMean());
+        assertThat(initial.precision()).containsExactly(model.priorPrecision());
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/MentalStatePosteriorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/MentalStatePosteriorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MentalStatePosterior}.
+ */
+class MentalStatePosteriorTest {
+
+    @Test
+    void validConstruction_defensiveCopyAndAccessors() {
+        float[] mean = {0.5f, -0.5f};
+        float[] prec = {2.0f, 3.0f};
+
+        MentalStatePosterior posterior = new MentalStatePosterior(mean, prec, 1000L, 1);
+
+        assertThat(posterior.dimensions()).isEqualTo(2);
+        assertThat(posterior.timestampMs()).isEqualTo(1000L);
+        assertThat(posterior.version()).isEqualTo(1);
+        assertThat(posterior.mean()).containsExactly(0.5f, -0.5f);
+        assertThat(posterior.precision()).containsExactly(2.0f, 3.0f);
+
+        // Mutating external array does not alter record
+        mean[0] = 99.0f;
+        assertThat(posterior.mean()[0]).isEqualTo(0.5f);
+    }
+
+    @Test
+    void invalidPrecisions_throwValidationException() {
+        float[] mean = {0.0f};
+        float[] zeroPrec = {0.0f};
+        float[] negPrec = {-1.0f};
+        float[] nanPrec = {Float.NaN};
+
+        assertThatThrownBy(() -> new MentalStatePosterior(mean, zeroPrec, 0L, 0))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new MentalStatePosterior(mean, negPrec, 0L, 0))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new MentalStatePosterior(mean, nanPrec, 0L, 0))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+
+    @Test
+    void withEvidence_updatesMeanAndPrecision() {
+        float[] mean = {0.0f};
+        float[] prec = {2.0f};
+        MentalStatePosterior prior = new MentalStatePosterior(mean, prec, 1000L, 1);
+
+        float[] evidenceMean = {4.0f};
+        float[] evidencePrec = {2.0f};
+
+        MentalStatePosterior updated = prior.withEvidence(evidenceMean, evidencePrec, 2000L, 2);
+
+        // Fused prec = 2+2=4. Fused mean = (2*0 + 2*4)/4 = 2.0
+        assertThat(updated.precision()[0]).isEqualTo(4.0f);
+        assertThat(updated.mean()[0]).isEqualTo(2.0f);
+        assertThat(updated.version()).isEqualTo(2);
+        assertThat(updated.timestampMs()).isEqualTo(2000L);
+    }
+
+    @Test
+    void decayTowards_blendsMeanAndPrecisionBackToPrior() {
+        float[] mean = {4.0f};
+        float[] prec = {8.0f};
+        MentalStatePosterior current = new MentalStatePosterior(mean, prec, 1000L, 1);
+
+        float[] priorMean = {0.0f};
+        float[] priorPrec = {2.0f};
+
+        MentalStatePosterior decayed = current.decayTowards(priorMean, priorPrec, 0.5f, 2000L, 2);
+
+        // mean = 0.5 * 4 + 0.5 * 0 = 2.0
+        // prec = 0.5 * 8 + 0.5 * 2 = 5.0
+        assertThat(decayed.mean()[0]).isCloseTo(2.0f, within(1e-5f));
+        assertThat(decayed.precision()[0]).isCloseTo(5.0f, within(1e-5f));
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/MentalStateTrackerTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/MentalStateTrackerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.fegr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MentalStateTracker}.
+ */
+class MentalStateTrackerTest {
+
+    private MentalStateTracker tracker;
+    private GenerativeSelfModel selfModel;
+
+    @BeforeEach
+    void setUp() {
+        selfModel = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.BALANCED, 2);
+        tracker = new MentalStateTracker(selfModel);
+    }
+
+    @Test
+    void initialPosterior_matchesPrior() {
+        MentalStatePosterior p = tracker.currentPosterior();
+        assertThat(p.version()).isEqualTo(0);
+        assertThat(p.mean()).containsExactly(selfModel.priorMean());
+    }
+
+    @Test
+    void updateWithObservation_shiftsMeanAndIncreasesPrecision() {
+        float[] observation = {2.0f, -2.0f};
+        tracker.updateWithObservation(observation, 1000L);
+
+        MentalStatePosterior updated = tracker.currentPosterior();
+        assertThat(updated.version()).isEqualTo(1);
+        assertThat(updated.timestampMs()).isEqualTo(1000L);
+        assertThat(updated.mean()[0]).isGreaterThan(0.0f);
+        assertThat(updated.mean()[1]).isLessThan(0.0f);
+        assertThat(updated.precision()[0]).isGreaterThan(selfModel.priorPrecision()[0]);
+    }
+
+    @Test
+    void decay_driftsMeanBackTowardsPrior() {
+        float[] observation = {5.0f, 5.0f};
+        tracker.updateWithObservation(observation, 1000L);
+
+        float shiftedMean = tracker.currentPosterior().mean()[0];
+
+        // Apply decay
+        tracker.decay(2000L, 0.5f);
+
+        float decayedMean = tracker.currentPosterior().mean()[0];
+        assertThat(decayedMean).isLessThan(shiftedMean);
+    }
+
+    @Test
+    void reset_reinitializesToPrior() {
+        float[] observation = {10.0f, 10.0f};
+        tracker.updateWithObservation(observation, 1000L);
+        tracker.reset();
+
+        MentalStatePosterior reset = tracker.currentPosterior();
+        assertThat(reset.version()).isEqualTo(0);
+        assertThat(reset.mean()).containsExactly(selfModel.priorMean());
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/FreeEnergyGuidedRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/FreeEnergyGuidedRelayTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.aisme.fegr.FreeEnergyCalculator;
+import com.spectrayan.spector.memory.aisme.fegr.GenerativeSelfModel;
+import com.spectrayan.spector.memory.aisme.fegr.MentalStateTracker;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link FreeEnergyGuidedRelay}.
+ */
+class FreeEnergyGuidedRelayTest {
+
+    @Test
+    void relayName_isFreeEnergyGuided() {
+        FreeEnergyGuidedRelay relay = new FreeEnergyGuidedRelay(null, null, null, null, null);
+        assertThat(relay.relayName()).isEqualTo("free-energy-guided");
+    }
+
+    @Test
+    void unconfigured_isPassThrough() {
+        FreeEnergyGuidedRelay relay = new FreeEnergyGuidedRelay(null, null, null, null, null);
+        RecallSignal signal = RecallSignal.forTextQuery("test query", RecallOptions.builder().build());
+
+        CognitiveResult item = createResult("m1", 0.75f);
+        signal.candidates().add(item);
+
+        boolean ok = relay.transmit(signal);
+        assertThat(ok).isTrue();
+        assertThat(signal.candidates().get(0).score()).isEqualTo(0.75f);
+    }
+
+    @Test
+    void configured_withVectorQueryAndEmbeddingLookup_appliesFersScoring() {
+        int dim = 2;
+        GenerativeSelfModel selfModel = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.BALANCED, dim);
+        MentalStateTracker tracker = new MentalStateTracker(selfModel);
+        FreeEnergyCalculator calculator = new FreeEnergyCalculator();
+
+        Map<String, float[]> memoryVectors = new HashMap<>();
+        memoryVectors.put("m1", new float[]{1.0f, 1.0f});
+
+        FreeEnergyGuidedRelay relay = new FreeEnergyGuidedRelay(
+                tracker, calculator, null, null, memoryVectors::get);
+
+        float[] queryVec = {1.0f, 1.0f};
+        RecallSignal signal = RecallSignal.forVectorQuery(queryVec, RecallOptions.builder().build());
+        signal.setQueryVector(queryVec);
+
+        CognitiveResult item = createResult("m1", 0.5f);
+        signal.candidates().add(item);
+
+        boolean ok = relay.transmit(signal);
+        assertThat(ok).isTrue();
+
+        // The score should be modified according to FERS
+        float newScore = signal.candidates().get(0).score();
+        assertThat(newScore).isNotEqualTo(0.5f);
+    }
+
+    private static CognitiveResult createResult(String id, float score) {
+        return new CognitiveResult(
+                id,
+                "memory text for " + id,
+                score,
+                1.0f,
+                0.1f,
+                0,
+                (byte) 0,
+                MemoryType.EPISODIC,
+                MemorySource.USER_STATED,
+                new String[0],
+                1.0f,
+                1.0f,
+                CognitiveResult.RetrievalMode.STANDARD,
+                null,
+                null,
+                null,
+                Map.of()
+        );
+    }
+}

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/FreeEnergyKernel.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/FreeEnergyKernel.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.simd.SimdCapability;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * SIMD-accelerated kernel for Variational Free Energy and Active Inference calculations.
+ *
+ * <h3>Biological Analog: Cortical Precision-Weighted Prediction Error Minimization</h3>
+ * <p>Implements the mathematical foundation of Karl Friston's Free Energy Principle for Gaussian
+ * density distributions. Computes analytical Kullback-Leibler (KL) divergence and expected log-likelihood
+ * across continuous latent mental state distributions using SIMD vectorization.</p>
+ */
+public final class FreeEnergyKernel {
+
+    private static final VectorSpecies<Float> SPECIES = SimdCapability.PREFERRED_SPECIES;
+    private static final float LN_2PI = 1.8378770664093453f; // ln(2*pi)
+
+    private FreeEnergyKernel() {
+        // utility class
+    }
+
+    /**
+     * Computes the Kullback-Leibler divergence between two diagonal multivariate Gaussians:
+     * D_KL(q || p) = 0.5 * sum( ln(pi_p / pi_q) + (pi_p / pi_q) + pi_p * (mu_q - mu_p)^2 - 1 )
+     *
+     * @param meanQ mean vector of posterior q(s)
+     * @param precisionQ precision vector (1/var) of posterior q(s)
+     * @param meanP mean vector of prior p(s)
+     * @param precisionP precision vector (1/var) of prior p(s)
+     * @return KL divergence >= 0.0f
+     */
+    public static float gaussianKLDivergence(float[] meanQ, float[] precisionQ, float[] meanP, float[] precisionP) {
+        validateInputs(meanQ, precisionQ, meanP, precisionP);
+        int length = meanQ.length;
+        int laneCount = SPECIES.length();
+        FloatVector sumVec = FloatVector.zero(SPECIES);
+
+        int i = 0;
+        int limit = SPECIES.loopBound(length);
+        for (; i < limit; i += laneCount) {
+            FloatVector vMq = FloatVector.fromArray(SPECIES, meanQ, i);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, precisionQ, i);
+            FloatVector vMp = FloatVector.fromArray(SPECIES, meanP, i);
+            FloatVector vPp = FloatVector.fromArray(SPECIES, precisionP, i);
+
+            FloatVector diff = vMq.sub(vMp);
+            FloatVector logRatio = vPq.div(vPp).lanewise(VectorOperators.LOG);
+            FloatVector precRatio = vPp.div(vPq);
+            FloatVector quad = vPp.mul(diff).mul(diff);
+
+            // term = log(pi_q/pi_p) + (pi_p/pi_q) + pi_p * (mu_q - mu_p)^2 - 1
+            FloatVector term = logRatio.add(precRatio).add(quad).sub(1.0f);
+            sumVec = sumVec.add(term);
+        }
+
+        float kl = sumVec.reduceLanes(VectorOperators.ADD);
+
+        // Masked tail
+        if (i < length) {
+            VectorMask<Float> mask = SPECIES.indexInRange(i, length);
+            FloatVector vMq = FloatVector.fromArray(SPECIES, meanQ, i, mask);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, precisionQ, i, mask);
+            FloatVector vMp = FloatVector.fromArray(SPECIES, meanP, i, mask);
+            FloatVector vPp = FloatVector.fromArray(SPECIES, precisionP, i, mask);
+
+            FloatVector diff = vMq.sub(vMp);
+            FloatVector logRatio = vPq.div(vPp).lanewise(VectorOperators.LOG);
+            FloatVector precRatio = vPp.div(vPq);
+            FloatVector quad = vPp.mul(diff).mul(diff);
+
+            FloatVector term = logRatio.add(precRatio).add(quad).sub(1.0f);
+            kl += term.reduceLanes(VectorOperators.ADD, mask);
+        }
+
+        return Math.max(0.0f, 0.5f * kl);
+    }
+
+    /**
+     * Computes the negative expected log-likelihood -E_q[log p(o | s)] for Gaussian observation model:
+     * -E_q[log p(o|s)] = 0.5 * sum( ln(2*pi) - ln(pi_o) + pi_o * ( (1/pi_q) + (mu_q - o)^2 ) )
+     *
+     * @param meanQ mean vector of posterior q(s)
+     * @param precisionQ precision vector (1/var) of posterior q(s)
+     * @param observation sensory observation vector o
+     * @param obsPrecision precision vector of observation likelihood
+     * @return negative expected log-likelihood
+     */
+    public static float negativeExpectedLogLikelihood(float[] meanQ, float[] precisionQ, float[] observation, float[] obsPrecision) {
+        validateInputs(meanQ, precisionQ, observation, obsPrecision);
+        int length = meanQ.length;
+        int laneCount = SPECIES.length();
+        FloatVector sumVec = FloatVector.zero(SPECIES);
+
+        int i = 0;
+        int limit = SPECIES.loopBound(length);
+        for (; i < limit; i += laneCount) {
+            FloatVector vMq = FloatVector.fromArray(SPECIES, meanQ, i);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, precisionQ, i);
+            FloatVector vObs = FloatVector.fromArray(SPECIES, observation, i);
+            FloatVector vPo = FloatVector.fromArray(SPECIES, obsPrecision, i);
+
+            FloatVector diff = vMq.sub(vObs);
+            FloatVector varQ = FloatVector.broadcast(SPECIES, 1.0f).div(vPq);
+            FloatVector logPo = vPo.lanewise(VectorOperators.LOG);
+
+            // term = ln(2*pi) - ln(pi_o) + pi_o * (var_q + diff^2)
+            FloatVector term = FloatVector.broadcast(SPECIES, LN_2PI).sub(logPo).add(vPo.mul(varQ.add(diff.mul(diff))));
+            sumVec = sumVec.add(term);
+        }
+
+        float nll = sumVec.reduceLanes(VectorOperators.ADD);
+
+        // Masked tail
+        if (i < length) {
+            VectorMask<Float> mask = SPECIES.indexInRange(i, length);
+            FloatVector vMq = FloatVector.fromArray(SPECIES, meanQ, i, mask);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, precisionQ, i, mask);
+            FloatVector vObs = FloatVector.fromArray(SPECIES, observation, i, mask);
+            FloatVector vPo = FloatVector.fromArray(SPECIES, obsPrecision, i, mask);
+
+            FloatVector diff = vMq.sub(vObs);
+            FloatVector varQ = FloatVector.broadcast(SPECIES, 1.0f).div(vPq);
+            FloatVector logPo = vPo.lanewise(VectorOperators.LOG);
+
+            FloatVector term = FloatVector.broadcast(SPECIES, LN_2PI).sub(logPo).add(vPo.mul(varQ.add(diff.mul(diff))));
+            nll += term.reduceLanes(VectorOperators.ADD, mask);
+        }
+
+        return 0.5f * nll;
+    }
+
+    /**
+     * Computes the Variational Free Energy F(q) = D_KL(q || p) - E_q[log p(o|s)].
+     *
+     * @param meanQ mean vector of posterior q(s)
+     * @param precisionQ precision vector of posterior q(s)
+     * @param meanP mean vector of prior p(s)
+     * @param precisionP precision vector of prior p(s)
+     * @param observation observation vector o
+     * @param obsPrecision precision vector of observation model
+     * @return Variational Free Energy F(q)
+     */
+    public static float variationalFreeEnergy(float[] meanQ, float[] precisionQ,
+                                              float[] meanP, float[] precisionP,
+                                              float[] observation, float[] obsPrecision) {
+        float kl = gaussianKLDivergence(meanQ, precisionQ, meanP, precisionP);
+        float nll = negativeExpectedLogLikelihood(meanQ, precisionQ, observation, obsPrecision);
+        return kl + nll;
+    }
+
+    /**
+     * Performs precision-weighted Bayesian fusion between two independent Gaussian distributions:
+     * pi_post = pi_A + pi_B
+     * mu_post = (pi_A * mu_A + pi_B * mu_B) / pi_post
+     *
+     * @param meanA mean of distribution A
+     * @param precisionA precision of distribution A
+     * @param meanB mean of distribution B
+     * @param precisionB precision of distribution B
+     * @param outMean destination array for fused mean
+     * @param outPrecision destination array for fused precision
+     */
+    public static void precisionWeightedFusion(float[] meanA, float[] precisionA,
+                                               float[] meanB, float[] precisionB,
+                                               float[] outMean, float[] outPrecision) {
+        validateInputs(meanA, precisionA, meanB, precisionB);
+        if (outMean.length != meanA.length || outPrecision.length != meanA.length) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Output arrays must have matching dimensions");
+        }
+
+        int length = meanA.length;
+        int laneCount = SPECIES.length();
+
+        int i = 0;
+        int limit = SPECIES.loopBound(length);
+        for (; i < limit; i += laneCount) {
+            FloatVector vMa = FloatVector.fromArray(SPECIES, meanA, i);
+            FloatVector vPa = FloatVector.fromArray(SPECIES, precisionA, i);
+            FloatVector vMb = FloatVector.fromArray(SPECIES, meanB, i);
+            FloatVector vPb = FloatVector.fromArray(SPECIES, precisionB, i);
+
+            FloatVector vPostPrec = vPa.add(vPb);
+            FloatVector vPostMean = (vPa.mul(vMa).add(vPb.mul(vMb))).div(vPostPrec);
+
+            vPostMean.intoArray(outMean, i);
+            vPostPrec.intoArray(outPrecision, i);
+        }
+
+        if (i < length) {
+            VectorMask<Float> mask = SPECIES.indexInRange(i, length);
+            FloatVector vMa = FloatVector.fromArray(SPECIES, meanA, i, mask);
+            FloatVector vPa = FloatVector.fromArray(SPECIES, precisionA, i, mask);
+            FloatVector vMb = FloatVector.fromArray(SPECIES, meanB, i, mask);
+            FloatVector vPb = FloatVector.fromArray(SPECIES, precisionB, i, mask);
+
+            FloatVector vPostPrec = vPa.add(vPb);
+            FloatVector vPostMean = (vPa.mul(vMa).add(vPb.mul(vMb))).div(vPostPrec);
+
+            vPostMean.intoArray(outMean, i, mask);
+            vPostPrec.intoArray(outPrecision, i, mask);
+        }
+    }
+
+    private static void validateInputs(float[] a, float[] b, float[] c, float[] d) {
+        if (a == null || b == null || c == null || d == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Input arrays must not be null");
+        }
+        int len = a.length;
+        if (b.length != len || c.length != len || d.length != len) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "All input vectors must have identical dimensions");
+        }
+        if (len == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Input vector length must be greater than zero");
+        }
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/FreeEnergyKernelTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/FreeEnergyKernelTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the SIMD-accelerated {@link FreeEnergyKernel}.
+ */
+class FreeEnergyKernelTest {
+
+    @Test
+    void identicalDistributions_klIsZero() {
+        float[] mean = {0.5f, -0.2f, 0.8f, 1.2f};
+        float[] prec = {2.0f, 3.0f, 1.5f, 4.0f};
+
+        float kl = FreeEnergyKernel.gaussianKLDivergence(mean, prec, mean, prec);
+        assertThat(kl).isCloseTo(0.0f, within(1e-5f));
+    }
+
+    @Test
+    void shiftedMeans_klIsPositive() {
+        float[] meanQ = {1.0f, 0.0f};
+        float[] precQ = {2.0f, 2.0f};
+        float[] meanP = {0.0f, 0.0f};
+        float[] precP = {2.0f, 2.0f};
+
+        // For equal precisions pi: KL = 0.5 * pi * (mu_q - mu_p)^2 = 0.5 * 2.0 * (1.0)^2 = 1.0
+        float kl = FreeEnergyKernel.gaussianKLDivergence(meanQ, precQ, meanP, precP);
+        assertThat(kl).isCloseTo(1.0f, within(1e-5f));
+    }
+
+    @Test
+    void differentPrecisions_klMatchesAnalyticalValue() {
+        float[] meanQ = {0.0f};
+        float[] precQ = {4.0f}; // varQ = 0.25
+        float[] meanP = {0.0f};
+        float[] precP = {1.0f}; // varP = 1.0
+
+        // D_KL = 0.5 * (ln(4/1) + 1/4 - 1) = 0.5 * (1.386294 + 0.25 - 1.0) = 0.5 * 0.636294 = 0.318147
+        float kl = FreeEnergyKernel.gaussianKLDivergence(meanQ, precQ, meanP, precP);
+        assertThat(kl).isCloseTo(0.318147f, within(1e-4f));
+    }
+
+    @Test
+    void precisionWeightedFusion_computesExactBayesianPosterior() {
+        float[] meanA = {1.0f, -2.0f};
+        float[] precA = {2.0f, 4.0f};
+        float[] meanB = {3.0f, 2.0f};
+        float[] precB = {2.0f, 4.0f};
+
+        float[] outMean = new float[2];
+        float[] outPrec = new float[2];
+
+        FreeEnergyKernel.precisionWeightedFusion(meanA, precA, meanB, precB, outMean, outPrec);
+
+        // Dim 0: prec = 2+2=4. mean = (2*1 + 2*3)/4 = 8/4 = 2.0
+        // Dim 1: prec = 4+4=8. mean = (4*-2 + 4*2)/8 = 0.0
+        assertThat(outPrec[0]).isEqualTo(4.0f);
+        assertThat(outPrec[1]).isEqualTo(8.0f);
+        assertThat(outMean[0]).isEqualTo(2.0f);
+        assertThat(outMean[1]).isEqualTo(0.0f);
+    }
+
+    @Test
+    void variationalFreeEnergy_sumsKlAndExpectedNll() {
+        float[] meanQ = {0.5f, -0.5f};
+        float[] precQ = {2.0f, 2.0f};
+        float[] meanP = {0.0f, 0.0f};
+        float[] precP = {1.0f, 1.0f};
+        float[] obs = {0.5f, -0.5f};
+        float[] obsPrec = {4.0f, 4.0f};
+
+        float fe = FreeEnergyKernel.variationalFreeEnergy(meanQ, precQ, meanP, precP, obs, obsPrec);
+        float kl = FreeEnergyKernel.gaussianKLDivergence(meanQ, precQ, meanP, precP);
+        float nll = FreeEnergyKernel.negativeExpectedLogLikelihood(meanQ, precQ, obs, obsPrec);
+
+        assertThat(fe).isCloseTo(kl + nll, within(1e-5f));
+    }
+
+    @Test
+    void nonSimdAlignedDimension_handlesMaskedTailAccurately() {
+        int dim = 17; // non-power-of-two, non-16/8 multiple
+        float[] meanA = new float[dim];
+        float[] precA = new float[dim];
+        float[] meanB = new float[dim];
+        float[] precB = new float[dim];
+
+        for (int i = 0; i < dim; i++) {
+            meanA[i] = i * 0.1f;
+            precA[i] = 1.0f + i * 0.2f;
+            meanB[i] = i * 0.1f + 0.05f;
+            precB[i] = 2.0f + i * 0.1f;
+        }
+
+        float kl = FreeEnergyKernel.gaussianKLDivergence(meanA, precA, meanB, precB);
+        assertThat(kl).isGreaterThan(0.0f);
+
+        float[] fusedMean = new float[dim];
+        float[] fusedPrec = new float[dim];
+        FreeEnergyKernel.precisionWeightedFusion(meanA, precA, meanB, precB, fusedMean, fusedPrec);
+        assertThat(fusedPrec[dim - 1]).isCloseTo(precA[dim - 1] + precB[dim - 1], within(1e-5f));
+    }
+
+    @Test
+    void inputValidation_throwsOnDimensionMismatch() {
+        float[] a = {1.0f, 2.0f};
+        float[] b = {1.0f};
+        assertThatThrownBy(() -> FreeEnergyKernel.gaussianKLDivergence(a, a, b, a))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Free-Energy Guided Recall (FEGR)** — Phase 2 of the Active Inference Self-Model Engine (AISME).

FEGR transforms memory retrieval from simple similarity lookup into variational free-energy minimization. Memories are evaluated by their capacity to reduce situational uncertainty ($\Delta \mathcal{F}$) under the agent generative self-model, combining semantic proximity, predictive surprise reduction, and affective resonance.

Closes #587

## Changes

### Layer 1: SIMD Kernel (`spector-core`)
- **`FreeEnergyKernel.java`** — SIMD Gaussian KL divergence $D_{\text{KL}}[q \| p]$, expected negative log-likelihood $-\mathbb{E}_q[\log p(o|s)]$, and precision-weighted Bayesian fusion using Java Vector API (AVX2/512 with masked loop tails)

### Layer 2: Data Models (`spector-memory`)
- **`MentalStatePosterior.java`** — Immutable record representing the approximate posterior distribution $q(s_t) = \mathcal{N}(\boldsymbol{\mu}_q, \text{diag}(\boldsymbol{\pi}_q^{-1}))$ with Bayesian cue combination and temporal decay towards prior
- **`GenerativeSelfModel.java`** — Encapsulates generative prior $p(s|m)$ and observation mapping $p(o|s)$ parameterized by `AgentSoul` and `CognitiveProfile` (e.g., HYPERFOCUS high precision, DIVERGENT flexible precision)

### Layer 3: Free Energy Engine (`spector-memory`)
- **`FreeEnergyCalculator.java`** — Variational free energy engine computing $\mathcal{F}(q)$ and candidate memory free-energy reduction $\Delta \mathcal{F}(\mu_i) = \mathcal{F}(q(s_t)) - \mathcal{F}(q(s_t | \mu_i))$, producing the Free-Energy Relevance Score (FERS)
- **`MentalStateTracker.java`** — Thread-safe manager maintaining continuous posterior belief state across conversational turns using `ReentrantLock`

### Layer 4: Pathway Integration (`spector-memory`)
- **`FreeEnergyGuidedRelay.java`** — `SynapticRelay<RecallSignal>` integrating FEGR into the `RecallPathway` chain. Transparent no-op fallback when unconfigured.

## Testing

| Test Class | Tests | Status |
|:---|:---|:---|
| `FreeEnergyKernelTest` | 7 | ✅ |
| `AffectiveDistanceTest` | 8 | ✅ |
| `MentalStatePosteriorTest` | 4 | ✅ |
| `GenerativeSelfModelTest` | 4 | ✅ |
| `FreeEnergyCalculatorTest` | 3 | ✅ |
| `MentalStateTrackerTest` | 4 | ✅ |
| `FreeEnergyGuidedRelayTest` | 3 | ✅ |
| `EmotionalRegulatorTest` | 8 | ✅ |
| `InteroceptiveStateTest` | 8 | ✅ |
| `HomeostaticCoreTest` | 9 | ✅ |
| **Total AISME Tests** | **58** | **All Pass (100%)** |

## Architecture

$$\text{FERS}(\mu_i | s_t, o_t) = \alpha \cdot \text{sim}(e_q, e_{\mu_i}) + \beta \cdot \text{sigmoid}(\Delta \mathcal{F}(\mu_i)) + \gamma \cdot \mathcal{A}(\mu_i, s_t)$$

```
Query Vector → ... → HomeostaticBiasRelay → FreeEnergyGuidedRelay → AssociativeGraphRelay → ...
                                                   │
                                                   ▼
                                         MentalStateTracker
                                         (Posterior q(s_t))
                                                   │
                                                   ▼
                                        FreeEnergyCalculator
                                        (ΔF = F(q) - F(q|μ))
                                                   │
                                                   ▼
                                         FreeEnergyKernel
                                         (SIMD Gaussian KL & NLL)
```

## Backward Compatibility
100% backward compatible. If unconfigured or query vectors are absent, `FreeEnergyGuidedRelay` operates as a transparent pass-through.

## Commits (dependency-ordered)
1. `feat(core): add SIMD-accelerated FreeEnergyKernel`
2. `feat(memory): add MentalStatePosterior and GenerativeSelfModel records`
3. `feat(memory): add FreeEnergyCalculator and MentalStateTracker`
4. `feat(memory): add FreeEnergyGuidedRelay for RecallPathway`