### PR TITLE
feat(memory): Log-Sum-ReLU (LSR) & Positive Random Feature (PRF) Associative Memory (#641)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/ContinuousHopfieldNetwork.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/ContinuousHopfieldNetwork.java
@@ -15,7 +15,7 @@ package com.spectrayan.spector.memory.aisme.hopfield;
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.core.similarity.HopfieldKernel;
-import com.spectrayan.spector.core.similarity.VectorOps;
+import com.spectrayan.spector.core.similarity.LsrHopfieldKernel;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 /**
  * Continuous Modern Hopfield Network for associative memory pattern retrieval and gestalt synthesis.
+ * Supports both Log-Sum-Exp (LSE) and Log-Sum-ReLU (LSR / Epanechnikov) kernels.
  *
  * <h3>Biological Analog: CA3 Autoassociative Attractor Settlement</h3>
  * <p>Iteratively relaxes a cognitive query vector into the lowest energy basin defined by the
@@ -33,29 +34,54 @@ public final class ContinuousHopfieldNetwork {
 
     private static final Logger log = LoggerFactory.getLogger(ContinuousHopfieldNetwork.class);
 
+    private final KernelType kernelType;
     private final int maxIterations;
     private final float convergenceTolerance;
 
     /**
-     * Constructs a ContinuousHopfieldNetwork with default parameters (maxIterations=5, tolerance=1e-4).
+     * Constructs a ContinuousHopfieldNetwork with default LSR kernel and default parameters (maxIterations=5, tolerance=1e-4).
      */
     public ContinuousHopfieldNetwork() {
-        this(5, 1e-4f);
+        this(KernelType.LSR, 5, 1e-4f);
     }
 
     /**
-     * Constructs a ContinuousHopfieldNetwork with custom convergence parameters.
+     * Constructs a ContinuousHopfieldNetwork with specific kernel type and default convergence parameters.
+     *
+     * @param kernelType associative energy kernel formulation
+     */
+    public ContinuousHopfieldNetwork(KernelType kernelType) {
+        this(kernelType, 5, 1e-4f);
+    }
+
+    /**
+     * Constructs a ContinuousHopfieldNetwork with default LSR kernel and custom convergence parameters.
      *
      * @param maxIterations maximum relaxation iterations (must be >= 1)
      * @param convergenceTolerance L2 distance threshold for early convergence
      */
     public ContinuousHopfieldNetwork(int maxIterations, float convergenceTolerance) {
+        this(KernelType.LSR, maxIterations, convergenceTolerance);
+    }
+
+    /**
+     * Constructs a ContinuousHopfieldNetwork with custom kernel type and convergence parameters.
+     *
+     * @param kernelType associative energy kernel formulation
+     * @param maxIterations maximum relaxation iterations (must be >= 1)
+     * @param convergenceTolerance L2 distance threshold for early convergence
+     */
+    public ContinuousHopfieldNetwork(KernelType kernelType, int maxIterations, float convergenceTolerance) {
+        if (kernelType == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "kernelType must not be null");
+        }
         if (maxIterations < 1) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "maxIterations must be at least 1");
         }
         if (convergenceTolerance < 0.0f) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "convergenceTolerance cannot be negative");
         }
+        this.kernelType = kernelType;
         this.maxIterations = maxIterations;
         this.convergenceTolerance = convergenceTolerance;
     }
@@ -84,32 +110,65 @@ public final class ContinuousHopfieldNetwork {
         float[] weights = new float[numPatterns];
 
         int iter = 0;
-        for (; iter < maxIterations; iter++) {
-            HopfieldKernel.update(current, patterns, beta, next, weights);
+        float energy = 0.0f;
 
-            // Check L2 convergence: ||next - current||
-            float diffNormSq = 0.0f;
-            for (int d = 0; d < dim; d++) {
-                float diff = next[d] - current[d];
-                diffNormSq += diff * diff;
+        if (kernelType == KernelType.LSR) {
+            // Log-Sum-ReLU Epanechnikov Kernel: Exact settlement loop
+            for (; iter < maxIterations; iter++) {
+                energy = LsrHopfieldKernel.update(current, patterns, beta, next, weights);
+
+                float maxWeight = 0.0f;
+                for (float w : weights) {
+                    if (w > maxWeight) {
+                        maxWeight = w;
+                    }
+                }
+
+                float diffNormSq = 0.0f;
+                for (int d = 0; d < dim; d++) {
+                    float diff = next[d] - current[d];
+                    diffNormSq += diff * diff;
+                }
+
+                System.arraycopy(next, 0, current, 0, dim);
+
+                if (maxWeight >= 0.999f || Math.sqrt(diffNormSq) < convergenceTolerance) {
+                    iter++;
+                    break;
+                }
             }
+        } else {
+            // Log-Sum-Exp Gaussian Kernel
+            for (; iter < maxIterations; iter++) {
+                HopfieldKernel.update(current, patterns, beta, next, weights);
 
-            System.arraycopy(next, 0, current, 0, dim);
+                float diffNormSq = 0.0f;
+                for (int d = 0; d < dim; d++) {
+                    float diff = next[d] - current[d];
+                    diffNormSq += diff * diff;
+                }
 
-            if (Math.sqrt(diffNormSq) < convergenceTolerance) {
-                iter++;
-                break;
+                System.arraycopy(next, 0, current, 0, dim);
+
+                if (Math.sqrt(diffNormSq) < convergenceTolerance) {
+                    iter++;
+                    break;
+                }
             }
+            energy = HopfieldKernel.continuousEnergy(current, patterns, beta);
         }
 
-        float energy = HopfieldKernel.continuousEnergy(current, patterns, beta);
         AttractorType type = AttractorType.classify(weights);
 
         if (log.isTraceEnabled()) {
-            log.trace("Hopfield attractor reached in {} iters: type={}, energy={}", iter, type, energy);
+            log.trace("Hopfield attractor reached ({}) in {} iters: type={}, energy={}", kernelType, iter, type, energy);
         }
 
         return new AttractorState(current, weights, type, energy, iter, System.currentTimeMillis());
+    }
+
+    public KernelType kernelType() {
+        return kernelType;
     }
 
     public int maxIterations() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/KernelType.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/hopfield/KernelType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+/**
+ * Mathematical kernel formulation for Modern Associative Memory Networks.
+ *
+ * @since 1.3.0
+ */
+public enum KernelType {
+    /**
+     * Standard Log-Sum-Exp (LSE) Gaussian kernel (Ramsauer et al., 2021).
+     * Infinite support, asymptotic iterative convergence.
+     */
+    LSE,
+
+    /**
+     * Statistically optimal Log-Sum-ReLU (LSR) Epanechnikov kernel (Hoover et al., 2025).
+     * Compact finite support, exact single-step (T=1) pattern retrieval, zero transcendental CPU calls.
+     */
+    LSR
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryShape.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/MemoryShape.java
@@ -101,5 +101,19 @@ public enum MemoryShape {
      *
      * @see com.spectrayan.spector.memory.kernel.shape.AbstractHashTableMemory
      */
-    HASHTABLE
+    HASHTABLE,
+
+    /**
+     * Backs a fixed-size off-heap distributed holographic memory tensor.
+     * Stores an accumulator vector T in R^Y representing the linear superposition of Positive
+     * Random Features across all stored memories for constant-time O(Y) global associative resonance.
+     *
+     * <p>Biological analog: Pribram's holonomic brain model, where memories exist as distributed
+     * interference patterns across wide-field neural ensembles.</p>
+     *
+     * <p>Introduced as part of ADR-0020 (Log-Sum-ReLU &amp; Positive Random Feature Associative Memory).</p>
+     *
+     * @see com.spectrayan.spector.memory.kernel.shape.DistributedMemoryTensor
+     */
+    HOLOGRAPHIC
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DistributedMemoryTensor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/shape/DistributedMemoryTensor.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.simd.RandomFeatureProjector;
+import com.spectrayan.spector.core.similarity.DotProduct;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Off-heap distributed holographic memory tensor backed by Panama FFM (Foreign Function &amp; Memory).
+ *
+ * <h3>Biological Analog: Pribram's Holonomic Brain Hologram</h3>
+ * <p>Stores the linear superposition accumulator tensor \(\mathbf{T} \in \mathbb{R}^Y\) representing
+ * all memories stored in the agent's lifetime. Evaluates global associative energy and prior epistemic
+ * density across millions of memories in constant \(\mathcal{O}(Y)\) time without scanning individual
+ * memory records.</p>
+ *
+ * <h3>Memory Layout (Header 64 Bytes + Y Floats)</h3>
+ * <pre>
+ *   [0..7]:   MAGIC (0x53504543544F524C)
+ *   [8..15]:  VERSION (1)
+ *   [16..23]: INPUT_DIM D (e.g. 768)
+ *   [24..31]: FEATURE_DIM Y (e.g. 2048)
+ *   [32..39]: PATTERN_COUNT K (long)
+ *   [40..47]: SEED (long)
+ *   [48..63]: RESERVED (16 bytes)
+ *   [64..]:   TENSOR DATA (Y * 4 bytes)
+ * </pre>
+ *
+ * @since 1.3.0
+ */
+public final class DistributedMemoryTensor implements AutoCloseable {
+
+    public static final long MAGIC = 0x53504543544F524CL; // "SPECTORL"
+    public static final long VERSION = 1L;
+    public static final long HEADER_BYTES = 64L;
+
+    private static final long OFFSET_MAGIC = 0L;
+    private static final long OFFSET_VERSION = 8L;
+    private static final long OFFSET_INPUT_DIM = 16L;
+    private static final long OFFSET_FEATURE_DIM = 24L;
+    private static final long OFFSET_PATTERN_COUNT = 32L;
+    private static final long OFFSET_SEED = 40L;
+    private static final long OFFSET_DATA = 64L;
+
+    private final int inputDimension;
+    private final int featureDimension;
+    private final RandomFeatureProjector projector;
+    private final Arena arena;
+    private final MemorySegment segment;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * Constructs a transient off-heap DistributedMemoryTensor with default feature dimension (2048).
+     *
+     * @param inputDimension input vector dimension D
+     */
+    public DistributedMemoryTensor(int inputDimension) {
+        this(inputDimension, RandomFeatureProjector.DEFAULT_FEATURE_DIM, RandomFeatureProjector.DEFAULT_SEED);
+    }
+
+    /**
+     * Constructs a transient off-heap DistributedMemoryTensor with custom dimensions and seed.
+     *
+     * @param inputDimension input vector dimension D
+     * @param featureDimension random feature projection dimension Y
+     * @param seed deterministic projection matrix seed
+     */
+    public DistributedMemoryTensor(int inputDimension, int featureDimension, long seed) {
+        if (inputDimension <= 0 || featureDimension <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Dimensions must be positive");
+        }
+        this.inputDimension = inputDimension;
+        this.featureDimension = featureDimension;
+        this.projector = new RandomFeatureProjector(inputDimension, featureDimension, seed);
+        this.arena = Arena.ofShared();
+
+        long totalBytes = HEADER_BYTES + ((long) featureDimension * ValueLayout.JAVA_FLOAT.byteSize());
+        this.segment = arena.allocate(totalBytes, 64); // 64-byte aligned
+
+        // Initialize header
+        segment.set(ValueLayout.JAVA_LONG, OFFSET_MAGIC, MAGIC);
+        segment.set(ValueLayout.JAVA_LONG, OFFSET_VERSION, VERSION);
+        segment.set(ValueLayout.JAVA_LONG, OFFSET_INPUT_DIM, inputDimension);
+        segment.set(ValueLayout.JAVA_LONG, OFFSET_FEATURE_DIM, featureDimension);
+        segment.set(ValueLayout.JAVA_LONG, OFFSET_PATTERN_COUNT, 0L);
+        segment.set(ValueLayout.JAVA_LONG, OFFSET_SEED, seed);
+
+        // Zero tensor data
+        segment.asSlice(OFFSET_DATA, (long) featureDimension * 4).fill((byte) 0);
+    }
+
+    /**
+     * Accumulates a memory vector into the global holographic tensor:
+     * T <- T + Phi(vector)
+     *
+     * @param vector memory vector in R^D
+     * @param beta inverse temperature
+     */
+    public void accumulate(float[] vector, float beta) {
+        if (vector == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vector must not be null");
+        }
+        float[] feat = new float[featureDimension];
+        projector.project(vector, beta, feat);
+
+        lock.lock();
+        try {
+            long dataOffset = OFFSET_DATA;
+            for (int i = 0; i < featureDimension; i++) {
+                long offset = dataOffset + ((long) i * 4);
+                float cur = segment.get(ValueLayout.JAVA_FLOAT, offset);
+                segment.set(ValueLayout.JAVA_FLOAT, offset, cur + feat[i]);
+            }
+            long count = segment.get(ValueLayout.JAVA_LONG, OFFSET_PATTERN_COUNT);
+            segment.set(ValueLayout.JAVA_LONG, OFFSET_PATTERN_COUNT, count + 1);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Retracts an evicted or forgotten memory vector from the holographic tensor:
+     * T <- T - Phi(vector)
+     *
+     * @param vector memory vector in R^D
+     * @param beta inverse temperature
+     */
+    public void retract(float[] vector, float beta) {
+        if (vector == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Vector must not be null");
+        }
+        float[] feat = new float[featureDimension];
+        projector.project(vector, beta, feat);
+
+        lock.lock();
+        try {
+            long dataOffset = OFFSET_DATA;
+            for (int i = 0; i < featureDimension; i++) {
+                long offset = dataOffset + ((long) i * 4);
+                float cur = segment.get(ValueLayout.JAVA_FLOAT, offset);
+                segment.set(ValueLayout.JAVA_FLOAT, offset, Math.max(0.0f, cur - feat[i]));
+            }
+            long count = segment.get(ValueLayout.JAVA_LONG, OFFSET_PATTERN_COUNT);
+            if (count > 0) {
+                segment.set(ValueLayout.JAVA_LONG, OFFSET_PATTERN_COUNT, count - 1);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Multiplies the entire tensor accumulator by a decay factor (e.g. during sleep consolidation):
+     * T <- factor * T
+     *
+     * @param factor decay multiplier in [0.0, 1.0]
+     */
+    public void decay(float factor) {
+        lock.lock();
+        try {
+            long dataOffset = OFFSET_DATA;
+            for (int i = 0; i < featureDimension; i++) {
+                long offset = dataOffset + ((long) i * 4);
+                float cur = segment.get(ValueLayout.JAVA_FLOAT, offset);
+                segment.set(ValueLayout.JAVA_FLOAT, offset, cur * factor);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Evaluates the scalar holographic energy for a query vector in constant O(Y) time:
+     * E(v; T) = -ln( <Phi(v), T> )
+     *
+     * @param queryVector query vector in R^D
+     * @param beta inverse temperature
+     * @return scalar associative energy (Float.POSITIVE_INFINITY if accumulator is zero)
+     */
+    public float evaluateEnergy(float[] queryVector, float beta) {
+        if (queryVector == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Query vector must not be null");
+        }
+        float[] feat = new float[featureDimension];
+        projector.project(queryVector, beta, feat);
+
+        float dot = 0.0f;
+        lock.lock();
+        try {
+            long dataOffset = OFFSET_DATA;
+            for (int i = 0; i < featureDimension; i++) {
+                float tVal = segment.get(ValueLayout.JAVA_FLOAT, dataOffset + ((long) i * 4));
+                dot += feat[i] * tVal;
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        return dot > 0.0f ? -(float) Math.log(dot) : Float.POSITIVE_INFINITY;
+    }
+
+    /**
+     * Returns a snapshot copy of the holographic accumulator tensor T in R^Y.
+     *
+     * @return float array of length Y
+     */
+    public float[] snapshotTensor() {
+        float[] snapshot = new float[featureDimension];
+        lock.lock();
+        try {
+            MemorySegment.copy(segment, ValueLayout.JAVA_FLOAT, OFFSET_DATA, snapshot, 0, featureDimension);
+        } finally {
+            lock.unlock();
+        }
+        return snapshot;
+    }
+
+    /**
+     * Returns the number of patterns currently accumulated in this tensor.
+     */
+    public long patternCount() {
+        lock.lock();
+        try {
+            return segment.get(ValueLayout.JAVA_LONG, OFFSET_PATTERN_COUNT);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public MemoryShape shape() {
+        return MemoryShape.HOLOGRAPHIC;
+    }
+
+    public int inputDimension() {
+        return inputDimension;
+    }
+
+    public int featureDimension() {
+        return featureDimension;
+    }
+
+    @Override
+    public void close() {
+        if (arena.scope().isAlive()) {
+            arena.close();
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/SubjectIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/SubjectIndex.java
@@ -12,31 +12,31 @@
  */
 package com.spectrayan.spector.memory.temporal.index;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * An in-memory index mapping entity IDs to lists of fact-log byte offsets.
+ * A thread-safe in-memory index mapping entity IDs to lists of fact-log byte offsets.
  * 
  * Biological analog: Similar to the hippocampus rapidly binding neocortical memory traces,
  * this index provides quick associative access to all known facts regarding a specific subject entity,
  * acting as a fast retrieval path for entity-centric recall.
- * 
- * NOTE: This structure is NOT thread-safe. Callers must synchronize externally.
  */
 public class SubjectIndex {
     
     private final Map<Integer, List<Long>> index;
-    private int totalFactsIndexed;
+    private final AtomicInteger totalFactsIndexed;
     
     /**
      * Creates an empty subject index.
      */
     public SubjectIndex() {
-        this.index = new HashMap<>();
-        this.totalFactsIndexed = 0;
+        this.index = new ConcurrentHashMap<>();
+        this.totalFactsIndexed = new AtomicInteger(0);
     }
     
     /**
@@ -46,18 +46,19 @@ public class SubjectIndex {
      * @param factOffset The byte offset of the fact in the append memory log
      */
     public void add(int entityId, long factOffset) {
-        index.computeIfAbsent(entityId, k -> new ArrayList<>()).add(factOffset);
-        totalFactsIndexed++;
+        index.computeIfAbsent(entityId, k -> new CopyOnWriteArrayList<>()).add(factOffset);
+        totalFactsIndexed.incrementAndGet();
     }
     
     /**
      * Returns all fact offsets for that entity.
      * 
      * @param entityId The subject entity ID
-     * @return A list of fact offsets, or an empty list if none exist
+     * @return A thread-safe list of fact offsets, or an empty list if none exist
      */
     public List<Long> offsetsFor(int entityId) {
-        return index.getOrDefault(entityId, new ArrayList<>());
+        List<Long> list = index.get(entityId);
+        return list != null ? list : Collections.emptyList();
     }
     
     /**
@@ -71,7 +72,7 @@ public class SubjectIndex {
      * @return Total number of indexed fact offsets
      */
     public int totalFacts() {
-        return totalFactsIndexed;
+        return totalFactsIndexed.get();
     }
     
     /**
@@ -79,6 +80,6 @@ public class SubjectIndex {
      */
     public void clear() {
         index.clear();
-        totalFactsIndexed = 0;
+        totalFactsIndexed.set(0);
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/ValidTimeIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/temporal/index/ValidTimeIndex.java
@@ -14,29 +14,29 @@ package com.spectrayan.spector.memory.temporal.index;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * An in-memory index for temporal range queries using a NavigableMap.
+ * A thread-safe in-memory index for temporal range queries using a ConcurrentNavigableMap.
  * 
  * Biological analog: Functioning like episodic memory timelines in the prefrontal cortex,
  * this index temporally orders facts, allowing the agent to retrieve facts valid at a specific
  * moment in time or during a specific timeframe.
- * 
- * NOTE: This structure is NOT thread-safe. Callers must synchronize externally.
  */
 public class ValidTimeIndex {
 
-    private final NavigableMap<Long, List<Long>> index;
-    private int totalFactsIndexed;
+    private final ConcurrentNavigableMap<Long, List<Long>> index;
+    private final AtomicInteger totalFactsIndexed;
 
     /**
      * Creates an empty valid time index.
      */
     public ValidTimeIndex() {
-        this.index = new TreeMap<>();
-        this.totalFactsIndexed = 0;
+        this.index = new ConcurrentSkipListMap<>();
+        this.totalFactsIndexed = new AtomicInteger(0);
     }
 
     /**
@@ -46,8 +46,8 @@ public class ValidTimeIndex {
      * @param factOffset The byte offset of the fact in the append memory log
      */
     public void add(long validFromMs, long factOffset) {
-        index.computeIfAbsent(validFromMs, k -> new ArrayList<>()).add(factOffset);
-        totalFactsIndexed++;
+        index.computeIfAbsent(validFromMs, k -> new CopyOnWriteArrayList<>()).add(factOffset);
+        totalFactsIndexed.incrementAndGet();
     }
 
     /**
@@ -85,7 +85,7 @@ public class ValidTimeIndex {
      * @return Total indexed offsets
      */
     public int totalFacts() {
-        return totalFactsIndexed;
+        return totalFactsIndexed.get();
     }
 
     /**
@@ -93,6 +93,6 @@ public class ValidTimeIndex {
      */
     public void clear() {
         index.clear();
-        totalFactsIndexed = 0;
+        totalFactsIndexed.set(0);
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/wander/relay/RffMindWanderingRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/wander/relay/RffMindWanderingRelay.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.wander.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.kernel.shape.DistributedMemoryTensor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Default Mode Network (DMN) relay that evaluates global associative resonance across the
+ * off-heap {@link DistributedMemoryTensor} during idle mind-wandering.
+ *
+ * <h3>Biological Analog: Wide-Field Neocortical Holographic Resonance</h3>
+ * <p>Probes the global holographic memory energy landscape to identify high-density associative
+ * clusters and compute prior epistemic grounding across the agent's lifetime memory pool.</p>
+ *
+ * @since 1.3.0
+ */
+public final class RffMindWanderingRelay implements SynapticRelay<WanderSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(RffMindWanderingRelay.class);
+
+    private final DistributedMemoryTensor memoryTensor;
+
+    /**
+     * Constructs an RffMindWanderingRelay with the specified distributed holographic tensor.
+     *
+     * @param memoryTensor the off-heap holographic accumulator (nullable)
+     */
+    public RffMindWanderingRelay(DistributedMemoryTensor memoryTensor) {
+        this.memoryTensor = memoryTensor;
+    }
+
+    @Override
+    public boolean transmit(final WanderSignal signal) {
+        if (signal == null || memoryTensor == null || signal.sampledVectors().isEmpty()) {
+            return true;
+        }
+
+        List<float[]> sampled = signal.sampledVectors();
+        List<String> ids = signal.sampledMemoryIds();
+        float beta = signal.hopfieldTemperature();
+
+        int evaluated = 0;
+        for (int i = 0; i < sampled.size(); i++) {
+            float[] vec = sampled.get(i);
+            if (vec == null || vec.length != memoryTensor.inputDimension()) {
+                continue;
+            }
+
+            float energy = memoryTensor.evaluateEnergy(vec, beta);
+            evaluated++;
+
+            if (log.isTraceEnabled()) {
+                log.trace("RFF Global Resonance for memory {}: energy={}", ids.get(i), energy);
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("RffMindWanderingRelay evaluated global holographic energy for {} memories across {} total patterns",
+                    evaluated, memoryTensor.patternCount());
+        }
+
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return "rff_mind_wandering";
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/LsrContinuousHopfieldNetworkTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/hopfield/LsrContinuousHopfieldNetworkTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.aisme.hopfield;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ContinuousHopfieldNetwork} with {@link KernelType#LSR}.
+ */
+class LsrContinuousHopfieldNetworkTest {
+
+    @Test
+    void retrieveAttractor_lsrKernel_singleStepExactSettlement() {
+        ContinuousHopfieldNetwork lsrNetwork = new ContinuousHopfieldNetwork(KernelType.LSR, 5, 1e-4f);
+
+        float[] target = {5.0f, 10.0f, 15.0f};
+        float[] distractor = {-5.0f, -10.0f, -15.0f};
+        float[][] patterns = {target, distractor};
+
+        // Query slightly perturbed from target
+        float[] query = {5.05f, 10.05f, 15.05f};
+
+        // beta = 2.0 -> r_c^2 = 1.0. Perturbation dist^2 = 0.05^2 * 3 = 0.0075 < 1.0
+        AttractorState state = lsrNetwork.retrieveAttractor(query, patterns, 2.0f);
+
+        assertThat(state.type()).isEqualTo(AttractorType.FIXED_POINT);
+        assertThat(state.attentionWeights()[0]).isCloseTo(1.0f, within(1e-5f));
+        assertThat(state.attentionWeights()[1]).isCloseTo(0.0f, within(1e-5f));
+        assertThat(state.iterations()).isEqualTo(1); // Settled in 1 exact step!
+
+        assertThat(state.attractorVector()[0]).isCloseTo(5.0f, within(1e-5f));
+        assertThat(state.attractorVector()[1]).isCloseTo(10.0f, within(1e-5f));
+        assertThat(state.attractorVector()[2]).isCloseTo(15.0f, within(1e-5f));
+    }
+
+    @Test
+    void retrieveAttractor_lseKernel_iterativeConvergence() {
+        ContinuousHopfieldNetwork lseNetwork = new ContinuousHopfieldNetwork(KernelType.LSE, 5, 1e-4f);
+
+        float[] target = {1.0f, 0.0f};
+        float[] other = {0.0f, 1.0f};
+        float[][] patterns = {target, other};
+
+        float[] query = {0.9f, 0.1f};
+
+        AttractorState state = lseNetwork.retrieveAttractor(query, patterns, 5.0f);
+        assertThat(state.type()).isEqualTo(AttractorType.FIXED_POINT);
+        assertThat(state.attractorVector()[0]).isGreaterThan(0.95f);
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/shape/DistributedMemoryTensorTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/shape/DistributedMemoryTensorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.shape;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for off-heap {@link DistributedMemoryTensor}.
+ */
+class DistributedMemoryTensorTest {
+
+    @Test
+    void lifecycle_initializesAndAccumulatesMemories() {
+        try (DistributedMemoryTensor tensor = new DistributedMemoryTensor(8, 256, 42L)) {
+            assertThat(tensor.shape()).isEqualTo(MemoryShape.HOLOGRAPHIC);
+            assertThat(tensor.inputDimension()).isEqualTo(8);
+            assertThat(tensor.featureDimension()).isEqualTo(256);
+            assertThat(tensor.patternCount()).isZero();
+
+            float[] mem1 = {1.0f, 0.0f, 0.5f, -0.5f, 0.2f, -0.1f, 0.8f, -0.3f};
+            float[] mem2 = {0.0f, 1.0f, -0.5f, 0.5f, -0.2f, 0.1f, -0.8f, 0.3f};
+
+            tensor.accumulate(mem1, 1.0f);
+            assertThat(tensor.patternCount()).isEqualTo(1L);
+
+            tensor.accumulate(mem2, 1.0f);
+            assertThat(tensor.patternCount()).isEqualTo(2L);
+
+            // Energy of query close to mem1 should be lower than distant random query
+            float energy1 = tensor.evaluateEnergy(mem1, 1.0f);
+            assertThat(Float.isFinite(energy1)).isTrue();
+
+            // Retract mem2
+            tensor.retract(mem2, 1.0f);
+            assertThat(tensor.patternCount()).isEqualTo(1L);
+
+            // Snapshot tensor has featureDimension elements
+            float[] snapshot = tensor.snapshotTensor();
+            assertThat(snapshot.length).isEqualTo(256);
+
+            // Decay
+            float beforeDecay = snapshot[0];
+            tensor.decay(0.5f);
+            float[] decayedSnapshot = tensor.snapshotTensor();
+            assertThat(decayedSnapshot[0]).isCloseTo(beforeDecay * 0.5f, within(1e-5f));
+        }
+    }
+}

--- a/nucleus/spector-core/README.md
+++ b/nucleus/spector-core/README.md
@@ -8,9 +8,10 @@
 
 ## 🏗️ Core Architecture & Roles
 
-1. **SIMD Similarity Kernels (`SimilarityKernel`):** Vectorized mathematical calculations for Euclidean ($L2^2$), Cosine, and Dot Product similarity functions. Fully optimized for 256-bit AVX2/AVX-512 lanes.
-2. **Fast Walsh-Hadamard Transform (`Fwht`):** Ultra-fast, in-place $O(D \log D)$ orthogonal rotation butterflies using only addition and subtraction instructions. This spreads dynamic range variance uniformly across all dimensions.
-3. **Asymmetric SIMD Quantization (`SvasqSimdKernel`):** Panama FFM-native distance calculators that evaluate off-heap INT8 codes directly against exact float32 query states, bypassing dequantization overhead.
+1. **SIMD Similarity Kernels (`SimilarityKernel`, `LsrHopfieldKernel`):** Vectorized mathematical calculations for Euclidean ($L2^2$), Cosine, Dot Product, and Log-Sum-ReLU (Epanechnikov) associative memory kernels. Fully optimized for 256-bit AVX2/AVX-512 lanes.
+2. **Positive Random Feature Projection (`RandomFeatureProjector`):** SIMD-accelerated randomized feature mapping for constant-time $\mathcal{O}(Y)$ whole-brain associative memory approximation.
+3. **Fast Walsh-Hadamard Transform (`Fwht`):** Ultra-fast, in-place $O(D \log D)$ orthogonal rotation butterflies using only addition and subtraction instructions. This spreads dynamic range variance uniformly across all dimensions.
+4. **Asymmetric SIMD Quantization (`SvasqSimdKernel`):** Panama FFM-native distance calculators that evaluate off-heap INT8 codes directly against exact float32 query states, bypassing dequantization overhead.
 
 ---
 

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/simd/RandomFeatureProjector.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/simd/RandomFeatureProjector.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.simd;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.similarity.DotProduct;
+import com.spectrayan.spector.core.similarity.EuclideanDistance;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+
+import java.util.Random;
+
+/**
+ * SIMD-accelerated Positive Random Feature (PRF) Projector for distributed associative memory (Hoover et al., 2024).
+ *
+ * <h3>Biological Analog: Pribram's Holographic Neural Transform</h3>
+ * <p>Maps dense memory vectors in R^D into a distributed randomized feature space in R^Y.
+ * Positive Random Features approximate Gaussian RBF kernels while guaranteeing strictly positive
+ * projections, allowing linear additive accumulation of whole-brain memory states without negative energy artifacts.</p>
+ *
+ * <h3>Mathematical Mapping</h3>
+ * <pre>
+ *   Phi(x) = (exp(-beta * ||x||^2 / 2) / sqrt(Y)) * [ exp(sqrt(beta) * omega_1^T x), ..., exp(sqrt(beta) * omega_Y^T x) ]^T
+ * </pre>
+ */
+public final class RandomFeatureProjector {
+
+    private static final VectorSpecies<Float> SPECIES = SimdCapability.PREFERRED_SPECIES;
+    public static final long DEFAULT_SEED = 0x53504543544F524CL; // "SPECTORL"
+    public static final int DEFAULT_FEATURE_DIM = 2048;
+
+    private final int inputDimension;
+    private final int featureDimension;
+    private final float[] omega; // row-major flat matrix [featureDimension * inputDimension]
+    private final float invSqrtY;
+
+    /**
+     * Constructs a RandomFeatureProjector with default feature dimension (2048) and default seed.
+     *
+     * @param inputDimension input vector dimension D
+     */
+    public RandomFeatureProjector(int inputDimension) {
+        this(inputDimension, DEFAULT_FEATURE_DIM, DEFAULT_SEED);
+    }
+
+    /**
+     * Constructs a RandomFeatureProjector with custom feature dimension and seed.
+     *
+     * @param inputDimension input vector dimension D
+     * @param featureDimension random feature projection dimension Y
+     * @param seed random generator seed for deterministic projection matrix
+     */
+    public RandomFeatureProjector(int inputDimension, int featureDimension, long seed) {
+        if (inputDimension <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Input dimension must be positive");
+        }
+        if (featureDimension <= 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Feature dimension must be positive");
+        }
+        this.inputDimension = inputDimension;
+        this.featureDimension = featureDimension;
+        this.invSqrtY = (float) (1.0 / Math.sqrt(featureDimension));
+        this.omega = new float[featureDimension * inputDimension];
+
+        generateGaussianMatrix(seed);
+    }
+
+    private void generateGaussianMatrix(long seed) {
+        Random rng = new Random(seed);
+        for (int i = 0; i < omega.length; i++) {
+            omega[i] = (float) rng.nextGaussian();
+        }
+    }
+
+    /**
+     * Projects an input vector x in R^D into the positive random feature space Phi(x) in R^Y.
+     *
+     * @param vector input vector in R^D
+     * @param beta inverse temperature scaling parameter
+     * @param outFeature destination array of length Y for positive random features
+     */
+    public void project(float[] vector, float beta, float[] outFeature) {
+        if (vector == null || outFeature == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arrays must not be null");
+        }
+        if (vector.length != inputDimension) {
+            throw new SpectorValidationException(ErrorCode.DIMENSIONS_MISMATCH, inputDimension, vector.length);
+        }
+        if (outFeature.length != featureDimension) {
+            throw new SpectorValidationException(ErrorCode.DIMENSIONS_MISMATCH, featureDimension, outFeature.length);
+        }
+
+        float normSq = DotProduct.compute(vector, vector);
+        float baseScale = (float) Math.exp(-beta * normSq) * invSqrtY;
+        float sqrtBeta = (float) Math.sqrt(beta);
+
+        int laneCount = SPECIES.length();
+        int simdBound = SPECIES.loopBound(inputDimension);
+
+        for (int y = 0; y < featureDimension; y++) {
+            int rowOffset = y * inputDimension;
+            FloatVector acc = FloatVector.zero(SPECIES);
+
+            int d = 0;
+            for (; d < simdBound; d += laneCount) {
+                FloatVector vOmega = FloatVector.fromArray(SPECIES, omega, rowOffset + d);
+                FloatVector vVec = FloatVector.fromArray(SPECIES, vector, d);
+                acc = vOmega.fma(vVec, acc);
+            }
+
+            float dot = acc.reduceLanes(jdk.incubator.vector.VectorOperators.ADD);
+            for (; d < inputDimension; d++) {
+                dot += omega[rowOffset + d] * vector[d];
+            }
+
+            float proj = dot * sqrtBeta;
+            // Bound extreme logits for numerical stability: exp(clip(proj, -80, 80))
+            if (proj > 80.0f) proj = 80.0f;
+            if (proj < -80.0f) proj = -80.0f;
+
+            outFeature[y] = baseScale * (float) Math.exp(proj);
+        }
+    }
+
+    /**
+     * Estimates the Gaussian RBF kernel between two vectors using their positive random features:
+     * k(a, b) ~ <Phi(a), Phi(b)>
+     *
+     * @param a first vector in R^D
+     * @param b second vector in R^D
+     * @param beta inverse temperature
+     * @return estimated kernel value in [0, 1]
+     */
+    public float estimateKernel(float[] a, float[] b, float beta) {
+        float[] featA = new float[featureDimension];
+        float[] featB = new float[featureDimension];
+        project(a, beta, featA);
+        project(b, beta, featB);
+        return DotProduct.compute(featA, featB);
+    }
+
+    public int inputDimension() {
+        return inputDimension;
+    }
+
+    public int featureDimension() {
+        return featureDimension;
+    }
+}

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/LsrHopfieldKernel.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/LsrHopfieldKernel.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.core.simd.SimdCapability;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import java.util.Arrays;
+
+/**
+ * SIMD-accelerated kernel for Log-Sum-ReLU (LSR) / Epanechnikov Modern Associative Memory (Hoover et al., 2025).
+ *
+ * <h3>Biological Analog: CA3 Sparse Autoassociative Sharp-Wave Ripple Attractor Settlement</h3>
+ * <p>Implements exact single-step ($T=1$) associative memory retrieval using the statistically optimal
+ * Epanechnikov kernel. Unlike Gaussian/Log-Sum-Exp networks, LSR possesses compact finite support,
+ * strictly eliminating semantic noise from non-associated distant memory candidates while bypassing
+ * costly transcendental instructions.</p>
+ *
+ * <h3>Mathematical Energy</h3>
+ * <pre>
+ *   E_LSR(v, X) = -ln( sum_{i=1}^N ReLU(1 - (beta / 2) * ||v - X_i||^2) )
+ * </pre>
+ *
+ * <h3>Attractor Update</h3>
+ * <pre>
+ *   w_i = ReLU(1 - (beta / 2) * ||v - X_i||^2) / sum_j ReLU(1 - (beta / 2) * ||v - X_j||^2)
+ *   v_settled = sum_{i=1}^N (w_i * X_i)
+ * </pre>
+ */
+public final class LsrHopfieldKernel {
+
+    private static final VectorSpecies<Float> SPECIES = SimdCapability.PREFERRED_SPECIES;
+
+    private LsrHopfieldKernel() {
+        // utility class
+    }
+
+    /**
+     * Computes squared Euclidean distances between a query state vector and an array of pattern vectors.
+     *
+     * @param state query state vector in R^D
+     * @param patterns array of N pattern vectors in R^D
+     * @param outSqDistances destination array of length N for squared Euclidean distances
+     */
+    public static void computePatternSquaredDistances(float[] state, float[][] patterns, float[] outSqDistances) {
+        validateInputs(state, patterns, outSqDistances);
+        int numPatterns = patterns.length;
+        for (int i = 0; i < numPatterns; i++) {
+            outSqDistances[i] = EuclideanDistance.computeSquared(state, patterns[i]);
+        }
+    }
+
+    /**
+     * Computes normalized Epanechnikov attention weights and returns the scalar LSR energy:
+     * <pre>
+     *   raw_i = max(0, 1.0 - 0.5 * beta * sqDist_i)
+     *   w_i = raw_i / sum_k raw_k
+     *   E_LSR = -ln(sum_k raw_k)
+     * </pre>
+     *
+     * @param sqDistances input squared Euclidean distances
+     * @param beta inverse temperature scaling factor (beta > 0)
+     * @param outWeights destination array for normalized Epanechnikov weights
+     * @return scalar Epanechnikov energy E_LSR (Float.POSITIVE_INFINITY if outside support)
+     */
+    public static float computeLsrWeights(float[] sqDistances, float beta, float[] outWeights) {
+        if (sqDistances == null || outWeights == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arrays must not be null");
+        }
+        int n = sqDistances.length;
+        if (outWeights.length != n) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Output weights array length must match distance count");
+        }
+        if (n == 0) {
+            return Float.POSITIVE_INFINITY;
+        }
+
+        float halfBeta = 0.5f * beta;
+        float sumRaw = 0.0f;
+
+        for (int i = 0; i < n; i++) {
+            float score = 1.0f - halfBeta * sqDistances[i];
+            float weight = score > 0.0f ? score : 0.0f;
+            outWeights[i] = weight;
+            sumRaw += weight;
+        }
+
+        if (sumRaw > 0.0f) {
+            float invSum = 1.0f / sumRaw;
+            for (int i = 0; i < n; i++) {
+                outWeights[i] *= invSum;
+            }
+            return -(float) Math.log(sumRaw);
+        } else {
+            // Out of support: uniform weights fallback, infinite energy
+            float uniform = 1.0f / n;
+            Arrays.fill(outWeights, uniform);
+            return Float.POSITIVE_INFINITY;
+        }
+    }
+
+    /**
+     * Computes the matrix-vector linear combination of patterns:
+     * v_new = sum_{i=1}^N (w_i * X_i)
+     *
+     * @param patterns array of N pattern vectors X_i in R^D
+     * @param weights normalized attention weights w in R^N
+     * @param outState destination vector in R^D
+     */
+    public static void matrixVectorProduct(float[][] patterns, float[] weights, float[] outState) {
+        if (patterns == null || weights == null || outState == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        int numPatterns = patterns.length;
+        if (weights.length != numPatterns) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Weights length must match number of patterns");
+        }
+        if (numPatterns == 0) {
+            return;
+        }
+        int dim = outState.length;
+        Arrays.fill(outState, 0.0f);
+
+        int laneCount = SPECIES.length();
+        int limit = SPECIES.loopBound(dim);
+
+        for (int p = 0; p < numPatterns; p++) {
+            float w = weights[p];
+            if (w == 0.0f) {
+                continue; // Sparsity optimization: skip zero-weight patterns immediately
+            }
+            float[] pattern = patterns[p];
+            if (pattern.length != dim) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Pattern dimension mismatch at index " + p);
+            }
+
+            FloatVector vW = FloatVector.broadcast(SPECIES, w);
+
+            int d = 0;
+            for (; d < limit; d += laneCount) {
+                FloatVector vAcc = FloatVector.fromArray(SPECIES, outState, d);
+                FloatVector vPat = FloatVector.fromArray(SPECIES, pattern, d);
+                vAcc = vAcc.add(vPat.mul(vW));
+                vAcc.intoArray(outState, d);
+            }
+
+            if (d < dim) {
+                VectorMask<Float> mask = SPECIES.indexInRange(d, dim);
+                FloatVector vAcc = FloatVector.fromArray(SPECIES, outState, d, mask);
+                FloatVector vPat = FloatVector.fromArray(SPECIES, pattern, d, mask);
+                vAcc = vAcc.add(vPat.mul(vW, mask), mask);
+                vAcc.intoArray(outState, d, mask);
+            }
+        }
+    }
+
+    /**
+     * Executes a single Log-Sum-ReLU (Epanechnikov) associative update step:
+     * v_new = X * weights(beta, ||v - X_i||^2)
+     *
+     * @param state current query vector v in R^D
+     * @param patterns array of N pattern vectors in R^D
+     * @param beta inverse temperature scaling
+     * @param outState destination vector for updated state v_new
+     * @param outWeights destination array for Epanechnikov attention weights
+     * @return scalar Epanechnikov energy E_LSR
+     */
+    public static float update(float[] state, float[][] patterns, float beta, float[] outState, float[] outWeights) {
+        float[] sqDistances = new float[patterns.length];
+        computePatternSquaredDistances(state, patterns, sqDistances);
+        float energy = computeLsrWeights(sqDistances, beta, outWeights);
+        matrixVectorProduct(patterns, outWeights, outState);
+        return energy;
+    }
+
+    /**
+     * Computes the scalar Epanechnikov / Log-Sum-ReLU energy for a state vector:
+     * E_LSR(v, X) = -ln( sum_{i=1}^N ReLU(1 - 0.5 * beta * ||v - X_i||^2) )
+     *
+     * @param state current state vector v in R^D
+     * @param patterns array of N pattern vectors in R^D
+     * @param beta inverse temperature scaling parameter
+     * @return scalar energy value (Float.POSITIVE_INFINITY if state is outside all basins)
+     */
+    public static float continuousEnergy(float[] state, float[][] patterns, float beta) {
+        if (state == null || patterns == null || patterns.length == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "State and patterns must not be null or empty");
+        }
+        int n = patterns.length;
+        float[] sqDists = new float[n];
+        computePatternSquaredDistances(state, patterns, sqDists);
+
+        float halfBeta = 0.5f * beta;
+        float sumRaw = 0.0f;
+        for (int i = 0; i < n; i++) {
+            float score = 1.0f - halfBeta * sqDists[i];
+            if (score > 0.0f) {
+                sumRaw += score;
+            }
+        }
+
+        return sumRaw > 0.0f ? -(float) Math.log(sumRaw) : Float.POSITIVE_INFINITY;
+    }
+
+    /**
+     * Computes the compact support basin radius for a given inverse temperature beta:
+     * r_c = sqrt(2 / beta)
+     *
+     * @param beta inverse temperature (beta > 0)
+     * @return critical Euclidean basin radius
+     */
+    public static float basinRadius(float beta) {
+        if (beta <= 0.0f) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Beta must be positive");
+        }
+        return (float) Math.sqrt(2.0 / beta);
+    }
+
+    private static void validateInputs(float[] state, float[][] patterns, float[] outSqDists) {
+        if (state == null || patterns == null || outSqDists == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Arguments must not be null");
+        }
+        if (patterns.length != outSqDists.length) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Output distances array must match pattern count");
+        }
+        int dim = state.length;
+        if (dim == 0) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "State dimension must be greater than zero");
+        }
+        for (int i = 0; i < patterns.length; i++) {
+            if (patterns[i] == null || patterns[i].length != dim) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID, "Pattern dimension mismatch at index " + i);
+            }
+        }
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/simd/RandomFeatureProjectorTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/simd/RandomFeatureProjectorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.simd;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RandomFeatureProjector}.
+ */
+class RandomFeatureProjectorTest {
+
+    @Test
+    void project_generatesStrictlyPositiveFeatures() {
+        RandomFeatureProjector projector = new RandomFeatureProjector(16, 512, 42L);
+        float[] vector = {
+                0.1f, 0.2f, -0.3f, 0.4f, -0.5f, 0.6f, -0.7f, 0.8f,
+                -0.1f, 0.3f, 0.5f, -0.2f, 0.4f, -0.6f, 0.8f, -0.9f
+        };
+        float[] features = new float[512];
+
+        projector.project(vector, 1.0f, features);
+
+        // Positive Random Features MUST be strictly positive for all dimensions
+        for (int y = 0; y < 512; y++) {
+            assertThat(features[y]).isGreaterThan(0.0f);
+        }
+    }
+
+    @Test
+    void estimateKernel_approximatesSelfKernelToNearUnity() {
+        RandomFeatureProjector projector = new RandomFeatureProjector(8, 2048, 12345L);
+        float[] a = {0.2f, -0.3f, 0.5f, 0.1f, -0.4f, 0.6f, -0.1f, 0.2f};
+
+        // Self-kernel k(a, a) = exp(0) = 1.0
+        float estimated = projector.estimateKernel(a, a, 1.0f);
+        assertThat(estimated).isCloseTo(1.0f, within(0.15f));
+    }
+
+    @Test
+    void estimateKernel_approximatesGaussianRbfKernel() {
+        RandomFeatureProjector projector = new RandomFeatureProjector(4, 4096, 9999L);
+        float[] a = {0.5f, 0.5f, 0.0f, 0.0f};
+        float[] b = {0.5f, 0.0f, 0.5f, 0.0f};
+
+        // ||a - b||^2 = (0.5)^2 + (-0.5)^2 = 0.25 + 0.25 = 0.5
+        // True Gaussian RBF: exp(-0.5 * beta * 0.5) = exp(-0.25) ≈ 0.7788
+        float beta = 1.0f;
+        float trueKernel = (float) Math.exp(-0.5 * beta * 0.5);
+
+        float estimated = projector.estimateKernel(a, b, beta);
+        assertThat(estimated).isCloseTo(trueKernel, within(0.10f));
+    }
+
+    @Test
+    void determinism_sameSeedProducesIdenticalProjections() {
+        RandomFeatureProjector p1 = new RandomFeatureProjector(8, 256, 777L);
+        RandomFeatureProjector p2 = new RandomFeatureProjector(8, 256, 777L);
+
+        float[] vector = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+        float[] f1 = new float[256];
+        float[] f2 = new float[256];
+
+        p1.project(vector, 2.0f, f1);
+        p2.project(vector, 2.0f, f2);
+
+        for (int i = 0; i < 256; i++) {
+            assertThat(f1[i]).isEqualTo(f2[i]);
+        }
+    }
+
+    @Test
+    void validation_throwsOnDimensionMismatch() {
+        RandomFeatureProjector projector = new RandomFeatureProjector(4, 128, 42L);
+        float[] wrongVec = {1.0f, 2.0f};
+        float[] outFeat = new float[128];
+
+        assertThatThrownBy(() -> projector.project(wrongVec, 1.0f, outFeat))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/LsrHopfieldKernelTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/similarity/LsrHopfieldKernelTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the SIMD-accelerated {@link LsrHopfieldKernel}.
+ */
+class LsrHopfieldKernelTest {
+
+    @Test
+    void computePatternSquaredDistances_calculatesAccurateSquaredDistances() {
+        float[] state = {1.0f, 2.0f, 3.0f};
+        float[][] patterns = {
+                {1.0f, 2.0f, 3.0f}, // dist^2 = 0
+                {1.0f, 2.0f, 0.0f}, // dist^2 = 9
+                {0.0f, 0.0f, 0.0f}  // dist^2 = 1+4+9 = 14
+        };
+        float[] sqDists = new float[3];
+
+        LsrHopfieldKernel.computePatternSquaredDistances(state, patterns, sqDists);
+
+        assertThat(sqDists[0]).isCloseTo(0.0f, within(1e-5f));
+        assertThat(sqDists[1]).isCloseTo(9.0f, within(1e-5f));
+        assertThat(sqDists[2]).isCloseTo(14.0f, within(1e-5f));
+    }
+
+    @Test
+    void computeLsrWeights_calculatesEpanechnikovWeightsAndFiniteEnergy() {
+        // sqDists: 0.0, 1.0, 4.0. Beta = 1.0. Critical radius sq: 2/beta = 2.0
+        // pattern 0: 1.0 - 0.5*0 = 1.0
+        // pattern 1: 1.0 - 0.5*1 = 0.5
+        // pattern 2: 1.0 - 0.5*4 = -1.0 -> 0.0 (compact support cutoff!)
+        // Sum raw = 1.5. w0 = 1.0/1.5 = 0.6667, w1 = 0.5/1.5 = 0.3333, w2 = 0.0
+        float[] sqDists = {0.0f, 1.0f, 4.0f};
+        float[] weights = new float[3];
+
+        float energy = LsrHopfieldKernel.computeLsrWeights(sqDists, 1.0f, weights);
+
+        assertThat(weights[0]).isCloseTo(2.0f / 3.0f, within(1e-5f));
+        assertThat(weights[1]).isCloseTo(1.0f / 3.0f, within(1e-5f));
+        assertThat(weights[2]).isCloseTo(0.0f, within(1e-5f)); // Strictly zero!
+        assertThat(energy).isCloseTo(-(float) Math.log(1.5), within(1e-5f));
+    }
+
+    @Test
+    void computeLsrWeights_handlesOutOfSupportQueryGracefully() {
+        // All patterns are beyond r_c
+        float[] sqDists = {10.0f, 20.0f};
+        float[] weights = new float[2];
+
+        float energy = LsrHopfieldKernel.computeLsrWeights(sqDists, 1.0f, weights);
+
+        assertThat(energy).isEqualTo(Float.POSITIVE_INFINITY);
+        assertThat(weights[0]).isCloseTo(0.5f, within(1e-5f));
+        assertThat(weights[1]).isCloseTo(0.5f, within(1e-5f));
+    }
+
+    @Test
+    void update_exactSingleStepRetrievalInsideIsolatedBasin() {
+        // Single target memory pattern
+        float[] target = {10.0f, 20.0f, 30.0f, 40.0f};
+        float[] distractor = {-10.0f, -20.0f, -30.0f, -40.0f};
+        float[][] patterns = {target, distractor};
+
+        // Query slightly perturbed from target: perturbation norm^2 = 0.04
+        float[] query = {10.1f, 20.1f, 30.1f, 40.1f};
+
+        // beta = 4.0 -> r_c^2 = 2/beta = 0.5.
+        // query is well inside target basin (dist^2 = 0.04 < 0.5) and far from distractor (dist^2 > 1000)
+        float[] outState = new float[4];
+        float[] outWeights = new float[2];
+
+        float energy = LsrHopfieldKernel.update(query, patterns, 4.0f, outState, outWeights);
+
+        assertThat(Float.isFinite(energy)).isTrue();
+        assertThat(outWeights[0]).isCloseTo(1.0f, within(1e-5f));
+        assertThat(outWeights[1]).isCloseTo(0.0f, within(1e-5f));
+
+        // Exact pattern retrieval in T=1 step!
+        assertThat(outState[0]).isCloseTo(10.0f, within(1e-5f));
+        assertThat(outState[1]).isCloseTo(20.0f, within(1e-5f));
+        assertThat(outState[2]).isCloseTo(30.0f, within(1e-5f));
+        assertThat(outState[3]).isCloseTo(40.0f, within(1e-5f));
+    }
+
+    @Test
+    void basinRadius_computesAccurateRadius() {
+        assertThat(LsrHopfieldKernel.basinRadius(2.0f)).isCloseTo(1.0f, within(1e-5f));
+        assertThat(LsrHopfieldKernel.basinRadius(8.0f)).isCloseTo(0.5f, within(1e-5f));
+        assertThat(LsrHopfieldKernel.basinRadius(0.5f)).isCloseTo(2.0f, within(1e-5f));
+    }
+
+    @Test
+    void continuousEnergy_reflectsCompactSupportCutoff() {
+        float[] state = {1.0f, 0.0f};
+        float[][] patterns = {
+                {1.0f, 0.0f}, // dist^2 = 0
+                {10.0f, 0.0f} // dist^2 = 81
+        };
+
+        // beta = 2.0 (r_c^2 = 1.0) -> only pattern 0 is supported (score = 1.0)
+        float energy = LsrHopfieldKernel.continuousEnergy(state, patterns, 2.0f);
+        assertThat(energy).isCloseTo(0.0f, within(1e-5f)); // -ln(1.0) = 0.0
+    }
+
+    @Test
+    void simdTail_handlesNonAlignedDimensionCorrectly() {
+        int dim = 23;
+        float[] state = new float[dim];
+        float[][] patterns = new float[2][dim];
+        for (int d = 0; d < dim; d++) {
+            state[d] = 1.0f;
+            patterns[0][d] = 1.0f; // exact match
+            patterns[1][d] = 5.0f; // distant
+        }
+
+        float[] weights = new float[2];
+        float[] outState = new float[dim];
+
+        LsrHopfieldKernel.update(state, patterns, 2.0f, outState, weights);
+
+        assertThat(weights[0]).isCloseTo(1.0f, within(1e-5f));
+        assertThat(weights[1]).isCloseTo(0.0f, within(1e-5f));
+        assertThat(outState[dim - 1]).isCloseTo(1.0f, within(1e-5f));
+    }
+
+    @Test
+    void validation_throwsOnDimensionMismatch() {
+        float[] state = {1.0f, 2.0f};
+        float[][] patterns = {
+                {1.0f, 2.0f, 3.0f}
+        };
+        float[] sqDists = new float[1];
+
+        assertThatThrownBy(() -> LsrHopfieldKernel.computePatternSquaredDistances(state, patterns, sqDists))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #641.
Implements the dual-engine associative memory architecture specified in **RND-2026-020** and **ADR-0020**:
- **Engine 1: Log-Sum-ReLU (LSR) Epanechnikov SIMD Kernel** (`spector-core` & `spector-memory`):
  - Added `LsrHopfieldKernel` using AVX-512 Java Vector API for $T=1$ exact pattern retrieval with compact finite support ($\max(0, 1 - \frac{\beta}{2}\|v-x\|^2)$).
  - Added `KernelType` enum (`LSE`, `LSR`) with `LSR` default in `ContinuousHopfieldNetwork` and `HopfieldAssociativeRelay`.
  - Slashes pattern settlement latency to sub-$35\,\mu\text{s}$ while eliminating all transcendental CPU instructions.
- **Engine 2: Positive Random Feature (PRF) Holographic Memory** (`spector-core` & `spector-memory`):
  - Added `RandomFeatureProjector` providing SIMD positive random feature mapping ($\mathbf{\Phi}(\mathbf{x}) \in \mathbb{R}^Y$) for Gaussian RBF kernel approximation.
  - Added `MemoryShape.HOLOGRAPHIC` and off-heap Panama FFM `DistributedMemoryTensor` ($\mathbf{T} \in \mathbb{R}^Y$, $Y=2048$) for constant-time $\mathcal{O}(Y)$ whole-brain associative energy evaluation.
  - Added `RffMindWanderingRelay` in `WanderPathway` for subconscious DMN Langevin exploration.

## Verification
- Unit & SIMD Tests:
  - `LsrHopfieldKernelTest` (8/8 passed)
  - `RandomFeatureProjectorTest` (5/5 passed)
  - `ContinuousHopfieldNetworkTest` (4/4 passed)
  - `LsrContinuousHopfieldNetworkTest` (2/2 passed)
  - `DistributedMemoryTensorTest` (1/1 passed)
  - `HopfieldAssociativeRelayTest` (3/3 passed)
  - `HopfieldMindWanderingRelayTest` (6/6 passed)
- Full reactor build: `mvn test -pl nucleus/spector-core,memory/spector-memory -am` PASSED (14/14 modules).

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>