### PR TITLE
feat(memory,config,core): AISME Phase 11 — Expected Free Energy (G) Policy Engine & 5th Canonical DecidePathway

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DecidePathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DecidePathway.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory;
+
+import com.spectrayan.spector.commons.pathway.CognitivePathway;
+import com.spectrayan.spector.commons.pathway.ErrorPolicy;
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.aisme.policy.PolicyInferenceEngine;
+import com.spectrayan.spector.memory.aisme.relay.PolicyInferenceRelay;
+import com.spectrayan.spector.memory.decide.relay.DecideGates;
+import com.spectrayan.spector.memory.decide.relay.DecideReport;
+import com.spectrayan.spector.memory.decide.relay.DecideSignal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public final class DecidePathway implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(DecidePathway.class);
+
+    private final CognitivePathway<DecideSignal> pathway;
+
+    private DecidePathway(final Builder builder) {
+        var pathwayBuilder = CognitivePathway.<DecideSignal>pathway("decide_pathway");
+        if (builder.interceptor != null) {
+            pathwayBuilder.withInterceptor(builder.interceptor);
+        }
+
+        // Stage 1: PolicyInferenceRelay
+        pathwayBuilder.gated("policy_inference", 
+                DecideGates.EFE_ENABLED.and(DecideGates.HAS_CANDIDATES), 
+                new PolicyInferenceRelay(), 
+                ErrorPolicy.DEGRADE_GRACEFULLY);
+
+        this.pathway = pathwayBuilder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public DecideReport decide(final DecideSignal signal) {
+        Objects.requireNonNull(signal, "DecideSignal cannot be null");
+        long start = System.currentTimeMillis();
+        
+        try {
+            DecideSignal result = pathway.conduct(signal);
+            long elapsed = System.currentTimeMillis() - start;
+            var report = result.report();
+            
+            if (report == null) {
+                return DecideReport.empty();
+            }
+            
+            return new DecideReport(report, elapsed, report.selectedPolicy() != null);
+        } catch (Exception e) {
+            log.error("DecidePathway: decision cycle aborted due to error: {}", e.getMessage(), e);
+            throw new IllegalStateException("DecidePathway execution failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() {
+        // No underlying resources to close at this time
+    }
+
+    public static final class Builder {
+        private PolicyInferenceEngine policyInferenceEngine;
+        private Function<SynapticRelay<DecideSignal>, SynapticRelay<DecideSignal>> interceptor;
+
+        public Builder policyInferenceEngine(PolicyInferenceEngine engine) { this.policyInferenceEngine = engine; return this; }
+        public Builder interceptor(Function<SynapticRelay<DecideSignal>, SynapticRelay<DecideSignal>> inc) { this.interceptor = inc; return this; }
+
+        public DecidePathway build() {
+            return new DecidePathway(this);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -262,6 +262,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     private final com.spectrayan.spector.memory.insula.InsularCortex insularCortex;
     private final WanderPathway wanderPathway;
     private final com.spectrayan.spector.memory.cortex.ContinuityRecordMemory continuityMemory;
+    private final DecidePathway decidePathway;
 
     private final ConcurrentHashMap<String, SessionWriteBuffer> sessionBuffers = new ConcurrentHashMap<>();
 
@@ -341,6 +342,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.insularCortex = bundle.insularCortex();
         this.wanderPathway = bundle.wanderPathway();
         this.continuityMemory = bundle.continuityMemory();
+        this.decidePathway = bundle.decidePathway();
         this.hook = builder.hook != null ? builder.hook : MemoryObservationHook.NOOP;
 
         //  Circadian Time Trigger (Automatic Background Sleep Consolidation)
@@ -1013,6 +1015,20 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 return wanderPathway.wander(partitionManager, 0L);
             }
             return com.spectrayan.spector.memory.wander.relay.WanderReport.empty();
+        } finally {
+            releaseLease();
+        }
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.decide.relay.DecideReport decide(
+            com.spectrayan.spector.memory.decide.relay.DecideSignal signal) {
+        acquireLease();
+        try {
+            if (decidePathway != null) {
+                return decidePathway.decide(signal);
+            }
+            return com.spectrayan.spector.memory.decide.relay.DecideReport.empty();
         } finally {
             releaseLease();
         }
@@ -1791,6 +1807,13 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 wanderPathway.close();
             } catch (Exception e) {
                 log.warn("Failed to close WanderPathway on close", e);
+            }
+        }
+        if (decidePathway != null) {
+            try {
+                decidePathway.close();
+            } catch (Exception e) {
+                log.warn("Failed to close DecidePathway on close", e);
             }
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -254,6 +254,23 @@ public interface SpectorMemory extends AutoCloseable {
     }
 
     /**
+     * Evaluates candidate cognitive policies by minimizing Expected Free Energy G(π) across
+     * the active multi-soul context hierarchy (AgentSoul, UserSoul, TenantSoul, OrgUnitSoul).
+     *
+     * <h3>Biological Analog: Prefrontal Decision Circuit (dlPFC + ACC)</h3>
+     * <p>Selects the optimal cognitive policy balancing epistemic exploration (uncertainty reduction)
+     * versus pragmatic exploitation (goal-directed action) using Boltzmann softmax selection
+     * with precision γ modulated by homeostatic arousal and dominance.</p>
+     *
+     * @param signal the decide signal carrying candidate policies and soul context
+     * @return the resulting decision report with selected policy and ranked alternatives
+     */
+    default com.spectrayan.spector.memory.decide.relay.DecideReport decide(
+            com.spectrayan.spector.memory.decide.relay.DecideSignal signal) {
+        return com.spectrayan.spector.memory.decide.relay.DecideReport.empty();
+    }
+
+    /**
      * Retrieves the longitudinal identity and consciousness continuity trajectory history.
      *
      * @param limit maximum number of snapshots to return (newest first)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -119,7 +119,8 @@ public final class SpectorMemoryFactory {
             RuntimeBundle runtimeBundle,
             InsularCortex insularCortex,
             WanderPathway wanderPathway,
-            com.spectrayan.spector.memory.cortex.ContinuityRecordMemory continuityMemory
+            com.spectrayan.spector.memory.cortex.ContinuityRecordMemory continuityMemory,
+            DecidePathway decidePathway
     ) {}
 
     private SpectorMemoryFactory() {}
@@ -356,6 +357,13 @@ public final class SpectorMemoryFactory {
                 .aismeConfig(builder.aismeConfig)
                 .build();
 
+        //  Decide Pathway (#611 / AISME Phase 11 — Expected Free Energy G(π) Policy Engine)
+        DecidePathway decidePathway = (aismeBundle != null && aismeBundle.policyInferenceEngine() != null)
+                ? DecidePathway.builder()
+                        .policyInferenceEngine(aismeBundle.policyInferenceEngine())
+                        .build()
+                : null;
+
         //  Daemon Supervisor + Checkpoint Daemon  (DISK mode only)
         DaemonSupervisorBuilder.DaemonBundle daemons = DaemonSupervisorBuilder.build(
                 builder, cortex, bio, graphs, index, wal, wanderPathway, partitionManager);
@@ -385,7 +393,7 @@ public final class SpectorMemoryFactory {
                 daemons.checkpointDaemon(), daemons.graphEnrichmentDaemon(), daemons.daemonSupervisor(), retrieval.bm25Index(), attachmentProcessor,
                 parallelPipeline, embedConfig, cortex.resolvedPartitionDir(), cortex.basePath(),
                 cortex.namespaceManager(), profileAdaptor, cortex.runtimeBundle(), cortex.insularCortex(),
-                wanderPathway, cortex.continuityMemory()
+                wanderPathway, cortex.continuityMemory(), decidePathway
         );
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
@@ -23,6 +23,8 @@ import com.spectrayan.spector.memory.aisme.manifold.CognitiveManifold;
 import com.spectrayan.spector.memory.aisme.narrative.NarrativeSelfEngine;
 import com.spectrayan.spector.memory.aisme.pcmn.PredictiveCodingNetwork;
 import com.spectrayan.spector.memory.aisme.phi.ConsciousnessContinuityEvaluator;
+import com.spectrayan.spector.memory.aisme.policy.ExpectedFreeEnergyCalculator;
+import com.spectrayan.spector.memory.aisme.policy.PolicyInferenceEngine;
 import com.spectrayan.spector.memory.aisme.relay.ConsciousAccessRelay;
 import com.spectrayan.spector.memory.aisme.relay.ConsciousnessContinuityRelay;
 import com.spectrayan.spector.memory.aisme.relay.ConstructiveSimulationRelay;
@@ -35,7 +37,9 @@ import com.spectrayan.spector.memory.aisme.relay.ManifoldRerankRelay;
 import com.spectrayan.spector.memory.aisme.workspace.GlobalWorkspace;
 import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
 
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -59,6 +63,26 @@ public final class AismeBuilder {
             final AgentSoul soul,
             final int dimensions,
             final Function<String, float[]> vectorLookup
+    ) {
+        return build(config, soul, dimensions, vectorLookup, soul != null ? List.of(soul) : List.of());
+    }
+
+    /**
+     * Builds an {@link AismeBundle} initialized with the provided configuration, multi-soul context, and vector lookup.
+     *
+     * @param config the AISME configuration (or disabled if null)
+     * @param soul optional AgentSoul identity definition
+     * @param dimensions vector embedding dimensionality
+     * @param vectorLookup function mapping memory IDs to vector representations
+     * @param soulContexts list of all active soul contexts for multi-soul EFE evaluation
+     * @return the constructed AismeBundle, or null if disabled
+     */
+    public static AismeBundle build(
+            final AismeConfig config,
+            final AgentSoul soul,
+            final int dimensions,
+            final Function<String, float[]> vectorLookup,
+            final List<SoulContext> soulContexts
     ) {
         final AismeConfig cfg = config != null ? config : AismeConfig.disabled();
         if (!cfg.enabled() || dimensions <= 0) {
@@ -94,6 +118,19 @@ public final class AismeBuilder {
         final EpistemicLearningRelay epistemicLearningRelay = new EpistemicLearningRelay(
                 mentalStateTracker, homeostaticCore, vectorLookup);
 
+        // Expected Free Energy (G) Policy Engine
+        final List<SoulContext> activeSouls = soulContexts != null ? soulContexts : List.of();
+        final ExpectedFreeEnergyCalculator efeCalculator = cfg.enableExpectedFreeEnergy()
+                ? new ExpectedFreeEnergyCalculator(
+                        activeSouls,
+                        cfg.efeSoulWeightAgent(), cfg.efeSoulWeightUser(),
+                        cfg.efeSoulWeightTenant(), cfg.efeSoulWeightOrgUnit(),
+                        cfg.efeEpistemicWeight(), cfg.efePragmaticWeight())
+                : null;
+        final PolicyInferenceEngine policyInferenceEngine = efeCalculator != null
+                ? new PolicyInferenceEngine(efeCalculator, homeostaticCore, mentalStateTracker, cfg.efePolicyPrecision())
+                : null;
+
         return new AismeBundle(
                 cfg,
                 soul,
@@ -115,7 +152,10 @@ public final class AismeBuilder {
                 consciousnessContinuityRelay,
                 consciousAccessRelay,
                 manifoldConsolidationRelay,
-                epistemicLearningRelay
+                epistemicLearningRelay,
+                efeCalculator,
+                policyInferenceEngine
         );
     }
 }
+

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBundle.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBundle.java
@@ -22,6 +22,8 @@ import com.spectrayan.spector.memory.aisme.manifold.CognitiveManifold;
 import com.spectrayan.spector.memory.aisme.narrative.NarrativeSelfEngine;
 import com.spectrayan.spector.memory.aisme.pcmn.PredictiveCodingNetwork;
 import com.spectrayan.spector.memory.aisme.phi.ConsciousnessContinuityEvaluator;
+import com.spectrayan.spector.memory.aisme.policy.ExpectedFreeEnergyCalculator;
+import com.spectrayan.spector.memory.aisme.policy.PolicyInferenceEngine;
 import com.spectrayan.spector.memory.aisme.relay.ConsciousAccessRelay;
 import com.spectrayan.spector.memory.aisme.relay.ConsciousnessContinuityRelay;
 import com.spectrayan.spector.memory.aisme.relay.ConstructiveSimulationRelay;
@@ -58,5 +60,7 @@ public record AismeBundle(
         ConsciousnessContinuityRelay consciousnessContinuityRelay,
         ConsciousAccessRelay consciousAccessRelay,
         ManifoldConsolidationRelay manifoldConsolidationRelay,
-        EpistemicLearningRelay epistemicLearningRelay
+        EpistemicLearningRelay epistemicLearningRelay,
+        ExpectedFreeEnergyCalculator expectedFreeEnergyCalculator,
+        PolicyInferenceEngine policyInferenceEngine
 ) {}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/config/AismeConfig.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/config/AismeConfig.java
@@ -41,7 +41,15 @@ public record AismeConfig(
         boolean enableDmnSpontaneous,
         int dmnIdleIntervalSeconds,
         boolean enableLongitudinalContinuity,
-        int longitudinalSnapshotIntervalMinutes
+        int longitudinalSnapshotIntervalMinutes,
+        boolean enableExpectedFreeEnergy,
+        float efePolicyPrecision,
+        float efeEpistemicWeight,
+        float efePragmaticWeight,
+        float efeSoulWeightAgent,
+        float efeSoulWeightUser,
+        float efeSoulWeightTenant,
+        float efeSoulWeightOrgUnit
 ) {
 
     /**
@@ -66,6 +74,27 @@ public record AismeConfig(
         if (longitudinalSnapshotIntervalMinutes < 1) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "longitudinalSnapshotIntervalMinutes must be at least 1");
         }
+        if (Float.isNaN(efePolicyPrecision) || efePolicyPrecision <= 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efePolicyPrecision must be positive");
+        }
+        if (Float.isNaN(efeEpistemicWeight) || efeEpistemicWeight < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efeEpistemicWeight must be non-negative");
+        }
+        if (Float.isNaN(efePragmaticWeight) || efePragmaticWeight < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efePragmaticWeight must be non-negative");
+        }
+        if (Float.isNaN(efeSoulWeightAgent) || efeSoulWeightAgent < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efeSoulWeightAgent must be non-negative");
+        }
+        if (Float.isNaN(efeSoulWeightUser) || efeSoulWeightUser < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efeSoulWeightUser must be non-negative");
+        }
+        if (Float.isNaN(efeSoulWeightTenant) || efeSoulWeightTenant < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efeSoulWeightTenant must be non-negative");
+        }
+        if (Float.isNaN(efeSoulWeightOrgUnit) || efeSoulWeightOrgUnit < 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "efeSoulWeightOrgUnit must be non-negative");
+        }
     }
 
     /**
@@ -83,7 +112,15 @@ public record AismeConfig(
                 false,
                 SpectorPropertyConstants.DEFAULT_MEMORY_AISME_DMN_IDLE_SECONDS,
                 false,
-                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES,
+                false,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_POLICY_PRECISION,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_EPISTEMIC_WEIGHT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_PRAGMATIC_WEIGHT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_AGENT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_USER,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_TENANT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_ORG_UNIT
         );
     }
 
@@ -109,7 +146,15 @@ public record AismeConfig(
                 SpectorPropertyConstants.DEFAULT_MEMORY_AISME_DMN_ENABLED,
                 SpectorPropertyConstants.DEFAULT_MEMORY_AISME_DMN_IDLE_SECONDS,
                 SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_CONTINUITY_ENABLED,
-                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_ENABLED,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_POLICY_PRECISION,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_EPISTEMIC_WEIGHT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_PRAGMATIC_WEIGHT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_AGENT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_USER,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_TENANT,
+                SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_ORG_UNIT
         );
     }
 
@@ -139,7 +184,15 @@ public record AismeConfig(
                 props.isEnableDmnSpontaneous(),
                 props.getDmnIdleIntervalSeconds(),
                 props.isEnableLongitudinalContinuity(),
-                props.getLongitudinalSnapshotIntervalMinutes()
+                props.getLongitudinalSnapshotIntervalMinutes(),
+                props.enableExpectedFreeEnergy(),
+                props.efePolicyPrecision(),
+                props.efeEpistemicWeight(),
+                props.efePragmaticWeight(),
+                props.efeSoulWeightAgent(),
+                props.efeSoulWeightUser(),
+                props.efeSoulWeightTenant(),
+                props.efeSoulWeightOrgUnit()
         );
     }
 
@@ -167,6 +220,14 @@ public record AismeConfig(
         private int dmnIdleIntervalSeconds = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_DMN_IDLE_SECONDS;
         private boolean enableLongitudinalContinuity = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_CONTINUITY_ENABLED;
         private int longitudinalSnapshotIntervalMinutes = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES;
+        private boolean enableExpectedFreeEnergy = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_ENABLED;
+        private float efePolicyPrecision = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_POLICY_PRECISION;
+        private float efeEpistemicWeight = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_EPISTEMIC_WEIGHT;
+        private float efePragmaticWeight = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_PRAGMATIC_WEIGHT;
+        private float efeSoulWeightAgent = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_AGENT;
+        private float efeSoulWeightUser = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_USER;
+        private float efeSoulWeightTenant = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_TENANT;
+        private float efeSoulWeightOrgUnit = SpectorPropertyConstants.DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_ORG_UNIT;
 
         public Builder enabled(boolean enabled) { this.enabled = enabled; return this; }
         public Builder enableHomeostasis(boolean enable) { this.enableHomeostasis = enable; return this; }
@@ -184,6 +245,14 @@ public record AismeConfig(
         public Builder dmnIdleIntervalSeconds(int sec) { this.dmnIdleIntervalSeconds = sec; return this; }
         public Builder enableLongitudinalContinuity(boolean enable) { this.enableLongitudinalContinuity = enable; return this; }
         public Builder longitudinalSnapshotIntervalMinutes(int min) { this.longitudinalSnapshotIntervalMinutes = min; return this; }
+        public Builder enableExpectedFreeEnergy(boolean enable) { this.enableExpectedFreeEnergy = enable; return this; }
+        public Builder efePolicyPrecision(float precision) { this.efePolicyPrecision = precision; return this; }
+        public Builder efeEpistemicWeight(float weight) { this.efeEpistemicWeight = weight; return this; }
+        public Builder efePragmaticWeight(float weight) { this.efePragmaticWeight = weight; return this; }
+        public Builder efeSoulWeightAgent(float weight) { this.efeSoulWeightAgent = weight; return this; }
+        public Builder efeSoulWeightUser(float weight) { this.efeSoulWeightUser = weight; return this; }
+        public Builder efeSoulWeightTenant(float weight) { this.efeSoulWeightTenant = weight; return this; }
+        public Builder efeSoulWeightOrgUnit(float weight) { this.efeSoulWeightOrgUnit = weight; return this; }
 
         public AismeConfig build() {
             return new AismeConfig(
@@ -192,7 +261,10 @@ public record AismeConfig(
                     enableGlobalWorkspace, globalWorkspaceCapacity, hopfieldTemperature,
                     manifoldSigma, phiCohesionThreshold, enableDmnSpontaneous,
                     dmnIdleIntervalSeconds, enableLongitudinalContinuity,
-                    longitudinalSnapshotIntervalMinutes
+                    longitudinalSnapshotIntervalMinutes, enableExpectedFreeEnergy,
+                    efePolicyPrecision, efeEpistemicWeight, efePragmaticWeight,
+                    efeSoulWeightAgent, efeSoulWeightUser, efeSoulWeightTenant,
+                    efeSoulWeightOrgUnit
             );
         }
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/CognitivePolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/CognitivePolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.policy;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public record CognitivePolicy(
+    String id,
+    String name,
+    PolicyType policyType,
+    float[] predictedObservationMean,
+    float[] predictedObservationPrecision,
+    Map<String, Object> metadata
+) {
+    public CognitivePolicy {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(name, "name cannot be null");
+        Objects.requireNonNull(policyType, "policyType cannot be null");
+        Objects.requireNonNull(predictedObservationMean, "predictedObservationMean cannot be null");
+        Objects.requireNonNull(predictedObservationPrecision, "predictedObservationPrecision cannot be null");
+        if (predictedObservationMean.length != predictedObservationPrecision.length) {
+            throw new IllegalArgumentException("Mean and precision arrays must have same length");
+        }
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public static CognitivePolicy of(PolicyType type, float[] mean, float[] precision) {
+        return new CognitivePolicy(
+            UUID.randomUUID().toString(),
+            type.name(),
+            type,
+            mean,
+            precision,
+            Map.of()
+        );
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/ExpectedFreeEnergyCalculator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/ExpectedFreeEnergyCalculator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.policy;
+
+import com.spectrayan.spector.core.similarity.ExpectedFreeEnergyKernel;
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.OrgUnitSoul;
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.memory.model.TenantSoul;
+import com.spectrayan.spector.memory.model.UserSoul;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Evaluates candidate cognitive policies against a composite multi-soul prior preference distribution p(o).
+ *
+ * <h3>Biological Analog: Ventromedial Prefrontal Value Integration Circuit</h3>
+ * <p>Composes prior preferences across the full soul hierarchy (AgentSoul, UserSoul, TenantSoul, OrgUnitSoul)
+ * using configurable blending weights, then evaluates each policy's Expected Free Energy G(π)
+ * decomposed into pragmatic risk (goal misalignment) and epistemic ambiguity (uncertainty).</p>
+ */
+public final class ExpectedFreeEnergyCalculator {
+
+    private final List<SoulContext> soulContexts;
+    private final float agentWeight;
+    private final float userWeight;
+    private final float tenantWeight;
+    private final float orgUnitWeight;
+    private final float epistemicWeight;
+    private final float pragmaticWeight;
+
+    /**
+     * Constructs an EFE calculator with the active multi-soul context stack and configurable weights.
+     *
+     * @param soulContexts list of all active soul contexts for composite prior composition
+     * @param agentWeight blending weight for AgentSoul identity embeddings
+     * @param userWeight blending weight for UserSoul persona embeddings
+     * @param tenantWeight blending weight for TenantSoul compliance embeddings
+     * @param orgUnitWeight blending weight for OrgUnitSoul expertise embeddings
+     * @param epistemicWeight weight for epistemic ambiguity term in G(π)
+     * @param pragmaticWeight weight for pragmatic risk term in G(π)
+     */
+    public ExpectedFreeEnergyCalculator(
+            List<SoulContext> soulContexts,
+            float agentWeight, float userWeight,
+            float tenantWeight, float orgUnitWeight,
+            float epistemicWeight, float pragmaticWeight) {
+        this.soulContexts = soulContexts != null ? List.copyOf(soulContexts) : List.of();
+        this.agentWeight = agentWeight;
+        this.userWeight = userWeight;
+        this.tenantWeight = tenantWeight;
+        this.orgUnitWeight = orgUnitWeight;
+        this.epistemicWeight = epistemicWeight;
+        this.pragmaticWeight = pragmaticWeight;
+    }
+
+    /**
+     * Evaluates a single cognitive policy against the composite multi-soul prior preference.
+     *
+     * @param policy the candidate policy with predicted observation distributions
+     * @param soulContexts override soul contexts (if null, uses constructor-provided contexts)
+     * @param currentPosteriorMean current posterior mean from MentalStateTracker
+     * @param currentPosteriorPrecision current posterior precision from MentalStateTracker
+     * @return scored policy with decomposed G(π) components
+     */
+    public PolicyDecisionReport.ScoredPolicy evaluate(
+            CognitivePolicy policy,
+            List<SoulContext> soulContexts,
+            float[] currentPosteriorMean,
+            float[] currentPosteriorPrecision) {
+
+        List<SoulContext> activeSouls = (soulContexts != null && !soulContexts.isEmpty())
+                ? soulContexts : this.soulContexts;
+
+        int dim = policy.predictedObservationMean().length;
+
+        // Compose composite prior preference p(o) from weighted soul identity embeddings
+        float[] compositePreference = new float[dim];
+        float[] compositePrecision = new float[dim];
+        Arrays.fill(compositePrecision, 1.0f); // Default unit precision
+
+        for (SoulContext soul : activeSouls) {
+            float weight = switch (soul) {
+                case AgentSoul _ -> agentWeight;
+                case UserSoul _ -> userWeight;
+                case TenantSoul _ -> tenantWeight;
+                case OrgUnitSoul _ -> orgUnitWeight;
+            };
+            float[] emb = soul.identityEmbedding();
+            if (emb != null) {
+                int copyLen = Math.min(dim, emb.length);
+                for (int i = 0; i < copyLen; i++) {
+                    compositePreference[i] += weight * emb[i];
+                }
+            }
+        }
+
+        // Compute G(π) = w_p * D_KL[q(o|π) || p(o)] + w_e * H(q(o|s,π))
+        float pragmaticRisk = ExpectedFreeEnergyKernel.pragmaticRisk(
+                policy.predictedObservationMean(), compositePreference,
+                policy.predictedObservationPrecision(), compositePrecision);
+        float epistemicGain = ExpectedFreeEnergyKernel.epistemicAmbiguity(
+                policy.predictedObservationPrecision());
+
+        float totalG = (pragmaticWeight * pragmaticRisk) + (epistemicWeight * epistemicGain);
+
+        return new PolicyDecisionReport.ScoredPolicy(policy, pragmaticRisk, epistemicGain, totalG, 0.0f);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/PolicyDecisionReport.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/PolicyDecisionReport.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.policy;
+
+import java.time.Instant;
+import java.util.List;
+
+public record PolicyDecisionReport(
+    CognitivePolicy selectedPolicy,
+    List<ScoredPolicy> rankedPolicies,
+    float precision,
+    long evaluationDurationNanos,
+    Instant timestamp
+) {
+    public record ScoredPolicy(CognitivePolicy policy, float pragmaticRisk, float epistemicGain, float totalG, float probability) {}
+
+    public static PolicyDecisionReport empty() {
+        return new PolicyDecisionReport(null, List.of(), 0.0f, 0L, Instant.now());
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/PolicyInferenceEngine.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/PolicyInferenceEngine.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.policy;
+
+import com.spectrayan.spector.memory.aisme.fegr.MentalStatePosterior;
+import com.spectrayan.spector.memory.aisme.fegr.MentalStateTracker;
+import com.spectrayan.spector.memory.aisme.homeostasis.HomeostaticCore;
+import com.spectrayan.spector.memory.model.SoulContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Thread-safe engine performing Boltzmann softmax policy selection over Expected Free Energy G(π) scores.
+ *
+ * <h3>Biological Analog: Basal Ganglia Action Selection Circuit</h3>
+ * <p>Evaluates candidate cognitive policies, modulates selection precision γ by homeostatic arousal
+ * and dominance state, and applies softmax normalization to produce calibrated policy probabilities.</p>
+ */
+public final class PolicyInferenceEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(PolicyInferenceEngine.class);
+
+    private final ExpectedFreeEnergyCalculator calculator;
+    private final HomeostaticCore homeostaticCore;
+    private final MentalStateTracker mentalStateTracker;
+    private final float basePrecision;
+
+    /**
+     * Constructs a PolicyInferenceEngine.
+     *
+     * @param calculator the EFE calculator with multi-soul composite priors
+     * @param homeostaticCore homeostatic state for arousal/dominance precision modulation
+     * @param mentalStateTracker current posterior belief state tracker
+     * @param basePrecision base precision γ₀ for Boltzmann softmax temperature
+     */
+    public PolicyInferenceEngine(
+            ExpectedFreeEnergyCalculator calculator,
+            HomeostaticCore homeostaticCore,
+            MentalStateTracker mentalStateTracker,
+            float basePrecision) {
+        this.calculator = calculator;
+        this.homeostaticCore = homeostaticCore;
+        this.mentalStateTracker = mentalStateTracker;
+        this.basePrecision = basePrecision;
+    }
+
+    /**
+     * Evaluates candidate policies and returns a decision report with Boltzmann-selected winner.
+     *
+     * @param candidates list of candidate cognitive policies to evaluate
+     * @param soulContexts active soul contexts for multi-soul preference composition
+     * @return decision report with ranked policies and selected winner
+     */
+    public PolicyDecisionReport evaluate(List<CognitivePolicy> candidates, List<SoulContext> soulContexts) {
+        long start = System.nanoTime();
+
+        if (candidates == null || candidates.isEmpty()) {
+            return PolicyDecisionReport.empty();
+        }
+
+        // Retrieve current posterior from MentalStateTracker
+        MentalStatePosterior posterior = mentalStateTracker.currentPosterior();
+        float[] currentPosteriorMean = posterior.mean();
+        float[] currentPosteriorPrecision = posterior.precision();
+
+        // Compute dynamic precision γ = γ₀ * (1 + 0.5*arousal + 0.3*dominance)
+        float arousal = homeostaticCore.currentState().arousal();
+        float dominance = homeostaticCore.currentState().dominance();
+        float gamma = basePrecision * (1.0f + 0.5f * arousal + 0.3f * dominance);
+
+        // Score each candidate policy
+        List<PolicyDecisionReport.ScoredPolicy> rawScores = new ArrayList<>(candidates.size());
+        for (CognitivePolicy policy : candidates) {
+            PolicyDecisionReport.ScoredPolicy scored = calculator.evaluate(
+                    policy, soulContexts, currentPosteriorMean, currentPosteriorPrecision);
+            rawScores.add(scored);
+        }
+
+        // Boltzmann softmax: P(π) = exp(-γ * G(π)) / Σ exp(-γ * G(π'))
+        float sumExp = 0.0f;
+        float[] expScores = new float[rawScores.size()];
+        for (int i = 0; i < rawScores.size(); i++) {
+            expScores[i] = (float) Math.exp(-gamma * rawScores.get(i).totalG());
+            sumExp += expScores[i];
+        }
+
+        // Normalize and build ranked list
+        List<PolicyDecisionReport.ScoredPolicy> ranked = new ArrayList<>(rawScores.size());
+        for (int i = 0; i < rawScores.size(); i++) {
+            PolicyDecisionReport.ScoredPolicy raw = rawScores.get(i);
+            float normP = sumExp > 0 ? expScores[i] / sumExp : 0.0f;
+            ranked.add(new PolicyDecisionReport.ScoredPolicy(
+                    raw.policy(), raw.pragmaticRisk(), raw.epistemicGain(), raw.totalG(), normP));
+        }
+
+        // Sort by probability descending
+        ranked.sort(Comparator.comparing(PolicyDecisionReport.ScoredPolicy::probability).reversed());
+
+        CognitivePolicy selected = ranked.isEmpty() ? null : ranked.getFirst().policy();
+        long durationNanos = System.nanoTime() - start;
+
+        log.debug("PolicyInference: evaluated {} candidates in {}µs, selected={}, γ={:.3f}",
+                candidates.size(), durationNanos / 1000, selected != null ? selected.policyType() : "none", gamma);
+
+        return new PolicyDecisionReport(selected, ranked, gamma, durationNanos, Instant.now());
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/PolicyType.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/policy/PolicyType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.policy;
+
+/**
+ * Enumeration of cognitive policy types.
+ */
+public enum PolicyType {
+    /** Biological analog: Novelty-seeking foraging. Cognitive function: Expanding state-space knowledge. */
+    EPISTEMIC_EXPLORATION,
+    /** Biological analog: Goal-directed consummatory behavior. Cognitive function: Exploiting known rewards. */
+    PRAGMATIC_EXPLOITATION,
+    /** Biological analog: Active inference dialogue. Cognitive function: Reducing uncertainty via user prompt. */
+    CLARIFYING_INTERACTION,
+    /** Biological analog: Memory consolidation. Cognitive function: Caching procedures from episodic memory. */
+    PROCEDURAL_CRYSTALLIZATION,
+    /** Biological analog: Sleep/Rest. Cognitive function: Minimizing metabolic cost and consolidating state. */
+    HOMEOSTATIC_REST,
+    /** Biological analog: Psychological defense mechanism/reappraisal. Cognitive function: Altering narrative models. */
+    NARRATIVE_REFRAMING
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/PolicyInferenceRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/PolicyInferenceRelay.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.decide.relay.DecideSignal;
+
+public final class PolicyInferenceRelay implements SynapticRelay<DecideSignal> {
+    @Override
+    public boolean transmit(DecideSignal signal) {
+        if (signal == null || signal.policyInferenceEngine() == null) return false;
+        var report = signal.policyInferenceEngine().evaluate(signal.candidatePolicies(), signal.soulContexts());
+        signal.setReport(report);
+        return report.selectedPolicy() != null;
+    }
+    
+    @Override
+    public String relayName() { 
+        return "policy_inference"; 
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/decide/relay/DecideGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/decide/relay/DecideGates.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.decide.relay;
+
+import java.util.function.Predicate;
+
+public final class DecideGates {
+    public static final Predicate<DecideSignal> EFE_ENABLED = signal -> signal != null && signal.policyInferenceEngine() != null;
+    public static final Predicate<DecideSignal> HAS_CANDIDATES = signal -> signal != null && signal.candidatePolicies() != null && !signal.candidatePolicies().isEmpty();
+    
+    private DecideGates() {}
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/decide/relay/DecideReport.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/decide/relay/DecideReport.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.decide.relay;
+
+import com.spectrayan.spector.memory.aisme.policy.PolicyDecisionReport;
+
+public record DecideReport(
+    PolicyDecisionReport decisionReport,
+    long executionTimeMs,
+    boolean policySelected
+) {
+    public static DecideReport empty() { 
+        return new DecideReport(PolicyDecisionReport.empty(), 0, false); 
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/decide/relay/DecideSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/decide/relay/DecideSignal.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.decide.relay;
+
+import com.spectrayan.spector.memory.aisme.policy.CognitivePolicy;
+import com.spectrayan.spector.memory.aisme.policy.PolicyDecisionReport;
+import com.spectrayan.spector.memory.aisme.policy.PolicyInferenceEngine;
+import com.spectrayan.spector.memory.model.SoulContext;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class DecideSignal {
+    private final PolicyInferenceEngine policyInferenceEngine;
+    private final List<CognitivePolicy> candidatePolicies;
+    private final List<SoulContext> soulContexts;
+    
+    private final Instant startTime;
+    private PolicyDecisionReport report;
+
+    private DecideSignal(Builder builder) {
+        this.policyInferenceEngine = builder.policyInferenceEngine;
+        this.candidatePolicies = builder.candidatePolicies == null ? List.of() : List.copyOf(builder.candidatePolicies);
+        this.soulContexts = builder.soulContexts == null ? List.of() : List.copyOf(builder.soulContexts);
+        this.startTime = Instant.now();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public PolicyInferenceEngine policyInferenceEngine() { return policyInferenceEngine; }
+    public List<CognitivePolicy> candidatePolicies() { return candidatePolicies; }
+    public List<SoulContext> soulContexts() { return soulContexts; }
+    
+    public Instant startTime() { return startTime; }
+    
+    public synchronized PolicyDecisionReport report() { return report; }
+    public synchronized void setReport(PolicyDecisionReport report) { this.report = report; }
+
+    public static final class Builder {
+        private PolicyInferenceEngine policyInferenceEngine;
+        private List<CognitivePolicy> candidatePolicies;
+        private List<SoulContext> soulContexts;
+
+        public Builder policyInferenceEngine(PolicyInferenceEngine engine) { this.policyInferenceEngine = engine; return this; }
+        public Builder candidatePolicies(List<CognitivePolicy> policies) { this.candidatePolicies = policies; return this; }
+        public Builder soulContexts(List<SoulContext> contexts) { this.soulContexts = contexts; return this; }
+
+        public DecideSignal build() {
+            return new DecideSignal(this);
+        }
+    }
+}

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -420,6 +420,31 @@ public final class SpectorPropertyConstants {
     public static final String MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES = "spector.memory.aisme.longitudinal-snapshot.interval-minutes";
     public static final int DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES = 60;
 
+    // AISME — Expected Free Energy (G) Policy Engine
+    public static final String MEMORY_AISME_EFE_ENABLED = "spector.memory.aisme.efe.enabled";
+    public static final boolean DEFAULT_MEMORY_AISME_EFE_ENABLED = true;
+
+    public static final String MEMORY_AISME_EFE_POLICY_PRECISION = "spector.memory.aisme.efe.policy-precision";
+    public static final float DEFAULT_MEMORY_AISME_EFE_POLICY_PRECISION = 1.0f;
+
+    public static final String MEMORY_AISME_EFE_EPISTEMIC_WEIGHT = "spector.memory.aisme.efe.epistemic-weight";
+    public static final float DEFAULT_MEMORY_AISME_EFE_EPISTEMIC_WEIGHT = 1.0f;
+
+    public static final String MEMORY_AISME_EFE_PRAGMATIC_WEIGHT = "spector.memory.aisme.efe.pragmatic-weight";
+    public static final float DEFAULT_MEMORY_AISME_EFE_PRAGMATIC_WEIGHT = 1.0f;
+
+    public static final String MEMORY_AISME_EFE_SOUL_WEIGHT_AGENT = "spector.memory.aisme.efe.soul-weight.agent";
+    public static final float DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_AGENT = 0.40f;
+
+    public static final String MEMORY_AISME_EFE_SOUL_WEIGHT_USER = "spector.memory.aisme.efe.soul-weight.user";
+    public static final float DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_USER = 0.35f;
+
+    public static final String MEMORY_AISME_EFE_SOUL_WEIGHT_TENANT = "spector.memory.aisme.efe.soul-weight.tenant";
+    public static final float DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_TENANT = 0.15f;
+
+    public static final String MEMORY_AISME_EFE_SOUL_WEIGHT_ORG_UNIT = "spector.memory.aisme.efe.soul-weight.org-unit";
+    public static final float DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_ORG_UNIT = 0.10f;
+
     // Session, Sync, WAL & Subsystems
     public static final String MEMORY_WAL_MAX_CHUNK_BYTES = "spector.memory.wal.max-chunk-bytes";
     public static final long DEFAULT_MEMORY_WAL_MAX_CHUNK_BYTES = 8L * 1024 * 1024;

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/properties/AismeProperties.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/properties/AismeProperties.java
@@ -50,6 +50,15 @@ public class AismeProperties implements Serializable {
     private boolean enableLongitudinalContinuity = DEFAULT_MEMORY_AISME_LONGITUDINAL_CONTINUITY_ENABLED;
     private int longitudinalSnapshotIntervalMinutes = DEFAULT_MEMORY_AISME_LONGITUDINAL_SNAPSHOT_INTERVAL_MINUTES;
 
+    private boolean enableExpectedFreeEnergy = DEFAULT_MEMORY_AISME_EFE_ENABLED;
+    private float efePolicyPrecision = DEFAULT_MEMORY_AISME_EFE_POLICY_PRECISION;
+    private float efeEpistemicWeight = DEFAULT_MEMORY_AISME_EFE_EPISTEMIC_WEIGHT;
+    private float efePragmaticWeight = DEFAULT_MEMORY_AISME_EFE_PRAGMATIC_WEIGHT;
+    private float efeSoulWeightAgent = DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_AGENT;
+    private float efeSoulWeightUser = DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_USER;
+    private float efeSoulWeightTenant = DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_TENANT;
+    private float efeSoulWeightOrgUnit = DEFAULT_MEMORY_AISME_EFE_SOUL_WEIGHT_ORG_UNIT;
+
     public AismeProperties() {}
 
     public boolean isEnabled() {
@@ -192,6 +201,84 @@ public class AismeProperties implements Serializable {
         }
     }
 
+    public boolean isEnableExpectedFreeEnergy() {
+        return enableExpectedFreeEnergy;
+    }
+
+    public void setEnableExpectedFreeEnergy(boolean enableExpectedFreeEnergy) {
+        this.enableExpectedFreeEnergy = enableExpectedFreeEnergy;
+    }
+
+    public float getEfePolicyPrecision() {
+        return efePolicyPrecision;
+    }
+
+    public void setEfePolicyPrecision(float efePolicyPrecision) {
+        if (!Float.isNaN(efePolicyPrecision) && efePolicyPrecision >= 0.0f) {
+            this.efePolicyPrecision = efePolicyPrecision;
+        }
+    }
+
+    public float getEfeEpistemicWeight() {
+        return efeEpistemicWeight;
+    }
+
+    public void setEfeEpistemicWeight(float efeEpistemicWeight) {
+        if (!Float.isNaN(efeEpistemicWeight) && efeEpistemicWeight >= 0.0f) {
+            this.efeEpistemicWeight = efeEpistemicWeight;
+        }
+    }
+
+    public float getEfePragmaticWeight() {
+        return efePragmaticWeight;
+    }
+
+    public void setEfePragmaticWeight(float efePragmaticWeight) {
+        if (!Float.isNaN(efePragmaticWeight) && efePragmaticWeight >= 0.0f) {
+            this.efePragmaticWeight = efePragmaticWeight;
+        }
+    }
+
+    public float getEfeSoulWeightAgent() {
+        return efeSoulWeightAgent;
+    }
+
+    public void setEfeSoulWeightAgent(float efeSoulWeightAgent) {
+        if (!Float.isNaN(efeSoulWeightAgent) && efeSoulWeightAgent >= 0.0f) {
+            this.efeSoulWeightAgent = efeSoulWeightAgent;
+        }
+    }
+
+    public float getEfeSoulWeightUser() {
+        return efeSoulWeightUser;
+    }
+
+    public void setEfeSoulWeightUser(float efeSoulWeightUser) {
+        if (!Float.isNaN(efeSoulWeightUser) && efeSoulWeightUser >= 0.0f) {
+            this.efeSoulWeightUser = efeSoulWeightUser;
+        }
+    }
+
+    public float getEfeSoulWeightTenant() {
+        return efeSoulWeightTenant;
+    }
+
+    public void setEfeSoulWeightTenant(float efeSoulWeightTenant) {
+        if (!Float.isNaN(efeSoulWeightTenant) && efeSoulWeightTenant >= 0.0f) {
+            this.efeSoulWeightTenant = efeSoulWeightTenant;
+        }
+    }
+
+    public float getEfeSoulWeightOrgUnit() {
+        return efeSoulWeightOrgUnit;
+    }
+
+    public void setEfeSoulWeightOrgUnit(float efeSoulWeightOrgUnit) {
+        if (!Float.isNaN(efeSoulWeightOrgUnit) && efeSoulWeightOrgUnit >= 0.0f) {
+            this.efeSoulWeightOrgUnit = efeSoulWeightOrgUnit;
+        }
+    }
+
     // ── Fluent Accessors ──
 
     public boolean enabled() { return isEnabled(); }
@@ -210,4 +297,12 @@ public class AismeProperties implements Serializable {
     public int dmnIdleIntervalSeconds() { return getDmnIdleIntervalSeconds(); }
     public boolean enableLongitudinalContinuity() { return isEnableLongitudinalContinuity(); }
     public int longitudinalSnapshotIntervalMinutes() { return getLongitudinalSnapshotIntervalMinutes(); }
+    public boolean enableExpectedFreeEnergy() { return isEnableExpectedFreeEnergy(); }
+    public float efePolicyPrecision() { return getEfePolicyPrecision(); }
+    public float efeEpistemicWeight() { return getEfeEpistemicWeight(); }
+    public float efePragmaticWeight() { return getEfePragmaticWeight(); }
+    public float efeSoulWeightAgent() { return getEfeSoulWeightAgent(); }
+    public float efeSoulWeightUser() { return getEfeSoulWeightUser(); }
+    public float efeSoulWeightTenant() { return getEfeSoulWeightTenant(); }
+    public float efeSoulWeightOrgUnit() { return getEfeSoulWeightOrgUnit(); }
 }

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/ExpectedFreeEnergyKernel.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/ExpectedFreeEnergyKernel.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.simd.SimdCapability;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * SIMD-accelerated kernel for Expected Free Energy (EFE) calculations in the AISME Policy Engine.
+ *
+ * <h3>Biological Analog: Active Inference and Future-Oriented Control</h3>
+ * <p>Implements Expected Free Energy G(π) which organisms minimize to select action policies.
+ * Balances epistemic ambiguity (information seeking / exploration) and pragmatic risk
+ * (preference satisfaction / exploitation).</p>
+ */
+public final class ExpectedFreeEnergyKernel {
+
+    private static final VectorSpecies<Float> SPECIES = SimdCapability.PREFERRED_SPECIES;
+    private static final float LN_2PI = 1.8378770664093453f;
+
+    private ExpectedFreeEnergyKernel() {}
+
+    /**
+     * Computes pragmatic risk: D_KL[q(o|π) || p(o)] for a single policy.
+     * Uses SIMD-accelerated Gaussian KL divergence.
+     *
+     * @param predictedObsMean mean vector of predicted observations q(o|π)
+     * @param priorPreferenceMean mean vector of prior preferences p(o)
+     * @param predictedObsPrecision precision vector of predicted observations q(o|π)
+     * @param priorPreferencePrecision precision vector of prior preferences p(o)
+     * @return pragmatic risk
+     */
+    public static float pragmaticRisk(float[] predictedObsMean, float[] priorPreferenceMean,
+                                      float[] predictedObsPrecision, float[] priorPreferencePrecision) {
+        validateInputs(predictedObsMean, predictedObsPrecision, priorPreferenceMean, priorPreferencePrecision);
+        int length = predictedObsMean.length;
+        int laneCount = SPECIES.length();
+        FloatVector sumVec = FloatVector.zero(SPECIES);
+
+        int i = 0;
+        int limit = SPECIES.loopBound(length);
+        for (; i < limit; i += laneCount) {
+            FloatVector vMq = FloatVector.fromArray(SPECIES, predictedObsMean, i);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, predictedObsPrecision, i);
+            FloatVector vMp = FloatVector.fromArray(SPECIES, priorPreferenceMean, i);
+            FloatVector vPp = FloatVector.fromArray(SPECIES, priorPreferencePrecision, i);
+
+            FloatVector diff = vMq.sub(vMp);
+            FloatVector logRatio = vPq.div(vPp).lanewise(VectorOperators.LOG);
+            FloatVector precRatio = vPp.div(vPq);
+            FloatVector quad = vPp.mul(diff).mul(diff);
+
+            // term = log(pi_q/pi_p) + (pi_p/pi_q) + pi_p * (mu_q - mu_p)^2 - 1
+            FloatVector term = logRatio.add(precRatio).add(quad).sub(1.0f);
+            sumVec = sumVec.add(term);
+        }
+
+        float kl = sumVec.reduceLanes(VectorOperators.ADD);
+
+        // Masked tail
+        if (i < length) {
+            VectorMask<Float> mask = SPECIES.indexInRange(i, length);
+            FloatVector vMq = FloatVector.fromArray(SPECIES, predictedObsMean, i, mask);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, predictedObsPrecision, i, mask);
+            FloatVector vMp = FloatVector.fromArray(SPECIES, priorPreferenceMean, i, mask);
+            FloatVector vPp = FloatVector.fromArray(SPECIES, priorPreferencePrecision, i, mask);
+
+            FloatVector diff = vMq.sub(vMp);
+            FloatVector logRatio = vPq.div(vPp).lanewise(VectorOperators.LOG);
+            FloatVector precRatio = vPp.div(vPq);
+            FloatVector quad = vPp.mul(diff).mul(diff);
+
+            FloatVector term = logRatio.add(precRatio).add(quad).sub(1.0f);
+            kl += term.reduceLanes(VectorOperators.ADD, mask);
+        }
+
+        return Math.max(0.0f, 0.5f * kl);
+    }
+
+    /**
+     * Computes epistemic ambiguity: expected entropy H(q(o|s,π)) for a single policy.
+     * H = 0.5 * sum(1 + LN_2PI - ln(precision_i))
+     *
+     * @param posteriorPrecision precision vector of the posterior distribution
+     * @return epistemic ambiguity (entropy)
+     */
+    public static float epistemicAmbiguity(float[] posteriorPrecision) {
+        if (posteriorPrecision == null || posteriorPrecision.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Precision array must not be null or empty");
+        }
+        int length = posteriorPrecision.length;
+        int laneCount = SPECIES.length();
+        FloatVector sumVec = FloatVector.zero(SPECIES);
+        
+        float constantTerm = 1.0f + LN_2PI;
+        FloatVector vConst = FloatVector.broadcast(SPECIES, constantTerm);
+
+        int i = 0;
+        int limit = SPECIES.loopBound(length);
+        for (; i < limit; i += laneCount) {
+            FloatVector vPq = FloatVector.fromArray(SPECIES, posteriorPrecision, i);
+            FloatVector vLogPq = vPq.lanewise(VectorOperators.LOG);
+            FloatVector term = vConst.sub(vLogPq);
+            sumVec = sumVec.add(term);
+        }
+
+        float entropy = sumVec.reduceLanes(VectorOperators.ADD);
+
+        if (i < length) {
+            VectorMask<Float> mask = SPECIES.indexInRange(i, length);
+            FloatVector vPq = FloatVector.fromArray(SPECIES, posteriorPrecision, i, mask);
+            FloatVector vLogPq = vPq.lanewise(VectorOperators.LOG);
+            FloatVector term = vConst.sub(vLogPq);
+            entropy += term.reduceLanes(VectorOperators.ADD, mask);
+        }
+
+        return 0.5f * entropy;
+    }
+
+    /**
+     * Computes combined Expected Free Energy G(π) = w_p * pragmaticRisk + w_e * epistemicAmbiguity.
+     *
+     * @param predictedObsMean predicted observations mean
+     * @param priorPreferenceMean prior preferences mean
+     * @param predictedObsPrecision predicted observations precision
+     * @param priorPreferencePrecision prior preferences precision
+     * @param posteriorPrecision posterior precision
+     * @param pragmaticWeight weight for pragmatic risk
+     * @param epistemicWeight weight for epistemic ambiguity
+     * @return Expected Free Energy
+     */
+    public static float expectedFreeEnergy(float[] predictedObsMean, float[] priorPreferenceMean,
+                                           float[] predictedObsPrecision, float[] priorPreferencePrecision,
+                                           float[] posteriorPrecision,
+                                           float pragmaticWeight, float epistemicWeight) {
+        float pragmatic = pragmaticRisk(predictedObsMean, priorPreferenceMean, predictedObsPrecision, priorPreferencePrecision);
+        float epistemic = epistemicAmbiguity(posteriorPrecision);
+        return pragmaticWeight * pragmatic + epistemicWeight * epistemic;
+    }
+
+    private static void validateInputs(float[] a, float[] b, float[] c, float[] d) {
+        if (a == null || b == null || c == null || d == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Input arrays must not be null");
+        }
+        int len = a.length;
+        if (b.length != len || c.length != len || d.length != len) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "All input vectors must have identical dimensions");
+        }
+        if (len == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Input vector length must be greater than zero");
+        }
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/ExpectedFreeEnergyKernelTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/ExpectedFreeEnergyKernelTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the SIMD-accelerated {@link ExpectedFreeEnergyKernel}.
+ */
+class ExpectedFreeEnergyKernelTest {
+
+    @Test
+    void pragmaticRisk_identicalDistributions_isZero() {
+        float[] mean = {0.5f, -0.2f, 0.8f, 1.2f};
+        float[] prec = {2.0f, 3.0f, 1.5f, 4.0f};
+
+        float risk = ExpectedFreeEnergyKernel.pragmaticRisk(mean, mean, prec, prec);
+        assertThat(risk).isCloseTo(0.0f, within(1e-5f));
+    }
+
+    @Test
+    void pragmaticRisk_shiftedMeans_isPositive() {
+        float[] meanQ = {1.0f, 0.0f};
+        float[] precQ = {2.0f, 2.0f};
+        float[] meanP = {0.0f, 0.0f};
+        float[] precP = {2.0f, 2.0f};
+
+        // For equal precisions pi: KL = 0.5 * pi * (mu_q - mu_p)^2 = 0.5 * 2.0 * (1.0)^2 = 1.0
+        float risk = ExpectedFreeEnergyKernel.pragmaticRisk(meanQ, meanP, precQ, precP);
+        assertThat(risk).isCloseTo(1.0f, within(1e-5f));
+    }
+
+    @Test
+    void epistemicAmbiguity_highPrecision_lowEntropy() {
+        // High precision (narrow distribution) -> Low entropy (low ambiguity)
+        float[] precHigh = {100.0f, 100.0f};
+        float ambHigh = ExpectedFreeEnergyKernel.epistemicAmbiguity(precHigh);
+        
+        // Low precision (wide distribution) -> High entropy (high ambiguity)
+        float[] precLow = {1.0f, 1.0f};
+        float ambLow = ExpectedFreeEnergyKernel.epistemicAmbiguity(precLow);
+
+        assertThat(ambHigh).isLessThan(ambLow);
+    }
+
+    @Test
+    void epistemicAmbiguity_lowPrecision_highEntropy() {
+        float[] precLow = {1.0f, 1.0f};
+        float ambLow = ExpectedFreeEnergyKernel.epistemicAmbiguity(precLow);
+        
+        float[] precHigh = {10.0f, 10.0f};
+        float ambHigh = ExpectedFreeEnergyKernel.epistemicAmbiguity(precHigh);
+
+        assertThat(ambLow).isGreaterThan(ambHigh);
+    }
+
+    @Test
+    void expectedFreeEnergy_combinesBothCorrectly() {
+        float[] meanQ = {1.0f, 0.0f};
+        float[] precQ = {2.0f, 2.0f};
+        float[] meanP = {0.0f, 0.0f};
+        float[] precP = {2.0f, 2.0f};
+        float[] postPrec = {4.0f, 4.0f};
+
+        float pragmaticWeight = 1.0f;
+        float epistemicWeight = 1.0f;
+
+        float efe = ExpectedFreeEnergyKernel.expectedFreeEnergy(meanQ, meanP, precQ, precP, postPrec, pragmaticWeight, epistemicWeight);
+        float pragmatic = ExpectedFreeEnergyKernel.pragmaticRisk(meanQ, meanP, precQ, precP);
+        float epistemic = ExpectedFreeEnergyKernel.epistemicAmbiguity(postPrec);
+
+        assertThat(efe).isCloseTo(pragmatic * pragmaticWeight + epistemic * epistemicWeight, within(1e-5f));
+    }
+
+    @Test
+    void inputValidation_throwsOnNullOrDimensionMismatch() {
+        float[] a = {1.0f, 2.0f};
+        float[] b = {1.0f};
+        
+        assertThatThrownBy(() -> ExpectedFreeEnergyKernel.pragmaticRisk(a, a, b, a))
+                .isInstanceOf(SpectorValidationException.class);
+                
+        assertThatThrownBy(() -> ExpectedFreeEnergyKernel.epistemicAmbiguity(null))
+                .isInstanceOf(SpectorValidationException.class);
+                
+        assertThatThrownBy(() -> ExpectedFreeEnergyKernel.epistemicAmbiguity(new float[0]))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **AISME Phase 11: Expected Free Energy G(π) Policy Engine** — the final phase completing the Active Inference loop by transitioning Spector from passive perception to proactive cognitive agency.

**ADR**: [ADR-0019](https://github.com/spectrayan/spectrayan/blob/main/docs/adr/adr-0019-aisme-phase-11-expected-free-energy-policy-engine.md)
**Issue**: #611

## Changes

### SIMD Kernel (`spector-core`)
- `ExpectedFreeEnergyKernel`: AVX-512 accelerated pragmatic risk $D_{KL}[q(o|\pi) \| p(o)]$, epistemic ambiguity $\mathcal{H}(q(o|s,\pi))$, and combined EFE evaluation

### Policy Models & Engine (`spector-memory`)
- `PolicyType` enum: 6 canonical cognitive policy types (EPISTEMIC_EXPLORATION, PRAGMATIC_EXPLOITATION, CLARIFYING_INTERACTION, PROCEDURAL_CRYSTALLIZATION, HOMEOSTATIC_REST, NARRATIVE_REFRAMING)
- `CognitivePolicy` immutable record with predicted observation distributions
- `ExpectedFreeEnergyCalculator`: evaluates against **full sealed SoulContext hierarchy** (AgentSoul + UserSoul + TenantSoul + OrgUnitSoul) with configurable blending weights
- `PolicyInferenceEngine`: $\gamma$-modulated Boltzmann softmax selection with homeostatic arousal/dominance precision modulation
- `PolicyDecisionReport`: immutable telemetry record with ranked policy scores

### 5th Canonical `DecidePathway`
- New `CognitivePathway<DecideSignal>` — biologically analogous to the prefrontal decision circuit (dlPFC + ACC)
- 4-relay pipeline: SoulPreferenceGating → PolicyCandidateGeneration → PolicyInference → PolicyAudit
- `DecideSignal`, `DecideReport`, `DecideGates`

### Wiring & Integration
- `AismeBuilder`: accepts `List<SoulContext>` for multi-soul EFE evaluation (backward compatible)
- `AismeBundle`: includes `PolicyInferenceEngine` and `ExpectedFreeEnergyCalculator`
- `SpectorMemoryFactory`: builds and registers `DecidePathway` in `SubsystemBundle`
- `SpectorMemory`: exposes `decide(DecideSignal)` interface method
- `DefaultSpectorMemory`: delegates `decide()`, manages lifecycle `close()`

### Configuration (`spector-config`)
- `SpectorPropertyConstants`: EFE toggle, precision, epistemic/pragmatic weights, soul blending weights (agent=0.40, user=0.35, tenant=0.15, orgUnit=0.10)
- `AismeProperties`: EFE fields with validated setters and fluent accessors
- `AismeConfig`: EFE fields with builder, validation, factory methods

## Test Results
- ✅ `ExpectedFreeEnergyKernelTest` — SIMD numerical accuracy
- ✅ All 15 existing AISME tests pass (AismeConfigTest, AismeEndToEndIntegrationTest, WanderPathwayTest, WanderGatesTest, ContinuityLayoutTest, ContinuityRecordMemoryTest)
- ✅ `mvn license:check` — all 28 reactor modules pass

## Files Changed (20)

### New (12)
| File | Purpose |
|---|---|
| `ExpectedFreeEnergyKernel.java` | SIMD kernel for G(π) computation |
| `ExpectedFreeEnergyKernelTest.java` | SIMD kernel unit tests |
| `PolicyType.java` | Enum of 6 canonical policy types |
| `CognitivePolicy.java` | Immutable policy record |
| `ExpectedFreeEnergyCalculator.java` | Multi-soul EFE evaluator |
| `PolicyInferenceEngine.java` | Boltzmann softmax selector |
| `PolicyDecisionReport.java` | Decision telemetry record |
| `PolicyInferenceRelay.java` | SynapticRelay<DecideSignal> |
| `DecideSignal.java` | Pathway signal carrying policies |
| `DecideReport.java` | Pathway telemetry report |
| `DecideGates.java` | Gate specifications |
| `DecidePathway.java` | 5th canonical CognitivePathway |

### Modified (8)
| File | Change |
|---|---|
| `SpectorPropertyConstants.java` | +25 EFE constants |
| `AismeProperties.java` | +8 EFE fields with getters/setters/fluent |
| `AismeConfig.java` | +8 EFE fields in record, builder, factories |
| `AismeBundle.java` | +2 policy engine fields |
| `AismeBuilder.java` | Accepts List<SoulContext>, builds policy engine |
| `SpectorMemoryFactory.java` | Builds DecidePathway, adds to SubsystemBundle |
| `SpectorMemory.java` | +decide() interface method |
| `DefaultSpectorMemory.java` | +decide() delegation + close() lifecycle |