### PR TITLE
feat(memory): Active Inference Self-Model Engine — Phase 4: Neural Manifold Distance (#591)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/manifold/CognitiveManifold.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/manifold/CognitiveManifold.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.manifold;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.similarity.NeuralManifoldDistance;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Thread-safe manager for the personal Riemannian cognitive manifold.
+ *
+ * <h3>Biological Analog: Experiential Manifold Curvature & Geodesic Calculation</h3>
+ * <p>Maintains the active metric tensor representation, evaluating subjective distances and
+ * similarities across memory vectors along experiential geodesic paths.</p>
+ */
+public final class CognitiveManifold {
+
+    private static final Logger log = LoggerFactory.getLogger(CognitiveManifold.class);
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final int dimensions;
+    private PersonalMetricTensor currentTensor;
+
+    /**
+     * Constructs a CognitiveManifold initialized with an identity metric tensor.
+     *
+     * @param dimensions embedding space dimensionality
+     */
+    public CognitiveManifold(int dimensions) {
+        if (dimensions <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimension must be positive");
+        }
+        this.dimensions = dimensions;
+        this.currentTensor = PersonalMetricTensor.identity(dimensions);
+    }
+
+    /**
+     * Constructs a CognitiveManifold with an initial explicit metric tensor.
+     *
+     * @param initialTensor the initial personal metric tensor
+     */
+    public CognitiveManifold(PersonalMetricTensor initialTensor) {
+        if (initialTensor == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Initial metric tensor must not be null");
+        }
+        this.dimensions = initialTensor.dimensions();
+        this.currentTensor = initialTensor;
+    }
+
+    /**
+     * Computes the squared Riemannian distance between two vectors on this manifold.
+     *
+     * @param x first vector
+     * @param y second vector
+     * @return squared Riemannian distance
+     */
+    public float squaredDistance(float[] x, float[] y) {
+        PersonalMetricTensor tensor = currentTensor();
+        return NeuralManifoldDistance.squaredDistance(x, y, tensor.diagonalScaling(), tensor.lowRankComponents());
+    }
+
+    /**
+     * Computes the Riemannian distance between two vectors on this manifold.
+     *
+     * @param x first vector
+     * @param y second vector
+     * @return Riemannian distance
+     */
+    public float distance(float[] x, float[] y) {
+        PersonalMetricTensor tensor = currentTensor();
+        return NeuralManifoldDistance.distance(x, y, tensor.diagonalScaling(), tensor.lowRankComponents());
+    }
+
+    /**
+     * Computes Gaussian manifold similarity between two vectors on this manifold.
+     *
+     * @param x first vector
+     * @param y second vector
+     * @param sigma kernel bandwidth
+     * @return similarity score in (0, 1]
+     */
+    public float similarity(float[] x, float[] y, float sigma) {
+        PersonalMetricTensor tensor = currentTensor();
+        return NeuralManifoldDistance.similarity(x, y, tensor.diagonalScaling(), tensor.lowRankComponents(), sigma);
+    }
+
+    /**
+     * Batch computes manifold similarity for a query vector against multiple candidate vectors.
+     *
+     * @param query query vector in R^D
+     * @param candidates array of candidate vectors
+     * @param sigma kernel bandwidth
+     * @return array of similarity scores
+     */
+    public float[] batchSimilarity(float[] query, float[][] candidates, float sigma) {
+        PersonalMetricTensor tensor = currentTensor();
+        return NeuralManifoldDistance.batchSimilarity(query, candidates, tensor.diagonalScaling(), tensor.lowRankComponents(), sigma);
+    }
+
+    /**
+     * @return an immutable snapshot of the active PersonalMetricTensor
+     */
+    public PersonalMetricTensor currentTensor() {
+        lock.lock();
+        try {
+            return currentTensor;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Updates the active metric tensor with a newly consolidated version.
+     *
+     * @param newTensor the new metric tensor (must have matching dimensions)
+     */
+    public void updateTensor(PersonalMetricTensor newTensor) {
+        if (newTensor == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Metric tensor must not be null");
+        }
+        if (newTensor.dimensions() != dimensions) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Metric tensor dimension mismatch");
+        }
+
+        lock.lock();
+        try {
+            PersonalMetricTensor old = currentTensor;
+            currentTensor = newTensor;
+            if (log.isTraceEnabled()) {
+                log.trace("Updated metric tensor from version {} to {}", old.version(), newTensor.version());
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Resets the manifold back to a Euclidean identity metric.
+     */
+    public void reset() {
+        lock.lock();
+        try {
+            currentTensor = PersonalMetricTensor.identity(dimensions);
+            log.debug("Reset cognitive manifold to Euclidean identity");
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public int dimensions() {
+        return dimensions;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/manifold/ManifoldConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/manifold/ManifoldConsolidator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.manifold;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Derives and updates the personal Riemannian metric tensor from Hebbian co-activations,
+ * temporal memory chains, and reflection cycles.
+ *
+ * <h3>Biological Analog: Sleep Consolidation of Cognitive Map Topography</h3>
+ * <p>During sleep replay and reflection cycles, associative links between memories warp the
+ * underlying cognitive geometry, adjusting coordinate precision and low-rank cross-coupling.</p>
+ */
+public final class ManifoldConsolidator {
+
+    private static final Logger log = LoggerFactory.getLogger(ManifoldConsolidator.class);
+
+    private final float defaultLearningRate;
+    private final int maxLowRankComponents;
+
+    /**
+     * Constructs a ManifoldConsolidator with default parameters (learningRate=0.05, maxRank=4).
+     */
+    public ManifoldConsolidator() {
+        this(0.05f, 4);
+    }
+
+    /**
+     * Constructs a ManifoldConsolidator with custom parameters.
+     *
+     * @param defaultLearningRate learning rate for metric tensor adaptation in (0, 1]
+     * @param maxLowRankComponents maximum number of low-rank factors to maintain
+     */
+    public ManifoldConsolidator(float defaultLearningRate, int maxLowRankComponents) {
+        if (defaultLearningRate <= 0.0f || defaultLearningRate > 1.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Learning rate must be in (0, 1]");
+        }
+        if (maxLowRankComponents < 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "maxLowRankComponents cannot be negative");
+        }
+        this.defaultLearningRate = defaultLearningRate;
+        this.maxLowRankComponents = maxLowRankComponents;
+    }
+
+    /**
+     * Consolidates co-activated memory pairs into an updated PersonalMetricTensor.
+     *
+     * @param current current metric tensor
+     * @param coActivatedPairs list of paired memory difference vectors (a - b)
+     * @param learningRate adaptation step size
+     * @return updated PersonalMetricTensor
+     */
+    public PersonalMetricTensor consolidate(PersonalMetricTensor current, List<float[]> coActivatedPairs, float learningRate) {
+        if (current == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Current metric tensor must not be null");
+        }
+        if (coActivatedPairs == null || coActivatedPairs.isEmpty()) {
+            return current;
+        }
+
+        int dim = current.dimensions();
+        float[] newDiag = Arrays.copyOf(current.diagonalScaling(), dim);
+        float lr = (learningRate > 0.0f) ? learningRate : defaultLearningRate;
+
+        for (float[] diff : coActivatedPairs) {
+            if (diff == null || diff.length != dim) {
+                continue;
+            }
+            for (int k = 0; k < dim; k++) {
+                float dVal = diff[k];
+                // Exponential moving adjustment of coordinate scaling
+                newDiag[k] = Math.max(0.1f, newDiag[k] + (lr * dVal * dVal));
+            }
+        }
+
+        float[][] newRank = current.lowRankComponents();
+        if (maxLowRankComponents > 0 && !coActivatedPairs.isEmpty()) {
+            // Incorporate leading co-activation direction as low-rank perturbation
+            float[] sampleDiff = coActivatedPairs.get(0);
+            if (sampleDiff.length == dim) {
+                float[] normSample = new float[dim];
+                float normSq = 0.0f;
+                for (float v : sampleDiff) {
+                    normSq += v * v;
+                }
+                float invNorm = (normSq > 0.0f) ? (float) (Math.sqrt(lr) / Math.sqrt(normSq)) : 0.0f;
+                for (int k = 0; k < dim; k++) {
+                    normSample[k] = sampleDiff[k] * invNorm;
+                }
+
+                if (newRank.length < maxLowRankComponents) {
+                    float[][] extended = Arrays.copyOf(newRank, newRank.length + 1);
+                    extended[extended.length - 1] = normSample;
+                    newRank = extended;
+                } else if (newRank.length > 0) {
+                    // Update existing component
+                    for (int k = 0; k < dim; k++) {
+                        newRank[0][k] = (1.0f - lr) * newRank[0][k] + lr * normSample[k];
+                    }
+                }
+            }
+        }
+
+        int nextVersion = current.version() + 1;
+        if (log.isTraceEnabled()) {
+            log.trace("Consolidated metric tensor to version {} with {} co-activation pairs",
+                    nextVersion, coActivatedPairs.size());
+        }
+
+        return new PersonalMetricTensor(newDiag, newRank, nextVersion, System.currentTimeMillis());
+    }
+
+    public float defaultLearningRate() {
+        return defaultLearningRate;
+    }
+
+    public int maxLowRankComponents() {
+        return maxLowRankComponents;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/manifold/PersonalMetricTensor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/manifold/PersonalMetricTensor.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.manifold;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import java.util.Arrays;
+
+/**
+ * Immutable representation of the personal Riemannian metric tensor M_person = diag(d) + U U^T.
+ *
+ * <h3>Biological Analog: Experiential Metric Warping</h3>
+ * <p>Encodes the idiosyncratic topological curvature of an individual mind's cognitive space,
+ * warping geometric distances according to personal semantic couplings and associative histories.</p>
+ */
+public record PersonalMetricTensor(
+        float[] diagonalScaling,
+        float[][] lowRankComponents,
+        int version,
+        long timestampMs
+) {
+
+    /**
+     * Compact constructor enforcing defensive copies and validation.
+     */
+    public PersonalMetricTensor {
+        if (diagonalScaling == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Diagonal scaling must not be null");
+        }
+        if (diagonalScaling.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimension must be positive");
+        }
+        if (version < 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Version cannot be negative");
+        }
+
+        diagonalScaling = Arrays.copyOf(diagonalScaling, diagonalScaling.length);
+        for (int i = 0; i < diagonalScaling.length; i++) {
+            if (Float.isNaN(diagonalScaling[i]) || diagonalScaling[i] <= 0.0f) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Diagonal scaling must be positive and non-NaN at index " + i);
+            }
+        }
+
+        if (lowRankComponents != null) {
+            float[][] copied = new float[lowRankComponents.length][];
+            for (int r = 0; r < lowRankComponents.length; r++) {
+                if (lowRankComponents[r] == null || lowRankComponents[r].length != diagonalScaling.length) {
+                    throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Low-rank component dimension mismatch at index " + r);
+                }
+                copied[r] = Arrays.copyOf(lowRankComponents[r], lowRankComponents[r].length);
+            }
+            lowRankComponents = copied;
+        } else {
+            lowRankComponents = new float[0][];
+        }
+    }
+
+    /**
+     * @return the dimensionality of the metric tensor
+     */
+    public int dimensions() {
+        return diagonalScaling.length;
+    }
+
+    /**
+     * @return the number of low-rank component factors
+     */
+    public int rank() {
+        return lowRankComponents.length;
+    }
+
+    /**
+     * Creates a default Euclidean identity metric tensor of the specified dimension.
+     *
+     * @param dimensions target dimension
+     * @return identity metric tensor (d = [1..1], U = empty)
+     */
+    public static PersonalMetricTensor identity(int dimensions) {
+        if (dimensions <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimension must be positive");
+        }
+        float[] diag = new float[dimensions];
+        Arrays.fill(diag, 1.0f);
+        return new PersonalMetricTensor(diag, new float[0][], 0, System.currentTimeMillis());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PersonalMetricTensor that)) return false;
+        return version == that.version &&
+                timestampMs == that.timestampMs &&
+                Arrays.equals(diagonalScaling, that.diagonalScaling) &&
+                Arrays.deepEquals(lowRankComponents, that.lowRankComponents);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(diagonalScaling);
+        result = 31 * result + Arrays.deepHashCode(lowRankComponents);
+        result = 31 * result + version;
+        result = 31 * result + Long.hashCode(timestampMs);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PersonalMetricTensor{" +
+                "dim=" + diagonalScaling.length +
+                ", rank=" + lowRankComponents.length +
+                ", version=" + version +
+                ", timestampMs=" + timestampMs +
+                '}';
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ManifoldRerankRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ManifoldRerankRelay.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.aisme.manifold.CognitiveManifold;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * RecallPathway relay that re-ranks candidate memories according to Riemannian distance
+ * on the personal cognitive manifold.
+ *
+ * <h3>Biological Analog: Experiential Manifold Distance Re-weighting</h3>
+ * <p>Warps Euclidean similarity scores by applying the personal metric tensor, rewarding memories
+ * that reside closer along experiential geodesic paths on the agent's subjective cognitive manifold.</p>
+ */
+public final class ManifoldRerankRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(ManifoldRerankRelay.class);
+
+    private final CognitiveManifold manifold;
+    private final Function<String, float[]> embeddingLookup;
+    private final float sigma;
+    private final float weight;
+
+    /**
+     * Constructs a ManifoldRerankRelay with default parameters (sigma=1.0, weight=0.35).
+     *
+     * @param manifold the cognitive manifold manager (nullable)
+     * @param embeddingLookup function to resolve candidate memory vectors by id (nullable)
+     */
+    public ManifoldRerankRelay(CognitiveManifold manifold, Function<String, float[]> embeddingLookup) {
+        this(manifold, embeddingLookup, 1.0f, 0.35f);
+    }
+
+    /**
+     * Constructs a ManifoldRerankRelay with explicit parameters.
+     *
+     * @param manifold cognitive manifold manager
+     * @param embeddingLookup embedding lookup function
+     * @param sigma kernel bandwidth for manifold similarity
+     * @param weight influence multiplier for manifold similarity
+     */
+    public ManifoldRerankRelay(CognitiveManifold manifold, Function<String, float[]> embeddingLookup, float sigma, float weight) {
+        this.manifold = manifold;
+        this.embeddingLookup = embeddingLookup;
+        this.sigma = sigma;
+        this.weight = weight;
+    }
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        if (manifold == null || embeddingLookup == null || signal == null) {
+            return true;
+        }
+
+        List<CognitiveResult> candidates = signal.candidates();
+        if (candidates == null || candidates.isEmpty()) {
+            return true;
+        }
+
+        float[] queryVector = signal.queryVector();
+        if (queryVector == null || queryVector.length != manifold.dimensions()) {
+            return true;
+        }
+
+        for (int i = 0; i < candidates.size(); i++) {
+            CognitiveResult r = candidates.get(i);
+            float[] candidateVec = embeddingLookup.apply(r.id());
+
+            if (candidateVec != null && candidateVec.length == manifold.dimensions()) {
+                float manifoldSim = manifold.similarity(queryVector, candidateVec, sigma);
+                float boost = 1.0f + (weight * manifoldSim);
+                float newScore = r.score() * boost;
+
+                candidates.set(i, new CognitiveResult(
+                        r.id(), r.text(), newScore, r.importance(),
+                        r.ageDays(), r.agentRecallCount(), r.valence(),
+                        r.memoryType(), r.source(), r.synapticTags(),
+                        r.decayFactor(), r.ltpAdjustedDecay(),
+                        r.retrievalMode(), r.breakdown(), r.trace(),
+                        r.sourceModality(), r.metadata()
+                ));
+            }
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("ManifoldRerankRelay re-ranked {} candidates with sigma={}, weight={}",
+                    candidates.size(), sigma, weight);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return "manifold-rerank";
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/manifold/CognitiveManifoldTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/manifold/CognitiveManifoldTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.manifold;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CognitiveManifold}.
+ */
+class CognitiveManifoldTest {
+
+    private CognitiveManifold manifold;
+
+    @BeforeEach
+    void setUp() {
+        manifold = new CognitiveManifold(2);
+    }
+
+    @Test
+    void initialTensor_isIdentity() {
+        PersonalMetricTensor tensor = manifold.currentTensor();
+        assertThat(tensor.dimensions()).isEqualTo(2);
+        assertThat(tensor.version()).isZero();
+        assertThat(tensor.diagonalScaling()).containsExactly(1.0f, 1.0f);
+    }
+
+    @Test
+    void distanceAndSimilarity_computedAccurately() {
+        float[] a = {1.0f, 0.0f};
+        float[] b = {1.0f, 3.0f};
+
+        float dist = manifold.distance(a, b);
+        float sim = manifold.similarity(a, b, 3.0f);
+
+        assertThat(dist).isCloseTo(3.0f, within(1e-5f));
+        // exp(-9 / (2*9)) = exp(-0.5) ≈ 0.6065
+        assertThat(sim).isCloseTo(0.6065f, within(1e-3f));
+    }
+
+    @Test
+    void updateTensor_modifiesDistanceMetric() {
+        float[] diag = {4.0f, 1.0f};
+        PersonalMetricTensor custom = new PersonalMetricTensor(diag, new float[0][], 1, 1000L);
+
+        manifold.updateTensor(custom);
+
+        float[] a = {0.0f, 0.0f};
+        float[] b = {1.0f, 0.0f};
+
+        // In X direction, scaling is 4.0 -> sqDist = 4*(1)^2 = 4 -> dist = 2.0
+        float dist = manifold.distance(a, b);
+        assertThat(dist).isCloseTo(2.0f, within(1e-5f));
+    }
+
+    @Test
+    void reset_reinitializesToIdentity() {
+        PersonalMetricTensor custom = new PersonalMetricTensor(new float[]{5.0f, 5.0f}, new float[0][], 2, 2000L);
+        manifold.updateTensor(custom);
+        manifold.reset();
+
+        assertThat(manifold.currentTensor().version()).isZero();
+        assertThat(manifold.currentTensor().diagonalScaling()).containsExactly(1.0f, 1.0f);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/manifold/ManifoldConsolidatorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/manifold/ManifoldConsolidatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.manifold;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link ManifoldConsolidator}.
+ */
+class ManifoldConsolidatorTest {
+
+    private ManifoldConsolidator consolidator;
+
+    @BeforeEach
+    void setUp() {
+        consolidator = new ManifoldConsolidator(0.1f, 2);
+    }
+
+    @Test
+    void consolidate_emptyPairs_returnsUnmodifiedTensor() {
+        PersonalMetricTensor initial = PersonalMetricTensor.identity(3);
+        PersonalMetricTensor consolidated = consolidator.consolidate(initial, List.of(), 0.1f);
+
+        assertThat(consolidated).isEqualTo(initial);
+    }
+
+    @Test
+    void consolidate_coActivatedPairs_updatesDiagonalAndRank() {
+        PersonalMetricTensor initial = PersonalMetricTensor.identity(2);
+        List<float[]> coActivations = List.of(
+                new float[]{2.0f, 0.0f},
+                new float[]{1.0f, 0.0f}
+        );
+
+        PersonalMetricTensor updated = consolidator.consolidate(initial, coActivations, 0.1f);
+
+        assertThat(updated.version()).isEqualTo(1);
+        // Coordinate 0 should have increased scaling due to co-activation variance
+        assertThat(updated.diagonalScaling()[0]).isGreaterThan(initial.diagonalScaling()[0]);
+        // Coordinate 1 should remain base (no variance along axis 1)
+        assertThat(updated.diagonalScaling()[1]).isEqualTo(initial.diagonalScaling()[1]);
+        // Low rank factor was added
+        assertThat(updated.rank()).isEqualTo(1);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/manifold/PersonalMetricTensorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/manifold/PersonalMetricTensorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.manifold;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PersonalMetricTensor}.
+ */
+class PersonalMetricTensorTest {
+
+    @Test
+    void identity_createsDefaultUnitTensor() {
+        PersonalMetricTensor identity = PersonalMetricTensor.identity(4);
+        assertThat(identity.dimensions()).isEqualTo(4);
+        assertThat(identity.rank()).isZero();
+        assertThat(identity.version()).isZero();
+        assertThat(identity.diagonalScaling()).containsExactly(1.0f, 1.0f, 1.0f, 1.0f);
+    }
+
+    @Test
+    void validConstruction_defensiveCopy() {
+        float[] diag = {2.0f, 3.0f};
+        float[][] rank = {
+                {0.5f, 0.5f}
+        };
+
+        PersonalMetricTensor tensor = new PersonalMetricTensor(diag, rank, 1, 1000L);
+
+        assertThat(tensor.dimensions()).isEqualTo(2);
+        assertThat(tensor.rank()).isEqualTo(1);
+        assertThat(tensor.version()).isEqualTo(1);
+        assertThat(tensor.timestampMs()).isEqualTo(1000L);
+
+        diag[0] = 999.0f;
+        rank[0][0] = 999.0f;
+        assertThat(tensor.diagonalScaling()[0]).isEqualTo(2.0f);
+        assertThat(tensor.lowRankComponents()[0][0]).isEqualTo(0.5f);
+    }
+
+    @Test
+    void invalidArguments_throwValidationException() {
+        float[] negDiag = {-1.0f};
+        float[] nanDiag = {Float.NaN};
+
+        assertThatThrownBy(() -> new PersonalMetricTensor(null, new float[0][], 0, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new PersonalMetricTensor(new float[0], new float[0][], 0, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new PersonalMetricTensor(negDiag, new float[0][], 0, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+        assertThatThrownBy(() -> new PersonalMetricTensor(nanDiag, new float[0][], 0, 0L))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ManifoldRerankRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ManifoldRerankRelayTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.aisme.manifold.CognitiveManifold;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ManifoldRerankRelay}.
+ */
+class ManifoldRerankRelayTest {
+
+    @Test
+    void relayName_isManifoldRerank() {
+        ManifoldRerankRelay relay = new ManifoldRerankRelay(null, null);
+        assertThat(relay.relayName()).isEqualTo("manifold-rerank");
+    }
+
+    @Test
+    void unconfigured_isPassThrough() {
+        ManifoldRerankRelay relay = new ManifoldRerankRelay(null, null);
+        RecallSignal signal = RecallSignal.forTextQuery("test", RecallOptions.builder().build());
+
+        CognitiveResult item = createResult("m1", 0.5f);
+        signal.candidates().add(item);
+
+        boolean ok = relay.transmit(signal);
+        assertThat(ok).isTrue();
+        assertThat(signal.candidates().get(0).score()).isEqualTo(0.5f);
+    }
+
+    @Test
+    void configured_modulatesScoresWithManifoldSimilarity() {
+        CognitiveManifold manifold = new CognitiveManifold(2);
+        Map<String, float[]> vectors = new HashMap<>();
+        vectors.put("m1", new float[]{1.0f, 0.0f}); // exact match to query
+        vectors.put("m2", new float[]{10.0f, 10.0f}); // distant from query
+
+        ManifoldRerankRelay relay = new ManifoldRerankRelay(manifold, vectors::get, 2.0f, 0.5f);
+
+        float[] query = {1.0f, 0.0f};
+        RecallSignal signal = RecallSignal.forVectorQuery(query, RecallOptions.builder().build());
+        signal.setQueryVector(query);
+
+        CognitiveResult item1 = createResult("m1", 0.5f);
+        CognitiveResult item2 = createResult("m2", 0.5f);
+        signal.candidates().add(item1);
+        signal.candidates().add(item2);
+
+        boolean ok = relay.transmit(signal);
+        assertThat(ok).isTrue();
+
+        float score1 = signal.candidates().get(0).score();
+        float score2 = signal.candidates().get(1).score();
+
+        assertThat(score1).isGreaterThan(score2);
+        assertThat(score1).isGreaterThan(0.5f);
+    }
+
+    private static CognitiveResult createResult(String id, float score) {
+        return new CognitiveResult(
+                id,
+                "memory " + id,
+                score,
+                1.0f,
+                0.1f,
+                0,
+                (byte) 0,
+                MemoryType.EPISODIC,
+                MemorySource.USER_STATED,
+                new String[0],
+                1.0f,
+                1.0f,
+                CognitiveResult.RetrievalMode.STANDARD,
+                null,
+                null,
+                null,
+                Map.of()
+        );
+    }
+}

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/NeuralManifoldDistance.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/NeuralManifoldDistance.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.simd.SimdCapability;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * SIMD-accelerated kernel for Neural Manifold Distance (NMD) on curved cognitive manifolds.
+ *
+ * <h3>Biological Analog: Subjective Cognitive Distance Warping</h3>
+ * <p>Computes Riemannian metric distance on personal cognitive spaces warped by subjective experience.
+ * Evaluates the Mahalanobis quadratic form {@code (x - y)^T M (x - y)} where {@code M = diag(d) + U U^T},
+ * capturing both coordinate scaling and non-orthogonal experiential associations.</p>
+ */
+public final class NeuralManifoldDistance {
+
+    private static final VectorSpecies<Float> SPECIES = SimdCapability.PREFERRED_SPECIES;
+
+    private NeuralManifoldDistance() {
+        // utility class
+    }
+
+    /**
+     * Computes the squared Riemannian distance on the personal cognitive manifold:
+     * d^2(x, y) = sum_k d_k * (x_k - y_k)^2 + sum_r (U_r^T * (x - y))^2
+     *
+     * @param x first embedding vector in R^D
+     * @param y second embedding vector in R^D
+     * @param diagonalScaling diagonal metric vector d in R^D (nullable, defaults to identity [1..1])
+     * @param lowRankComponents low-rank factor vectors U_r in R^D (nullable or empty)
+     * @return squared Riemannian distance >= 0.0f
+     */
+    public static float squaredDistance(float[] x, float[] y, float[] diagonalScaling, float[][] lowRankComponents) {
+        validateVectors(x, y);
+        int dim = x.length;
+
+        if (diagonalScaling != null && diagonalScaling.length != dim) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Diagonal scaling length must match vector dimension");
+        }
+
+        int laneCount = SPECIES.length();
+        int limit = SPECIES.loopBound(dim);
+        float[] diff = new float[dim];
+
+        FloatVector sumDiag = FloatVector.zero(SPECIES);
+
+        int i = 0;
+        for (; i < limit; i += laneCount) {
+            FloatVector vx = FloatVector.fromArray(SPECIES, x, i);
+            FloatVector vy = FloatVector.fromArray(SPECIES, y, i);
+            FloatVector vDiff = vx.sub(vy);
+            vDiff.intoArray(diff, i);
+
+            FloatVector vDiag = (diagonalScaling != null)
+                    ? FloatVector.fromArray(SPECIES, diagonalScaling, i)
+                    : FloatVector.broadcast(SPECIES, 1.0f);
+
+            sumDiag = sumDiag.add(vDiag.mul(vDiff).mul(vDiff));
+        }
+
+        if (i < dim) {
+            VectorMask<Float> mask = SPECIES.indexInRange(i, dim);
+            FloatVector vx = FloatVector.fromArray(SPECIES, x, i, mask);
+            FloatVector vy = FloatVector.fromArray(SPECIES, y, i, mask);
+            FloatVector vDiff = vx.sub(vy);
+            vDiff.intoArray(diff, i, mask);
+
+            FloatVector vDiag = (diagonalScaling != null)
+                    ? FloatVector.fromArray(SPECIES, diagonalScaling, i, mask)
+                    : FloatVector.broadcast(SPECIES, 1.0f);
+
+            FloatVector term = vDiag.mul(vDiff).mul(vDiff);
+            sumDiag = sumDiag.add(term, mask);
+        }
+
+        float totalSq = sumDiag.reduceLanes(VectorOperators.ADD);
+
+        // Low-rank projection: sum_r (U_r^T * diff)^2
+        if (lowRankComponents != null && lowRankComponents.length > 0) {
+            for (float[] uComp : lowRankComponents) {
+                if (uComp != null && uComp.length == dim) {
+                    float proj = DotProduct.compute(uComp, diff);
+                    totalSq += proj * proj;
+                }
+            }
+        }
+
+        return Math.max(0.0f, totalSq);
+    }
+
+    /**
+     * Computes the Riemannian distance on the personal cognitive manifold.
+     *
+     * @param x first vector
+     * @param y second vector
+     * @param diagonalScaling diagonal metric vector
+     * @param lowRankComponents low-rank factor vectors
+     * @return Riemannian distance d_NMD(x, y)
+     */
+    public static float distance(float[] x, float[] y, float[] diagonalScaling, float[][] lowRankComponents) {
+        return (float) Math.sqrt(squaredDistance(x, y, diagonalScaling, lowRankComponents));
+    }
+
+    /**
+     * Computes the Gaussian Riemannian manifold similarity:
+     * sim_NMD(x, y) = exp(-d^2_NMD(x, y) / (2 * sigma^2))
+     *
+     * @param x first vector
+     * @param y second vector
+     * @param diagonalScaling diagonal metric vector
+     * @param lowRankComponents low-rank factor vectors
+     * @param sigma kernel bandwidth parameter
+     * @return similarity score in (0, 1]
+     */
+    public static float similarity(float[] x, float[] y, float[] diagonalScaling, float[][] lowRankComponents, float sigma) {
+        if (sigma <= 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Sigma must be positive");
+        }
+        float sqDist = squaredDistance(x, y, diagonalScaling, lowRankComponents);
+        return (float) Math.exp(-sqDist / (2.0 * sigma * sigma));
+    }
+
+    /**
+     * Batch computes manifold similarity for a query vector against multiple candidate vectors.
+     *
+     * @param query query vector in R^D
+     * @param candidates candidate vectors array
+     * @param diagonalScaling diagonal metric vector
+     * @param lowRankComponents low-rank factor vectors
+     * @param sigma kernel bandwidth
+     * @return array of similarity scores
+     */
+    public static float[] batchSimilarity(float[] query, float[][] candidates, float[] diagonalScaling, float[][] lowRankComponents, float sigma) {
+        if (candidates == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Candidates array must not be null");
+        }
+        float[] results = new float[candidates.length];
+        for (int i = 0; i < candidates.length; i++) {
+            results[i] = similarity(query, candidates[i], diagonalScaling, lowRankComponents, sigma);
+        }
+        return results;
+    }
+
+    private static void validateVectors(float[] x, float[] y) {
+        if (x == null || y == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vectors must not be null");
+        }
+        if (x.length != y.length) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vector dimensions must match");
+        }
+        if (x.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vector dimension must be positive");
+        }
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/NeuralManifoldDistanceTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/NeuralManifoldDistanceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link NeuralManifoldDistance} SIMD kernel.
+ */
+class NeuralManifoldDistanceTest {
+
+    @Test
+    void identityMetric_matchesStandardEuclideanDistance() {
+        float[] x = {1.0f, 2.0f, 3.0f};
+        float[] y = {1.0f, 5.0f, 7.0f};
+
+        // delta = [0, -3, -4]
+        // Euclidean sqDist = 0^2 + (-3)^2 + (-4)^2 = 25
+        float sqDist = NeuralManifoldDistance.squaredDistance(x, y, null, null);
+        float dist = NeuralManifoldDistance.distance(x, y, null, null);
+
+        assertThat(sqDist).isCloseTo(25.0f, within(1e-5f));
+        assertThat(dist).isCloseTo(5.0f, within(1e-5f));
+    }
+
+    @Test
+    void diagonalScaling_warpsAxesCorrectly() {
+        float[] x = {1.0f, 2.0f};
+        float[] y = {3.0f, 4.0f};
+        // delta = [-2, -2]
+
+        float[] diag = {2.0f, 0.5f};
+        // sqDist = 2*(-2)^2 + 0.5*(-2)^2 = 2*4 + 0.5*4 = 8 + 2 = 10
+        float sqDist = NeuralManifoldDistance.squaredDistance(x, y, diag, null);
+
+        assertThat(sqDist).isCloseTo(10.0f, within(1e-5f));
+    }
+
+    @Test
+    void lowRankComponents_addsCovarianceDistance() {
+        float[] x = {1.0f, 1.0f};
+        float[] y = {0.0f, 0.0f};
+        // delta = [1, 1]
+
+        float[] diag = {1.0f, 1.0f}; // diag sqDist = 2
+        float[][] lowRank = {
+                {2.0f, 1.0f} // U_0^T * delta = 2*1 + 1*1 = 3 -> squared = 9
+        };
+
+        // Total sqDist = 2 + 9 = 11
+        float sqDist = NeuralManifoldDistance.squaredDistance(x, y, diag, lowRank);
+
+        assertThat(sqDist).isCloseTo(11.0f, within(1e-5f));
+    }
+
+    @Test
+    void similarity_gaussianKernelProperties() {
+        float[] x = {1.0f, 2.0f};
+        float[] identical = {1.0f, 2.0f};
+        float[] distant = {10.0f, 20.0f};
+
+        float simIdentical = NeuralManifoldDistance.similarity(x, identical, null, null, 1.0f);
+        float simDistant = NeuralManifoldDistance.similarity(x, distant, null, null, 1.0f);
+
+        assertThat(simIdentical).isCloseTo(1.0f, within(1e-5f));
+        assertThat(simDistant).isLessThan(0.001f);
+    }
+
+    @Test
+    void batchSimilarity_computesAllElements() {
+        float[] query = {1.0f, 0.0f};
+        float[][] candidates = {
+                {1.0f, 0.0f},
+                {0.0f, 1.0f}
+        };
+
+        float[] sims = NeuralManifoldDistance.batchSimilarity(query, candidates, null, null, 1.0f);
+
+        assertThat(sims).hasSize(2);
+        assertThat(sims[0]).isCloseTo(1.0f, within(1e-5f));
+        assertThat(sims[1]).isLessThan(sims[0]);
+    }
+
+    @Test
+    void simdTail_handlesNonAlignedDimensionCorrectly() {
+        int dim = 23;
+        float[] x = new float[dim];
+        float[] y = new float[dim];
+        float[] diag = new float[dim];
+
+        for (int i = 0; i < dim; i++) {
+            x[i] = i * 0.1f;
+            y[i] = i * 0.1f + 1.0f; // delta = -1.0 everywhere
+            diag[i] = 2.0f;
+        }
+
+        // sqDist = 23 * (2.0 * (-1)^2) = 46.0
+        float sqDist = NeuralManifoldDistance.squaredDistance(x, y, diag, null);
+
+        assertThat(sqDist).isCloseTo(46.0f, within(1e-4f));
+    }
+
+    @Test
+    void validation_throwsOnDimensionMismatch() {
+        float[] a = {1.0f, 2.0f};
+        float[] b = {1.0f};
+
+        assertThatThrownBy(() -> NeuralManifoldDistance.squaredDistance(a, b, null, null))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Neural Manifold Distance (NMD)** — Phase 4 of the Active Inference Self-Model Engine (AISME).

NMD replaces flat Euclidean and cosine distances with a learned **Riemannian metric on the personal cognitive manifold**:
$$d_{\text{NMD}}(x, y) = \sqrt{(x-y)^T M_{\text{person}}(x-y)}$$

The personal metric tensor $M_{\text{person}} = \text{diag}(\mathbf{d}) + \mathbf{U}\mathbf{U}^T$ dynamically curves retrieval space based on the persona Hebbian co-activation patterns, temporal sequence chains, and reflective consolidation.

Closes #591

## Changes

### Layer 1: SIMD Kernel (`spector-core`)
- **`NeuralManifoldDistance.java`** — Vectorized Mahalanobis quadratic form $(x-y)^T \text{diag}(\mathbf{d}) (x-y) + \|\mathbf{U}^T (x-y)\|^2$ and Gaussian manifold similarity using Java Vector API (AVX2/512 with masked loop tails)

### Layer 2: Data Models (`spector-memory`)
- **`PersonalMetricTensor.java`** — Immutable record representing the metric tensor decomposition $(\mathbf{d}, \mathbf{U})$ with dimension validation, defensive copies, and identity factory
- **`CognitiveManifold.java`** — Thread-safe manager maintaining the active metric tensor representation and computing Riemannian distances/similarities using `ReentrantLock`
- **`ManifoldConsolidator.java`** — Consolidates memory co-activations into updated metric tensor coordinate scalings and low-rank factors during reflection cycles

### Layer 3: Pathway Integration (`spector-memory`)
- **`ManifoldRerankRelay.java`** — `SynapticRelay<RecallSignal>` integrating NMD into the `RecallPathway` relay chain, re-ranking candidates according to Riemannian geodesic similarity

## Testing

| Test Class | Tests | Status |
|:---|:---|:---|
| `NeuralManifoldDistanceTest` | 7 | ✅ |
| `PersonalMetricTensorTest` | 3 | ✅ |
| `CognitiveManifoldTest` | 4 | ✅ |
| `ManifoldConsolidatorTest` | 2 | ✅ |
| `ManifoldRerankRelayTest` | 3 | ✅ |
| `HopfieldKernelTest` | 8 | ✅ |
| `AttractorTypeTest` | 4 | ✅ |
| `AttractorStateTest` | 2 | ✅ |
| `PersonalityTemperatureTest` | 4 | ✅ |
| `ContinuousHopfieldNetworkTest` | 4 | ✅ |
| `HopfieldAssociativeRelayTest` | 3 | ✅ |
| `FreeEnergyKernelTest` | 7 | ✅ |
| `MentalStatePosteriorTest` | 4 | ✅ |
| `GenerativeSelfModelTest` | 4 | ✅ |
| `FreeEnergyCalculatorTest` | 3 | ✅ |
| `MentalStateTrackerTest` | 4 | ✅ |
| `FreeEnergyGuidedRelayTest` | 3 | ✅ |
| `AffectiveDistanceTest` | 8 | ✅ |
| `EmotionalRegulatorTest` | 8 | ✅ |
| `InteroceptiveStateTest` | 8 | ✅ |
| `HomeostaticCoreTest` | 9 | ✅ |
| **Total AISME Test Suite** | **102** | **All Pass (100%)** |

## Architecture

$$d_{\text{NMD}}^2(x, y) = \sum_{k=1}^D d_k (x_k - y_k)^2 + \sum_{r=1}^R \left( \mathbf{u}_r^T (x - y) \right)^2$$

$$\text{sim}_{\text{NMD}}(x, y) = \exp\left(-\frac{d_{\text{NMD}}^2(x, y)}{2\sigma^2}\right)$$

```
Query Vector → ... → HopfieldAssociativeRelay → ManifoldRerankRelay → AssociativeGraphRelay → ...
                                                       │
                                                       ▼
                                               CognitiveManifold
                                           (PersonalMetricTensor)
                                                       │
                                                       ▼
                                            NeuralManifoldDistance
                                           (SIMD Quadratic Form)
```

## Backward Compatibility
100% backward compatible. Unconfigured or non-matching signals pass through without alteration.

## Commits (dependency-ordered)
1. `feat(core): add SIMD-accelerated NeuralManifoldDistance kernel`
2. `feat(memory): add PersonalMetricTensor record for NMD`
3. `feat(memory): add CognitiveManifold manager and ManifoldConsolidator`
4. `feat(memory): add ManifoldRerankRelay for RecallPathway`