### PR TITLE
feat(memory): Active Inference Self-Model Engine — Phase 3: Modern Hopfield Associative Memory (#589)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorState.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorState.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import java.util.Arrays;
+
+/**
+ * Immutable record capturing the converged attractor state of a Continuous Hopfield Network.
+ *
+ * <h3>Biological Analog: Settled Attractor in Hippocampal-Cortical Circuit</h3>
+ * <p>Represents the synthesized memory gestalt after relaxation through the energy landscape,
+ * including its energetic depth and the attention weights over constituent memory traces.</p>
+ */
+public record AttractorState(
+        float[] attractorVector,
+        float[] attentionWeights,
+        AttractorType type,
+        float energy,
+        int iterations,
+        long timestampMs
+) {
+
+    /**
+     * Compact constructor with defensive copies and validation.
+     */
+    public AttractorState {
+        if (attractorVector == null || attentionWeights == null || type == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        if (attractorVector.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Attractor vector dimension must be greater than zero");
+        }
+        if (iterations < 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Iteration count cannot be negative");
+        }
+
+        attractorVector = Arrays.copyOf(attractorVector, attractorVector.length);
+        attentionWeights = Arrays.copyOf(attentionWeights, attentionWeights.length);
+    }
+
+    /**
+     * @return the dimensionality of the attractor state
+     */
+    public int dimensions() {
+        return attractorVector.length;
+    }
+
+    /**
+     * @return the number of pattern memories participating in the attractor
+     */
+    public int patternCount() {
+        return attentionWeights.length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AttractorState that)) return false;
+        return Float.compare(that.energy, energy) == 0 &&
+                iterations == that.iterations &&
+                timestampMs == that.timestampMs &&
+                type == that.type &&
+                Arrays.equals(attractorVector, that.attractorVector) &&
+                Arrays.equals(attentionWeights, that.attentionWeights);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Float.hashCode(energy);
+        result = 31 * result + iterations;
+        result = 31 * result + Long.hashCode(timestampMs);
+        result = 31 * result + type.hashCode();
+        result = 31 * result + Arrays.hashCode(attractorVector);
+        result = 31 * result + Arrays.hashCode(attentionWeights);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AttractorState{" +
+                "dim=" + attractorVector.length +
+                ", patterns=" + attentionWeights.length +
+                ", type=" + type +
+                ", energy=" + energy +
+                ", iterations=" + iterations +
+                '}';
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorType.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorType.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+/**
+ * Classification of associative memory attractor basins discovered by the Modern Hopfield Network.
+ *
+ * <h3>Biological Analog: Hippocampal Pattern Completion & Gestalt Superposition</h3>
+ * <p>Identifies whether an associative recall event resolves into a distinct singular episode
+ * (fixed point), a rich blended intuition of related memories (metastable state), or a broad
+ * diffuse activation of contextual associations.</p>
+ */
+public enum AttractorType {
+
+    /**
+     * A single memory pattern strongly dominates the energy basin (attention weight >= 0.70).
+     * Corresponds to vivid, unambiguous episodic recollection.
+     */
+    FIXED_POINT,
+
+    /**
+     * Multiple complementary memories co-exist in an associative superposition (0.30 <= max weight < 0.70).
+     * Corresponds to intuitive gestalt synthesis or multifaceted perspective.
+     */
+    METASTABLE,
+
+    /**
+     * Broad, low-contrast distribution of attention across memories (max weight < 0.30).
+     * Corresponds to open contextual priming or exploratory cognitive state.
+     */
+    DIFFUSE;
+
+    /**
+     * Classifies an attention weight distribution into an attractor type.
+     *
+     * @param weights normalized attention weights
+     * @return classified AttractorType
+     */
+    public static AttractorType classify(float[] weights) {
+        if (weights == null || weights.length == 0) {
+            return DIFFUSE;
+        }
+        float maxW = 0.0f;
+        for (float w : weights) {
+            if (w > maxW) {
+                maxW = w;
+            }
+        }
+        if (maxW >= 0.70f) {
+            return FIXED_POINT;
+        } else if (maxW >= 0.30f) {
+            return METASTABLE;
+        } else {
+            return DIFFUSE;
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/ContinuousHopfieldNetwork.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/ContinuousHopfieldNetwork.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.similarity.HopfieldKernel;
+import com.spectrayan.spector.core.similarity.VectorOps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Continuous Modern Hopfield Network for associative memory pattern retrieval and gestalt synthesis.
+ *
+ * <h3>Biological Analog: CA3 Autoassociative Attractor Settlement</h3>
+ * <p>Iteratively relaxes a cognitive query vector into the lowest energy basin defined by the
+ * candidate memory patterns, synthesizing multi-memory superpositions into cohesive mental representations.</p>
+ */
+public final class ContinuousHopfieldNetwork {
+
+    private static final Logger log = LoggerFactory.getLogger(ContinuousHopfieldNetwork.class);
+
+    private final int maxIterations;
+    private final float convergenceTolerance;
+
+    /**
+     * Constructs a ContinuousHopfieldNetwork with default parameters (maxIterations=5, tolerance=1e-4).
+     */
+    public ContinuousHopfieldNetwork() {
+        this(5, 1e-4f);
+    }
+
+    /**
+     * Constructs a ContinuousHopfieldNetwork with custom convergence parameters.
+     *
+     * @param maxIterations maximum relaxation iterations (must be >= 1)
+     * @param convergenceTolerance L2 distance threshold for early convergence
+     */
+    public ContinuousHopfieldNetwork(int maxIterations, float convergenceTolerance) {
+        if (maxIterations < 1) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "maxIterations must be at least 1");
+        }
+        if (convergenceTolerance < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "convergenceTolerance cannot be negative");
+        }
+        this.maxIterations = maxIterations;
+        this.convergenceTolerance = convergenceTolerance;
+    }
+
+    /**
+     * Relaxes an initial query vector into the nearest associative attractor defined by pattern memories.
+     *
+     * @param initialQuery initial retrieval query vector xi_0 in R^D
+     * @param patterns array of N candidate pattern memory vectors in R^D
+     * @param beta inverse temperature scaling parameter
+     * @return converged AttractorState
+     */
+    public AttractorState retrieveAttractor(float[] initialQuery, float[][] patterns, float beta) {
+        if (initialQuery == null || patterns == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Initial query and patterns must not be null");
+        }
+        int numPatterns = patterns.length;
+        int dim = initialQuery.length;
+        if (numPatterns == 0) {
+            float[] emptyWeights = new float[0];
+            return new AttractorState(initialQuery, emptyWeights, AttractorType.DIFFUSE, 0.0f, 0, System.currentTimeMillis());
+        }
+
+        float[] current = Arrays.copyOf(initialQuery, dim);
+        float[] next = new float[dim];
+        float[] weights = new float[numPatterns];
+
+        int iter = 0;
+        for (; iter < maxIterations; iter++) {
+            HopfieldKernel.update(current, patterns, beta, next, weights);
+
+            // Check L2 convergence: ||next - current||
+            float diffNormSq = 0.0f;
+            for (int d = 0; d < dim; d++) {
+                float diff = next[d] - current[d];
+                diffNormSq += diff * diff;
+            }
+
+            System.arraycopy(next, 0, current, 0, dim);
+
+            if (Math.sqrt(diffNormSq) < convergenceTolerance) {
+                iter++;
+                break;
+            }
+        }
+
+        float energy = HopfieldKernel.continuousEnergy(current, patterns, beta);
+        AttractorType type = AttractorType.classify(weights);
+
+        if (log.isTraceEnabled()) {
+            log.trace("Hopfield attractor reached in {} iters: type={}, energy={}", iter, type, energy);
+        }
+
+        return new AttractorState(current, weights, type, energy, iter, System.currentTimeMillis());
+    }
+
+    public int maxIterations() {
+        return maxIterations;
+    }
+
+    public float convergenceTolerance() {
+        return convergenceTolerance;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/PersonalityTemperature.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/PersonalityTemperature.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+/**
+ * Maps cognitive profile traits and real-time interoceptive arousal to the Modern Hopfield
+ * inverse temperature parameter beta.
+ *
+ * <h3>Biological Analog: Noradrenergic Neuromodulation of Attractor Precision</h3>
+ * <p>High norepinephrine and focused attentional profiles tighten the attractor basins
+ * (high beta, sharp retrieval), whereas divergent or relaxed states broaden attractor basins
+ * (low beta, associative blending across memory traces).</p>
+ */
+public final class PersonalityTemperature {
+
+    private static final float DEFAULT_BETA = 4.0f;
+
+    private PersonalityTemperature() {
+        // utility class
+    }
+
+    /**
+     * Derives the adaptive inverse temperature beta from the agent cognitive profile and current affective state.
+     *
+     * @param profile the agent's cognitive profile (nullable)
+     * @param state the current interoceptive state (nullable)
+     * @return positive inverse temperature beta > 0.0f
+     */
+    public static float deriveBeta(CognitiveProfile profile, InteroceptiveState state) {
+        float arousal = (state != null) ? state.arousal() : 0.0f;
+        return deriveBeta(profile, arousal);
+    }
+
+    /**
+     * Derives the adaptive inverse temperature beta from the agent cognitive profile and scalar arousal.
+     *
+     * @param profile the cognitive profile (nullable)
+     * @param arousal normalized arousal in [-1, 1]
+     * @return positive inverse temperature beta > 0.0f
+     */
+    public static float deriveBeta(CognitiveProfile profile, float arousal) {
+        float baseBeta = DEFAULT_BETA;
+        if (profile != null) {
+            switch (profile) {
+                case HYPERFOCUS -> baseBeta = 12.0f;
+                case SYSTEMATIZER -> baseBeta = 8.0f;
+                case BALANCED -> baseBeta = 4.0f;
+                case DEFAULT_MODE_NETWORK -> baseBeta = 3.0f;
+                case EXPLORING -> baseBeta = 2.0f;
+                case DIVERGENT -> baseBeta = 1.0f;
+                case EXECUTIVE_DYSFUNCTION -> baseBeta = 1.2f;
+                case PARANOID_SENTINEL -> baseBeta = 15.0f;
+                default -> baseBeta = DEFAULT_BETA;
+            }
+        }
+
+        // Modulate with arousal: high arousal sharpens focus, low arousal broadens associations
+        float clampedArousal = Math.max(-1.0f, Math.min(1.0f, arousal));
+        float arousalMultiplier = 1.0f + (0.5f * clampedArousal);
+        return Math.max(0.2f, baseBeta * arousalMultiplier);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/HopfieldAssociativeRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/HopfieldAssociativeRelay.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.aisme.homeostasis.HomeostaticCore;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.aisme.hopfield.AttractorState;
+import com.spectrayan.spector.memory.aisme.hopfield.ContinuousHopfieldNetwork;
+import com.spectrayan.spector.memory.aisme.hopfield.PersonalityTemperature;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * RecallPathway relay that discovers Modern Hopfield attractor states across candidate memories
+ * and modulates retrieval scores based on attractor attention weights.
+ *
+ * <h3>Biological Analog: CA3 Associative Attractor Dynamic Modulation</h3>
+ * <p>Enhances memories that participate strongly in the coherent cognitive gestalt discovered
+ * by the continuous Hopfield network, modulated by personality temperature and current arousal.</p>
+ */
+public final class HopfieldAssociativeRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(HopfieldAssociativeRelay.class);
+
+    private final ContinuousHopfieldNetwork network;
+    private final Function<String, float[]> embeddingLookup;
+    private final CognitiveProfile profile;
+    private final HomeostaticCore homeostaticCore;
+    private final float blendWeight;
+
+    /**
+     * Constructs a HopfieldAssociativeRelay with default blend weight (0.35).
+     *
+     * @param network the continuous Hopfield network engine (nullable)
+     * @param embeddingLookup function to resolve candidate memory vectors by id (nullable)
+     * @param profile the agent's cognitive profile (nullable)
+     * @param homeostaticCore the homeostatic affective core (nullable)
+     */
+    public HopfieldAssociativeRelay(
+            ContinuousHopfieldNetwork network,
+            Function<String, float[]> embeddingLookup,
+            CognitiveProfile profile,
+            HomeostaticCore homeostaticCore) {
+        this(network, embeddingLookup, profile, homeostaticCore, 0.35f);
+    }
+
+    /**
+     * Constructs a HopfieldAssociativeRelay with custom blend weight.
+     *
+     * @param network the continuous Hopfield network engine
+     * @param embeddingLookup function to resolve candidate memory vectors by id
+     * @param profile the agent's cognitive profile
+     * @param homeostaticCore the homeostatic core
+     * @param blendWeight weight of the Hopfield attention boost multiplier
+     */
+    public HopfieldAssociativeRelay(
+            ContinuousHopfieldNetwork network,
+            Function<String, float[]> embeddingLookup,
+            CognitiveProfile profile,
+            HomeostaticCore homeostaticCore,
+            float blendWeight) {
+        this.network = network;
+        this.embeddingLookup = embeddingLookup;
+        this.profile = profile;
+        this.homeostaticCore = homeostaticCore;
+        this.blendWeight = blendWeight;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        if (network == null || embeddingLookup == null || signal == null) {
+            return true;
+        }
+
+        List<CognitiveResult> candidates = signal.candidates();
+        if (candidates == null || candidates.isEmpty()) {
+            return true;
+        }
+
+        float[] queryVector = signal.queryVector();
+        if (queryVector == null || queryVector.length == 0) {
+            return true;
+        }
+
+        int n = candidates.size();
+        List<float[]> validPatternsList = new ArrayList<>(n);
+        List<Integer> validIndices = new ArrayList<>(n);
+
+        for (int i = 0; i < n; i++) {
+            CognitiveResult r = candidates.get(i);
+            float[] vec = embeddingLookup.apply(r.id());
+            if (vec != null && vec.length == queryVector.length) {
+                validPatternsList.add(vec);
+                validIndices.add(i);
+            }
+        }
+
+        if (validPatternsList.isEmpty()) {
+            return true;
+        }
+
+        float[][] patterns = validPatternsList.toArray(new float[0][]);
+        InteroceptiveState interoceptiveState = (homeostaticCore != null) ? homeostaticCore.currentState() : null;
+        float beta = PersonalityTemperature.deriveBeta(profile, interoceptiveState);
+
+        AttractorState attractor = network.retrieveAttractor(queryVector, patterns, beta);
+        float[] weights = attractor.attentionWeights();
+
+        for (int k = 0; k < validIndices.size(); k++) {
+            int candidateIdx = validIndices.get(k);
+            CognitiveResult r = candidates.get(candidateIdx);
+            float weight = (k < weights.length) ? weights[k] : 0.0f;
+
+            float boost = 1.0f + (blendWeight * weight);
+            float newScore = r.score() * boost;
+
+            candidates.set(candidateIdx, new CognitiveResult(
+                    r.id(), r.text(), newScore, r.importance(),
+                    r.ageDays(), r.agentRecallCount(), r.valence(),
+                    r.memoryType(), r.source(), r.synapticTags(),
+                    r.decayFactor(), r.ltpAdjustedDecay(),
+                    r.retrievalMode(), r.breakdown(), r.trace(),
+                    r.sourceModality(), r.metadata()
+            ));
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("HopfieldAssociativeRelay settled attractor type={} with {} patterns at beta={}",
+                    attractor.type(), patterns.length, beta);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return "hopfield-associative";
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorStateTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorStateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AttractorState}.
+ */
+class AttractorStateTest {
+
+    @Test
+    void construction_defensiveCopyAndAccessors() {
+        float[] vector = {1.0f, 2.0f, 3.0f};
+        float[] weights = {0.8f, 0.2f};
+
+        AttractorState state = new AttractorState(
+                vector, weights, AttractorType.FIXED_POINT, -5.5f, 3, 1000L);
+
+        assertThat(state.dimensions()).isEqualTo(3);
+        assertThat(state.patternCount()).isEqualTo(2);
+        assertThat(state.type()).isEqualTo(AttractorType.FIXED_POINT);
+        assertThat(state.energy()).isEqualTo(-5.5f);
+        assertThat(state.iterations()).isEqualTo(3);
+        assertThat(state.timestampMs()).isEqualTo(1000L);
+
+        vector[0] = 999.0f;
+        weights[0] = 999.0f;
+        assertThat(state.attractorVector()[0]).isEqualTo(1.0f);
+        assertThat(state.attentionWeights()[0]).isEqualTo(0.8f);
+    }
+
+    @Test
+    void invalidArguments_throwValidationException() {
+        float[] vector = {1.0f};
+        float[] weights = {1.0f};
+
+        assertThatThrownBy(() -> new AttractorState(null, weights, AttractorType.FIXED_POINT, 0f, 1, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new AttractorState(vector, null, AttractorType.FIXED_POINT, 0f, 1, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new AttractorState(vector, weights, null, 0f, 1, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new AttractorState(new float[0], weights, AttractorType.FIXED_POINT, 0f, 1, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new AttractorState(vector, weights, AttractorType.FIXED_POINT, 0f, -1, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorTypeTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/AttractorTypeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AttractorType} classification.
+ */
+class AttractorTypeTest {
+
+    @Test
+    void classify_dominantWeight_fixedPoint() {
+        float[] weights = {0.85f, 0.10f, 0.05f};
+        assertThat(AttractorType.classify(weights)).isEqualTo(AttractorType.FIXED_POINT);
+    }
+
+    @Test
+    void classify_superposition_metastable() {
+        float[] weights = {0.50f, 0.35f, 0.15f};
+        assertThat(AttractorType.classify(weights)).isEqualTo(AttractorType.METASTABLE);
+    }
+
+    @Test
+    void classify_uniformWeights_diffuse() {
+        float[] weights = {0.25f, 0.25f, 0.25f, 0.25f};
+        assertThat(AttractorType.classify(weights)).isEqualTo(AttractorType.DIFFUSE);
+    }
+
+    @Test
+    void classify_emptyOrNull_returnsDiffuse() {
+        assertThat(AttractorType.classify(null)).isEqualTo(AttractorType.DIFFUSE);
+        assertThat(AttractorType.classify(new float[0])).isEqualTo(AttractorType.DIFFUSE);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/ContinuousHopfieldNetworkTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/ContinuousHopfieldNetworkTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ContinuousHopfieldNetwork}.
+ */
+class ContinuousHopfieldNetworkTest {
+
+    private ContinuousHopfieldNetwork network;
+
+    @BeforeEach
+    void setUp() {
+        network = new ContinuousHopfieldNetwork(10, 1e-4f);
+    }
+
+    @Test
+    void retrieveAttractor_emptyPatterns_returnsDiffuseState() {
+        float[] query = {1.0f, 0.0f};
+        float[][] patterns = new float[0][];
+
+        AttractorState state = network.retrieveAttractor(query, patterns, 5.0f);
+        assertThat(state.type()).isEqualTo(AttractorType.DIFFUSE);
+        assertThat(state.patternCount()).isZero();
+        assertThat(state.attractorVector()).containsExactly(query);
+    }
+
+    @Test
+    void retrieveAttractor_singlePattern_convergesToFixedPoint() {
+        float[] query = {0.8f, 0.2f};
+        float[][] patterns = {
+                {1.0f, 0.0f}
+        };
+
+        AttractorState state = network.retrieveAttractor(query, patterns, 5.0f);
+        assertThat(state.type()).isEqualTo(AttractorType.FIXED_POINT);
+        assertThat(state.attentionWeights()[0]).isEqualTo(1.0f);
+        assertThat(state.attractorVector()[0]).isCloseTo(1.0f, within(1e-4f));
+        assertThat(state.attractorVector()[1]).isCloseTo(0.0f, within(1e-4f));
+    }
+
+    @Test
+    void retrieveAttractor_highBeta_convergesToClosestFixedPoint() {
+        float[] query = {0.9f, 0.1f};
+        float[][] patterns = {
+                {1.0f, 0.0f}, // closer
+                {0.0f, 1.0f}  // orthogonal
+        };
+
+        // High beta (10.0) -> sharp retrieval
+        AttractorState state = network.retrieveAttractor(query, patterns, 10.0f);
+        assertThat(state.type()).isEqualTo(AttractorType.FIXED_POINT);
+        assertThat(state.attentionWeights()[0]).isGreaterThan(0.95f);
+        assertThat(state.attractorVector()[0]).isGreaterThan(0.95f);
+    }
+
+    @Test
+    void retrieveAttractor_lowBeta_settlesInMetastableBlend() {
+        float[] query = {0.6f, 0.6f};
+        float[][] patterns = {
+                {1.0f, 0.0f},
+                {0.0f, 1.0f}
+        };
+
+        // Low beta (0.5) -> blended associative superposition
+        AttractorState state = network.retrieveAttractor(query, patterns, 0.5f);
+        assertThat(state.type()).isIn(AttractorType.METASTABLE, AttractorType.DIFFUSE);
+        assertThat(state.attentionWeights()[0]).isCloseTo(state.attentionWeights()[1], within(0.2f));
+        assertThat(state.attractorVector()[0]).isGreaterThan(0.2f);
+        assertThat(state.attractorVector()[1]).isGreaterThan(0.2f);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/PersonalityTemperatureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/PersonalityTemperatureTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PersonalityTemperature}.
+ */
+class PersonalityTemperatureTest {
+
+    @Test
+    void deriveBeta_hyperfocus_sharpTemperature() {
+        float beta = PersonalityTemperature.deriveBeta(CognitiveProfile.HYPERFOCUS, 0.0f);
+        assertThat(beta).isEqualTo(12.0f);
+    }
+
+    @Test
+    void deriveBeta_divergent_broadTemperature() {
+        float beta = PersonalityTemperature.deriveBeta(CognitiveProfile.DIVERGENT, 0.0f);
+        assertThat(beta).isEqualTo(1.0f);
+    }
+
+    @Test
+    void deriveBeta_arousalModulation_highArousalIncreasesBeta() {
+        float betaCalm = PersonalityTemperature.deriveBeta(CognitiveProfile.BALANCED, -1.0f);
+        float betaNeutral = PersonalityTemperature.deriveBeta(CognitiveProfile.BALANCED, 0.0f);
+        float betaAroused = PersonalityTemperature.deriveBeta(CognitiveProfile.BALANCED, 1.0f);
+
+        assertThat(betaCalm).isLessThan(betaNeutral);
+        assertThat(betaNeutral).isLessThan(betaAroused);
+    }
+
+    @Test
+    void deriveBeta_withInteroceptiveState() {
+        InteroceptiveState state = new InteroceptiveState(0f, 0.8f, 0f, new float[0], 0L, 0);
+        float beta = PersonalityTemperature.deriveBeta(CognitiveProfile.BALANCED, state);
+        assertThat(beta).isGreaterThan(4.0f);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/HopfieldAssociativeRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/HopfieldAssociativeRelayTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.aisme.hopfield.ContinuousHopfieldNetwork;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link HopfieldAssociativeRelay}.
+ */
+class HopfieldAssociativeRelayTest {
+
+    @Test
+    void relayName_isHopfieldAssociative() {
+        HopfieldAssociativeRelay relay = new HopfieldAssociativeRelay(null, null, null, null);
+        assertThat(relay.relayName()).isEqualTo("hopfield-associative");
+    }
+
+    @Test
+    void unconfigured_isPassThrough() {
+        HopfieldAssociativeRelay relay = new HopfieldAssociativeRelay(null, null, null, null);
+        RecallSignal signal = RecallSignal.forTextQuery("test", RecallOptions.builder().build());
+
+        CognitiveResult item = createResult("m1", 0.6f);
+        signal.candidates().add(item);
+
+        boolean ok = relay.transmit(signal);
+        assertThat(ok).isTrue();
+        assertThat(signal.candidates().get(0).score()).isEqualTo(0.6f);
+    }
+
+    @Test
+    void configured_boostsDominantAttractorMemory() {
+        ContinuousHopfieldNetwork network = new ContinuousHopfieldNetwork();
+        Map<String, float[]> vectors = new HashMap<>();
+        vectors.put("m1", new float[]{1.0f, 0.0f});
+        vectors.put("m2", new float[]{0.0f, 1.0f});
+
+        HopfieldAssociativeRelay relay = new HopfieldAssociativeRelay(
+                network, vectors::get, CognitiveProfile.HYPERFOCUS, null, 0.5f);
+
+        float[] query = {0.95f, 0.05f};
+        RecallSignal signal = RecallSignal.forVectorQuery(query, RecallOptions.builder().build());
+        signal.setQueryVector(query);
+
+        CognitiveResult item1 = createResult("m1", 0.5f);
+        CognitiveResult item2 = createResult("m2", 0.5f);
+        signal.candidates().add(item1);
+        signal.candidates().add(item2);
+
+        boolean ok = relay.transmit(signal);
+        assertThat(ok).isTrue();
+
+        float score1 = signal.candidates().get(0).score();
+        float score2 = signal.candidates().get(1).score();
+
+        // m1 is closer to query, so in Hopfield network it receives dominant attention weight -> higher boost
+        assertThat(score1).isGreaterThan(score2);
+        assertThat(score1).isGreaterThan(0.5f);
+    }
+
+    private static CognitiveResult createResult(String id, float score) {
+        return new CognitiveResult(
+                id,
+                "memory " + id,
+                score,
+                1.0f,
+                0.1f,
+                0,
+                (byte) 0,
+                MemoryType.EPISODIC,
+                MemorySource.USER_STATED,
+                new String[0],
+                1.0f,
+                1.0f,
+                CognitiveResult.RetrievalMode.STANDARD,
+                null,
+                null,
+                null,
+                Map.of()
+        );
+    }
+}

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/HopfieldKernel.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/HopfieldKernel.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.simd.SimdCapability;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import java.util.Arrays;
+
+/**
+ * SIMD-accelerated kernel for Modern Continuous Hopfield Networks (Ramsauer et al., 2021).
+ *
+ * <h3>Biological Analog: CA3 Associative Memory Attractor Dynamics</h3>
+ * <p>Implements continuous energy-based memory retrieval. Projects state representations
+ * onto memory pattern manifolds and performs exponential attractor convergence through
+ * SIMD-vectorized attention operations.</p>
+ */
+public final class HopfieldKernel {
+
+    private static final VectorSpecies<Float> SPECIES = SimdCapability.PREFERRED_SPECIES;
+
+    private HopfieldKernel() {
+        // utility class
+    }
+
+    /**
+     * Computes dot products between a query state vector and an array of pattern vectors.
+     *
+     * @param state query state vector xi in R^D
+     * @param patterns array of N pattern vectors X_i in R^D
+     * @param outDotProducts destination array of length N for dot products
+     */
+    public static void computePatternProjections(float[] state, float[][] patterns, float[] outDotProducts) {
+        validateInputs(state, patterns, outDotProducts);
+        int numPatterns = patterns.length;
+        for (int i = 0; i < numPatterns; i++) {
+            outDotProducts[i] = DotProduct.compute(state, patterns[i]);
+        }
+    }
+
+    /**
+     * Computes a numerically stable scaled softmax over logits:
+     * w_i = exp(beta * l_i - max_j(beta * l_j)) / sum_k exp(beta * l_k - max_j(beta * l_j))
+     *
+     * @param logits input logit array
+     * @param beta inverse temperature scaling factor
+     * @param outWeights destination array for normalized probability weights
+     */
+    public static void softmax(float[] logits, float beta, float[] outWeights) {
+        if (logits == null || outWeights == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arrays must not be null");
+        }
+        int n = logits.length;
+        if (outWeights.length != n) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Output weights array length must match logits length");
+        }
+        if (n == 0) {
+            return;
+        }
+
+        // Find max for numerical stability
+        float maxScaled = logits[0] * beta;
+        for (int i = 1; i < n; i++) {
+            float scaled = logits[i] * beta;
+            if (scaled > maxScaled) {
+                maxScaled = scaled;
+            }
+        }
+
+        float sumExp = 0.0f;
+        for (int i = 0; i < n; i++) {
+            float expVal = (float) Math.exp(logits[i] * beta - maxScaled);
+            outWeights[i] = expVal;
+            sumExp += expVal;
+        }
+
+        if (sumExp > 0.0f) {
+            float invSum = 1.0f / sumExp;
+            for (int i = 0; i < n; i++) {
+                outWeights[i] *= invSum;
+            }
+        } else {
+            float uniform = 1.0f / n;
+            Arrays.fill(outWeights, uniform);
+        }
+    }
+
+    /**
+     * Computes the matrix-vector linear combination of patterns:
+     * xi_new = sum_{i=1}^N (w_i * X_i)
+     *
+     * @param patterns array of N pattern vectors X_i in R^D
+     * @param weights normalized attention weights w in R^N
+     * @param outState destination vector in R^D
+     */
+    public static void matrixVectorProduct(float[][] patterns, float[] weights, float[] outState) {
+        if (patterns == null || weights == null || outState == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        int numPatterns = patterns.length;
+        if (weights.length != numPatterns) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Weights length must match number of patterns");
+        }
+        if (numPatterns == 0) {
+            return;
+        }
+        int dim = outState.length;
+        Arrays.fill(outState, 0.0f);
+
+        int laneCount = SPECIES.length();
+        int limit = SPECIES.loopBound(dim);
+
+        for (int p = 0; p < numPatterns; p++) {
+            float w = weights[p];
+            if (w == 0.0f) {
+                continue;
+            }
+            float[] pattern = patterns[p];
+            if (pattern.length != dim) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Pattern dimension mismatch at index " + p);
+            }
+
+            FloatVector vW = FloatVector.broadcast(SPECIES, w);
+
+            int d = 0;
+            for (; d < limit; d += laneCount) {
+                FloatVector vAcc = FloatVector.fromArray(SPECIES, outState, d);
+                FloatVector vPat = FloatVector.fromArray(SPECIES, pattern, d);
+                vAcc = vAcc.add(vPat.mul(vW));
+                vAcc.intoArray(outState, d);
+            }
+
+            if (d < dim) {
+                VectorMask<Float> mask = SPECIES.indexInRange(d, dim);
+                FloatVector vAcc = FloatVector.fromArray(SPECIES, outState, d, mask);
+                FloatVector vPat = FloatVector.fromArray(SPECIES, pattern, d, mask);
+                vAcc = vAcc.add(vPat.mul(vW, mask), mask);
+                vAcc.intoArray(outState, d, mask);
+            }
+        }
+    }
+
+    /**
+     * Executes a single continuous Modern Hopfield update step:
+     * xi_new = X * softmax(beta * X^T * xi)
+     *
+     * @param state current state vector xi in R^D
+     * @param patterns array of N pattern vectors in R^D
+     * @param beta inverse temperature scaling
+     * @param outState destination vector for updated state xi_new
+     * @param outWeights destination array for intermediate attention weights
+     */
+    public static void update(float[] state, float[][] patterns, float beta, float[] outState, float[] outWeights) {
+        float[] dotProducts = new float[patterns.length];
+        computePatternProjections(state, patterns, dotProducts);
+        softmax(dotProducts, beta, outWeights);
+        matrixVectorProduct(patterns, outWeights, outState);
+    }
+
+    /**
+     * Computes the continuous Modern Hopfield energy:
+     * E(xi, X) = -1/beta * log( sum_{i=1}^N exp(beta * X_i^T * xi) ) + 0.5 * ||xi||^2
+     *
+     * @param state current state vector xi in R^D
+     * @param patterns array of N pattern vectors in R^D
+     * @param beta inverse temperature scaling parameter
+     * @return scalar energy value
+     */
+    public static float continuousEnergy(float[] state, float[][] patterns, float beta) {
+        if (state == null || patterns == null || patterns.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "State and patterns must not be null or empty");
+        }
+        int n = patterns.length;
+        float[] dots = new float[n];
+        computePatternProjections(state, patterns, dots);
+
+        // Numerically stable Log-Sum-Exp: lse(z) = max(z) + ln(sum(exp(z - max(z))))
+        float maxScaled = dots[0] * beta;
+        for (int i = 1; i < n; i++) {
+            float scaled = dots[i] * beta;
+            if (scaled > maxScaled) {
+                maxScaled = scaled;
+            }
+        }
+
+        float sumExp = 0.0f;
+        for (int i = 0; i < n; i++) {
+            sumExp += (float) Math.exp(dots[i] * beta - maxScaled);
+        }
+
+        float lse = maxScaled + (float) Math.log(sumExp);
+        float normSq = DotProduct.compute(state, state);
+
+        return (-1.0f / beta) * lse + 0.5f * normSq;
+    }
+
+    private static void validateInputs(float[] state, float[][] patterns, float[] outDots) {
+        if (state == null || patterns == null || outDots == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        if (patterns.length != outDots.length) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Output dot products array must match pattern count");
+        }
+        int dim = state.length;
+        if (dim == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "State dimension must be greater than zero");
+        }
+        for (int i = 0; i < patterns.length; i++) {
+            if (patterns[i] == null || patterns[i].length != dim) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Pattern dimension mismatch at index " + i);
+            }
+        }
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/HopfieldKernelTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/HopfieldKernelTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the SIMD-accelerated {@link HopfieldKernel}.
+ */
+class HopfieldKernelTest {
+
+    @Test
+    void computePatternProjections_calculatesAccurateDotProducts() {
+        float[] state = {1.0f, 2.0f, 3.0f};
+        float[][] patterns = {
+                {1.0f, 0.0f, 0.0f},
+                {0.0f, 1.0f, 0.0f},
+                {1.0f, 1.0f, 1.0f}
+        };
+        float[] dots = new float[3];
+
+        HopfieldKernel.computePatternProjections(state, patterns, dots);
+
+        assertThat(dots[0]).isCloseTo(1.0f, within(1e-5f));
+        assertThat(dots[1]).isCloseTo(2.0f, within(1e-5f));
+        assertThat(dots[2]).isCloseTo(6.0f, within(1e-5f));
+    }
+
+    @Test
+    void softmax_sumsToOneAndRespectsBetaTemperature() {
+        float[] logits = {1.0f, 2.0f, 3.0f};
+        float[] sharpWeights = new float[3];
+        float[] flatWeights = new float[3];
+
+        HopfieldKernel.softmax(logits, 10.0f, sharpWeights);
+        HopfieldKernel.softmax(logits, 0.1f, flatWeights);
+
+        float sumSharp = sharpWeights[0] + sharpWeights[1] + sharpWeights[2];
+        float sumFlat = flatWeights[0] + flatWeights[1] + flatWeights[2];
+
+        assertThat(sumSharp).isCloseTo(1.0f, within(1e-5f));
+        assertThat(sumFlat).isCloseTo(1.0f, within(1e-5f));
+
+        // High beta sharpens distribution towards highest logit (index 2)
+        assertThat(sharpWeights[2]).isGreaterThan(0.99f);
+
+        // Low beta yields near-uniform distribution
+        assertThat(flatWeights[0]).isCloseTo(0.333f, within(0.05f));
+        assertThat(flatWeights[1]).isCloseTo(0.333f, within(0.05f));
+        assertThat(flatWeights[2]).isCloseTo(0.333f, within(0.05f));
+    }
+
+    @Test
+    void softmax_handlesExtremeValuesWithoutOverflow() {
+        float[] extremeLogits = {1000.0f, 1005.0f, 1010.0f};
+        float[] weights = new float[3];
+
+        HopfieldKernel.softmax(extremeLogits, 1.0f, weights);
+
+        assertThat(weights[2]).isGreaterThan(weights[1]);
+        assertThat(weights[1]).isGreaterThan(weights[0]);
+        assertThat(weights[0] + weights[1] + weights[2]).isCloseTo(1.0f, within(1e-5f));
+    }
+
+    @Test
+    void matrixVectorProduct_computesLinearCombinationAccurately() {
+        float[][] patterns = {
+                {1.0f, 0.0f, 0.0f, 4.0f},
+                {0.0f, 2.0f, 0.0f, 2.0f}
+        };
+        float[] weights = {0.75f, 0.25f};
+        float[] outState = new float[4];
+
+        HopfieldKernel.matrixVectorProduct(patterns, weights, outState);
+
+        assertThat(outState[0]).isCloseTo(0.75f, within(1e-5f));
+        assertThat(outState[1]).isCloseTo(0.50f, within(1e-5f));
+        assertThat(outState[2]).isCloseTo(0.00f, within(1e-5f));
+        assertThat(outState[3]).isCloseTo(3.50f, within(1e-5f)); // 0.75*4 + 0.25*2 = 3.5
+    }
+
+    @Test
+    void update_performsFullHopfieldStep() {
+        float[] state = {0.9f, 0.1f};
+        float[][] patterns = {
+                {1.0f, 0.0f},
+                {0.0f, 1.0f}
+        };
+        float[] outState = new float[2];
+        float[] outWeights = new float[2];
+
+        HopfieldKernel.update(state, patterns, 5.0f, outState, outWeights);
+
+        assertThat(outWeights[0]).isGreaterThan(outWeights[1]);
+        assertThat(outState[0]).isGreaterThan(0.9f);
+    }
+
+    @Test
+    void continuousEnergy_computesFiniteEnergy() {
+        float[] state = {1.0f, 1.0f};
+        float[][] patterns = {
+                {1.0f, 0.0f},
+                {0.0f, 1.0f}
+        };
+
+        float energy = HopfieldKernel.continuousEnergy(state, patterns, 2.0f);
+        assertThat(Float.isFinite(energy)).isTrue();
+    }
+
+    @Test
+    void simdTail_handlesNonAlignedDimensionCorrectly() {
+        int dim = 19;
+        float[] state = new float[dim];
+        float[][] patterns = new float[3][dim];
+        for (int d = 0; d < dim; d++) {
+            state[d] = 1.0f;
+            patterns[0][d] = 0.5f;
+            patterns[1][d] = 1.5f;
+            patterns[2][d] = 0.2f;
+        }
+
+        float[] weights = new float[3];
+        float[] outState = new float[dim];
+
+        HopfieldKernel.update(state, patterns, 1.0f, outState, weights);
+
+        assertThat(weights[1]).isGreaterThan(weights[0]);
+        assertThat(outState[dim - 1]).isGreaterThan(0.0f);
+    }
+
+    @Test
+    void validation_throwsOnDimensionMismatch() {
+        float[] state = {1.0f, 2.0f};
+        float[][] patterns = {
+                {1.0f, 2.0f, 3.0f}
+        };
+        float[] dots = new float[1];
+
+        assertThatThrownBy(() -> HopfieldKernel.computePatternProjections(state, patterns, dots))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **Modern Hopfield Associative Memory Network (MHAMN)** — Phase 3 of the Active Inference Self-Model Engine (AISME).

MHAMN introduces continuous energy-based attractor dynamics (Ramsauer et al., 2021) into the memory retrieval process. Instead of retrieving isolated nearest neighbors, MHAMN discovers coherent **attractor states** (gestalts) that blend complementary memories under personality-specific retrieval temperatures ($\beta$).

Closes #589

## Changes

### Layer 1: SIMD Kernel (`spector-core`)
- **`HopfieldKernel.java`** — Vectorized pattern projections, numerically stable scaled softmax, matrix-vector product, and continuous energy computation $E(\boldsymbol{\xi}, \mathbf{X})$ using Java Vector API (AVX2/512 with masked loop tails)

### Layer 2: Data Models (`spector-memory`)
- **`AttractorType.java`** — Enum classifying attractor basins into `FIXED_POINT` (vivid recollection), `METASTABLE` (intuitive superposition), and `DIFFUSE` (contextual priming)
- **`AttractorState.java`** — Immutable record capturing converged state vector, attention weights, energy, and attractor type
- **`PersonalityTemperature.java`** — Maps `CognitiveProfile` (e.g. sharp $\beta=12.0$ for `HYPERFOCUS`, broad $\beta=1.0$ for `DIVERGENT`) and `InteroceptiveState.arousal()` to adaptive inverse temperature $\beta_{\text{person}}$

### Layer 3: Hopfield Engine (`spector-memory`)
- **`ContinuousHopfieldNetwork.java`** — Dynamical systems engine that iteratively updates memory state representations $\boldsymbol{\xi}^{(k+1)} = \mathbf{X} \cdot \text{softmax}(\beta \mathbf{X}^T \boldsymbol{\xi}^{(k)})$ until $\epsilon$-convergence

### Layer 4: Pathway Integration (`spector-memory`)
- **`HopfieldAssociativeRelay.java`** — `SynapticRelay<RecallSignal>` integrating MHAMN into the `RecallPathway` relay chain, boosting candidate retrieval scores by their settled attractor attention weights

## Testing

| Test Class | Tests | Status |
|:---|:---|:---|
| `HopfieldKernelTest` | 8 | ✅ |
| `FreeEnergyKernelTest` | 7 | ✅ |
| `AffectiveDistanceTest` | 8 | ✅ |
| `AttractorTypeTest` | 4 | ✅ |
| `AttractorStateTest` | 2 | ✅ |
| `PersonalityTemperatureTest` | 4 | ✅ |
| `ContinuousHopfieldNetworkTest` | 4 | ✅ |
| `HopfieldAssociativeRelayTest` | 3 | ✅ |
| `MentalStatePosteriorTest` | 4 | ✅ |
| `GenerativeSelfModelTest` | 4 | ✅ |
| `FreeEnergyCalculatorTest` | 3 | ✅ |
| `MentalStateTrackerTest` | 4 | ✅ |
| `FreeEnergyGuidedRelayTest` | 3 | ✅ |
| `EmotionalRegulatorTest` | 8 | ✅ |
| `InteroceptiveStateTest` | 8 | ✅ |
| `HomeostaticCoreTest` | 9 | ✅ |
| **Total AISME Test Suite** | **83** | **All Pass (100%)** |

## Architecture

$$E(\boldsymbol{\xi}, \mathbf{X}) = -\frac{1}{\beta}\ln\left(\sum_{i=1}^N \exp(\beta \mathbf{x}_i^T \boldsymbol{\xi})\right) + \frac{1}{2}\|\boldsymbol{\xi}\|^2$$

$$\boldsymbol{\xi}^{(k+1)} = \mathbf{X} \cdot \text{softmax}(\beta \mathbf{X}^T \boldsymbol{\xi}^{(k)})$$

```
Query Vector → ... → FreeEnergyGuidedRelay → HopfieldAssociativeRelay → AssociativeGraphRelay → ...
                                                     │
                                                     ▼
                                         ContinuousHopfieldNetwork
                                         (Attractor Relaxation)
                                                     │
                                                     ▼
                                              HopfieldKernel
                                         (SIMD Softmax & Matrix Ops)
```

## Backward Compatibility
100% backward compatible. If unconfigured or candidate patterns are empty, `HopfieldAssociativeRelay` operates as a transparent pass-through.

## Commits (dependency-ordered)
1. `feat(core): add SIMD-accelerated HopfieldKernel`
2. `feat(memory): add AttractorState, AttractorType, and PersonalityTemperature`
3. `feat(memory): add ContinuousHopfieldNetwork dynamical engine`
4. `feat(memory): add HopfieldAssociativeRelay for RecallPathway`