### PR TITLE
fix(cortex): sanitize rendered markdown HTML

### DIFF
--- a/cortex/spector-cortex/src/app/shared/pipes/markdown.pipe.spec.ts
+++ b/cortex/spector-cortex/src/app/shared/pipes/markdown.pipe.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { MarkdownPipe } from './markdown.pipe';
+
+describe('MarkdownPipe', () => {
+  it('removes executable HTML from rendered markdown', () => {
+    const html = new MarkdownPipe().transform(
+      '<img src=x onerror=alert(1)><script>alert(1)</script><iframe src="evil"></iframe>',
+    );
+
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('<iframe');
+  });
+});

--- a/cortex/spector-cortex/src/app/shared/pipes/markdown.pipe.ts
+++ b/cortex/spector-cortex/src/app/shared/pipes/markdown.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 
 /**
@@ -28,16 +29,11 @@ export class MarkdownPipe implements PipeTransform {
   }
 
   /**
-   * Basic HTML sanitization — strips script, iframe, object, embed tags
-   * and on* event handlers. For production, consider DOMPurify.
+   * Sanitize rendered Markdown with the project's trusted HTML sanitizer.
+   * Regex-based removal is unsafe for multi-character tags and attributes
+   * because it can leave an exploitable remainder in the HTML.
    */
   private sanitize(html: string): string {
-    return html
-      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-      .replace(/<iframe\b[^>]*>.*?<\/iframe>/gi, '')
-      .replace(/<object\b[^>]*>.*?<\/object>/gi, '')
-      .replace(/<embed\b[^>]*\/?>/gi, '')
-      .replace(/\bon\w+\s*=\s*"[^"]*"/gi, '')
-      .replace(/\bon\w+\s*=\s*'[^']*'/gi, '');
+    return DOMPurify.sanitize(html);
   }
 }


### PR DESCRIPTION
## Summary

Closes #377.

The Cortex Markdown pipe used regex replacements to remove dangerous HTML. CodeQL identified incomplete multi-character sanitization that could leave `script`, `iframe`, and event-handler content exploitable.

## Changes

- Use the existing `DOMPurify` dependency to sanitize rendered Markdown.
- Add a regression test covering `onerror`, `script`, and `iframe` payloads.

## Validation

- `npm ci --ignore-scripts --prefer-offline`
- `npm test -- --watch=false` — 1 test passed
- `npm run build -- --configuration production` — passed
- `git diff --check` — passed

## Limitations

The full repository test suite was not run; the focused Cortex test and production build were run instead.