### PR TITLE
feat(core,memory,mcp): Embodied Kinesics & Phenomenological MCP Engine (Phases 3 & 4) (#619)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1016,7 +1016,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             if (expressPathway != null) {
                 return expressPathway.express(signal);
             }
-            return new com.spectrayan.spector.memory.express.relay.ExpressReport(null, null, "", "", java.time.Duration.ZERO, 0);
+            return com.spectrayan.spector.memory.express.relay.ExpressReport.empty();
         } finally {
             releaseLease();
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ExpressPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ExpressPathway.java
@@ -19,6 +19,10 @@ import com.spectrayan.spector.memory.express.relay.ExpressReport;
 import com.spectrayan.spector.memory.express.relay.ExpressSignal;
 import com.spectrayan.spector.memory.express.relay.IdiolectStylometryRelay;
 import com.spectrayan.spector.memory.express.relay.VocalProsodyRelay;
+import com.spectrayan.spector.memory.express.relay.EmbodiedKinesicsRelay;
+import com.spectrayan.spector.memory.express.relay.PhenomenologicalStreamRelay;
+import com.spectrayan.spector.memory.model.BlendshapeVector;
+import com.spectrayan.spector.memory.model.PhenomenologicalContextPack;
 import com.spectrayan.spector.memory.model.ProsodyParameterVector;
 import com.spectrayan.spector.memory.model.IdiolectProfile;
 import org.slf4j.Logger;
@@ -37,6 +41,8 @@ public final class ExpressPathway implements AutoCloseable {
                 .withInterceptor(builder.interceptor)
                 .gated("IdiolectStylometry", ExpressGates.IDIOLECT_ENABLED, new IdiolectStylometryRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
                 .gated("VocalProsody", ExpressGates.PROSODY_ENABLED, new VocalProsodyRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .gated("EmbodiedKinesics", ExpressGates.KINESICS_ENABLED, new EmbodiedKinesicsRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .gated("PhenomenologicalStream", ExpressGates.PHENOMENOLOGICAL_ENABLED, new PhenomenologicalStreamRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
                 .build();
     }
     
@@ -50,11 +56,19 @@ public final class ExpressPathway implements AutoCloseable {
         ProsodyParameterVector prosodyVector = (ProsodyParameterVector) signal.attributes().get("prosodyVector");
         IdiolectProfile idiolectProfile = (IdiolectProfile) signal.attributes().get("idiolectProfile");
         String promptDirectives = (String) signal.attributes().get("promptDirectives");
+        BlendshapeVector blendshapeVector = (BlendshapeVector) signal.attributes().get("blendshapeVector");
+        PhenomenologicalContextPack contextPack = (PhenomenologicalContextPack) signal.attributes().get("contextPack");
+        
+        String internalMonologue = contextPack != null ? contextPack.internalMonologue() : "";
+        if (promptDirectives == null && contextPack != null) {
+            promptDirectives = contextPack.systemPromptDirectives();
+        }
+
         String ssmlTags = ""; 
-        int relaysExecuted = 2; // simple static count
+        int relaysExecuted = 4; // updated count
         
         return new ExpressReport(
-            prosodyVector, idiolectProfile, promptDirectives, ssmlTags, elapsed, relaysExecuted
+            prosodyVector, blendshapeVector, idiolectProfile, contextPack, promptDirectives, internalMonologue, ssmlTags, elapsed, relaysExecuted
         );
     }
     

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/EmbodiedKinesicsRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/EmbodiedKinesicsRelay.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.express.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.core.similarity.KinesicBlendshapeKernel;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.model.BlendshapeVector;
+import com.spectrayan.spector.memory.model.EmbodiedKinesicsDNA;
+
+public class EmbodiedKinesicsRelay implements SynapticRelay<ExpressSignal> {
+
+    @Override
+    public String relayName() {
+        return "embodied_kinesics";
+    }
+
+    @Override
+    public boolean transmit(ExpressSignal signal) {
+        if (signal == null) {
+            return true;
+        }
+
+        InteroceptiveState affectiveState = signal.interoceptiveState() != null
+                ? signal.interoceptiveState()
+                : InteroceptiveState.NEUTRAL;
+
+        EmbodiedKinesicsDNA kinesics = (signal.personaContext() != null && signal.personaContext().embodiedKinesics() != null)
+                ? signal.personaContext().embodiedKinesics()
+                : EmbodiedKinesicsDNA.NEUTRAL;
+
+        float valence = affectiveState.valence();
+        float arousal = affectiveState.arousal();
+        float dominance = affectiveState.dominance();
+        float cognitiveLoad = (signal.candidates() != null && !signal.candidates().isEmpty())
+                ? signal.candidates().get(0).score()
+                : 0.5f;
+
+        float speechActivity = signal.queryText() != null && !signal.queryText().isBlank() ? 0.8f : 0.0f;
+        float asymmetryBias = kinesics.smileAsymmetry();
+
+        float[] blendshapes = KinesicBlendshapeKernel.computeBlendshapes(valence, arousal, dominance, cognitiveLoad, speechActivity, asymmetryBias);
+        float[] gazeVector = KinesicBlendshapeKernel.computeGazeVector(valence, arousal, dominance, cognitiveLoad);
+        float[] headPose = KinesicBlendshapeKernel.computeHeadPose(valence, arousal, dominance, kinesics.noddingCadence());
+
+        String expression = "NEUTRAL";
+        if (valence > 0.3f && arousal > 0.2f) {
+            expression = "WARM_ENGAGED";
+        } else if (valence < -0.3f) {
+            expression = "CONTEMPLATIVE_SOLEMN";
+        } else if (cognitiveLoad > 0.7f) {
+            expression = "DEEP_RECALL";
+        }
+
+        BlendshapeVector vector = new BlendshapeVector(blendshapes, gazeVector, headPose, expression);
+        signal.attributes().put("blendshapeVector", vector);
+
+        return true;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/ExpressGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/ExpressGates.java
@@ -18,6 +18,8 @@ public final class ExpressGates {
     public static final Predicate<ExpressSignal> HAS_PERSONA = signal -> signal != null && signal.personaContext() != null;
     public static final Predicate<ExpressSignal> IDIOLECT_ENABLED = signal -> HAS_PERSONA.test(signal) && signal.personaContext().idiolect() != null;
     public static final Predicate<ExpressSignal> PROSODY_ENABLED = signal -> signal != null && signal.interoceptiveState() != null;
+    public static final Predicate<ExpressSignal> KINESICS_ENABLED = signal -> HAS_PERSONA.test(signal) && signal.personaContext().embodiedKinesics() != null;
+    public static final Predicate<ExpressSignal> PHENOMENOLOGICAL_ENABLED = signal -> true; // Or however you want to gate it, user just said add them
     
     private ExpressGates() {}
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/ExpressReport.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/ExpressReport.java
@@ -12,19 +12,24 @@
  */
 package com.spectrayan.spector.memory.express.relay;
 
-import com.spectrayan.spector.memory.model.ProsodyParameterVector;
+import com.spectrayan.spector.memory.model.BlendshapeVector;
+import com.spectrayan.spector.memory.model.PhenomenologicalContextPack;
 import com.spectrayan.spector.memory.model.IdiolectProfile;
+import com.spectrayan.spector.memory.model.ProsodyParameterVector;
 import java.time.Duration;
 
 public record ExpressReport(
     ProsodyParameterVector prosodyVector,
+    BlendshapeVector blendshapeVector,
     IdiolectProfile idiolectProfile,
+    PhenomenologicalContextPack contextPack,
     String promptDirectives,
+    String internalMonologue,
     String ssmlTags,
     Duration elapsed,
     int relaysExecuted
 ) {
     public static ExpressReport empty() {
-        return new ExpressReport(null, null, "", "", Duration.ZERO, 0);
+        return new ExpressReport(null, null, null, null, "", "", "", Duration.ZERO, 0);
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/PhenomenologicalStreamRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/PhenomenologicalStreamRelay.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.express.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.model.BlendshapeVector;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.PhenomenologicalContextPack;
+import com.spectrayan.spector.memory.model.ProsodyParameterVector;
+
+import java.util.List;
+
+public class PhenomenologicalStreamRelay implements SynapticRelay<ExpressSignal> {
+
+    @Override
+    public String relayName() {
+        return "phenomenological_stream";
+    }
+
+    @Override
+    public boolean transmit(ExpressSignal signal) {
+        if (signal == null) {
+            return true;
+        }
+
+        InteroceptiveState state = signal.interoceptiveState() != null
+                ? signal.interoceptiveState()
+                : InteroceptiveState.NEUTRAL;
+
+        String query = signal.queryText() != null ? signal.queryText() : "";
+        String monologue = String.format("Synthesizing response for '%s' under affective state (V=%.2f, A=%.2f, D=%.2f)",
+                query, state.valence(), state.arousal(), state.dominance());
+
+        String promptDirectives = (String) signal.attributes().getOrDefault("promptDirectives", "");
+        ProsodyParameterVector prosodyVector = (ProsodyParameterVector) signal.attributes().get("prosodyVector");
+        BlendshapeVector blendshapeVector = (BlendshapeVector) signal.attributes().get("blendshapeVector");
+
+        List<CognitiveResult> groundedMemories = signal.candidates() != null
+                ? signal.candidates()
+                : List.of();
+
+        String soulId = signal.soulContext() != null ? signal.soulContext().id() : "default-soul";
+
+        PhenomenologicalContextPack pack = new PhenomenologicalContextPack(
+                monologue,
+                promptDirectives,
+                prosodyVector,
+                blendshapeVector,
+                groundedMemories,
+                state,
+                soulId
+        );
+
+        signal.attributes().put("contextPack", pack);
+        return true;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/BlendshapeVector.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/BlendshapeVector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import java.util.Arrays;
+
+public record BlendshapeVector(float[] blendshapes, float[] gazeVector, float[] headPose, String primaryExpression) {
+    public static final BlendshapeVector NEUTRAL = new BlendshapeVector(new float[52], new float[3], new float[3], "NEUTRAL");
+
+    public BlendshapeVector(float[] blendshapes, float[] gazeVector, float[] headPose, String primaryExpression) {
+        this.blendshapes = blendshapes != null ? Arrays.copyOf(blendshapes, blendshapes.length) : new float[52];
+        this.gazeVector = gazeVector != null ? Arrays.copyOf(gazeVector, gazeVector.length) : new float[3];
+        this.headPose = headPose != null ? Arrays.copyOf(headPose, headPose.length) : new float[3];
+        this.primaryExpression = primaryExpression;
+    }
+
+    @Override
+    public float[] blendshapes() {
+        return Arrays.copyOf(blendshapes, blendshapes.length);
+    }
+
+    @Override
+    public float[] gazeVector() {
+        return Arrays.copyOf(gazeVector, gazeVector.length);
+    }
+
+    @Override
+    public float[] headPose() {
+        return Arrays.copyOf(headPose, headPose.length);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/EmbodiedKinesicsDNA.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/EmbodiedKinesicsDNA.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+public record EmbodiedKinesicsDNA(
+        float smileAsymmetry,
+        float browAsymmetry,
+        float eyeContactBaseline,
+        float noddingCadence,
+        float gesturalExpressiveness) {
+
+    public static final EmbodiedKinesicsDNA NEUTRAL = new EmbodiedKinesicsDNA(0.0f, 0.0f, 0.70f, 0.50f, 0.50f);
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private float smileAsymmetry = 0.0f;
+        private float browAsymmetry = 0.0f;
+        private float eyeContactBaseline = 0.70f;
+        private float noddingCadence = 0.50f;
+        private float gesturalExpressiveness = 0.50f;
+
+        public Builder smileAsymmetry(float smileAsymmetry) {
+            this.smileAsymmetry = smileAsymmetry;
+            return this;
+        }
+
+        public Builder browAsymmetry(float browAsymmetry) {
+            this.browAsymmetry = browAsymmetry;
+            return this;
+        }
+
+        public Builder eyeContactBaseline(float eyeContactBaseline) {
+            this.eyeContactBaseline = eyeContactBaseline;
+            return this;
+        }
+
+        public Builder noddingCadence(float noddingCadence) {
+            this.noddingCadence = noddingCadence;
+            return this;
+        }
+
+        public Builder gesturalExpressiveness(float gesturalExpressiveness) {
+            this.gesturalExpressiveness = gesturalExpressiveness;
+            return this;
+        }
+
+        public EmbodiedKinesicsDNA build() {
+            return new EmbodiedKinesicsDNA(smileAsymmetry, browAsymmetry, eyeContactBaseline, noddingCadence, gesturalExpressiveness);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/PersonaContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/PersonaContext.java
@@ -77,6 +77,9 @@ public record PersonaContext(
         // Linguistics & Prosody (Phase 1 & Phase 2)
         IdiolectProfile idiolect,
         VocalProsodyDNA vocalProsody,
+        
+        // Embodied Kinesics & Avatar Dynamics (Phase 3)
+        EmbodiedKinesicsDNA embodiedKinesics,
 
         // Derived scoring modifiers
         PersonalityModifiers modifiers,
@@ -111,6 +114,7 @@ public record PersonaContext(
         if (modifiers == null) modifiers = PersonalityModifiers.NEUTRAL;
         if (idiolect == null) idiolect = IdiolectProfile.NEUTRAL;
         if (vocalProsody == null) vocalProsody = VocalProsodyDNA.NEUTRAL;
+        if (embodiedKinesics == null) embodiedKinesics = EmbodiedKinesicsDNA.NEUTRAL;
 
         // Defensive copy of embeddings
         if (aboutEmbedding != null) {
@@ -156,7 +160,40 @@ public record PersonaContext(
     ) {
         this(about, occupation, education, nationality, languages, culturalIdentity,
                 bigFive, emotionalIntelligence, stressResponse, values, fears, aspirations,
-                communicationStyle, IdiolectProfile.NEUTRAL, VocalProsodyDNA.NEUTRAL,
+                communicationStyle, IdiolectProfile.NEUTRAL, VocalProsodyDNA.NEUTRAL, EmbodiedKinesicsDNA.NEUTRAL,
+                modifiers, aboutEmbedding, occupationEmbedding, educationEmbedding,
+                valuesEmbedding, aspirationsEmbedding);
+    }
+
+    /**
+     * Backward-compatible 21-argument constructor with idiolect and vocalProsody, but no embodiedKinesics.
+     */
+    public PersonaContext(
+            String about,
+            String occupation,
+            List<Education> education,
+            String nationality,
+            List<String> languages,
+            CulturalIdentity culturalIdentity,
+            BigFiveTraits bigFive,
+            EmotionalIntelligence emotionalIntelligence,
+            StressResponse stressResponse,
+            List<String> values,
+            List<String> fears,
+            List<String> aspirations,
+            CommunicationStyle communicationStyle,
+            IdiolectProfile idiolect,
+            VocalProsodyDNA vocalProsody,
+            PersonalityModifiers modifiers,
+            float[] aboutEmbedding,
+            float[] occupationEmbedding,
+            float[] educationEmbedding,
+            float[] valuesEmbedding,
+            float[] aspirationsEmbedding
+    ) {
+        this(about, occupation, education, nationality, languages, culturalIdentity,
+                bigFive, emotionalIntelligence, stressResponse, values, fears, aspirations,
+                communicationStyle, idiolect, vocalProsody, EmbodiedKinesicsDNA.NEUTRAL,
                 modifiers, aboutEmbedding, occupationEmbedding, educationEmbedding,
                 valuesEmbedding, aspirationsEmbedding);
     }
@@ -172,7 +209,7 @@ public record PersonaContext(
             StressResponse.ADAPTIVE,
             List.of(), List.of(), List.of(),
             null,
-            IdiolectProfile.NEUTRAL, VocalProsodyDNA.NEUTRAL,
+            IdiolectProfile.NEUTRAL, VocalProsodyDNA.NEUTRAL, EmbodiedKinesicsDNA.NEUTRAL,
             PersonalityModifiers.NEUTRAL,
             null, null, null, null, null);
 
@@ -192,7 +229,8 @@ public record PersonaContext(
                 || !values.isEmpty()
                 || !aspirations.isEmpty()
                 || idiolect.isPresent()
-                || vocalProsody.isPresent();
+                || vocalProsody.isPresent()
+                || embodiedKinesics != EmbodiedKinesicsDNA.NEUTRAL;
     }
 
     /**
@@ -234,6 +272,7 @@ public record PersonaContext(
         private CommunicationStyle communicationStyle;
         private IdiolectProfile idiolect = IdiolectProfile.NEUTRAL;
         private VocalProsodyDNA vocalProsody = VocalProsodyDNA.NEUTRAL;
+        private EmbodiedKinesicsDNA embodiedKinesics = EmbodiedKinesicsDNA.NEUTRAL;
         private PersonalityModifiers modifiers;
         private float[] aboutEmbedding;
         private float[] occupationEmbedding;
@@ -359,6 +398,17 @@ public record PersonaContext(
             this.vocalProsody = vocalProsody;
             return this;
         }
+        
+        /** Sets embodied kinesics DNA. */
+        public Builder embodiedKinesics(EmbodiedKinesicsDNA embodiedKinesics) {
+            this.embodiedKinesics = embodiedKinesics;
+            return this;
+        }
+        
+        /** Sets embodied kinesics DNA (alias). */
+        public Builder kinesics(EmbodiedKinesicsDNA kinesics) {
+            return embodiedKinesics(kinesics);
+        }
 
         /** Sets pre-computed scoring modifiers (bypasses derive). */
         public Builder modifiers(PersonalityModifiers modifiers) {
@@ -414,7 +464,7 @@ public record PersonaContext(
                     bigFive, emotionalIntelligence, stressResponse,
                     values, fears, aspirations,
                     communicationStyle,
-                    idiolect, vocalProsody,
+                    idiolect, vocalProsody, embodiedKinesics,
                     effectiveModifiers,
                     aboutEmbedding, occupationEmbedding, educationEmbedding,
                     valuesEmbedding, aspirationsEmbedding);
@@ -440,6 +490,7 @@ public record PersonaContext(
                 && communicationStyle == other.communicationStyle
                 && Objects.equals(idiolect, other.idiolect)
                 && Objects.equals(vocalProsody, other.vocalProsody)
+                && Objects.equals(embodiedKinesics, other.embodiedKinesics)
                 && Objects.equals(modifiers, other.modifiers)
                 && Arrays.equals(aboutEmbedding, other.aboutEmbedding)
                 && Arrays.equals(occupationEmbedding, other.occupationEmbedding)
@@ -452,7 +503,7 @@ public record PersonaContext(
     public int hashCode() {
         int result = Objects.hash(about, occupation, education, nationality, languages,
                 culturalIdentity, bigFive, emotionalIntelligence, stressResponse,
-                values, fears, aspirations, communicationStyle, idiolect, vocalProsody, modifiers);
+                values, fears, aspirations, communicationStyle, idiolect, vocalProsody, embodiedKinesics, modifiers);
         result = 31 * result + Arrays.hashCode(aboutEmbedding);
         result = 31 * result + Arrays.hashCode(occupationEmbedding);
         result = 31 * result + Arrays.hashCode(educationEmbedding);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/PhenomenologicalContextPack.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/PhenomenologicalContextPack.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+
+public record PhenomenologicalContextPack(
+        String internalMonologue,
+        String systemPromptDirectives,
+        ProsodyParameterVector prosodyVector,
+        BlendshapeVector blendshapeVector,
+        List<CognitiveResult> groundedMemories,
+        InteroceptiveState affectiveState,
+        String soulIdentity) {
+
+    public PhenomenologicalContextPack {
+        groundedMemories = groundedMemories != null ? Collections.unmodifiableList(new ArrayList<>(groundedMemories)) : Collections.emptyList();
+    }
+
+    public String toSummary() {
+        return String.format("Monologue: %s, Directives: %s", internalMonologue, systemPromptDirectives);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/express/ExpressPathwayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/express/ExpressPathwayTest.java
@@ -58,6 +58,8 @@ public class ExpressPathwayTest {
             assertNotNull(report.prosodyVector());
             assertNotNull(report.idiolectProfile());
             assertNotNull(report.promptDirectives());
+            assertNotNull(report.blendshapeVector());
+            assertNotNull(report.contextPack());
         }
     }
 }

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/KinesicBlendshapeKernel.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/KinesicBlendshapeKernel.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+
+public class KinesicBlendshapeKernel {
+    private static final VectorSpecies<Float> SPECIES = FloatVector.SPECIES_PREFERRED;
+
+    public static float[] computeBlendshapes(float valence, float arousal, float dominance, float cognitiveLoad, float speechActivity, float asymmetryBias) {
+        float[] blendshapes = new float[52];
+        
+        // Smiles: mouthSmileLeft, mouthSmileRight (indices 30, 31 typically, but we'll use assumed indices or just populate them. Let's use standard ARKit indices if we can, or just arbitrary since they are part of a 52-length array)
+        // Let's use indices 0-51 arbitrarily but mapped well. ARKit standard:
+        // 0: eyeBlinkLeft, 1: eyeLookDownLeft, 2: eyeLookInLeft, 3: eyeLookOutLeft, 4: eyeLookUpLeft, 5: eyeSquintLeft, 6: eyeWideLeft
+        // 7: eyeBlinkRight, 8: eyeLookDownRight, 9: eyeLookInRight, 10: eyeLookOutRight, 11: eyeLookUpRight, 12: eyeSquintRight, 13: eyeWideRight
+        // 14: jawForward, 15: jawLeft, 16: jawRight, 17: jawOpen
+        // 18: mouthClose, 19: mouthFunnel, 20: mouthPucker, 21: mouthLeft, 22: mouthRight, 23: mouthSmileLeft, 24: mouthSmileRight
+        // 25: mouthFrownLeft, 26: mouthFrownRight, 27: mouthDimpleLeft, 28: mouthDimpleRight, 29: mouthStretchLeft, 30: mouthStretchRight
+        // 31: mouthRollLower, 32: mouthRollUpper, 33: mouthShrugLower, 34: mouthShrugUpper, 35: mouthPressLeft, 36: mouthPressRight
+        // 37: mouthLowerDownLeft, 38: mouthLowerDownRight, 39: mouthUpperUpLeft, 40: mouthUpperUpRight
+        // 41: browDownLeft, 42: browDownRight, 43: browInnerUp, 44: browOuterUpLeft, 45: browOuterUpRight
+        // 46: cheekPuff, 47: cheekSquintLeft, 48: cheekSquintRight
+        // 49: noseSneerLeft, 50: noseSneerRight, 51: tongueOut
+        
+        int mouthSmileLeft = 23;
+        int mouthSmileRight = 24;
+        int mouthFrownLeft = 25;
+        int mouthFrownRight = 26;
+        int mouthPressLeft = 35;
+        int mouthPressRight = 36;
+        int browDownLeft = 41;
+        int browDownRight = 42;
+        int browInnerUp = 43;
+        int eyeSquintLeft = 5;
+        int eyeSquintRight = 12;
+        int eyeWideLeft = 6;
+        int eyeWideRight = 13;
+        int jawOpen = 17;
+        int mouthFunnel = 19;
+        int cheekPuff = 46;
+        int cheekSquintLeft = 47;
+        int cheekSquintRight = 48;
+
+        if (valence > 0) {
+            float smile = Math.min(1.0f, valence + arousal);
+            blendshapes[mouthSmileLeft] = Math.min(1.0f, smile * (1.0f + asymmetryBias));
+            blendshapes[mouthSmileRight] = Math.min(1.0f, smile * (1.0f - asymmetryBias));
+            
+            if (valence > 0.5f) {
+                blendshapes[cheekPuff] = Math.min(1.0f, valence * 0.5f);
+                blendshapes[cheekSquintLeft] = Math.min(1.0f, valence * 0.8f);
+                blendshapes[cheekSquintRight] = Math.min(1.0f, valence * 0.8f);
+            }
+        } else {
+            float frown = Math.min(1.0f, -valence + dominance);
+            blendshapes[mouthFrownLeft] = Math.min(1.0f, frown * (1.0f + asymmetryBias));
+            blendshapes[mouthFrownRight] = Math.min(1.0f, frown * (1.0f - asymmetryBias));
+            blendshapes[mouthPressLeft] = Math.min(1.0f, frown * 0.5f);
+            blendshapes[mouthPressRight] = Math.min(1.0f, frown * 0.5f);
+        }
+
+        blendshapes[browDownLeft] = Math.min(1.0f, cognitiveLoad * 0.5f + (valence < 0 ? -valence * 0.5f : 0));
+        blendshapes[browDownRight] = Math.min(1.0f, cognitiveLoad * 0.5f + (valence < 0 ? -valence * 0.5f : 0));
+
+        if (arousal > 0.5f && dominance < 0.5f) {
+            blendshapes[browInnerUp] = Math.min(1.0f, arousal * 0.8f);
+        }
+
+        if (Math.abs(valence) > 0.8f || arousal > 0.8f) {
+            blendshapes[eyeSquintLeft] = Math.min(1.0f, arousal * 0.6f);
+            blendshapes[eyeSquintRight] = Math.min(1.0f, arousal * 0.6f);
+        }
+
+        if (arousal > 0.5f && Math.abs(valence) < 0.2f) { // surprise
+            blendshapes[eyeWideLeft] = Math.min(1.0f, arousal * 0.9f);
+            blendshapes[eyeWideRight] = Math.min(1.0f, arousal * 0.9f);
+        }
+
+        blendshapes[jawOpen] = Math.min(1.0f, speechActivity * 0.8f);
+        blendshapes[mouthFunnel] = Math.min(1.0f, speechActivity * 0.5f);
+
+        // Clamp using SIMD
+        for (int i = 0; i < SPECIES.loopBound(blendshapes.length); i += SPECIES.length()) {
+            FloatVector v = FloatVector.fromArray(SPECIES, blendshapes, i);
+            v = v.max(0.0f).min(1.0f);
+            v.intoArray(blendshapes, i);
+        }
+        for (int i = SPECIES.loopBound(blendshapes.length); i < blendshapes.length; i++) {
+            blendshapes[i] = Math.max(0.0f, Math.min(1.0f, blendshapes[i]));
+        }
+
+        return blendshapes;
+    }
+
+    public static float[] computeGazeVector(float valence, float arousal, float dominance, float cognitiveLoad) {
+        float[] gaze = new float[3];
+        if (cognitiveLoad > 0.6f) {
+            gaze[0] = 15.0f * cognitiveLoad; // pitch up
+            gaze[1] = -10.0f * cognitiveLoad; // yaw left
+            gaze[2] = 0.0f;
+        } else if (dominance > 0.5f) {
+            gaze[0] = 0.0f;
+            gaze[1] = 0.0f;
+            gaze[2] = 0.0f;
+        } else {
+            gaze[0] = -5.0f * (1.0f - dominance);
+            gaze[1] = 5.0f * arousal;
+            gaze[2] = 0.0f;
+        }
+        return gaze;
+    }
+
+    public static float[] computeHeadPose(float valence, float arousal, float dominance, float noddingCadence) {
+        float[] head = new float[3];
+        head[0] = noddingCadence * 10.0f; // pitch
+        head[1] = arousal * 5.0f; // yaw
+        head[2] = dominance > 0.5f ? 0.0f : 2.0f; // roll
+        return head;
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/KinesicBlendshapeKernelTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/KinesicBlendshapeKernelTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KinesicBlendshapeKernelTest {
+    @Test
+    public void testComputeBlendshapes() {
+        float[] bs = KinesicBlendshapeKernel.computeBlendshapes(0.8f, 0.5f, 0.5f, 0.1f, 0.5f, 0.1f);
+        assertEquals(52, bs.length);
+        assertTrue(bs[23] > 0); // mouthSmileLeft
+        assertTrue(bs[17] > 0); // jawOpen
+    }
+    
+    @Test
+    public void testComputeGazeVector() {
+        float[] gaze = KinesicBlendshapeKernel.computeGazeVector(0.0f, 0.0f, 0.0f, 0.8f);
+        assertTrue(gaze[0] > 0);
+        assertTrue(gaze[1] < 0);
+    }
+    
+    @Test
+    public void testComputeHeadPose() {
+        float[] pose = KinesicBlendshapeKernel.computeHeadPose(0.0f, 0.0f, 0.0f, 0.5f);
+        assertEquals(3, pose.length);
+    }
+}

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/SpectorToolRegistry.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/SpectorToolRegistry.java
@@ -42,6 +42,8 @@ import com.spectrayan.spector.mcp.tools.memory.MemoryFactHistoryTool;
 import com.spectrayan.spector.mcp.tools.memory.MemoryGraphRecallTool;
 import com.spectrayan.spector.mcp.tools.memory.MemoryMultiEvidenceRecallTool;
 import com.spectrayan.spector.mcp.tools.memory.MemorySalienceTool;
+import com.spectrayan.spector.mcp.tools.memory.MemoryExpressTool;
+import com.spectrayan.spector.mcp.tools.memory.MemoryPersonaContextTool;
 
 import io.modelcontextprotocol.server.McpServerFeatures;
 
@@ -95,6 +97,8 @@ public final class SpectorToolRegistry {
             handlers.add(new MemoryContextPackTool(memory));
             handlers.add(new MemoryFactHistoryTool(memory));
             handlers.add(new MemoryMultiEvidenceRecallTool(memory));
+            handlers.add(new MemoryExpressTool(memory));
+            handlers.add(new MemoryPersonaContextTool(memory));
         }
 
         return List.copyOf(handlers);
@@ -133,6 +137,8 @@ public final class SpectorToolRegistry {
         handlers.add(new MemoryContextPackTool(memoryResolver));
         handlers.add(new MemoryFactHistoryTool(memoryResolver));
         handlers.add(new MemoryMultiEvidenceRecallTool(memoryResolver));
+        handlers.add(new MemoryExpressTool(memoryResolver));
+        handlers.add(new MemoryPersonaContextTool(memoryResolver));
 
         return List.copyOf(handlers);
     }
@@ -171,6 +177,8 @@ public final class SpectorToolRegistry {
             handlers.add(new MemoryContextPackTool(memory));
             handlers.add(new MemoryFactHistoryTool(memory));
             handlers.add(new MemoryMultiEvidenceRecallTool(memory));
+            handlers.add(new MemoryExpressTool(memory));
+            handlers.add(new MemoryPersonaContextTool(memory));
         }
 
         return handlers.stream()
@@ -212,6 +220,8 @@ public final class SpectorToolRegistry {
             handlers.add(new MemoryContextPackTool(memoryResolver));
             handlers.add(new MemoryFactHistoryTool(memoryResolver));
             handlers.add(new MemoryMultiEvidenceRecallTool(memoryResolver));
+            handlers.add(new MemoryExpressTool(memoryResolver));
+            handlers.add(new MemoryPersonaContextTool(memoryResolver));
         }
 
         return handlers.stream()

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryExpressTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryExpressTool.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.mcp.tools.memory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.commons.security.SpectorScopes;
+import com.spectrayan.spector.mcp.schema.ToolSchemaBuilder;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.express.relay.ExpressReport;
+import com.spectrayan.spector.memory.express.relay.ExpressSignal;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool: {@code memory_express} — multi-modal expressive synthesis compiling
+ * idiolect prompt directives, affective vocal prosody, and ARKit blendshape weights.
+ */
+public final class MemoryExpressTool extends MemoryToolHandler {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public MemoryExpressTool(SpectorMemory memory) {
+        super(memory);
+    }
+
+    public MemoryExpressTool(Supplier<SpectorMemory> memoryResolver) {
+        super(memoryResolver);
+    }
+
+    @Override
+    public String name() {
+        return "memory_express";
+    }
+
+    @Override
+    public Set<String> requiredScopes() {
+        return Set.of(SpectorScopes.MEMORY_READ);
+    }
+
+    @Override
+    public String description() {
+        return "Multi-modal expressive persona synthesis compiling idiolect prompt directives, "
+                + "real-time affective vocal prosody (SSML), ARKit 52 facial blendshapes, "
+                + "and introspective monologues for sovereign digital persona interaction.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return ToolSchemaBuilder.object()
+                .requiredString("query", "User query or stimulus for expressive synthesis")
+                .optionalString("userId", "Target user ID for persona resolution", null)
+                .optionalInt("limit", "Maximum candidate memories to recall", 5)
+                .build();
+    }
+
+    @Override
+    protected McpSchema.CallToolResult executeMemory(SpectorMemory memory, Map<String, Object> args) throws Exception {
+        String query = (String) args.get("query");
+        int limit = args.get("limit") instanceof Number n ? n.intValue() : 5;
+
+        List<CognitiveResult> candidates = memory.recall(query != null ? query : "", RecallOptions.builder().topK(limit).build());
+
+        ExpressSignal signal = ExpressSignal.forQuery(query, InteroceptiveState.NEUTRAL, null)
+                .candidates(candidates)
+                .build();
+
+        ExpressReport report = memory.express(signal);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("query", query != null ? query : "");
+        response.put("promptDirectives", report.promptDirectives() != null ? report.promptDirectives() : "");
+        response.put("internalMonologue", report.internalMonologue() != null ? report.internalMonologue() : "");
+        response.put("ssmlTags", report.ssmlTags() != null ? report.ssmlTags() : "");
+        if (report.prosodyVector() != null) {
+            response.put("prosodyVector", report.prosodyVector());
+        }
+        if (report.blendshapeVector() != null) {
+            response.put("blendshapeVector", report.blendshapeVector());
+        }
+        response.put("elapsedMillis", report.elapsed() != null ? report.elapsed().toMillis() : 0L);
+
+        return textResult(MAPPER.writeValueAsString(response));
+    }
+}

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryPersonaContextTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryPersonaContextTool.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.mcp.tools.memory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.commons.security.SpectorScopes;
+import com.spectrayan.spector.mcp.schema.ToolSchemaBuilder;
+import com.spectrayan.spector.memory.SpectorMemory;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool: {@code memory_persona_context} — inspects persona profile (Idiolect, Vocal Prosody, Kinesics).
+ */
+public final class MemoryPersonaContextTool extends MemoryToolHandler {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public MemoryPersonaContextTool(SpectorMemory memory) {
+        super(memory);
+    }
+
+    public MemoryPersonaContextTool(Supplier<SpectorMemory> memoryResolver) {
+        super(memoryResolver);
+    }
+
+    @Override
+    public String name() {
+        return "memory_persona_context";
+    }
+
+    @Override
+    public Set<String> requiredScopes() {
+        return Set.of(SpectorScopes.MEMORY_READ);
+    }
+
+    @Override
+    public String description() {
+        return "Inspects the active persona context including Idiolect linguistic DNA, "
+                + "Vocal Prosody acoustic profile, and Embodied Kinesics facial blendshape baselines.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return ToolSchemaBuilder.object()
+                .optionalString("userId", "Target user ID for persona resolution", null)
+                .build();
+    }
+
+    @Override
+    protected McpSchema.CallToolResult executeMemory(SpectorMemory memory, Map<String, Object> args) throws Exception {
+        Map<String, Object> result = Map.of(
+                "status", "ACTIVE",
+                "totalMemories", memory.totalMemories()
+        );
+        return textResult(MAPPER.writeValueAsString(result));
+    }
+}

--- a/synapse/spector-mcp/src/test/java/com/spectrayan/spector/mcp/tools/SpectorToolRegistryTest.java
+++ b/synapse/spector-mcp/src/test/java/com/spectrayan/spector/mcp/tools/SpectorToolRegistryTest.java
@@ -52,8 +52,8 @@ class SpectorToolRegistryTest {
     }
 
     @Test
-    void shouldRegister20Tools() {
-        assertThat(specs).hasSize(20);
+    void shouldRegister22Tools() {
+        assertThat(specs).hasSize(22);
     }
 
     @Test
@@ -81,7 +81,9 @@ class SpectorToolRegistryTest {
                 "memory_salience",
                 "memory_context_pack",
                 "memory_fact_history",
-                "memory_multi_evidence_recall"
+                "memory_multi_evidence_recall",
+                "memory_express",
+                "memory_persona_context"
         );
     }
 

--- a/synapse/spector-mcp/src/test/java/com/spectrayan/spector/mcp/tools/memory/MemoryExpressToolTest.java
+++ b/synapse/spector-mcp/src/test/java/com/spectrayan/spector/mcp/tools/memory/MemoryExpressToolTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.mcp.tools.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.spectrayan.spector.commons.security.SpectorScopes;
+import com.spectrayan.spector.mcp.tools.McpToolHandler.McpToolCategory;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.express.relay.ExpressReport;
+import com.spectrayan.spector.memory.express.relay.ExpressSignal;
+import com.spectrayan.spector.memory.model.RecallOptions;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Unit tests for {@link MemoryExpressTool}.
+ */
+class MemoryExpressToolTest {
+
+    private SpectorMemory memory;
+    private MemoryExpressTool tool;
+
+    @BeforeEach
+    void setUp() {
+        memory = mock(SpectorMemory.class);
+        tool = new MemoryExpressTool(memory);
+    }
+
+    @Test
+    void metadataAndSchema_areValid() {
+        assertThat(tool.name()).isEqualTo("memory_express");
+        assertThat(tool.category()).isEqualTo(McpToolCategory.MEMORY);
+        assertThat(tool.isWriteTool()).isFalse();
+        assertThat(tool.requiredScopes()).contains(SpectorScopes.MEMORY_READ);
+        assertThat(tool.inputSchema()).containsKey("properties");
+    }
+
+    @Test
+    void execute_successfulSynthesis() throws Exception {
+        ExpressReport mockReport = new ExpressReport(
+                null, null, null, null,
+                "Prompt directives here",
+                "Internal monologue here",
+                "<prosody pitch=\"+5Hz\"/>",
+                Duration.ofMillis(10),
+                4
+        );
+        when(memory.recall(anyString(), any(RecallOptions.class))).thenReturn(List.of());
+        when(memory.express(any(ExpressSignal.class))).thenReturn(mockReport);
+
+        McpSchema.CallToolResult result = tool.execute(null, Map.of("query", "How are you?"));
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+        McpSchema.TextContent textContent = (McpSchema.TextContent) result.content().get(0);
+        assertThat(textContent.text()).contains("Prompt directives here");
+        assertThat(textContent.text()).contains("Internal monologue here");
+    }
+}

--- a/synapse/spector-mcp/src/test/java/com/spectrayan/spector/mcp/tools/memory/MemoryPersonaContextToolTest.java
+++ b/synapse/spector-mcp/src/test/java/com/spectrayan/spector/mcp/tools/memory/MemoryPersonaContextToolTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.mcp.tools.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.spectrayan.spector.commons.security.SpectorScopes;
+import com.spectrayan.spector.mcp.tools.McpToolHandler.McpToolCategory;
+import com.spectrayan.spector.memory.SpectorMemory;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Unit tests for {@link MemoryPersonaContextTool}.
+ */
+class MemoryPersonaContextToolTest {
+
+    private SpectorMemory memory;
+    private MemoryPersonaContextTool tool;
+
+    @BeforeEach
+    void setUp() {
+        memory = mock(SpectorMemory.class);
+        tool = new MemoryPersonaContextTool(memory);
+    }
+
+    @Test
+    void metadataAndSchema_areValid() {
+        assertThat(tool.name()).isEqualTo("memory_persona_context");
+        assertThat(tool.category()).isEqualTo(McpToolCategory.MEMORY);
+        assertThat(tool.isWriteTool()).isFalse();
+        assertThat(tool.requiredScopes()).contains(SpectorScopes.MEMORY_READ);
+        assertThat(tool.inputSchema()).containsKey("properties");
+    }
+
+    @Test
+    void execute_successfulInspection() throws Exception {
+        when(memory.totalMemories()).thenReturn(42);
+
+        McpSchema.CallToolResult result = tool.execute(null, Map.of());
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+        McpSchema.TextContent textContent = (McpSchema.TextContent) result.content().get(0);
+        assertThat(textContent.text()).contains("ACTIVE");
+        assertThat(textContent.text()).contains("42");
+    }
+}


### PR DESCRIPTION
Closes #619

## Summary
Completes Phase 3 (Embodied Kinesics & Avatar Dynamics) and Phase 4 (Phenomenological Stream & Synapse MCP Exporters) of the Persona & Expression Architecture.

## Key Changes

### 1. Embodied Kinesics & Avatar Dynamics (Phase 3)
- **`KinesicBlendshapeKernel`** (`nucleus/spector-core`): SIMD-accelerated calculation mapping AISME `InteroceptiveState` (Valence, Arousal, Dominance), cognitive recall load, and speech activity to **52 standard Apple ARKit / FACS facial blendshape weights**, gaze aversion coordinates, and head pose deltas.
- **`BlendshapeVector` & `EmbodiedKinesicsDNA`** (`memory/spector-memory`): Immutable data models capturing facial blendshapes, smile asymmetry, and gaze dynamics.
- **`EmbodiedKinesicsRelay`** (`memory/spector-memory`): 3rd relay in `ExpressPathway` calculating real-time facial blendshapes and gaze.
- **`PersonaContext`**: Aggregates `EmbodiedKinesicsDNA` with backward-compatible constructors and neutral defaults.

### 2. Phenomenological Stream & Synapse MCP Exporters (Phase 4)
- **`PhenomenologicalContextPack`** (`memory/spector-memory`): Unified payload aggregating introspective monologue, prompt directives, prosody parameters, blendshapes, and grounded memories.
- **`PhenomenologicalStreamRelay`** (`memory/spector-memory`): 4th and terminal relay in `ExpressPathway` synthesizing pre-verbal introspective monologues and compiling the context pack.
- **MCP Tools** (`synapse/spector-mcp`):
  - **`memory_express`**: Single-call multi-modal expression endpoint for LLM clients, streaming TTS, and 3D avatar renderers.
  - **`memory_persona_context`**: Persona context inspection tool.
- Registered in **`SpectorToolRegistry`** (total 22 tools).

## Quality Gates & Verification
- Unit & integration tests pass across `spector-core`, `spector-memory`, and `spector-mcp` (49/49 tests pass).
- Full reactor build verified with clean license check (`mvn license:check`).