### PR TITLE
fix(docs): update mkdocs snippet paths for nucleus modules and add missing module doc includes

### DIFF
--- a/docs/docs/modules/spector-batch.md
+++ b/docs/docs/modules/spector-batch.md
@@ -1,0 +1,1 @@
+﻿--8<-- "synapse/spector-batch/README.md"

--- a/docs/docs/modules/spector-bom.md
+++ b/docs/docs/modules/spector-bom.md
@@ -1,0 +1,1 @@
+﻿--8<-- "nucleus/spector-bom/README.md"

--- a/docs/docs/modules/spector-connector.md
+++ b/docs/docs/modules/spector-connector.md
@@ -1,0 +1,1 @@
+﻿--8<-- "synapse/spector-connector/README.md"

--- a/docs/docs/modules/spector-cpu.md
+++ b/docs/docs/modules/spector-cpu.md
@@ -1,0 +1,1 @@
+﻿--8<-- "nucleus/spector-cpu/README.md"

--- a/docs/docs/modules/spector-gpu.md
+++ b/docs/docs/modules/spector-gpu.md
@@ -1,1 +1,1 @@
---8<-- "memory/spector-gpu/README.md"
+--8<-- "nucleus/spector-gpu/README.md"

--- a/docs/docs/modules/spector-hdc.md
+++ b/docs/docs/modules/spector-hdc.md
@@ -1,0 +1,1 @@
+﻿--8<-- "nucleus/spector-hdc/README.md"

--- a/docs/docs/modules/spector-index.md
+++ b/docs/docs/modules/spector-index.md
@@ -1,1 +1,1 @@
---8<-- "memory/spector-index/README.md"
+--8<-- "nucleus/spector-index/README.md"

--- a/docs/docs/modules/spector-inspect.md
+++ b/docs/docs/modules/spector-inspect.md
@@ -1,0 +1,1 @@
+﻿--8<-- "memory/spector-inspect/README.md"

--- a/memory/spector-inspect/README.md
+++ b/memory/spector-inspect/README.md
@@ -1,0 +1,15 @@
+﻿# Spector Inspect CLI
+
+The `spector-inspect` module provides a command-line utility for offline and runtime inspection, debugging, and verification of Panama off-heap storage bundles, cognitive indexes, and memory partitions.
+
+## Features
+
+- **Header Validation**: Inspects 64-byte synaptic headers for byte layout, checksum, and corruption.
+- **Partition Dumping**: Dumps metadata, record counts, active memory tiers, and Bloom filter statistics.
+- **Vector Dump**: Inspects raw dense embedding vectors and cluster centroid assignments.
+
+## Usage
+
+```bash
+java -jar spector-inspect.jar --path /path/to/.spector/partitions/
+```

--- a/nucleus/spector-bom/README.md
+++ b/nucleus/spector-bom/README.md
@@ -1,0 +1,21 @@
+﻿# Spector Bill of Materials (BOM)
+
+The `spector-bom` module provides centralized dependency management for all Spector modules and consumer projects.
+
+## Usage
+
+Import the BOM into your Maven `dependencyManagement` section:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.spectrayan</groupId>
+            <artifactId>spector-bom</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```

--- a/nucleus/spector-cpu/README.md
+++ b/nucleus/spector-cpu/README.md
@@ -1,0 +1,26 @@
+﻿# Spector CPU Accelerator
+
+The `spector-cpu` module provides the standard CPU SIMD Hardware Acceleration Layer implementation for the Spector kernel SPI (`ComputeAccelerator`).
+
+## Overview
+
+`spector-cpu` compiles and executes hardware-accelerated vector and matrix operations utilizing the Java Vector API (`jdk.incubator.vector`) across AVX-512, AVX2, and ARM NEON instruction sets.
+
+Key features:
+- **`CpuSimdAccelerator`**: Implements `ComputeAccelerator` SPI for CPU compute targets.
+- **`CpuSimdSimilarityKernel`**: Vectorized dot product, cosine distance, and Euclidean distance kernels with zero allocations.
+- **`CpuSimdMaxSimKernel`**: Vectorized late-interaction MaxSim operations for ColBERT-style retrieval.
+- **`CpuSimdSvasqKernel`**: Fast vectorized SVASQ asymmetric scalar quantized distance scoring.
+- **`CpuSimdCandidateKernel`**: Batch candidate distance computations.
+
+## Usage
+
+```xml
+<dependency>
+    <groupId>com.spectrayan</groupId>
+    <artifactId>spector-cpu</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+
+When placed on the module-path or classpath, `CpuSimdAccelerator` automatically registers via `java.util.ServiceLoader` under `com.spectrayan.spector.core.spi.ComputeAccelerator`.


### PR DESCRIPTION
## Description

Fixes the GitHub Actions CI documentation build failure on `main` caused by stale snippet paths and missing documentation files following the recent HAL restructuring and module relocations.

## Root Cause

`mkdocs` raised `SnippetMissingError` because:
- `docs/docs/modules/spector-gpu.md` referenced `memory/spector-gpu/README.md` (relocated to `nucleus/spector-gpu/`).
- `docs/docs/modules/spector-index.md` referenced `memory/spector-index/README.md` (relocated to `nucleus/spector-index/`).
- Missing snippet include files and `README.md` files for `spector-cpu`, `spector-bom`, and `spector-inspect`.

## Summary of Changes

- **Snippet Path Fixes**:
  - Updated `docs/docs/modules/spector-gpu.md` to point to `nucleus/spector-gpu/README.md`.
  - Updated `docs/docs/modules/spector-index.md` to point to `nucleus/spector-index/README.md`.
- **New Module READMEs**:
  - Added `nucleus/spector-cpu/README.md`
  - Added `nucleus/spector-bom/README.md`
  - Added `memory/spector-inspect/README.md`
- **New Module Doc Include Pages**:
  - Added `docs/docs/modules/spector-bom.md`
  - Added `docs/docs/modules/spector-cpu.md`
  - Added `docs/docs/modules/spector-hdc.md`
  - Added `docs/docs/modules/spector-inspect.md`
  - Added `docs/docs/modules/spector-connector.md`
  - Added `docs/docs/modules/spector-batch.md`

## Related Issue

Closes #655

## Verification

- Local `mkdocs build --clean` executed with **0 errors** (all snippets resolved successfully).
- `mvn license:check` — **100% COMPLIANT**.
- `mvn test-compile` — **100% SUCCESS**.
