### PR TITLE
feat(memory): AISME complete loop closure, CognitiveVectorAccessor, and FLAG_SIMULATED standard (#621)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ExpressPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ExpressPathway.java
@@ -36,7 +36,10 @@ public final class ExpressPathway implements AutoCloseable {
     
     private final CognitivePathway<ExpressSignal> pathway;
     
+    private final java.util.function.Consumer<ExpressReport> somaticFeedbackConsumer;
+
     private ExpressPathway(Builder builder) {
+        this.somaticFeedbackConsumer = builder.somaticFeedbackConsumer;
         this.pathway = CognitivePathway.<ExpressSignal>pathway("ExpressPathway")
                 .withInterceptor(builder.interceptor)
                 .gated("IdiolectStylometry", ExpressGates.IDIOLECT_ENABLED, new IdiolectStylometryRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
@@ -67,9 +70,19 @@ public final class ExpressPathway implements AutoCloseable {
         String ssmlTags = ""; 
         int relaysExecuted = 4; // updated count
         
-        return new ExpressReport(
+        ExpressReport report = new ExpressReport(
             prosodyVector, blendshapeVector, idiolectProfile, contextPack, promptDirectives, internalMonologue, ssmlTags, elapsed, relaysExecuted
         );
+
+        if (somaticFeedbackConsumer != null) {
+            try {
+                somaticFeedbackConsumer.accept(report);
+            } catch (Exception e) {
+                log.trace("Somatic feedback hook execution degraded: {}", e.getMessage());
+            }
+        }
+
+        return report;
     }
     
     public static Builder builder() {
@@ -82,9 +95,15 @@ public final class ExpressPathway implements AutoCloseable {
     
     public static class Builder {
         private java.util.function.Function<com.spectrayan.spector.commons.pathway.SynapticRelay<ExpressSignal>, com.spectrayan.spector.commons.pathway.SynapticRelay<ExpressSignal>> interceptor;
+        private java.util.function.Consumer<ExpressReport> somaticFeedbackConsumer;
         
         public Builder interceptor(java.util.function.Function<com.spectrayan.spector.commons.pathway.SynapticRelay<ExpressSignal>, com.spectrayan.spector.commons.pathway.SynapticRelay<ExpressSignal>> interceptor) {
             this.interceptor = interceptor;
+            return this;
+        }
+
+        public Builder onSomaticFeedback(java.util.function.Consumer<ExpressReport> consumer) {
+            this.somaticFeedbackConsumer = consumer;
             return this;
         }
         

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -235,19 +235,16 @@ public final class SpectorMemoryFactory {
         // Active Inference Self-Model Engine (AISME) (#597)
         com.spectrayan.spector.memory.aisme.AismeBundle aismeBundle = null;
         if (builder.aismeConfig != null && builder.aismeConfig.enabled()) {
+            com.spectrayan.spector.memory.cortex.CognitiveVectorAccessor vectorAccessor =
+                    new com.spectrayan.spector.memory.cortex.CognitiveVectorAccessor(
+                            index, partitionManager, cortex.quantizer());
             aismeBundle = com.spectrayan.spector.memory.aisme.AismeBuilder.build(
                     builder.aismeConfig,
                     builder.agentSoul,
                     builder.dimensions,
-                    id -> {
-                        var loc = index.locate(id);
-                        if (loc == null) return null;
-                        var router = partitionManager.routerFor(loc.colocatedPartition());
-                        if (router == null) return null;
-                        var seg = router.segmentFor(loc.type());
-                        if (seg == null) return null;
-                        return null;
-                    }
+                    cognitiveTarget,
+                    vectorAccessor,
+                    builder.agentSoul != null ? java.util.List.of(builder.agentSoul) : java.util.List.of()
             );
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
@@ -39,6 +39,7 @@ import com.spectrayan.spector.memory.aisme.workspace.GlobalWorkspace;
 import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
 
 import java.util.List;
 import java.util.function.Function;
@@ -65,7 +66,7 @@ public final class AismeBuilder {
             final int dimensions,
             final Function<String, float[]> vectorLookup
     ) {
-        return build(config, soul, dimensions, vectorLookup, soul != null ? List.of(soul) : List.of());
+        return build(config, soul, dimensions, null, vectorLookup, soul != null ? List.of(soul) : List.of());
     }
 
     /**
@@ -82,6 +83,28 @@ public final class AismeBuilder {
             final AismeConfig config,
             final AgentSoul soul,
             final int dimensions,
+            final Function<String, float[]> vectorLookup,
+            final List<SoulContext> soulContexts
+    ) {
+        return build(config, soul, dimensions, null, vectorLookup, soulContexts);
+    }
+
+    /**
+     * Builds an {@link AismeBundle} with full cognitive target wiring, multi-soul context, and vector lookup.
+     *
+     * @param config the AISME configuration (or disabled if null)
+     * @param soul optional AgentSoul identity definition
+     * @param dimensions vector embedding dimensionality
+     * @param ingestionTarget target for persisting high-alignment constructive simulations
+     * @param vectorLookup function mapping memory IDs to vector representations
+     * @param soulContexts list of all active soul contexts for multi-soul EFE evaluation
+     * @return the constructed AismeBundle, or null if disabled
+     */
+    public static AismeBundle build(
+            final AismeConfig config,
+            final AgentSoul soul,
+            final int dimensions,
+            final CognitiveIngestionTarget ingestionTarget,
             final Function<String, float[]> vectorLookup,
             final List<SoulContext> soulContexts
     ) {
@@ -135,7 +158,7 @@ public final class AismeBuilder {
         // Constructive Memory Persistence (#613 / AISME Phase 12)
         final ConstructiveMemoryPersistenceRelay constructiveMemoryPersistenceRelay =
                 cfg.constructivePersistenceEnabled()
-                        ? new ConstructiveMemoryPersistenceRelay(null, vectorLookup, cfg.constructivePersistenceThreshold())
+                        ? new ConstructiveMemoryPersistenceRelay(ingestionTarget, vectorLookup, cfg.constructivePersistenceThreshold())
                         : null;
 
         return new AismeBundle(

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelay.java
@@ -13,7 +13,13 @@
 package com.spectrayan.spector.memory.aisme.relay;
 
 import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.core.similarity.VectorOps;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.id.TsidGenerator;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
 import com.spectrayan.spector.memory.recall.relay.RecallSignal;
 
@@ -24,7 +30,7 @@ import java.util.function.Function;
 
 /**
  * RecallPathway relay that persists high-alignment constructive simulations as durable
- * episodic memories with SIMULATED provenance in the consolidation flags.
+ * episodic memories with FLAG_SIMULATED provenance in the binary header flags.
  *
  * <h3>Biological Analog: Hippocampal Replay of Imagined Future Scenarios</h3>
  * <p>When the brain imagines future events or counterfactual alternatives with sufficient
@@ -35,6 +41,7 @@ import java.util.function.Function;
 public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<RecallSignal> {
 
     private static final Logger log = LoggerFactory.getLogger(ConstructiveMemoryPersistenceRelay.class);
+    private static final TsidGenerator TSID = new TsidGenerator();
 
     private final CognitiveIngestionTarget ingestionTarget;
     private final Function<String, float[]> embeddingLookup;
@@ -58,19 +65,19 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
 
     @Override
     public boolean transmit(RecallSignal signal) {
-        if (ingestionTarget == null || embeddingLookup == null || signal == null) {
+        if (ingestionTarget == null || signal == null) {
             return true;
         }
 
         var candidates = signal.candidates();
-        if (candidates == null) {
+        if (candidates == null || candidates.isEmpty()) {
             return true;
         }
 
         int persisted = 0;
         for (CognitiveResult result : candidates) {
-            // Only persist constructive simulations (ID starts with "sim-")
-            if (result.id() == null || !result.id().startsWith("sim-")) {
+            // Only persist constructive simulations flagged with FLAG_SIMULATED
+            if (!SynapticHeaderConstants.isSimulated(result.consolidationFlags())) {
                 continue;
             }
 
@@ -81,15 +88,28 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
 
             try {
                 String text = result.text();
-                float[] vector = embeddingLookup.apply(result.id());
+                float[] vector = (float[]) signal.attributes().get("simVec:" + result.id());
+                if (vector == null && embeddingLookup != null) {
+                    vector = embeddingLookup.apply(result.id());
+                }
                 if (text == null || vector == null) {
                     continue;
                 }
 
-                // Persist via CognitiveIngestionTarget.ingest(id, text, vector)
-                // The SIMULATED flag should be set post-ingestion via consolidation flags
-                String durableId = "sim-durable-" + System.nanoTime();
-                ingestionTarget.ingest(durableId, text, vector);
+                String durableId = TSID.generate();
+                byte procFlags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.EPISODIC.ordinal());
+                byte cFlags = SynapticHeaderConstants.FLAG_SIMULATED;
+                float norm = VectorOps.magnitude(vector);
+                CognitiveHeader header = new CognitiveHeader(
+                        System.currentTimeMillis(), 0L, norm, result.importance(), 1,
+                        (short) 0, result.valence(), procFlags, cFlags, 1.0f
+                );
+
+                ingestionTarget.ingestCognitiveWithHeader(
+                        durableId, text, vector, MemoryType.EPISODIC,
+                        result.synapticTags() != null ? result.synapticTags() : new String[]{"simulated", "constructive"},
+                        MemorySource.INFERRED, header
+                );
                 persisted++;
 
                 log.debug("Persisted constructive simulation as durable memory: sourceId={}, durableId={}, score={}",

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveSimulationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveSimulationRelay.java
@@ -128,8 +128,9 @@ public final class ConstructiveSimulationRelay implements SynapticRelay<RecallSi
                 float alignSim = narrativeEngine.evaluateAlignment(simVec, narrativePrior);
                 if (alignSim > 0.3f) {
                     float simScore = (r1.score() + r2.score()) * 0.5f * (1.0f + narrativeWeight * alignSim);
+                    String simId = new com.spectrayan.spector.memory.id.TsidGenerator().generate();
                     CognitiveResult simResult = new CognitiveResult(
-                            "sim-" + r1.id() + "-" + r2.id(),
+                            simId,
                             "[Constructive Simulation] " + r1.text() + " | " + r2.text(),
                             simScore,
                             Math.max(r1.importance(), r2.importance()),
@@ -137,17 +138,19 @@ public final class ConstructiveSimulationRelay implements SynapticRelay<RecallSi
                             0,
                             (byte) ((r1.valence() + r2.valence()) / 2),
                             com.spectrayan.spector.memory.model.MemoryType.EPISODIC,
-                            com.spectrayan.spector.memory.cortex.MemorySource.REFLECTED,
+                            com.spectrayan.spector.memory.cortex.MemorySource.INFERRED,
                             new String[]{"simulated", "counterfactual", "constructive"},
                             1.0f,
                             1.0f,
                             com.spectrayan.spector.memory.model.CognitiveResult.RetrievalMode.STANDARD,
                             null,
                             null,
-                            null,
-                            java.util.Map.of("simulation", "counterfactual_recombination")
+                            com.spectrayan.spector.memory.model.SourceModality.TEXT,
+                            java.util.Map.of("simulation", "counterfactual_recombination"),
+                            com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.FLAG_SIMULATED
                     );
                     candidates.add(simResult);
+                    signal.attributes().put("simVec:" + simId, simVec);
                 }
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveVectorAccessor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveVectorAccessor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Objects;
+import java.util.function.Function;
+
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+
+/**
+ * Encapsulates point vector retrieval and scalar dequantization from partitioned off-heap memory.
+ *
+ * <p>Resolves memory ID via {@link MemoryIndex}, routes to the enclosing {@link PartitionHandle},
+ * locates the off-heap {@link MemorySegment}, and dequantizes the vector payload using
+ * the calibrated {@link ScalarQuantizer}.</p>
+ *
+ * <h3>Design Principles</h3>
+ * <ul>
+ *   <li><b>SRP</b>: Dedicated strictly to off-heap vector location and decoding.</li>
+ *   <li><b>DIP</b>: Implements {@link Function Function&lt;String, float[]&gt;} for zero coupling with callers.</li>
+ *   <li><b>Thread Safety</b>: Read-only operations over partitioned mmap segments; fully thread-safe.</li>
+ * </ul>
+ */
+public final class CognitiveVectorAccessor implements Function<String, float[]> {
+
+    private final MemoryIndex index;
+    private final PartitionRegistry partitionRegistry;
+    private final ScalarQuantizer quantizer;
+
+    /**
+     * Constructs a CognitiveVectorAccessor.
+     *
+     * @param index             memory index for ID-to-location resolution
+     * @param partitionRegistry partition registry for partition router lookup
+     * @param quantizer         calibrated scalar quantizer for INT8-to-FLOAT32 dequantization
+     */
+    public CognitiveVectorAccessor(MemoryIndex index,
+                                   PartitionRegistry partitionRegistry,
+                                   ScalarQuantizer quantizer) {
+        this.index = Objects.requireNonNull(index, "index must not be null");
+        this.partitionRegistry = Objects.requireNonNull(partitionRegistry, "partitionRegistry must not be null");
+        this.quantizer = quantizer;
+    }
+
+    /**
+     * Retrieves and dequantizes the float32 vector for a memory by ID.
+     *
+     * @param memoryId unique memory identifier
+     * @return decoded float[] vector, or {@code null} if memory not found or quantizer uncalibrated
+     */
+    @Override
+    public float[] apply(String memoryId) {
+        if (memoryId == null || quantizer == null) {
+            return null;
+        }
+
+        float[] mins = quantizer.mins();
+        float[] scales = quantizer.scales();
+        if (mins == null || scales == null) {
+            return null;
+        }
+
+        MemoryIndex.MemoryLocation loc = index.locate(memoryId);
+        if (loc == null) {
+            return null;
+        }
+
+        CognitiveMemoryRouter router = partitionRegistry.routerFor(loc.colocatedPartition());
+        if (router == null) {
+            return null;
+        }
+
+        MemorySegment seg = router.segmentFor(loc.type());
+        if (seg == null) {
+            return null;
+        }
+
+        CognitiveRecordLayout layout = router.layoutFor(loc.type());
+        if (layout == null) {
+            return null;
+        }
+
+        long offset = layout.vectorOffset(loc.offset());
+        int length = mins.length;
+        float[] vec = new float[length];
+        for (int i = 0; i < length; i++) {
+            int q = Byte.toUnsignedInt(seg.get(ValueLayout.JAVA_BYTE, offset + i));
+            vec[i] = mins[i] + (q / 255.0f) * scales[i];
+        }
+        return vec;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
@@ -45,6 +45,8 @@ public final class RecallSignal implements DivergentCapable<RecallSignal>, Trace
     private float effectiveTemperature = 1.0f;
     private final List<RelayTrace> traces = Collections.synchronizedList(new ArrayList<>());
 
+    private final java.util.Map<String, Object> attributes = new java.util.concurrent.ConcurrentHashMap<>();
+
     // Output
     private List<CognitiveResult> finalizedResults = Collections.emptyList();
 
@@ -85,10 +87,18 @@ public final class RecallSignal implements DivergentCapable<RecallSignal>, Trace
         fork.textSearchExecuted = this.textSearchExecuted;
         fork.rrfFused = this.rrfFused;
         fork.effectiveTemperature = this.effectiveTemperature;
+        fork.attributes.putAll(this.attributes);
         synchronized (this.traces) {
             fork.traces.addAll(this.traces);
         }
         return fork;
+    }
+
+    /**
+     * Returns the mutable contextual attributes map for inter-relay parameter passing.
+     */
+    public java.util.Map<String, Object> attributes() {
+        return attributes;
     }
 
     @Override

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelayTest.java
@@ -15,13 +15,14 @@ package com.spectrayan.spector.memory.aisme.relay;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
@@ -49,7 +50,7 @@ class ConstructiveMemoryPersistenceRelayTest {
         ConstructiveMemoryPersistenceRelay relay = new ConstructiveMemoryPersistenceRelay(null, null, 0.70f);
         RecallSignal signal = RecallSignal.forTextQuery("test", RecallOptions.builder().build());
 
-        signal.candidates().add(createResult("sim-1-2", 0.85f));
+        signal.candidates().add(createResult("0123456789ABC", 0.85f, SynapticHeaderConstants.FLAG_SIMULATED));
         boolean ok = relay.transmit(signal);
 
         assertThat(ok).isTrue();
@@ -59,39 +60,41 @@ class ConstructiveMemoryPersistenceRelayTest {
     void highAlignmentSimulation_isPersisted() {
         CognitiveIngestionTarget target = mock(CognitiveIngestionTarget.class);
         Map<String, float[]> vectors = new HashMap<>();
-        vectors.put("sim-1-2", new float[]{1.0f, 0.0f});
+        vectors.put("0123456789ABC", new float[]{1.0f, 0.0f});
 
         ConstructiveMemoryPersistenceRelay relay = new ConstructiveMemoryPersistenceRelay(target, vectors::get, 0.70f);
         RecallSignal signal = RecallSignal.forTextQuery("test", RecallOptions.builder().build());
 
-        signal.candidates().add(createResult("sim-1-2", 0.85f));
-        signal.candidates().add(createResult("sim-low", 0.50f));
-        signal.candidates().add(createResult("mem-normal", 0.95f));
+        signal.candidates().add(createResult("0123456789ABC", 0.85f, SynapticHeaderConstants.FLAG_SIMULATED));
+        signal.candidates().add(createResult("0123456789LOW", 0.50f, SynapticHeaderConstants.FLAG_SIMULATED));
+        signal.candidates().add(createResult("0123456789NRM", 0.95f, (byte) 0)); // Not simulated
 
         boolean ok = relay.transmit(signal);
 
         assertThat(ok).isTrue();
-        verify(target, times(1)).ingest(startsWith("sim-durable-"), anyString(), any(float[].class));
+        verify(target, times(1)).ingestCognitiveWithHeader(
+                anyString(), anyString(), any(float[].class), eq(MemoryType.EPISODIC), any(), eq(MemorySource.INFERRED), any());
     }
 
     @Test
     void belowThresholdSimulation_isNotPersisted() {
         CognitiveIngestionTarget target = mock(CognitiveIngestionTarget.class);
         Map<String, float[]> vectors = new HashMap<>();
-        vectors.put("sim-1-2", new float[]{1.0f, 0.0f});
+        vectors.put("0123456789ABC", new float[]{1.0f, 0.0f});
 
         ConstructiveMemoryPersistenceRelay relay = new ConstructiveMemoryPersistenceRelay(target, vectors::get, 0.70f);
         RecallSignal signal = RecallSignal.forTextQuery("test", RecallOptions.builder().build());
 
-        signal.candidates().add(createResult("sim-1-2", 0.65f));
+        signal.candidates().add(createResult("0123456789ABC", 0.65f, SynapticHeaderConstants.FLAG_SIMULATED));
 
         boolean ok = relay.transmit(signal);
 
         assertThat(ok).isTrue();
-        verify(target, never()).ingest(anyString(), anyString(), any(float[].class));
+        verify(target, never()).ingestCognitiveWithHeader(
+                anyString(), anyString(), any(float[].class), any(), any(), any(), any());
     }
 
-    private static CognitiveResult createResult(String id, float score) {
+    private static CognitiveResult createResult(String id, float score, byte consolidationFlags) {
         return new CognitiveResult(
                 id,
                 "Simulated memory text " + id,
@@ -101,15 +104,16 @@ class ConstructiveMemoryPersistenceRelayTest {
                 0,
                 (byte) 0,
                 MemoryType.EPISODIC,
-                MemorySource.REFLECTED,
+                MemorySource.INFERRED,
                 new String[]{"simulated", "counterfactual"},
                 1.0f,
                 1.0f,
                 CognitiveResult.RetrievalMode.STANDARD,
                 null,
                 null,
-                null,
-                Map.of("simulation", "counterfactual_recombination")
+                com.spectrayan.spector.memory.model.SourceModality.TEXT,
+                Map.of("simulation", "counterfactual_recombination"),
+                consolidationFlags
         );
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveSimulationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveSimulationRelayTest.java
@@ -99,11 +99,12 @@ class ConstructiveSimulationRelayTest {
         // Should synthesize a 3rd candidate representing the recombined counterfactual episode
         assertThat(signal.candidates()).hasSize(3);
         CognitiveResult simulated = signal.candidates().get(2);
-        assertThat(simulated.id()).isEqualTo("sim-m1-m2");
+        assertThat(simulated.id()).isNotNull().hasSize(13);
+        assertThat(com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.isSimulated(simulated.consolidationFlags())).isTrue();
         assertThat(simulated.text()).contains("[Constructive Simulation]");
         assertThat(simulated.synapticTags()).contains("simulated", "counterfactual", "constructive");
         assertThat(simulated.memoryType()).isEqualTo(MemoryType.EPISODIC);
-        assertThat(simulated.source()).isEqualTo(MemorySource.REFLECTED);
+        assertThat(simulated.source()).isEqualTo(MemorySource.INFERRED);
     }
 
     private static CognitiveResult createResult(String id, float score) {

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/CognitiveVectorAccessorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/CognitiveVectorAccessorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import org.junit.jupiter.api.Test;
+
+import com.spectrayan.spector.core.quantization.ScalarQuantizer;
+import com.spectrayan.spector.memory.index.MemoryIndex;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.model.MemoryType;
+
+class CognitiveVectorAccessorTest {
+
+    @Test
+    void testNullInputs() {
+        MemoryIndex index = mock(MemoryIndex.class);
+        PartitionRegistry registry = mock(PartitionRegistry.class);
+        ScalarQuantizer quantizer = mock(ScalarQuantizer.class);
+
+        CognitiveVectorAccessor accessor = new CognitiveVectorAccessor(index, registry, quantizer);
+
+        assertNull(accessor.apply(null));
+
+        when(index.locate("missing-id")).thenReturn(null);
+        assertNull(accessor.apply("missing-id"));
+    }
+
+    @Test
+    void testUncalibratedQuantizer() {
+        MemoryIndex index = mock(MemoryIndex.class);
+        PartitionRegistry registry = mock(PartitionRegistry.class);
+        ScalarQuantizer quantizer = mock(ScalarQuantizer.class);
+        when(quantizer.mins()).thenReturn(null);
+
+        CognitiveVectorAccessor accessor = new CognitiveVectorAccessor(index, registry, quantizer);
+        assertNull(accessor.apply("any-id"));
+    }
+
+    @Test
+    void testSuccessfulVectorRetrievalAndDequantization() {
+        MemoryIndex index = mock(MemoryIndex.class);
+        PartitionRegistry registry = mock(PartitionRegistry.class);
+        CognitiveMemoryRouter router = mock(CognitiveMemoryRouter.class);
+        CognitiveRecordLayout layout = mock(CognitiveRecordLayout.class);
+        ScalarQuantizer quantizer = mock(ScalarQuantizer.class);
+
+        float[] mins = new float[]{0.0f, -1.0f};
+        float[] scales = new float[]{2.0f, 4.0f};
+        when(quantizer.mins()).thenReturn(mins);
+        when(quantizer.scales()).thenReturn(scales);
+
+        MemoryIndex.MemoryLocation loc = new MemoryIndex.MemoryLocation(MemoryType.EPISODIC, 100L, 0);
+        when(index.locate("mem-123")).thenReturn(loc);
+        when(registry.routerFor(0)).thenReturn(router);
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(256);
+            long vectorOffset = 64L;
+            when(router.segmentFor(MemoryType.EPISODIC)).thenReturn(segment);
+            when(router.layoutFor(MemoryType.EPISODIC)).thenReturn(layout);
+            when(layout.vectorOffset(100L)).thenReturn(vectorOffset);
+
+            // Write test bytes at vectorOffset: byte 0 = 128 (~0.5), byte 1 = 255 (1.0)
+            segment.set(ValueLayout.JAVA_BYTE, vectorOffset, (byte) 128);
+            segment.set(ValueLayout.JAVA_BYTE, vectorOffset + 1, (byte) -1); // 255 unsigned
+
+            CognitiveVectorAccessor accessor = new CognitiveVectorAccessor(index, registry, quantizer);
+            float[] result = accessor.apply("mem-123");
+
+            assertNotNull(result);
+            assertEquals(2, result.length);
+            // dim 0: 0.0 + (128 / 255.0f) * 2.0 ≈ 1.0039f
+            assertEquals(0.0f + (128 / 255.0f) * 2.0f, result[0], 0.001f);
+            // dim 1: -1.0 + (255 / 255.0f) * 4.0 = 3.0f
+            assertEquals(3.0f, result[1], 0.001f);
+        }
+    }
+}


### PR DESCRIPTION
Closes #621

## Summary
Completes full loop closure for the Active Inference Self-Model Engine (AISME), introduces a decoupled `CognitiveVectorAccessor` in cortex, replaces string-based `sim-` prefixes with native off-heap `FLAG_SIMULATED` binary header flags, and adds an expressive somatic feedback loop.

## Key Changes

### 1. Dedicated `CognitiveVectorAccessor` (Cortex)
- **`CognitiveVectorAccessor`** (`memory/spector-memory`): Implements `Function<String, float[]>` to resolve point vectors from partitioned off-heap memory segments and perform `ScalarQuantizer` dequantization.
- Completely decouples factory classes from storage layout offsets and byte manipulations.
- Covered by unit tests in `CognitiveVectorAccessorTest`.

### 2. Native `FLAG_SIMULATED` Header Standard & Durable Persistence
- **`ConstructiveSimulationRelay`**: Replaces `"sim-"` ID prefixes with standard Crockford Base32 `TsidGenerator` IDs and sets `SynapticHeaderConstants.FLAG_SIMULATED` (bit 5 at header offset 34) on the synthesized `CognitiveResult`.
- **`ConstructiveMemoryPersistenceRelay`**: Replaces string prefix checking with `SynapticHeaderConstants.isSimulated(result.consolidationFlags())` and persists high-alignment simulations via `CognitiveIngestionTarget.ingestCognitiveWithHeader(...)` with `FLAG_SIMULATED` and standard TSID.
- **`AismeBuilder` & `SpectorMemoryFactory`**: Wired with the live `CognitiveIngestionTarget` and `CognitiveVectorAccessor`.

### 3. Somatic Feedback Loop
- **`ExpressPathway`**: Added somatic feedback consumer hook allowing expressive releases (affective vocal/facial output) to modulate interoceptive state in `MentalStateTracker`.
- **`RecallSignal`**: Added mutable `attributes` map for zero-recalculation vector sharing between relays.

## Quality Gates & Verification
- Unit tests: `CognitiveVectorAccessorTest`, `ConstructiveSimulationRelayTest`, `ConstructiveMemoryPersistenceRelayTest`, `AismeBuilderTest`, and `ExpressPathwayTest` pass cleanly.
- Full reactor tests (49/49) pass with 0 failures across `spector-core`, `spector-memory`, and `spector-mcp`.
- Clean license verification across all 28 modules (`mvn license:check`).