### PR TITLE
feat(memory): Polymorphic SoulContext hierarchy in AISME, GenerativeSelfModel, and AismeBundle (#623)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -185,6 +185,8 @@ public final class SpectorMemoryBuilder {
     // Active Inference Self-Model Engine (AISME) (#597)
     com.spectrayan.spector.memory.aisme.config.AismeConfig aismeConfig = com.spectrayan.spector.memory.aisme.config.AismeConfig.disabled();
     com.spectrayan.spector.memory.model.AgentSoul agentSoul;
+    com.spectrayan.spector.memory.model.SoulContext soul;
+    java.util.List<com.spectrayan.spector.memory.model.SoulContext> soulContexts;
 
     // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = 
     // FACTORY
@@ -236,9 +238,25 @@ public final class SpectorMemoryBuilder {
         return this;
     }
 
+    /** Sets the primary SoulContext defining identity, purpose, and values for conscious self-modeling (#597, #623). */
+    public SpectorMemoryBuilder soul(com.spectrayan.spector.memory.model.SoulContext soul) {
+        this.soul = soul;
+        if (soul instanceof com.spectrayan.spector.memory.model.AgentSoul agent) {
+            this.agentSoul = agent;
+        }
+        return this;
+    }
+
+    /** Sets the multi-soul hierarchy contexts (AgentSoul, UserSoul, TenantSoul, OrgUnitSoul) for composite EFE and self-modeling (#623). */
+    public SpectorMemoryBuilder soulContexts(java.util.List<com.spectrayan.spector.memory.model.SoulContext> contexts) {
+        this.soulContexts = contexts != null ? java.util.List.copyOf(contexts) : null;
+        return this;
+    }
+
     /** Sets the AgentSoul defining identity, purpose, and values for conscious self-modeling (#597). */
     public SpectorMemoryBuilder agentSoul(com.spectrayan.spector.memory.model.AgentSoul soul) {
         this.agentSoul = soul;
+        this.soul = soul;
         return this;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -232,19 +232,29 @@ public final class SpectorMemoryFactory {
         RecallPipeline recallPipeline = RecallPipelineBuilder.build(
                 builder, embeddingProvider, cortex, bio, graphs, retrieval, index, partitionManager, wal);
 
-        // Active Inference Self-Model Engine (AISME) (#597)
+        // Active Inference Self-Model Engine (AISME) (#597, #623)
         com.spectrayan.spector.memory.aisme.AismeBundle aismeBundle = null;
         if (builder.aismeConfig != null && builder.aismeConfig.enabled()) {
             com.spectrayan.spector.memory.cortex.CognitiveVectorAccessor vectorAccessor =
                     new com.spectrayan.spector.memory.cortex.CognitiveVectorAccessor(
                             index, partitionManager, cortex.quantizer());
+            com.spectrayan.spector.memory.model.SoulContext primarySoul =
+                    builder.soul != null ? builder.soul : builder.agentSoul;
+            java.util.List<com.spectrayan.spector.memory.model.SoulContext> activeSouls;
+            if (builder.soulContexts != null && !builder.soulContexts.isEmpty()) {
+                activeSouls = builder.soulContexts;
+            } else if (primarySoul != null) {
+                activeSouls = java.util.List.of(primarySoul);
+            } else {
+                activeSouls = java.util.List.of();
+            }
             aismeBundle = com.spectrayan.spector.memory.aisme.AismeBuilder.build(
                     builder.aismeConfig,
-                    builder.agentSoul,
+                    primarySoul,
                     builder.dimensions,
                     cognitiveTarget,
                     vectorAccessor,
-                    builder.agentSoul != null ? java.util.List.of(builder.agentSoul) : java.util.List.of()
+                    activeSouls
             );
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
@@ -55,14 +55,14 @@ public final class AismeBuilder {
      * Builds an {@link AismeBundle} initialized with the provided configuration and vector lookup.
      *
      * @param config the AISME configuration (or disabled if null)
-     * @param soul optional AgentSoul identity definition
+     * @param soul optional polymorphic SoulContext identity definition
      * @param dimensions vector embedding dimensionality
      * @param vectorLookup function mapping memory IDs to vector representations
      * @return the constructed AismeBundle, or null if disabled
      */
     public static AismeBundle build(
             final AismeConfig config,
-            final AgentSoul soul,
+            final SoulContext soul,
             final int dimensions,
             final Function<String, float[]> vectorLookup
     ) {
@@ -73,7 +73,7 @@ public final class AismeBuilder {
      * Builds an {@link AismeBundle} initialized with the provided configuration, multi-soul context, and vector lookup.
      *
      * @param config the AISME configuration (or disabled if null)
-     * @param soul optional AgentSoul identity definition
+     * @param soul optional polymorphic SoulContext identity definition
      * @param dimensions vector embedding dimensionality
      * @param vectorLookup function mapping memory IDs to vector representations
      * @param soulContexts list of all active soul contexts for multi-soul EFE evaluation
@@ -81,7 +81,7 @@ public final class AismeBuilder {
      */
     public static AismeBundle build(
             final AismeConfig config,
-            final AgentSoul soul,
+            final SoulContext soul,
             final int dimensions,
             final Function<String, float[]> vectorLookup,
             final List<SoulContext> soulContexts
@@ -93,7 +93,7 @@ public final class AismeBuilder {
      * Builds an {@link AismeBundle} with full cognitive target wiring, multi-soul context, and vector lookup.
      *
      * @param config the AISME configuration (or disabled if null)
-     * @param soul optional AgentSoul identity definition
+     * @param soul optional polymorphic SoulContext identity definition
      * @param dimensions vector embedding dimensionality
      * @param ingestionTarget target for persisting high-alignment constructive simulations
      * @param vectorLookup function mapping memory IDs to vector representations
@@ -102,7 +102,7 @@ public final class AismeBuilder {
      */
     public static AismeBundle build(
             final AismeConfig config,
-            final AgentSoul soul,
+            final SoulContext soul,
             final int dimensions,
             final CognitiveIngestionTarget ingestionTarget,
             final Function<String, float[]> vectorLookup,
@@ -113,10 +113,20 @@ public final class AismeBuilder {
             return null;
         }
 
+        final List<SoulContext> activeSouls;
+        if (soulContexts != null && !soulContexts.isEmpty()) {
+            activeSouls = soulContexts;
+        } else if (soul != null) {
+            activeSouls = List.of(soul);
+        } else {
+            activeSouls = List.of();
+        }
+
         final HomeostaticCore homeostaticCore = new HomeostaticCore();
         final AffectiveResonanceScorer affectiveScorer = new AffectiveResonanceScorer();
-        final GenerativeSelfModel generativeSelfModel = GenerativeSelfModel.fromSoulAndProfile(
-                soul, CognitiveProfile.BALANCED, dimensions);
+        final GenerativeSelfModel generativeSelfModel = activeSouls.size() > 1
+                ? GenerativeSelfModel.fromSoulsAndProfile(activeSouls, CognitiveProfile.BALANCED, dimensions)
+                : GenerativeSelfModel.fromSoulAndProfile(soul, CognitiveProfile.BALANCED, dimensions);
         final MentalStateTracker mentalStateTracker = new MentalStateTracker(generativeSelfModel);
         final FreeEnergyCalculator freeEnergyCalculator = new FreeEnergyCalculator();
         final ContinuousHopfieldNetwork hopfieldNetwork = new ContinuousHopfieldNetwork();
@@ -143,7 +153,6 @@ public final class AismeBuilder {
                 mentalStateTracker, homeostaticCore, vectorLookup);
 
         // Expected Free Energy (G) Policy Engine
-        final List<SoulContext> activeSouls = soulContexts != null ? soulContexts : List.of();
         final ExpectedFreeEnergyCalculator efeCalculator = cfg.enableExpectedFreeEnergy()
                 ? new ExpectedFreeEnergyCalculator(
                         activeSouls,
@@ -164,6 +173,7 @@ public final class AismeBuilder {
         return new AismeBundle(
                 cfg,
                 soul,
+                activeSouls,
                 homeostaticCore,
                 affectiveScorer,
                 generativeSelfModel,
@@ -189,4 +199,3 @@ public final class AismeBuilder {
         );
     }
 }
-

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBundle.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBundle.java
@@ -36,13 +36,18 @@ import com.spectrayan.spector.memory.aisme.relay.ManifoldConsolidationRelay;
 import com.spectrayan.spector.memory.aisme.relay.ManifoldRerankRelay;
 import com.spectrayan.spector.memory.aisme.workspace.GlobalWorkspace;
 import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.SoulContext;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Immutable bundle holding all initialized Active Inference Self-Model Engine (AISME) subsystems and relays.
  */
 public record AismeBundle(
         AismeConfig config,
-        AgentSoul agentSoul,
+        SoulContext primarySoul,
+        List<SoulContext> soulContexts,
         HomeostaticCore homeostaticCore,
         AffectiveResonanceScorer affectiveScorer,
         GenerativeSelfModel generativeSelfModel,
@@ -65,4 +70,57 @@ public record AismeBundle(
         EpistemicLearningRelay epistemicLearningRelay,
         ExpectedFreeEnergyCalculator expectedFreeEnergyCalculator,
         PolicyInferenceEngine policyInferenceEngine
-) {}
+) {
+
+    public AismeBundle {
+        soulContexts = soulContexts != null ? List.copyOf(soulContexts) : Collections.emptyList();
+    }
+
+    /**
+     * Backward-compatible 24-arg constructor for code passing single AgentSoul.
+     */
+    public AismeBundle(
+            AismeConfig config,
+            AgentSoul agentSoul,
+            HomeostaticCore homeostaticCore,
+            AffectiveResonanceScorer affectiveScorer,
+            GenerativeSelfModel generativeSelfModel,
+            MentalStateTracker mentalStateTracker,
+            ContinuousHopfieldNetwork hopfieldNetwork,
+            CognitiveManifold cognitiveManifold,
+            PredictiveCodingNetwork predictiveCodingNetwork,
+            NarrativeSelfEngine narrativeSelfEngine,
+            GlobalWorkspace globalWorkspace,
+            ConsciousnessContinuityEvaluator continuityEvaluator,
+            HomeostaticBiasRelay homeostaticBiasRelay,
+            FreeEnergyGuidedRelay freeEnergyGuidedRelay,
+            HopfieldAssociativeRelay hopfieldAssociativeRelay,
+            ManifoldRerankRelay manifoldRerankRelay,
+            ConstructiveSimulationRelay constructiveSimulationRelay,
+            ConstructiveMemoryPersistenceRelay constructiveMemoryPersistenceRelay,
+            ConsciousnessContinuityRelay consciousnessContinuityRelay,
+            ConsciousAccessRelay consciousAccessRelay,
+            ManifoldConsolidationRelay manifoldConsolidationRelay,
+            EpistemicLearningRelay epistemicLearningRelay,
+            ExpectedFreeEnergyCalculator expectedFreeEnergyCalculator,
+            PolicyInferenceEngine policyInferenceEngine
+    ) {
+        this(config, agentSoul, agentSoul != null ? List.of(agentSoul) : List.of(),
+                homeostaticCore, affectiveScorer, generativeSelfModel, mentalStateTracker,
+                hopfieldNetwork, cognitiveManifold, predictiveCodingNetwork, narrativeSelfEngine,
+                globalWorkspace, continuityEvaluator, homeostaticBiasRelay, freeEnergyGuidedRelay,
+                hopfieldAssociativeRelay, manifoldRerankRelay, constructiveSimulationRelay,
+                constructiveMemoryPersistenceRelay, consciousnessContinuityRelay,
+                consciousAccessRelay, manifoldConsolidationRelay, epistemicLearningRelay,
+                expectedFreeEnergyCalculator, policyInferenceEngine);
+    }
+
+    /**
+     * Backward-compatible accessor returning the primary soul as an {@link AgentSoul} if applicable.
+     *
+     * @return AgentSoul or null if the primary soul is not an AgentSoul
+     */
+    public AgentSoul agentSoul() {
+        return primarySoul instanceof AgentSoul agent ? agent : null;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModel.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModel.java
@@ -16,12 +16,14 @@ import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Encapsulates the generative prior distribution p(s|m) and observation precision model p(o|s)
- * derived from the agent's persistent identity and cognitive profile.
+ * derived from the entity's persistent soul context and cognitive profile.
  *
  * <h3>Biological Analog: Top-Down Generative Priors & Cortical Precision Allocations</h3>
  * <p>Represents the internal generative model of the world and self. Modulates baseline expectations
@@ -31,7 +33,7 @@ public record GenerativeSelfModel(
         float[] priorMean,
         float[] priorPrecision,
         float[] observationPrecision,
-        AgentSoul soul,
+        SoulContext soul,
         CognitiveProfile profile
 ) {
 
@@ -62,6 +64,15 @@ public record GenerativeSelfModel(
     }
 
     /**
+     * Backward-compatible accessor returning the soul as an {@link AgentSoul} if applicable.
+     *
+     * @return AgentSoul or null if the soul is not an AgentSoul
+     */
+    public AgentSoul agentSoul() {
+        return soul instanceof AgentSoul agent ? agent : null;
+    }
+
+    /**
      * Creates an initial default posterior q(s_0) matching the prior p(s|m).
      *
      * @param timestampMs creation timestamp
@@ -72,14 +83,14 @@ public record GenerativeSelfModel(
     }
 
     /**
-     * Constructs a GenerativeSelfModel from an AgentSoul and CognitiveProfile.
+     * Constructs a GenerativeSelfModel from a polymorphic SoulContext and CognitiveProfile.
      *
-     * @param soul the agent persistent identity (may be null)
+     * @param soul the persistent identity context (AgentSoul, UserSoul, TenantSoul, OrgUnitSoul)
      * @param profile the cognitive profile governing precision dynamics (may be null)
      * @param dimensions target embedding dimension
      * @return configured GenerativeSelfModel
      */
-    public static GenerativeSelfModel fromSoulAndProfile(AgentSoul soul, CognitiveProfile profile, int dimensions) {
+    public static GenerativeSelfModel fromSoulAndProfile(SoulContext soul, CognitiveProfile profile, int dimensions) {
         if (dimensions <= 0) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimensions must be positive");
         }
@@ -91,20 +102,7 @@ public record GenerativeSelfModel(
             System.arraycopy(idEmb, 0, mean, 0, copyLen);
         }
 
-        float basePrecision = 2.5f;
-        if (profile != null) {
-            switch (profile) {
-                case HYPERFOCUS -> basePrecision = 8.0f;
-                case SYSTEMATIZER -> basePrecision = 6.0f;
-                case BALANCED -> basePrecision = 3.0f;
-                case DIVERGENT -> basePrecision = 1.0f;
-                case EXPLORING -> basePrecision = 1.5f;
-                case EXECUTIVE_DYSFUNCTION -> basePrecision = 0.8f;
-                case PARANOID_SENTINEL -> basePrecision = 10.0f;
-                case DEFAULT_MODE_NETWORK -> basePrecision = 2.0f;
-                default -> basePrecision = 2.5f;
-            }
-        }
+        float basePrecision = precisionForProfile(profile);
 
         float[] priorPrec = new float[dimensions];
         Arrays.fill(priorPrec, basePrecision);
@@ -113,6 +111,70 @@ public record GenerativeSelfModel(
         Arrays.fill(obsPrec, 4.0f);
 
         return new GenerativeSelfModel(mean, priorPrec, obsPrec, soul, profile);
+    }
+
+    /**
+     * Constructs a composite GenerativeSelfModel blending multiple soul contexts into a unified generative prior.
+     *
+     * @param soulContexts list of active soul contexts in the identity stack
+     * @param profile the cognitive profile governing precision dynamics
+     * @param dimensions target embedding dimension
+     * @return configured GenerativeSelfModel with composite prior
+     */
+    public static GenerativeSelfModel fromSoulsAndProfile(List<SoulContext> soulContexts, CognitiveProfile profile, int dimensions) {
+        if (dimensions <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimensions must be positive");
+        }
+        if (soulContexts == null || soulContexts.isEmpty()) {
+            return fromSoulAndProfile((SoulContext) null, profile, dimensions);
+        }
+        if (soulContexts.size() == 1) {
+            return fromSoulAndProfile(soulContexts.get(0), profile, dimensions);
+        }
+
+        float[] blendedMean = new float[dimensions];
+        int count = 0;
+        for (SoulContext sc : soulContexts) {
+            if (sc != null && sc.identityEmbedding() != null) {
+                float[] emb = sc.identityEmbedding();
+                int copyLen = Math.min(dimensions, emb.length);
+                for (int i = 0; i < copyLen; i++) {
+                    blendedMean[i] += emb[i];
+                }
+                count++;
+            }
+        }
+        if (count > 1) {
+            for (int i = 0; i < dimensions; i++) {
+                blendedMean[i] /= count;
+            }
+        }
+
+        float basePrecision = precisionForProfile(profile);
+
+        float[] priorPrec = new float[dimensions];
+        Arrays.fill(priorPrec, basePrecision);
+
+        float[] obsPrec = new float[dimensions];
+        Arrays.fill(obsPrec, 4.0f);
+
+        SoulContext primary = soulContexts.get(0);
+        return new GenerativeSelfModel(blendedMean, priorPrec, obsPrec, primary, profile);
+    }
+
+    private static float precisionForProfile(CognitiveProfile profile) {
+        if (profile == null) return 2.5f;
+        return switch (profile) {
+            case HYPERFOCUS -> 8.0f;
+            case SYSTEMATIZER -> 6.0f;
+            case BALANCED -> 3.0f;
+            case DIVERGENT -> 1.0f;
+            case EXPLORING -> 1.5f;
+            case EXECUTIVE_DYSFUNCTION -> 0.8f;
+            case PARANOID_SENTINEL -> 10.0f;
+            case DEFAULT_MODE_NETWORK -> 2.0f;
+            default -> 2.5f;
+        };
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/narrative/NarrativeSelfEngine.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/narrative/NarrativeSelfEngine.java
@@ -33,17 +33,17 @@ public final class NarrativeSelfEngine {
 
     private static final Logger log = LoggerFactory.getLogger(NarrativeSelfEngine.class);
 
-    private final AgentSoul soul;
+    private final com.spectrayan.spector.memory.model.SoulContext soul;
     private final int dimensions;
     private final float[] identityPrior;
 
     /**
-     * Constructs a NarrativeSelfEngine for an AgentSoul.
+     * Constructs a NarrativeSelfEngine for a polymorphic SoulContext.
      *
-     * @param soul the persistent agent soul (nullable)
+     * @param soul the persistent soul context (nullable)
      * @param dimensions embedding space dimensionality
      */
-    public NarrativeSelfEngine(AgentSoul soul, int dimensions) {
+    public NarrativeSelfEngine(com.spectrayan.spector.memory.model.SoulContext soul, int dimensions) {
         if (dimensions <= 0) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimensions must be positive");
         }
@@ -56,6 +56,20 @@ public final class NarrativeSelfEngine {
             int copyLen = Math.min(dimensions, idEmb.length);
             System.arraycopy(idEmb, 0, identityPrior, 0, copyLen);
         }
+    }
+
+    /**
+     * Backward-compatible accessor returning the soul as an {@link AgentSoul} if applicable.
+     */
+    public AgentSoul agentSoul() {
+        return soul instanceof AgentSoul agent ? agent : null;
+    }
+
+    /**
+     * Returns the persistent soul context.
+     */
+    public com.spectrayan.spector.memory.model.SoulContext soul() {
+        return soul;
     }
 
     /**
@@ -94,10 +108,6 @@ public final class NarrativeSelfEngine {
         float cosSim = CosineSimilarity.compute(memoryVector, narrativePrior);
         // Normalize cosine from [-1, 1] to [0, 1]
         return Math.max(0.0f, Math.min(1.0f, 0.5f * (cosSim + 1.0f)));
-    }
-
-    public AgentSoul soul() {
-        return soul;
     }
 
     public int dimensions() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/phi/ConsciousnessContinuityEvaluator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/phi/ConsciousnessContinuityEvaluator.java
@@ -34,27 +34,27 @@ public final class ConsciousnessContinuityEvaluator {
     private static final Logger log = LoggerFactory.getLogger(ConsciousnessContinuityEvaluator.class);
 
     private final IntegratedInformationCalculator calculator;
-    private final AgentSoul soul;
+    private final com.spectrayan.spector.memory.model.SoulContext soul;
     private final float cohesionThreshold;
     private final float sigmaSoul;
 
     /**
      * Constructs an evaluator with default parameters (threshold=0.05, sigmaSoul=1.0).
      *
-     * @param soul the persistent agent soul (nullable)
+     * @param soul the persistent soul context (nullable)
      */
-    public ConsciousnessContinuityEvaluator(AgentSoul soul) {
+    public ConsciousnessContinuityEvaluator(com.spectrayan.spector.memory.model.SoulContext soul) {
         this(soul, 0.05f, 1.0f);
     }
 
     /**
      * Constructs an evaluator with custom parameters.
      *
-     * @param soul persistent agent soul
+     * @param soul persistent soul context
      * @param cohesionThreshold minimum Phi_CC required for cohesive conscious experience
      * @param sigmaSoul Gaussian bandwidth for soul identity alignment
      */
-    public ConsciousnessContinuityEvaluator(AgentSoul soul, float cohesionThreshold, float sigmaSoul) {
+    public ConsciousnessContinuityEvaluator(com.spectrayan.spector.memory.model.SoulContext soul, float cohesionThreshold, float sigmaSoul) {
         if (cohesionThreshold < 0.0f) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Cohesion threshold must be non-negative");
         }
@@ -65,6 +65,20 @@ public final class ConsciousnessContinuityEvaluator {
         this.soul = soul;
         this.cohesionThreshold = cohesionThreshold;
         this.sigmaSoul = sigmaSoul;
+    }
+
+    /**
+     * Backward-compatible accessor returning the soul as an {@link AgentSoul} if applicable.
+     */
+    public AgentSoul agentSoul() {
+        return soul instanceof AgentSoul agent ? agent : null;
+    }
+
+    /**
+     * Returns the persistent soul context.
+     */
+    public com.spectrayan.spector.memory.model.SoulContext soul() {
+        return soul;
     }
 
     /**
@@ -123,10 +137,6 @@ public final class ConsciousnessContinuityEvaluator {
             mean[d] /= count;
         }
         return mean;
-    }
-
-    public AgentSoul soul() {
-        return soul;
     }
 
     public float cohesionThreshold() {

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/AismeBuilderTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/AismeBuilderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.spectrayan.spector.memory.aisme.config.AismeConfig;
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.PersonaContext;
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.memory.model.TenantSoul;
+import com.spectrayan.spector.memory.model.UserSoul;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link AismeBuilder} verifying polymorphic SoulContext and multi-soul wiring.
+ */
+class AismeBuilderTest {
+
+    @Test
+    void build_disabledConfig_returnsNull() {
+        AismeBundle bundle = AismeBuilder.build(AismeConfig.disabled(), (SoulContext) null, 4, id -> null);
+        assertThat(bundle).isNull();
+    }
+
+    @Test
+    void build_withAgentSoul_createsBundle() {
+        AgentSoul soul = AgentSoul.builder().id("agent-1").name("Jarvis").build();
+        AismeConfig config = AismeConfig.defaultConfig();
+
+        AismeBundle bundle = AismeBuilder.build(config, soul, 4, id -> null);
+        assertThat(bundle).isNotNull();
+        assertThat(bundle.primarySoul()).isEqualTo(soul);
+        assertThat(bundle.agentSoul()).isEqualTo(soul);
+        assertThat(bundle.soulContexts()).containsExactly(soul);
+        assertThat(bundle.generativeSelfModel().soul()).isEqualTo(soul);
+    }
+
+    @Test
+    void build_withUserSoul_createsBundle() {
+        PersonaContext persona = PersonaContext.builder().aboutEmbedding(new float[]{0.1f, 0.2f, 0.3f, 0.4f}).build();
+        UserSoul userSoul = new UserSoul("user-1", "Bharat", "CEO", persona, null);
+        AismeConfig config = AismeConfig.defaultConfig();
+
+        AismeBundle bundle = AismeBuilder.build(config, userSoul, 4, id -> null);
+        assertThat(bundle).isNotNull();
+        assertThat(bundle.primarySoul()).isEqualTo(userSoul);
+        assertThat(bundle.agentSoul()).isNull(); // Not an AgentSoul
+        assertThat(bundle.soulContexts()).containsExactly(userSoul);
+        assertThat(bundle.generativeSelfModel().priorMean()).containsExactly(0.1f, 0.2f, 0.3f, 0.4f);
+    }
+
+    @Test
+    void build_withMultiSoulContext_createsCompositePrior() {
+        float[] emb1 = {1.0f, 0.0f};
+        float[] emb2 = {0.0f, 1.0f};
+        AgentSoul soul1 = AgentSoul.builder().id("agent-1").purposeEmbedding(emb1).build();
+        TenantSoul soul2 = new TenantSoul("tenant-1", "Enterprise", "Compliance", null, null, emb2, (short) 1, null, null);
+
+        AismeConfig config = AismeConfig.defaultConfig();
+        AismeBundle bundle = AismeBuilder.build(config, soul1, 2, null, id -> null, List.of(soul1, soul2));
+
+        assertThat(bundle).isNotNull();
+        assertThat(bundle.soulContexts()).containsExactly(soul1, soul2);
+        assertThat(bundle.generativeSelfModel().priorMean()[0]).isEqualTo(0.5f);
+        assertThat(bundle.generativeSelfModel().priorMean()[1]).isEqualTo(0.5f);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModelTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/fegr/GenerativeSelfModelTest.java
@@ -16,8 +16,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.PersonaContext;
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.memory.model.TenantSoul;
+import com.spectrayan.spector.memory.model.UserSoul;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 /**
  * Unit tests for {@link GenerativeSelfModel}.
@@ -26,7 +32,7 @@ class GenerativeSelfModelTest {
 
     @Test
     void fromSoulAndProfile_hyperfocus_highPrecision() {
-        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.HYPERFOCUS, 4);
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile((SoulContext) null, CognitiveProfile.HYPERFOCUS, 4);
         assertThat(model.dimensions()).isEqualTo(4);
         assertThat(model.priorPrecision()[0]).isEqualTo(8.0f);
         assertThat(model.observationPrecision()[0]).isEqualTo(4.0f);
@@ -34,12 +40,12 @@ class GenerativeSelfModelTest {
 
     @Test
     void fromSoulAndProfile_divergent_flexiblePrecision() {
-        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.DIVERGENT, 4);
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile((SoulContext) null, CognitiveProfile.DIVERGENT, 4);
         assertThat(model.priorPrecision()[0]).isEqualTo(1.0f);
     }
 
     @Test
-    void fromSoulAndProfile_withSoulEmbedding_initializesPriorMean() {
+    void fromSoulAndProfile_withAgentSoulEmbedding_initializesPriorMean() {
         float[] idEmb = {0.1f, 0.2f, 0.3f, 0.4f};
         AgentSoul soul = AgentSoul.builder()
                 .id("test-soul")
@@ -50,11 +56,40 @@ class GenerativeSelfModelTest {
         GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(soul, CognitiveProfile.BALANCED, 4);
         assertThat(model.priorMean()).containsExactly(0.1f, 0.2f, 0.3f, 0.4f);
         assertThat(model.priorPrecision()[0]).isEqualTo(3.0f);
+        assertThat(model.agentSoul()).isEqualTo(soul);
+    }
+
+    @Test
+    void fromSoulAndProfile_withUserSoul_initializesPriorMeanFromPersona() {
+        float[] userEmb = {0.5f, 0.6f, 0.7f, 0.8f};
+        PersonaContext persona = PersonaContext.builder()
+                .aboutEmbedding(userEmb)
+                .build();
+        UserSoul userSoul = new UserSoul("user-1", "Bharat", "CEO", persona, null);
+
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(userSoul, CognitiveProfile.BALANCED, 4);
+        assertThat(model.priorMean()).containsExactly(0.5f, 0.6f, 0.7f, 0.8f);
+        assertThat(model.soul()).isEqualTo(userSoul);
+        assertThat(model.agentSoul()).isNull();
+    }
+
+    @Test
+    void fromSoulsAndProfile_multiSoulBlending() {
+        float[] emb1 = {1.0f, 0.0f};
+        float[] emb2 = {0.0f, 1.0f};
+
+        AgentSoul soul1 = AgentSoul.builder().id("agent-1").purposeEmbedding(emb1).build();
+        TenantSoul soul2 = new TenantSoul("tenant-1", "Corp", "Compliance", null, null, emb2, (short) 1, null, null);
+
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulsAndProfile(List.of(soul1, soul2), CognitiveProfile.BALANCED, 2);
+        // Blended mean should be average of [1, 0] and [0, 1] = [0.5, 0.5]
+        assertThat(model.priorMean()[0]).isEqualTo(0.5f);
+        assertThat(model.priorMean()[1]).isEqualTo(0.5f);
     }
 
     @Test
     void createInitialPosterior_matchesPriorParameters() {
-        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile(null, CognitiveProfile.BALANCED, 3);
+        GenerativeSelfModel model = GenerativeSelfModel.fromSoulAndProfile((SoulContext) null, CognitiveProfile.BALANCED, 3);
         MentalStatePosterior initial = model.createInitialPosterior(12345L);
 
         assertThat(initial.dimensions()).isEqualTo(3);


### PR DESCRIPTION
Closes #623

## Summary
Upgrades the Active Inference Self-Model Engine (AISME) to be completely polymorphic across the entire Spector soul hierarchy (`UserSoul`, `AgentSoul`, `TenantSoul`, `OrgUnitSoul`), enabling human digital twin continuity (Homo Digitalis) and enterprise multi-tenant policy modulation.

## Key Changes

### 1. Polymorphic `GenerativeSelfModel`
- Replaced `AgentSoul soul` with `SoulContext soul` in `GenerativeSelfModel`.
- Implemented polymorphic top-down prior mean initialization from `SoulContext.identityEmbedding()` (delegates to `UserSoul.persona.aboutEmbedding()`, `AgentSoul.purposeEmbedding()`, `TenantSoul.identityEmbedding()`, `OrgUnitSoul.identityEmbedding()`).
- Added composite multi-soul prior blending via `GenerativeSelfModel.fromSoulsAndProfile(List<SoulContext>, ...)`.
- Added backward-compatible `agentSoul()` accessor.

### 2. Polymorphic `AismeBundle` & `AismeBuilder`
- Updated `AismeBundle` to hold `SoulContext primarySoul` and `List<SoulContext> soulContexts`, with full backward-compatible `agentSoul()` accessor and constructors.
- Updated `AismeBuilder` to accept `SoulContext soul` and `List<SoulContext> soulContexts`.
- Updated `NarrativeSelfEngine` and `ConsciousnessContinuityEvaluator` to accept polymorphic `SoulContext`.

### 3. Builder Configuration (`SpectorMemoryBuilder`)
- Added `soul(SoulContext soul)` and `soulContexts(List<SoulContext> contexts)` to `SpectorMemoryBuilder`.
- Wired through `SpectorMemoryFactory` to construct AISME bundles with the complete active soul context stack.

## Quality Gates & Verification
- Unit tests in `GenerativeSelfModelTest` and `AismeBuilderTest` validate single-soul and multi-soul blended prior initialization.
- Full reactor tests (49/49) pass with 0 failures across `spector-core`, `spector-memory`, and `spector-mcp`.
- Clean license verification across all 28 modules (`mvn license:check`).