### PR TITLE
refactor(memory): remove deprecated API references (#685)

### DIFF
--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/ContributingSubsystem.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/ContributingSubsystem.java
@@ -23,9 +23,8 @@ import java.util.Set;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 
 /**

--- a/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/MmapDatasetIntegrityValidator.java
+++ b/bench/spector-bench/src/main/java/com/spectrayan/spector/bench/cognitive/MmapDatasetIntegrityValidator.java
@@ -36,7 +36,7 @@ import com.spectrayan.spector.bench.cognitive.model.TemporalChainDef;
 import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/BiologicalSubsystemsBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/BiologicalSubsystemsBuilder.java
@@ -79,10 +79,7 @@ final class BiologicalSubsystemsBuilder {
             java.lang.foreign.MemorySegment ckptSlice = cortex.runtimeBundle().regionSegment(com.spectrayan.spector.memory.kernel.bundle.RegionId.CHECKPOINT);
             coActivationTracker = CoActivationRecordMemory.fromBundle(
                     cortex.runtimeBundle().arena(), regionSlice, 10_000, 20_000,
-                    StorageLayout.coactivationTracker(basePath), isNew, ckptSlice);
-        } else if (isDisk && basePath != null) {
-            coActivationTracker = CoActivationRecordMemory.load(
-                    StorageLayout.coactivationTracker(basePath), 10_000, 20_000);
+                    cortex.runtimeBundle().bundlePath(), isNew, ckptSlice);
         } else {
             coActivationTracker = new CoActivationRecordMemory();
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveCortexBuilder.java
@@ -158,24 +158,16 @@ final class CognitiveCortexBuilder {
                 : 0;
 
         //  Cognitive Memory stores 
+        boolean useBundleMode = isDisk && basePath != null;
         CognitiveMemoryRouter cognitiveRouter;
-        WorkingRecordMemory workingStore;
+        WorkingRecordMemory workingStore = new WorkingRecordMemory(quantizedVecBytes, builder.workingCapacity);
         PartitionBundle partitionBundle = null;
         TextAppendMemory textStore = null;
         RuntimeBundle runtimeBundle = null;
         InsularCortex insularCortex = null;
         ContinuityRecordMemory continuityMemory = null;
-        if (isDisk && builder.persistWorkingMemory && basePath != null) {
-            workingStore = new WorkingRecordMemory(quantizedVecBytes, builder.workingCapacity,
-                     StorageLayout.workingMem(basePath));
-        } else {
-            workingStore = new WorkingRecordMemory(quantizedVecBytes, builder.workingCapacity);
-        }
 
-        boolean activeHasBundle = resolvedPartitionDir != null && Files.exists(StorageLayout.partitionBundleFile(resolvedPartitionDir));
-        boolean useBundleMode = builder.useBundleMode || activeHasBundle;
-
-        if (isDisk && basePath != null && resolvedPartitionDir != null && useBundleMode) {
+        if (isDisk && basePath != null && resolvedPartitionDir != null) {
             // ── V4 Runtime Bundle & Insular Cortex ──
             Path runtimeBundleFile = StorageLayout.runtimeBundleFile(basePath);
             boolean isNewRuntime = !Files.exists(runtimeBundleFile);
@@ -221,7 +213,7 @@ final class CognitiveCortexBuilder {
             boolean isWorkingNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(workingSlice, 0L);
             workingStore = WorkingRecordMemory.fromBundle(runtimeBundle.arena(), workingSlice,
                     quantizedVecBytes, builder.workingCapacity,
-                    StorageLayout.workingMem(basePath), isWorkingNew);
+                    runtimeBundleFile, isWorkingNew);
 
             MemorySegment insulaSlice = runtimeBundle.regionSegment(RegionId.INSULA);
             insularCortex = InsularCortex.fromBundle(runtimeBundle.arena(), insulaSlice, isNewRuntime);
@@ -233,6 +225,13 @@ final class CognitiveCortexBuilder {
 
             // ── V4 Partition Bundle ──
             Path bundleFile = StorageLayout.partitionBundleFile(resolvedPartitionDir);
+            if (!Files.exists(bundleFile)) {
+                try {
+                    com.spectrayan.spector.memory.kernel.bundle.BundleMigrationCli.migratePartition(resolvedPartitionDir, quantizedVecBytes);
+                } catch (Exception e) {
+                    log.debug("Partition auto-migration check: {}", e.getMessage());
+                }
+            }
             boolean isNew = !Files.exists(bundleFile);
 
             CognitiveRecordLayout cogLayout = new CognitiveRecordLayout(quantizedVecBytes);
@@ -282,22 +281,6 @@ final class CognitiveCortexBuilder {
             log.info("V4 bundle mode: {} ({}, {} stores, episodic=log-structured)",
                     bundleFile.getFileName(), isNew ? "created" : "opened", 4);
 
-        } else if (isDisk && basePath != null && resolvedPartitionDir != null) {
-            // ── V3 Legacy Mode ──
-            EpisodicRecordMemory episodicStore = new EpisodicRecordMemory(
-                    StorageLayout.episodicMem(resolvedPartitionDir),
-                    quantizedVecBytes, builder.episodicPartitionCapacity);
-            EpisodicLogMemory episodicLogStore = new EpisodicLogMemory(
-                    (long) builder.episodicPartitionCapacity * 256L);
-            ProceduralRecordMemory proceduralStore = new ProceduralRecordMemory(
-                    quantizedVecBytes, builder.proceduralCapacity,
-                    StorageLayout.proceduralMem(resolvedPartitionDir));
-            SemanticRecordMemory semanticStore = new SemanticRecordMemory(
-                    quantizedVecBytes, builder.semanticCapacity,
-                    StorageLayout.semanticMem(resolvedPartitionDir));
-            textStore = new TextAppendMemory(
-                    StorageLayout.textDat(resolvedPartitionDir), builder.dataEncryptor);
-            cognitiveRouter = new CognitiveMemoryRouter(workingStore, episodicStore, semanticStore, proceduralStore, episodicLogStore);
         } else {
             EpisodicRecordMemory episodicStore = new EpisodicRecordMemory(
                     quantizedVecBytes, builder.episodicPartitionCapacity);
@@ -390,7 +373,7 @@ final class CognitiveCortexBuilder {
                 ),
                 new RegionSizeSpec(
                         RegionId.HEBBIAN,
-                        64 + 8 + 24L * graphCapacity + 12L * graphCapacity * builder.hebbianMaxDegree,
+                        64 + 16 + (long) (graphCapacity + 1) * Integer.BYTES + (long) graphCapacity * (builder.hebbianMaxDegree > 0 ? builder.hebbianMaxDegree : 16) * 12L,
                         graphCapacity,
                         0,
                         new com.spectrayan.spector.memory.kernel.layout.HebbianLayout().layoutId(),

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
@@ -92,29 +92,7 @@ final class CognitiveGraphBuilder {
             hebbianGraph = HebbianGraphMemory.fromBundle(
                     cortex.runtimeBundle().arena(), regionSlice, graphCapacity, edgeCapacity,
                     builder.hebbianMaxDegree, builder.edgeImportance,
-                    StorageLayout.hebbianGraphRuntime(basePath), isNew);
-        } else if (isDisk && basePath != null) {
-            Path runtimeGraph = StorageLayout.hebbianGraphRuntime(basePath);
-            Path legacyGraph = basePath.resolve(StorageLayout.FILE_HEBBIAN);
-            Path v2Graph = resolvedPartitionDir != null
-                    ? resolvedPartitionDir.resolve(StorageLayout.FILE_HEBBIAN) : null;
-            Path loadFrom = MigrationPathResolver.getNewerPath(runtimeGraph, v2Graph, legacyGraph);
-            if (loadFrom == null) {
-                loadFrom = legacyGraph;
-            }
-            if (loadFrom != null) {
-                try {
-                    com.spectrayan.spector.memory.kernel.codec.Codecs.ensureCurrent(
-                            com.spectrayan.spector.memory.kernel.codec.Codecs.defaultRegistry(),
-                            SystemMemoryId.HEBBIAN_CSR.id(),
-                            new com.spectrayan.spector.memory.kernel.layout.HebbianLayout(),
-                            loadFrom, null, null);
-                } catch (Exception e) {
-                    log.warn("Operation failed: Codec validation for HebbianLayout", e);
-                }
-            }
-            hebbianGraph = HebbianGraphMemory.load(loadFrom, graphCapacity,
-                    builder.hebbianMaxDegree, builder.edgeImportance);
+                    cortex.runtimeBundle().bundlePath(), isNew);
         } else {
             hebbianGraph = new HebbianGraphMemory(graphCapacity);
         }
@@ -127,26 +105,7 @@ final class CognitiveGraphBuilder {
             boolean isNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(regionSlice, 0L);
             temporalChain = TemporalChainMemory.fromBundle(
                     cortex.runtimeBundle().arena(), regionSlice, temporalCapacity,
-                    StorageLayout.temporalChainRuntime(basePath), isNew);
-        } else if (isDisk && basePath != null) {
-            Path runtimeChain = StorageLayout.temporalChainRuntime(basePath);
-            Path legacyChain = basePath.resolve(StorageLayout.FILE_TEMPORAL);
-            Path v2Chain = resolvedPartitionDir != null
-                    ? resolvedPartitionDir.resolve(StorageLayout.FILE_TEMPORAL) : null;
-            Path loadFrom = MigrationPathResolver.getNewerPath(runtimeChain, v2Chain, legacyChain);
-            if (loadFrom == null) {
-                loadFrom = legacyChain;
-            }
-            try {
-                com.spectrayan.spector.memory.kernel.codec.Codecs.ensureCurrent(
-                        com.spectrayan.spector.memory.kernel.codec.Codecs.defaultRegistry(),
-                        SystemMemoryId.TEMPORAL_CHAIN.id(),
-                        new com.spectrayan.spector.memory.kernel.layout.TemporalLayout(),
-                        loadFrom, null, null);
-            } catch (Exception e) {
-                log.warn("Operation failed: Codec validation for TemporalLayout", e);
-            }
-            temporalChain = new TemporalChainMemory(loadFrom, temporalCapacity);
+                    cortex.runtimeBundle().bundlePath(), isNew);
         } else {
             temporalChain = new TemporalChainMemory(temporalCapacity);
         }
@@ -176,21 +135,7 @@ final class CognitiveGraphBuilder {
                 boolean isNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(regionSlice, 0L);
                 hyperEntityGraph = HyperEntityGraphMemory.fromBundle(
                         cortex.runtimeBundle().arena(), regionSlice, hyperCap, hyperEdgeCap,
-                        StorageLayout.hyperEntityGraphRuntime(basePath), isNew);
-            } else if (isDisk && basePath != null) {
-                Path runtimeHyper = StorageLayout.hyperEntityGraphRuntime(basePath);
-                Path v2Hyper = resolvedPartitionDir != null
-                        ? resolvedPartitionDir.resolve(StorageLayout.FILE_HYPERGRAPH) : null;
-                Path loadFrom = MigrationPathResolver.getNewerPath(runtimeHyper, v2Hyper, null);
-                if (loadFrom == null) {
-                    loadFrom = runtimeHyper;
-                }
-
-                if (java.nio.file.Files.exists(loadFrom)) {
-                    hyperEntityGraph = HyperEntityGraphMemory.load(loadFrom, hyperCap, hyperEdgeCap);
-                } else {
-                    hyperEntityGraph = new HyperEntityGraphMemory(hyperCap, hyperEdgeCap);
-                }
+                        cortex.runtimeBundle().bundlePath(), isNew);
             } else {
                 hyperEntityGraph = new HyperEntityGraphMemory(hyperCap, hyperEdgeCap);
             }
@@ -212,10 +157,8 @@ final class CognitiveGraphBuilder {
                 boolean isNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(regionSlice, 0L);
                 entityTypeRegistry = TypeRegistryMemory.fromBundle(
                         SystemMemoryId.ENTITY_TYPE, cortex.runtimeBundle().arena(), regionSlice,
-                        StorageLayout.entityTypesRuntime(basePath), isNew,
+                        cortex.runtimeBundle().bundlePath(), isNew,
                         entitySeedTypes);
-            } else if (isDisk && basePath != null) {
-                entityTypeRegistry = TypeRegistryMemory.load(StorageLayout.entityTypesRuntime(basePath), SystemMemoryId.ENTITY_TYPE, entitySeedTypes);
             } else {
                 entityTypeRegistry = TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, entitySeedTypes);
             }
@@ -227,16 +170,7 @@ final class CognitiveGraphBuilder {
                 entityDirectory = EntityDirectory.fromBundle(
                         cortex.runtimeBundle().arena(), entitySlice, adjSlice,
                         dirCap, entityTypeRegistry,
-                        StorageLayout.entityDirectoryRuntime(basePath), isNew);
-            } else if (isDisk && basePath != null) {
-                Path edir = StorageLayout.entityDirectoryRuntime(basePath);
-                if (java.nio.file.Files.exists(edir)) {
-                    entityDirectory = EntityDirectory.load(edir, dirCap, entityTypeRegistry,
-                            builder.dataEncryptor);
-                } else {
-                    entityDirectory = new EntityDirectory(edir, dirCap, entityTypeRegistry);
-                    entityDirectory.setDataEncryptor(builder.dataEncryptor);
-                }
+                        cortex.runtimeBundle().bundlePath(), isNew);
             } else {
                 entityDirectory = new EntityDirectory(dirCap, entityTypeRegistry);
             }
@@ -251,9 +185,7 @@ final class CognitiveGraphBuilder {
             boolean isNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(regionSlice, 0L);
             predRegistry = TypeRegistryMemory.fromBundle(
                     SystemMemoryId.RELATION_TYPE, cortex.runtimeBundle().arena(), regionSlice,
-                    StorageLayout.relationTypesRuntime(basePath), isNew);
-        } else if (isDisk && basePath != null) {
-            predRegistry = TypeRegistryMemory.load(StorageLayout.relationTypesRuntime(basePath), SystemMemoryId.RELATION_TYPE);
+                    cortex.runtimeBundle().bundlePath(), isNew);
         } else {
             predRegistry = new TypeRegistryMemory(SystemMemoryId.RELATION_TYPE);
         }
@@ -263,11 +195,7 @@ final class CognitiveGraphBuilder {
             boolean isNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(regionSlice, 0L);
             temporalKnowledgeGraph = TemporalKnowledgeGraph.fromBundle(
                     predRegistry, cortex.runtimeBundle().arena(), regionSlice,
-                    StorageLayout.temporalFactsRuntime(basePath), isNew);
-        } else if (isDisk && basePath != null) {
-            Path runtimeTkg = StorageLayout.temporalFactsRuntime(basePath);
-            long initialSize = 16L * 1024 * 1024; // 16MB
-            temporalKnowledgeGraph = new TemporalKnowledgeGraph(runtimeTkg, initialSize, predRegistry);
+                    cortex.runtimeBundle().bundlePath(), isNew);
         } else {
             temporalKnowledgeGraph = new TemporalKnowledgeGraph(predRegistry);
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/CognitiveGraphBuilder.java
@@ -198,6 +198,11 @@ final class CognitiveGraphBuilder {
             hyperEntityGraph = null;
         }
 
+        OntologyConfig ontConfig = builder.ontologyConfig != null
+                ? builder.ontologyConfig
+                : OntologyConfig.defaultInstance();
+        String[] entitySeedTypes = ontConfig.canonicalTypes().toArray(String[]::new);
+
         EntityDirectory entityDirectory;
         if (entityEnabled) {
             int dirCap = builder.entityGraphCapacity;
@@ -208,11 +213,11 @@ final class CognitiveGraphBuilder {
                 entityTypeRegistry = TypeRegistryMemory.fromBundle(
                         SystemMemoryId.ENTITY_TYPE, cortex.runtimeBundle().arena(), regionSlice,
                         StorageLayout.entityTypesRuntime(basePath), isNew,
-                        com.spectrayan.spector.memory.graph.EntityType.SEED);
+                        entitySeedTypes);
             } else if (isDisk && basePath != null) {
-                entityTypeRegistry = TypeRegistryMemory.load(StorageLayout.entityTypesRuntime(basePath), SystemMemoryId.ENTITY_TYPE, com.spectrayan.spector.memory.graph.EntityType.SEED);
+                entityTypeRegistry = TypeRegistryMemory.load(StorageLayout.entityTypesRuntime(basePath), SystemMemoryId.ENTITY_TYPE, entitySeedTypes);
             } else {
-                entityTypeRegistry = TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, com.spectrayan.spector.memory.graph.EntityType.SEED);
+                entityTypeRegistry = TypeRegistryMemory.seeded(SystemMemoryId.ENTITY_TYPE, entitySeedTypes);
             }
 
             if (cortex.useBundleMode() && cortex.runtimeBundle() != null) {
@@ -266,10 +271,6 @@ final class CognitiveGraphBuilder {
         } else {
             temporalKnowledgeGraph = new TemporalKnowledgeGraph(predRegistry);
         }
-
-        OntologyConfig ontConfig = builder.ontologyConfig != null
-                ? builder.ontologyConfig
-                : OntologyConfig.defaultInstance();
 
         //  Cognitive Graph Facade 
         CognitiveGraphFacade graphFacade = new CognitiveGraphFacade(

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DaemonSupervisorBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DaemonSupervisorBuilder.java
@@ -77,16 +77,14 @@ final class DaemonSupervisorBuilder {
             daemonSupervisor = new DaemonSupervisor("memory");
 
             if (builder.checkpointIntervalSeconds > 0) {
-                Path indexSavePath = resolvedPartitionDir != null
-                        ? resolvedPartitionDir.resolve(StorageLayout.FILE_INDEX)
-                        : StorageLayout.indexMidxRuntime(basePath);
                 java.lang.foreign.MemorySegment ckptSlice = cortex.useBundleMode() && cortex.runtimeBundle() != null
                         ? cortex.runtimeBundle().regionSegment(com.spectrayan.spector.memory.kernel.bundle.RegionId.CHECKPOINT)
                         : null;
+                Path bundlePath = cortex.runtimeBundle() != null ? cortex.runtimeBundle().bundlePath() : null;
                 checkpointDaemon = new CheckpointDaemon(
                         cortex.cognitiveRouter(), wal,
-                        StorageLayout.checkpointMeta(basePath),
-                        index, indexSavePath,
+                        bundlePath,
+                        index, null,
                         graphs.hebbianGraph(), graphs.temporalChain(),
                         graphs.entityDirectory(), graphs.hyperEntityGraph(), bio.coActivationTracker(),
                         graphs.temporalKnowledgeGraph(),

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -62,7 +62,6 @@ import com.spectrayan.spector.memory.graph.LlmEntityExtractor;
 import com.spectrayan.spector.memory.graph.NoOpEntityExtractor;
 import com.spectrayan.spector.memory.habituation.HabituationPenalty;
 import com.spectrayan.spector.memory.hebbian.CoActivationRecordMemory;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 import com.spectrayan.spector.memory.hippocampus.CircadianPolicy;
@@ -91,9 +90,8 @@ import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
 import com.spectrayan.spector.memory.pipeline.HebbianCoActivationListener;
 import com.spectrayan.spector.memory.pipeline.ContentTagExtractor;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.pipeline.LtpReconsolidationListener;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
 import com.spectrayan.spector.memory.pipeline.GraphScoringPolicy;
 import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
 import com.spectrayan.spector.memory.prospective.Reminder;
@@ -173,12 +171,10 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSpectorMemory.class);
 
-    //  Core Subsystems (Façade composition) 
-    private final CognitiveIngestionTarget cognitiveTarget;
+    //  Core Subsystems (Façade composition)
     private final RememberPathway rememberPathway;   // #561 relay-based remember engine (nullable)
     private final EmbeddingProvider embeddingProvider;
-    private final RecallPipeline recallPipeline;
-    private final RecallPathway recallPathway;       // #561 relay-based engine (nullable)
+    private final RecallPathway recallPathway;       // #561 relay-based engine
     private final ReflectPathway reflectPathway;     // #503 relay-based sleep reflection engine
     private final ExpressPathway expressPathway;     // #602 relay-based express engine
     private final DreamPathway dreamPathway;         // #679 relay-based generative dreaming & thought experiment engine
@@ -276,12 +272,10 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     DefaultSpectorMemory(SpectorMemoryBuilder builder) {
         var bundle = SpectorMemoryFactory.assemble(builder);
-        this.cognitiveTarget = bundle.cognitiveTarget();
         this.rememberPathway = bundle.rememberPathway();
         this.reflectPathway = bundle.reflectPathway();
         this.expressPathway = bundle.expressPathway();
         this.embeddingProvider = bundle.embeddingProvider();
-        this.recallPipeline = bundle.recallPipeline();
         this.recallPathway = bundle.recallPathway();
         this.usePathwayEngine = (builder.usePathwayEngine || bundle.recallPathway() != null || bundle.rememberPathway() != null)
                 && (bundle.recallPathway() != null || bundle.rememberPathway() != null);
@@ -409,8 +403,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     // ==============================================================
 
     @Override
-    public CognitiveIngestionTarget target() {
-        return cognitiveTarget;
+    public RememberPathway target() {
+        return rememberPathway;
     }
 
     /** Returns the embedding provider for reconsolidation/update operations. */
@@ -441,7 +435,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             } else {
                 String[] finalTags = tags;
                 if (tags == null || tags.length == 0) {
-                    var tagExtractor = cognitiveTarget.tagExtractor();
+                    var tagExtractor = rememberPathway.tagExtractor();
                     if (tagExtractor != null) {
                         finalTags = tagExtractor.extract(id, text);
                     }
@@ -452,11 +446,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                     sessionBuffers.computeIfAbsent(sessionId, k -> new SessionWriteBuffer())
                             .add(id, text, vector, type, System.currentTimeMillis());
                 }
-                if (usePathwayEngine && rememberPathway != null) {
-                    rememberPathway.ingestCognitive(id, text, vector, type, finalTags, source, hints);
-                } else {
-                    cognitiveTarget.ingestCognitive(id, text, vector, type, finalTags, source, hints);
-                }
+                rememberPathway.ingestCognitive(id, text, vector, type, finalTags, source, hints);
+                
             }
             checkCircadianTrigger(type);
             if (eagerConsolidator != null && (type == MemoryType.SEMANTIC || type == MemoryType.PROCEDURAL)) {
@@ -516,17 +507,14 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             } else {
                 String[] finalTags = tags;
                 if (tags == null || tags.length == 0) {
-                    var tagExtractor = cognitiveTarget.tagExtractor();
+                    var tagExtractor = rememberPathway.tagExtractor();
                     if (tagExtractor != null) {
                         finalTags = tagExtractor.extract(id, text);
                     }
                 }
                 float[] vector = embeddingProvider.embed(text).vector();
-                if (usePathwayEngine && rememberPathway != null) {
-                    rememberPathway.ingestCognitive(id, text, vector, type, finalTags, source, context);
-                } else {
-                    cognitiveTarget.ingestCognitive(id, text, vector, type, finalTags, source, context);
-                }
+                rememberPathway.ingestCognitive(id, text, vector, type, finalTags, source, context);
+                
             }
 
             // Process attachments if present in context metadata
@@ -702,7 +690,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         // Per-chunk tag extraction  --  each chunk gets its own content-derived tags
         // merged with the shared provenance tags.
         // Use the configured tag extractor (LLM when available, content-based fallback).
-        var chunkTagExtractor = cognitiveTarget.tagExtractor();
+        var chunkTagExtractor = rememberPathway.tagExtractor();
 
         // Split chunks into parent and child chunks
         List<com.spectrayan.spector.commons.chunker.Chunk> parentChunks = new ArrayList<>();
@@ -729,13 +717,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                 IngestionContext parentContext = IngestionContext.builder()
                         .metadata(chunk.metadata())
                         .build();
-                if (usePathwayEngine && rememberPathway != null) {
-                    rememberPathway.ingestCognitive(chunk.chunkId(), chunk.text(),
+                rememberPathway.ingestCognitive(chunk.chunkId(), chunk.text(),
                             dummyVector, type, provenanceTags, source, parentContext);
-                } else {
-                    cognitiveTarget.ingestCognitive(chunk.chunkId(), chunk.text(),
-                            dummyVector, type, provenanceTags, source, parentContext);
-                }
+                
                 ingestedChunkIds.add(chunk.chunkId());
             }
 
@@ -782,13 +766,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                             .build();
                 }
 
-                if (usePathwayEngine && rememberPathway != null) {
-                    rememberPathway.ingestCognitive(chunk.chunkId(), chunk.text(),
+                rememberPathway.ingestCognitive(chunk.chunkId(), chunk.text(),
                             embedding.embedding(), type, chunkTags, source, childContext);
-                } else {
-                    cognitiveTarget.ingestCognitive(chunk.chunkId(), chunk.text(),
-                            embedding.embedding(), type, chunkTags, source, childContext);
-                }
+                
                 ingestedChunkIds.add(chunk.chunkId());
             }
 
@@ -858,13 +838,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                         .build();
 
                 float[] vector = embeddingProvider.embed(result.text()).vector();
-                if (usePathwayEngine && rememberPathway != null) {
-                    rememberPathway.ingestCognitive(
+                rememberPathway.ingestCognitive(
                             result.chunkId(), result.text(), vector, type, tags, source, subContext);
-                } else {
-                    cognitiveTarget.ingestCognitive(
-                            result.chunkId(), result.text(), vector, type, tags, source, subContext);
-                }
+                
                 ingested++;
             } catch (RuntimeException e) {
                 log.warn("[Attachment] Failed to ingest chunk '{}': {}", result.chunkId(), e.getMessage());
@@ -899,7 +875,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             }
 
             // Step 3: Resolve effective salience profile
-            com.spectrayan.spector.memory.model.SalienceProfile profile = cognitiveTarget.salienceProfile();
+            com.spectrayan.spector.memory.model.SalienceProfile profile = rememberPathway.salienceProfile();
 
             // Step 4: Build context and delegate to provider
             // Note: zScore=0.0 placeholder — DefaultImportanceProvider computes it
@@ -927,7 +903,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                     // Extract context tags from the query text
                     var tagExtractor = (usePathwayEngine && rememberPathway != null)
                             ? rememberPathway.tagExtractor()
-                            : cognitiveTarget.tagExtractor();
+                            : rememberPathway.tagExtractor();
                     String[] tags = tagExtractor != null
                             ? tagExtractor.extract("query", queryText)
                             : new String[0];
@@ -951,9 +927,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                         .autoProfile(true)
                         .build();
             }
-            List<CognitiveResult> storeResults = usePathwayEngine
-                    ? recallPathway.recall(queryText, options)
-                    : recallPipeline.recall(queryText, options);
+            List<CognitiveResult> storeResults = recallPathway.recall(queryText, options);
             String sessionId = MemoryScope.sessionId();
             if (sessionId != null) {
                 SessionWriteBuffer buffer = sessionBuffers.get(sessionId);
@@ -1010,9 +984,9 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         acquireLease();
         try {
             if (reflectPathway != null) {
-                return reflectPathway.reflect(partitionManager, index, rememberPathway, cognitiveTarget, salienceProfile());
+                return reflectPathway.reflect(partitionManager, index, rememberPathway, rememberPathway, salienceProfile());
             }
-            return reflectionOrchestrator.reflect(partitionManager, index, cognitiveTarget);
+            return reflectionOrchestrator.reflect(partitionManager, index, rememberPathway);
         } finally {
             releaseLease();
         }
@@ -1104,7 +1078,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                     entityDirectory,
                     hyperEntityGraph,
                     temporalKnowledgeGraph,
-                    cognitiveTarget,
+                    rememberPathway,
                     wal,
                     this::inspect
             );
@@ -1159,7 +1133,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             if (loc != null) {
                 suppressionSet.registerOffset(loc.type().ordinal(), loc.offset());
             }
-            if (recallPipeline.wasLateral(memoryId)) {
+            if (recallPathway.wasLateral(memoryId)) {
                 lateralEvaluator.recordLateralSuppression();
                 log.debug("Lateral suppression: '{}' (reason={})", memoryId, reason);
             }
@@ -1487,7 +1461,6 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public void setSalienceProfile(SalienceProfile profile) {
-        cognitiveTarget.setSalienceProfile(profile);
         if (rememberPathway != null) {
             rememberPathway.setSalienceProfile(profile);
         }
@@ -1500,7 +1473,6 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public void setSoulVersion(short version) {
-        cognitiveTarget.setSoulVersion(version);
         if (rememberPathway != null) {
             rememberPathway.setSoulVersion(version);
         }
@@ -1511,7 +1483,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         if (usePathwayEngine && rememberPathway != null) {
             return rememberPathway.salienceProfile();
         }
-        return cognitiveTarget.salienceProfile();
+        return rememberPathway.salienceProfile();
     }
 
     @Override
@@ -1551,8 +1523,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     @Override public SuppressionSet suppression() { return suppressionSet; }
     @Override public HabituationPenalty habituation() { return habituationPenalty; }
     @Override public ScalarQuantizer quantizer() { return quantizer; }
-    @Override public CognitiveIngestionTarget cognitiveTarget() { return cognitiveTarget; }
-    @Override public RecallPipeline recallPipeline() { return recallPipeline; }
+    @Override public RememberPathway rememberPathway() { return rememberPathway; }
+    @Override public RecallPathway recallPathway() { return recallPathway; }
     @Override public CognitiveMemoryRouter cognitiveRouter() { return partitionManager.cognitiveRouter(); }
     @Override public MemoryIndex index() { return index; }
     @Override public LateralEvaluator lateralEvaluator() { return lateralEvaluator; }
@@ -1824,14 +1796,6 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
             }
         }
 
-        // Close ingestion target (stops async entity extraction queue)
-        if (cognitiveTarget != null) {
-            try {
-                cognitiveTarget.close();
-            } catch (Exception e) {
-                log.warn("Failed to close CognitiveIngestionTarget on close", e);
-            }
-        }
         if (rememberPathway != null) {
             try {
                 rememberPathway.close();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -42,7 +42,6 @@ import com.spectrayan.spector.memory.pipeline.reranker.ColBERTReranker;
 import com.spectrayan.spector.memory.pipeline.reranker.ColBERTTokenCache;
 import com.spectrayan.spector.memory.amygdala.ValenceTracker;
 import com.spectrayan.spector.memory.cortex.CentroidRouter;
-import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
 import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
@@ -984,7 +983,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         acquireLease();
         try {
             if (reflectPathway != null) {
-                return reflectPathway.reflect(partitionManager, index, rememberPathway, rememberPathway, salienceProfile());
+                return reflectPathway.reflect(partitionManager, index, rememberPathway, salienceProfile());
             }
             return reflectionOrchestrator.reflect(partitionManager, index, rememberPathway);
         } finally {
@@ -1842,17 +1841,8 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         if (persistenceMode == MemoryPersistenceMode.DISK
                 && partitionManager.activePartitionDir() != null
                 && bm25Index != null && bm25Index.totalDocuments() > 0) {
-            int written = -1;
             if (runtimeBundle != null) {
-                written = bm25Index.persistToBundle(runtimeBundle, null);
-            }
-            if (written <= 0) {
-                try {
-                    bm25Index.partition(0).save(
-                            StorageLayout.bm25BidxRuntime(persistencePath));
-                } catch (Exception e) {
-                    log.warn("Failed to save BM25 index on close", e);
-                }
+                bm25Index.persistToBundle(runtimeBundle, null);
             }
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryIndexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryIndexBuilder.java
@@ -47,22 +47,9 @@ final class MemoryIndexBuilder {
             java.lang.foreign.MemorySegment midxSlice = cortex.runtimeBundle().regionSegment(com.spectrayan.spector.memory.kernel.bundle.RegionId.INDEX_MIDX);
             java.lang.foreign.MemorySegment idplSlice = cortex.runtimeBundle().regionSegment(com.spectrayan.spector.memory.kernel.bundle.RegionId.INDEX_IDPL);
             boolean isNew = !com.spectrayan.spector.memory.kernel.MemoryHeader.isValid(midxSlice, 0L);
-            index = com.spectrayan.spector.memory.index.IndexRecordMemory.fromBundle(cortex.runtimeBundle().arena(), midxSlice, idplSlice, StorageLayout.indexMidxRuntime(basePath), isNew);
-        } else if (isDisk && basePath != null) {
-            Path runtimeIndex = StorageLayout.indexMidxRuntime(basePath);
-            Path partitionIndex = resolvedPartitionDir != null ? resolvedPartitionDir.resolve(StorageLayout.FILE_INDEX) : null;
-
-            Path loadFrom = MigrationPathResolver.getNewerPath(runtimeIndex, partitionIndex, null);
-            if (loadFrom != null) {
-                index = MemoryIndex.load(loadFrom);
-                if (loadFrom.equals(partitionIndex)) {
-                    log.info("Loaded index from partition (newer than runtime index): {}", loadFrom);
-                } else {
-                    log.info("Loaded index from runtime: {}", loadFrom);
-                }
-            } else {
-                index = new MemoryIndex();
-            }
+            index = com.spectrayan.spector.memory.index.IndexRecordMemory.fromBundle(
+                    cortex.runtimeBundle().arena(), midxSlice, idplSlice,
+                    cortex.runtimeBundle().bundlePath(), isNew);
         } else {
             index = new MemoryIndex();
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
@@ -72,15 +72,23 @@ final class MemoryWalRecovery {
             CoActivationRecordMemory coActivationTracker,
             RememberPathway cognitiveTarget,
             Path basePath,
-            int activePartitionSeq) {
+            int activePartitionSeq,
+            java.lang.foreign.MemorySegment checkpointRegion) {
 
         if (wal == null || !wal.isPersistent()) {
             return;
         }
 
         long checkpointHwm = 0;
-        if (basePath != null) {
-            Path metaPath = StorageLayout.checkpointMeta(basePath);
+        if (checkpointRegion != null) {
+            long hwm = CheckpointDaemon.readCheckpointHwm(checkpointRegion);
+            if (hwm > 0) {
+                checkpointHwm = hwm;
+                log.info("WAL recovery: loaded checkpoint HWM {} from bundle region", checkpointHwm);
+            }
+        }
+        if (checkpointHwm == 0 && basePath != null) {
+            Path metaPath = StorageLayout.runtimeDir(basePath).resolve("checkpoint.meta");
             if (Files.exists(metaPath)) {
                 checkpointHwm = CheckpointDaemon.readCheckpointHwm(metaPath);
                 log.info("WAL recovery: loaded checkpoint HWM {}", checkpointHwm);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/MemoryWalRecovery.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.SystemMemoryId;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.model.MemoryType;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.CheckpointDaemon;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.sync.WalEvent;
@@ -70,7 +70,7 @@ final class MemoryWalRecovery {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             CoActivationRecordMemory coActivationTracker,
-            CognitiveIngestionTarget cognitiveTarget,
+            RememberPathway cognitiveTarget,
             Path basePath,
             int activePartitionSeq) {
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.memory.kernel.bundle.PartitionBundle;
 import com.spectrayan.spector.memory.kernel.bundle.RegionId;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.TextBlobLayout;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 
 import com.spectrayan.spector.commons.error.ErrorCode;
@@ -86,7 +86,7 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
     private final MemoryIndex index;
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
-    private final CognitiveIngestionTarget cognitiveTarget;
+    private final RememberPathway cognitiveTarget;
     private final DataEncryptor encryptor;
     private final boolean useBundleMode;
     private volatile RememberPathway rememberPathway;
@@ -115,7 +115,7 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
                      MemoryIndex index,
                      HebbianGraphBase hebbianGraph,
                      TemporalChainMemory temporalChain,
-                     CognitiveIngestionTarget cognitiveTarget,
+                     RememberPathway cognitiveTarget,
                      DataEncryptor encryptor,
                      boolean useBundleMode,
                      PartitionBundle activePartitionBundle) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManager.java
@@ -262,28 +262,32 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
                                                int episodicPartitionCapacity,
                                                int proceduralCapacity,
                                                DataEncryptor encryptor) {
-        // V4 auto-detect: if partition.bundle exists, open via bundle
+        // V4 bundle loading (with auto-migration if unbundled legacy files exist)
         Path bundleFile = StorageLayout.partitionBundleFile(dir);
+        if (!Files.exists(bundleFile)) {
+            try {
+                com.spectrayan.spector.memory.kernel.bundle.BundleMigrationCli.migratePartition(dir, quantizedVecBytes);
+            } catch (Exception e) {
+                log.debug("Partition auto-migration check: {}", e.getMessage());
+            }
+        }
         if (Files.exists(bundleFile)) {
-            return openFrozenBundlePartition(dir, seq, workingStore, bundleFile, encryptor);
+            return openFrozenBundlePartition(
+                    dir, seq, workingStore, bundleFile,
+                    quantizedVecBytes, semanticCapacity, episodicPartitionCapacity, proceduralCapacity,
+                    encryptor);
         }
 
-        // V3 legacy: open individual .mem files
-        EpisodicRecordMemory episodic = new EpisodicRecordMemory(
-                StorageLayout.episodicMem(dir), quantizedVecBytes, episodicPartitionCapacity);
-        ProceduralRecordMemory procedural = new ProceduralRecordMemory(
-                quantizedVecBytes, proceduralCapacity, StorageLayout.proceduralMem(dir));
-        SemanticRecordMemory semantic = new SemanticRecordMemory(
-                quantizedVecBytes, semanticCapacity, StorageLayout.semanticMem(dir));
-
-        TextAppendMemory text = new TextAppendMemory(
-                StorageLayout.textDat(dir), encryptor != null ? encryptor : DataEncryptor.NOOP);
-        text.readAll();
-
+        // Fallback in-memory router if partition has no bundle
+        EpisodicLogMemory episodicLog = EpisodicLogMemory.heap();
         CognitiveMemoryRouter router = new CognitiveMemoryRouter(
-                workingStore, episodic, semantic, procedural);
-        log.info("Opened frozen partition seq={} ({}) [V3]", seq, dir.getFileName());
-        return new PartitionHandle(seq, dir, router, text, false);
+                workingStore,
+                new EpisodicRecordMemory(quantizedVecBytes, episodicPartitionCapacity),
+                new SemanticRecordMemory(quantizedVecBytes, semanticCapacity),
+                new ProceduralRecordMemory(quantizedVecBytes, proceduralCapacity),
+                episodicLog);
+        log.info("Opened empty fallback frozen partition seq={} ({})", seq, dir.getFileName());
+        return new PartitionHandle(seq, dir, router, null, false);
     }
 
     /**
@@ -292,6 +296,10 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
     private static PartitionHandle openFrozenBundlePartition(Path dir, int seq,
                                                               WorkingRecordMemory workingStore,
                                                               Path bundleFile,
+                                                              int quantizedVecBytes,
+                                                              int semanticCapacity,
+                                                              int episodicPartitionCapacity,
+                                                              int proceduralCapacity,
                                                               DataEncryptor encryptor) {
         PartitionBundle bundle = PartitionBundle.Init.open(bundleFile);
 
@@ -300,25 +308,20 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
         MemorySegment procSlice = bundle.regionSegment(RegionId.PROCEDURAL);
         MemorySegment textSlice = bundle.regionSegment(RegionId.TEXT);
 
-        // Read capacities from region entries
-        var semEntry = bundle.directory().findRegion(RegionId.SEMANTIC);
-        var epiEntry = bundle.directory().findRegion(RegionId.EPISODIC);
-        var procEntry = bundle.directory().findRegion(RegionId.PROCEDURAL);
-        int quantizedVecBytes = semEntry.stride() - 64; // stride = HEADER_BYTES(64) + vecBytes
-
         SemanticRecordMemory semantic = SemanticRecordMemory.fromBundle(
-                bundle.arena(), semSlice, semEntry.capacity(), quantizedVecBytes, bundleFile, false);
+                bundle.arena(), semSlice, semanticCapacity, quantizedVecBytes, bundleFile, false);
         EpisodicRecordMemory episodic = EpisodicRecordMemory.fromBundle(
-                bundle.arena(), epiSlice, epiEntry.capacity(), quantizedVecBytes, bundleFile, false);
+                bundle.arena(), epiSlice, episodicPartitionCapacity, quantizedVecBytes, bundleFile, false);
+        EpisodicLogMemory episodicLog = EpisodicLogMemory.fromBundle(
+                bundle.arena(), epiSlice, bundleFile, false);
         ProceduralRecordMemory procedural = ProceduralRecordMemory.fromBundle(
-                bundle.arena(), procSlice, procEntry.capacity(), quantizedVecBytes, bundleFile, false);
+                bundle.arena(), procSlice, proceduralCapacity, quantizedVecBytes, bundleFile, false);
         TextAppendMemory text = TextAppendMemory.fromBundle(
                 bundle.arena(), textSlice, bundleFile, false, encryptor);
-        text.readAll();
 
         CognitiveMemoryRouter router = new CognitiveMemoryRouter(
-                workingStore, episodic, semantic, procedural);
-        log.info("Opened frozen partition seq={} ({}) [V4 bundle]", seq, dir.getFileName());
+                workingStore, episodic, semantic, procedural, episodicLog);
+        log.info("Opened frozen bundle partition seq={} ({})", seq, dir.getFileName());
         return new PartitionHandle(seq, dir, router, text, false, bundle);
     }
 
@@ -366,58 +369,41 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
                 TextAppendMemory newText;
                 PartitionBundle newBundle = null;
 
-                if (useBundleMode) {
-                    // ── V4 Bundle Mode ──
-                    Path bundleFile = StorageLayout.partitionBundleFile(newPartition);
-                    CognitiveRecordLayout cogLayout = new CognitiveRecordLayout(quantizedVecBytes);
-                    TextBlobLayout textLayout = new TextBlobLayout();
-                    long textSize = Long.getLong("spector.memory.text-segment-size", 32 * 1024 * 1024L);
+                // ── V4 Bundle Mode ──
+                Path bundleFile = StorageLayout.partitionBundleFile(newPartition);
+                CognitiveRecordLayout cogLayout = new CognitiveRecordLayout(quantizedVecBytes);
+                TextBlobLayout textLayout = new TextBlobLayout();
+                long textSize = Long.getLong("spector.memory.text-segment-size", 32 * 1024 * 1024L);
 
-                    long episodicSize = Long.getLong("spector.memory.episodic-segment-size",
-                            (long) episodicPartitionCapacity * cogLayout.stride());
+                long episodicSize = Long.getLong("spector.memory.episodic-segment-size",
+                        (long) episodicPartitionCapacity * cogLayout.stride());
 
-                    newBundle = PartitionBundle.Init.mmap(
-                            bundleFile,
-                            semanticCapacity, episodicSize,
-                            proceduralCapacity, textSize,
-                            quantizedVecBytes,
-                            cogLayout.layoutId(), cogLayout.schemaVersion(),
-                            textLayout.layoutId(), textLayout.schemaVersion());
+                newBundle = PartitionBundle.Init.mmap(
+                        bundleFile,
+                        semanticCapacity, episodicSize,
+                        proceduralCapacity, textSize,
+                        quantizedVecBytes,
+                        cogLayout.layoutId(), cogLayout.schemaVersion(),
+                        textLayout.layoutId(), textLayout.schemaVersion());
 
-                    SemanticRecordMemory newSemantic = SemanticRecordMemory.fromBundle(
-                            newBundle.arena(), newBundle.regionSegment(RegionId.SEMANTIC),
-                            semanticCapacity, quantizedVecBytes, bundleFile, true);
-                    EpisodicRecordMemory newEpisodic = EpisodicRecordMemory.fromBundle(
-                            newBundle.arena(), newBundle.regionSegment(RegionId.EPISODIC),
-                            episodicPartitionCapacity, quantizedVecBytes, bundleFile, true);
-                    EpisodicLogMemory newEpisodicLog = EpisodicLogMemory.fromBundle(
-                            newBundle.arena(), newBundle.regionSegment(RegionId.EPISODIC),
-                            bundleFile, true);
-                    ProceduralRecordMemory newProcedural = ProceduralRecordMemory.fromBundle(
-                            newBundle.arena(), newBundle.regionSegment(RegionId.PROCEDURAL),
-                            proceduralCapacity, quantizedVecBytes, bundleFile, true);
-                    newText = TextAppendMemory.fromBundle(
-                            newBundle.arena(), newBundle.regionSegment(RegionId.TEXT),
-                            bundleFile, true, encryptor);
+                SemanticRecordMemory newSemantic = SemanticRecordMemory.fromBundle(
+                        newBundle.arena(), newBundle.regionSegment(RegionId.SEMANTIC),
+                        semanticCapacity, quantizedVecBytes, bundleFile, true);
+                EpisodicRecordMemory newEpisodic = EpisodicRecordMemory.fromBundle(
+                        newBundle.arena(), newBundle.regionSegment(RegionId.EPISODIC),
+                        episodicPartitionCapacity, quantizedVecBytes, bundleFile, true);
+                EpisodicLogMemory newEpisodicLog = EpisodicLogMemory.fromBundle(
+                        newBundle.arena(), newBundle.regionSegment(RegionId.EPISODIC),
+                        bundleFile, true);
+                ProceduralRecordMemory newProcedural = ProceduralRecordMemory.fromBundle(
+                        newBundle.arena(), newBundle.regionSegment(RegionId.PROCEDURAL),
+                        proceduralCapacity, quantizedVecBytes, bundleFile, true);
+                newText = TextAppendMemory.fromBundle(
+                        newBundle.arena(), newBundle.regionSegment(RegionId.TEXT),
+                        bundleFile, true, encryptor);
 
-                    newRouter = new CognitiveMemoryRouter(
-                            workingStore, newEpisodic, newSemantic, newProcedural, newEpisodicLog);
-                } else {
-                    // ── V3 Legacy Mode ──
-                    EpisodicRecordMemory newEpisodic = new EpisodicRecordMemory(
-                            StorageLayout.episodicMem(newPartition),
-                            quantizedVecBytes, episodicPartitionCapacity);
-                    ProceduralRecordMemory newProcedural = new ProceduralRecordMemory(
-                            quantizedVecBytes, proceduralCapacity,
-                            StorageLayout.proceduralMem(newPartition));
-                    SemanticRecordMemory newSemantic = new SemanticRecordMemory(
-                            quantizedVecBytes, semanticCapacity,
-                            StorageLayout.semanticMem(newPartition));
-                    newText = new TextAppendMemory(
-                            StorageLayout.textDat(newPartition), encryptor);
-                    newRouter = new CognitiveMemoryRouter(
-                            workingStore, newEpisodic, newSemantic, newProcedural);
-                }
+                newRouter = new CognitiveMemoryRouter(
+                        workingStore, newEpisodic, newSemantic, newProcedural, newEpisodicLog);
 
                 // Flush index + graphs to runtime/ before rolling
                 flushGlobalState();
@@ -427,7 +413,9 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
                 List<PartitionHandle> current = registry;
                 PartitionHandle oldActive = current.get(current.size() - 1);
                 
-                oldActive.router().episodic().markFrozen();
+                if (oldActive.router().episodic() != null) {
+                    oldActive.router().episodic().markFrozen();
+                }
                 oldActive.router().semantic().markFrozen();
                 oldActive.router().procedural().markFrozen();
 
@@ -512,21 +500,23 @@ public final class PartitionManager implements PartitionRegistry, AutoCloseable 
      * persisted. Entity graph flush is included (was missing in V2).</p>
      */
     private void flushGlobalState() {
+        if (basePath == null) return;
+        Path targetPath = useBundleMode ? StorageLayout.runtimeBundleFile(basePath) : StorageLayout.indexMidxRuntime(basePath);
         try {
-            index.save(StorageLayout.indexMidxRuntime(basePath));
-            log.info("Flushed MemoryIndex to runtime/ during partition roll");
+            index.save(targetPath);
+            log.info("Flushed MemoryIndex during partition roll");
         } catch (Exception e) {
             log.error("Failed to flush MemoryIndex during partition roll: {}",
                     e.getMessage(), e);
         }
         try {
-            hebbianGraph.save(StorageLayout.hebbianGraphRuntime(basePath));
+            hebbianGraph.save(useBundleMode ? targetPath : StorageLayout.hebbianGraphRuntime(basePath));
         } catch (Exception e) {
             log.error("Failed to flush HebbianGraph during partition roll: {}",
                     e.getMessage(), e);
         }
         try {
-            temporalChain.save(StorageLayout.temporalChainRuntime(basePath));
+            temporalChain.save(useBundleMode ? targetPath : StorageLayout.temporalChainRuntime(basePath));
         } catch (Exception e) {
             log.error("Failed to flush TemporalChain during partition roll: {}",
                     e.getMessage(), e);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManagerBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PartitionManagerBuilder.java
@@ -16,7 +16,7 @@ import com.spectrayan.spector.memory.cortex.PartitionHandle;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.kernel.bundle.PartitionBundle;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -50,7 +50,7 @@ final class PartitionManagerBuilder {
             RetrievalIndexBuilder.RetrievalIndices retrieval,
             MemoryIndex index,
             CognitiveGraphBuilder.CognitiveGraphs graphs,
-            CognitiveIngestionTarget cognitiveTarget) {
+            RememberPathway cognitiveTarget) {
 
         boolean isDisk = cortex.isDisk();
         Path basePath = cortex.basePath();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PersistenceManager.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/PersistenceManager.java
@@ -79,33 +79,32 @@ final class PersistenceManager {
 
         // ── Phase 1: Persist to disk (DISK mode only) ──
         if (persistenceMode == MemoryPersistenceMode.DISK && persistencePath != null) {
+            Path bundlePath = StorageLayout.runtimeBundleFile(persistencePath);
 
-            // 1. MemoryIndex: runtime/ (V3 layout)
-            saveIndex(index, persistencePath);
+            // 1. MemoryIndex
+            saveIndex(index, bundlePath);
 
-            // 2. HebbianGraph: runtime/
+            // 2. HebbianGraph
             saveSubsystem("HebbianGraph", () ->
-                    hebbianGraph.save(StorageLayout.hebbianGraphRuntime(persistencePath)));
+                    hebbianGraph.save(bundlePath));
 
-            // 3. TemporalChain: runtime/
+            // 3. TemporalChain
             saveSubsystem("TemporalChain", () ->
-                    temporalChain.save(StorageLayout.temporalChainRuntime(persistencePath)));
+                    temporalChain.save(bundlePath));
 
-
-
-            // 5. HyperEntityGraph: runtime/ (if enabled)
+            // 5. HyperEntityGraph (if enabled)
             if (hyperEntityGraph != null) {
                 saveSubsystem("HyperEntityGraph", () ->
-                        hyperEntityGraph.save(StorageLayout.hyperEntityGraphRuntime(persistencePath)));
+                        hyperEntityGraph.save(bundlePath));
             }
 
-            // 5b. EntityDirectory: runtime/ (ADR-0003 #455 — identity companion)
+            // 5b. EntityDirectory (ADR-0003 #455 — identity companion)
             if (entityDirectory != null) {
                 saveSubsystem("EntityDirectory", () ->
-                        entityDirectory.save(StorageLayout.entityDirectoryRuntime(persistencePath)));
+                        entityDirectory.save(bundlePath));
                 saveSubsystem("EntityTypeRegistry", () -> {
                     try {
-                        entityDirectory.entityTypeRegistry().save(StorageLayout.entityTypesRuntime(persistencePath));
+                        entityDirectory.entityTypeRegistry().save(bundlePath);
                     } catch (java.io.IOException e) {
                         throw new java.io.UncheckedIOException(e);
                     }
@@ -115,17 +114,16 @@ final class PersistenceManager {
             if (temporalKnowledgeGraph != null) {
                 saveSubsystem("RelationTypeRegistry", () -> {
                     try {
-                        temporalKnowledgeGraph.predicateRegistry().save(StorageLayout.relationTypesRuntime(persistencePath));
+                        temporalKnowledgeGraph.predicateRegistry().save(bundlePath);
                     } catch (java.io.IOException e) {
                         throw new java.io.UncheckedIOException(e);
                     }
                 });
             }
 
-            // 6. CoActivationTracker: runtime/
+            // 6. CoActivationTracker
             saveSubsystem("CoActivationTracker", () ->
-                    coActivationTracker.save(
-                            StorageLayout.coactivationTracker(persistencePath)));
+                    coActivationTracker.save(bundlePath));
         }
 
         // ── Phase 2: Close resources ──
@@ -146,10 +144,9 @@ final class PersistenceManager {
         if (hyperEntityGraph != null) hyperEntityGraph.close();
     }
 
-    private static void saveIndex(MemoryIndex index, Path persistencePath) {
+    private static void saveIndex(MemoryIndex index, Path bundlePath) {
         try {
-            Path indexPath = StorageLayout.indexMidxRuntime(persistencePath);
-            index.save(indexPath);
+            index.save(bundlePath);
         } catch (Exception e) {
             log.error("Failed to save MemoryIndex on close: {}", e.getMessage(), e);
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -653,6 +653,17 @@ public final class RecallPathway {
     }
 
     /**
+     * Checks if a memory was recently returned as a lateral thought.
+     *
+     * @param memoryId the memory ID to check
+     * @return true if the memory was a lateral result, false otherwise
+     */
+    public boolean wasLateral(String memoryId) {
+        RetrievalMode mode = recentRetrievalModes.get(memoryId);
+        return mode == RetrievalMode.LATERAL;
+    }
+
+    /**
      * Builder for {@link RecallPathway}.
      */
     public static final class Builder {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPipelineBuilder.java
@@ -92,7 +92,7 @@ public final class RecallPipelineBuilder {
         return recallPipeline;
     }
 
-    private static void rebuildHnswIfNeeded(SpectorMemoryBuilder builder, PartitionManager partitionManager, MemoryIndex index, ScalarQuantizer quantizer) {
+    static void rebuildHnswIfNeeded(SpectorMemoryBuilder builder, PartitionManager partitionManager, MemoryIndex index, ScalarQuantizer quantizer) {
         if (builder.semanticIndex == null || builder.semanticIndex.isReadOnly() || builder.semanticIndex.size() > 0) {
             return;
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectPathway.java
@@ -186,14 +186,12 @@ public final class ReflectPathway implements AutoCloseable {
     public ReflectReport reflect(final PartitionManager partitionManager,
                                  final MemoryIndex index,
                                  final RememberPathway rememberPathway,
-                                 final RememberPathway ingestionTarget,
                                  final SalienceProfile salienceProfile) {
         ReflectSignal signal = ReflectSignal.builder()
                 .partitionManager(partitionManager)
                 .index(index)
                 .quantizer(quantizer)
                 .rememberPathway(rememberPathway)
-                .ingestionTarget(ingestionTarget)
                 .embeddingProvider(embeddingProvider)
                 .textGenerator(textGenerator)
                 .importanceProvider(importanceProvider)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectPathway.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.memory.hippocampus.CircadianPolicy;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.model.SalienceProfile;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.reflect.relay.CrossLayerPromotionRelay;
 import com.spectrayan.spector.memory.reflect.relay.EntityMaintenanceRelay;
 import com.spectrayan.spector.memory.reflect.relay.EpisodicLogConsolidationRelay;
@@ -186,7 +186,7 @@ public final class ReflectPathway implements AutoCloseable {
     public ReflectReport reflect(final PartitionManager partitionManager,
                                  final MemoryIndex index,
                                  final RememberPathway rememberPathway,
-                                 final CognitiveIngestionTarget ingestionTarget,
+                                 final RememberPathway ingestionTarget,
                                  final SalienceProfile salienceProfile) {
         ReflectSignal signal = ReflectSignal.builder()
                 .partitionManager(partitionManager)

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
@@ -157,17 +157,17 @@ final class ReflectionOrchestrator {
      *
      * @param partitionManager the partition manager providing all open partition handles
      * @param index            the memory index (for text lookups and graph slot resolution)
-     * @param ingestionTarget  the ingestion target for promoted semantic memories (active partition)
+     * @param rememberPathway  the ingestion target for promoted semantic memories (active partition)
      * @return a {@link ReflectReport} summarizing what was consolidated, pruned, and promoted
      */
-    ReflectReport reflect(PartitionManager partitionManager, MemoryIndex index, RememberPathway ingestionTarget) {
+    ReflectReport reflect(PartitionManager partitionManager, MemoryIndex index, RememberPathway rememberPathway) {
         log.info("Manual reflection triggered across partitions");
 
         // Create metrics collector for this cycle
         var graphMetrics = new GraphHealthMetrics();
 
         // Phase 1: REM cycle — episodic → semantic consolidation across all partition handles
-        ReflectReport daemonReport = reflectDaemon.runCycle(partitionManager, ingestionTarget, index);
+        ReflectReport daemonReport = reflectDaemon.runCycle(partitionManager, rememberPathway, index);
 
         // Phase 2: Hebbian decay (synaptic homeostasis, arousal-modulated across all partitions)
         decayHebbianEdges(partitionManager, index, graphMetrics);
@@ -211,13 +211,13 @@ final class ReflectionOrchestrator {
     /**
      * Backward-compatible reflect overload using a single cognitive router.
      */
-    ReflectReport reflect(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, RememberPathway ingestionTarget) {
+    ReflectReport reflect(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, RememberPathway rememberPathway) {
         log.info("Manual reflection triggered (single-router fallback)");
 
         var graphMetrics = new GraphHealthMetrics();
 
         ReflectReport daemonReport = reflectDaemon.runCycle(
-                cognitiveRouter != null ? cognitiveRouter.episodic() : null, ingestionTarget,
+                cognitiveRouter != null ? cognitiveRouter.episodic() : null, rememberPathway,
                 offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null);
 
         decayHebbianEdges(cognitiveRouter, graphMetrics);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReflectionOrchestrator.java
@@ -25,7 +25,7 @@ import com.spectrayan.spector.memory.hippocampus.ReflectDaemon;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.sync.WalEvent;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
@@ -160,7 +160,7 @@ final class ReflectionOrchestrator {
      * @param ingestionTarget  the ingestion target for promoted semantic memories (active partition)
      * @return a {@link ReflectReport} summarizing what was consolidated, pruned, and promoted
      */
-    ReflectReport reflect(PartitionManager partitionManager, MemoryIndex index, CognitiveIngestionTarget ingestionTarget) {
+    ReflectReport reflect(PartitionManager partitionManager, MemoryIndex index, RememberPathway ingestionTarget) {
         log.info("Manual reflection triggered across partitions");
 
         // Create metrics collector for this cycle
@@ -211,7 +211,7 @@ final class ReflectionOrchestrator {
     /**
      * Backward-compatible reflect overload using a single cognitive router.
      */
-    ReflectReport reflect(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, CognitiveIngestionTarget ingestionTarget) {
+    ReflectReport reflect(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, RememberPathway ingestionTarget) {
         log.info("Manual reflection triggered (single-router fallback)");
 
         var graphMetrics = new GraphHealthMetrics();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/ReinforcementHandler.java
@@ -22,7 +22,7 @@ import com.spectrayan.spector.memory.index.IndexRecordMemory.MemoryLocation;
 import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
 import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
+import com.spectrayan.spector.memory.RecallPathway;
 import com.spectrayan.spector.memory.synapse.ActRActivation;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.synapse.DecayStrategy;
@@ -64,7 +64,7 @@ final class ReinforcementHandler {
     private final ValenceTracker valenceTracker;
     private final HebbianGraphBase hebbianGraph;
     private final LateralEvaluator lateralEvaluator;
-    private final RecallPipeline recallPipeline;
+    private final RecallPathway recallPathway;
     private final MemoryWal wal;
     private final TwoFactorConfig twoFactorConfig;
     private final ProfileAdaptor profileAdaptor;
@@ -72,14 +72,14 @@ final class ReinforcementHandler {
     ReinforcementHandler(ValenceTracker valenceTracker,
                          HebbianGraphBase hebbianGraph,
                          LateralEvaluator lateralEvaluator,
-                         RecallPipeline recallPipeline,
+                         RecallPathway recallPathway,
                          MemoryWal wal,
                          TwoFactorConfig twoFactorConfig,
                          ProfileAdaptor profileAdaptor) {
         this.valenceTracker = valenceTracker;
         this.hebbianGraph = hebbianGraph;
         this.lateralEvaluator = lateralEvaluator;
-        this.recallPipeline = recallPipeline;
+        this.recallPathway = recallPathway;
         this.wal = wal;
         this.twoFactorConfig = twoFactorConfig;
         this.profileAdaptor = profileAdaptor;
@@ -136,7 +136,7 @@ final class ReinforcementHandler {
         }
 
         // Step 5: Lateral evaluator feedback
-        if (recallPipeline.wasLateral(memoryId)) {
+        if (recallPathway.wasLateral(memoryId)) {
             if (valence > 0) {
                 lateralEvaluator.recordLateralReinforcement();
                 log.debug("Lateral reinforcement: '{}' (positive valence={})", memoryId, valence);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
@@ -40,6 +40,7 @@ import com.spectrayan.spector.memory.remember.relay.SynapticGraphLinkingRelay;
 import com.spectrayan.spector.memory.remember.relay.SynapticTagTransductionRelay;
 import com.spectrayan.spector.memory.session.SessionRegistry;
 import com.spectrayan.spector.memory.sync.MemoryWal;
+import com.spectrayan.spector.ingestion.IngestionTarget;
 import com.spectrayan.spector.provider.embedding.SparseEmbeddingProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p>Replaces procedural ingestion in {@code CognitiveIngestionTarget} with a type-safe,
  * observable synaptic relay chain.</p>
  */
-public final class RememberPathway implements AutoCloseable {
+public final class RememberPathway implements IngestionTarget, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(RememberPathway.class);
 
@@ -268,6 +269,27 @@ public final class RememberPathway implements AutoCloseable {
 
     public AsyncEntityExtractionQueue asyncEntityExtractionQueue() {
         return asyncEntityExtractionQueue;
+    }
+
+    public ScalarQuantizer quantizer() {
+        return corticalWriteRelay.quantizer();
+    }
+
+    /**
+     * Ingests a cognitive memory preserving the provided cognitive header.
+     */
+    public void ingestCognitiveWithHeader(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader preservedHeader) {
+        final RememberSignal signal = RememberSignal.forCognitiveWithHeader(
+                id, text, vector, type, tags, source, preservedHeader
+        );
+        pathway.conduct(signal);
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RetrievalIndexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RetrievalIndexBuilder.java
@@ -67,26 +67,12 @@ final class RetrievalIndexBuilder {
             textDataStore.readAll();
             index.setTextDataStore(textDataStore);
 
-            // V4 bundle path: try loading from BM25 region first
+            // V4 bundle path: load from BM25 region
             BM25Index loadedBm25 = null;
             if (cortex.useBundleMode() && cortex.runtimeBundle() != null) {
                 loadedBm25 = MemoryBM25Index.loadFromBundle(cortex.runtimeBundle());
                 if (loadedBm25 != null) {
                     log.info("BM25 loaded from bundle region: {} docs", loadedBm25.size());
-                }
-            }
-
-            // V3 fallback: load from bm25.bidx file
-            if (loadedBm25 == null) {
-                java.nio.file.Path bm25Path = StorageLayout.bm25BidxRuntime(basePath);
-                java.nio.file.Path v2Bm25 = resolvedPartitionDir != null ? resolvedPartitionDir.resolve(StorageLayout.FILE_BM25) : null;
-                java.nio.file.Path loadFrom = MigrationPathResolver.getNewerPath(bm25Path, v2Bm25, null);
-                if (loadFrom != null) {
-                    bm25Path = loadFrom;
-                }
-                loadedBm25 = BM25Index.load(bm25Path);
-                if (loadedBm25 != null) {
-                    log.info("BM25 loaded from binary index: {} docs", loadedBm25.size());
                 }
             }
 
@@ -104,14 +90,9 @@ final class RetrievalIndexBuilder {
                 if (!allTexts.isEmpty()) {
                     bm25Index.rebuildPartition(0, allTexts);
                     log.info("Rebuilt BM25 index with {} documents from memory index", allTexts.size());
-                    // Save to bundle region (V4) or file (V3 fallback)
-                    int written = -1;
+                    // Save to bundle region (V4)
                     if (cortex.useBundleMode() && cortex.runtimeBundle() != null) {
-                        written = bm25Index.persistToBundle(cortex.runtimeBundle(), null);
-                    }
-                    if (written <= 0) {
-                        java.nio.file.Path bm25Path = StorageLayout.bm25BidxRuntime(basePath);
-                        bm25Index.partition(0).save(bm25Path);
+                        bm25Index.persistToBundle(cortex.runtimeBundle(), null);
                     }
                 }
             }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -36,8 +36,7 @@ import com.spectrayan.spector.memory.model.GraphRecallOptions;
 import com.spectrayan.spector.memory.model.GraphTraversalResult;
 import com.spectrayan.spector.memory.graph.CognitiveGraphFacade;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
 import com.spectrayan.spector.memory.prospective.Reminder;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -84,7 +83,7 @@ public interface SpectorMemory extends AutoCloseable {
     // ══════════════════════════════════════════════════════════════
 
     /** Returns the cognitive ingestion target for use with the unified IngestionPipeline. */
-    CognitiveIngestionTarget target();
+    RememberPathway target();
 
     /** Returns the namespace ID of this memory. */
     default String namespaceId() { return "default"; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
@@ -23,8 +23,8 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
+import com.spectrayan.spector.memory.RememberPathway;
+import com.spectrayan.spector.memory.RecallPathway;
 import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.model.MemoryType;
@@ -58,10 +58,10 @@ public interface SpectorMemoryAdmin {
     // ══════════════════════════════════════════════════════════════
 
     /** Returns the cognitive ingestion target for use with the unified IngestionPipeline. */
-    CognitiveIngestionTarget target();
+    RememberPathway target();
 
     /** Returns the cognitive ingestion target. */
-    CognitiveIngestionTarget cognitiveTarget();
+    RememberPathway rememberPathway();
 
     // ══════════════════════════════════════════════════════════════
     // SUBSYSTEM ACCESSORS
@@ -88,8 +88,8 @@ public interface SpectorMemoryAdmin {
     /** Returns the scalar quantizer used for vector compression. */
     ScalarQuantizer quantizer();
 
-    /** Returns the recall pipeline. */
-    RecallPipeline recallPipeline();
+    /** Returns the recall pathway. */
+    RecallPathway recallPathway();
 
     /** Returns the cognitive memory router (Working, Episodic, Semantic, Procedural). */
     CognitiveMemoryRouter cognitiveRouter();

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -25,7 +25,6 @@ import com.spectrayan.spector.memory.graph.EdgeImportance;
 import com.spectrayan.spector.memory.graph.EntityExtractionMode;
 import com.spectrayan.spector.memory.graph.EntityExtractor;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph;
 import com.spectrayan.spector.memory.hippocampus.CircadianPolicy;
 import com.spectrayan.spector.memory.id.IdStrategy;
 import com.spectrayan.spector.memory.id.MemoryIdGenerator;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -218,10 +218,14 @@ public final class SpectorMemoryFactory {
         rememberPathway.setPartitionRollCallback(partitionManager::rollPartition);
 
         //  WAL Recovery 
+        java.lang.foreign.MemorySegment ckptSlice = cortex.useBundleMode() && cortex.runtimeBundle() != null
+                ? cortex.runtimeBundle().regionSegment(com.spectrayan.spector.memory.kernel.bundle.RegionId.CHECKPOINT)
+                : null;
         MemoryWalRecovery.recover(wal, cortex.cognitiveRouter(), index, graphs.hebbianGraph(),
                 graphs.temporalChain(), graphs.temporalKnowledgeGraph(),
                 graphs.entityDirectory(), graphs.hyperEntityGraph(),
-                bio.coActivationTracker(), rememberPathway, cortex.basePath(), cortex.initialPartitionSeq());
+                bio.coActivationTracker(), rememberPathway, cortex.basePath(), cortex.initialPartitionSeq(),
+                ckptSlice);
         // ADR-0003 #456 (P2): the EntityDirectory is now the authoritative identity store, WAL-bound
         // and recovered directly (WalRecoveryDispatcher GRAPH_ADD_NODE/LINK repointed to it).
         if (wal != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryFactory.java
@@ -33,13 +33,11 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 import com.spectrayan.spector.memory.id.MemoryIdGenerator;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
-import com.spectrayan.spector.memory.metamemory.MemoryIntrospector;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.metamemory.MemoryIntrospector;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
 import com.spectrayan.spector.memory.pipeline.AttachmentProcessor;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
 import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
 import com.spectrayan.spector.memory.sync.CheckpointDaemon;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -48,25 +46,25 @@ import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.kernel.bundle.RuntimeBundle;
+import com.spectrayan.spector.memory.kernel.bundle.PartitionBundle;
+import com.spectrayan.spector.memory.cortex.TextAppendMemory;
+import com.spectrayan.spector.memory.synapse.TwoFactorConfig;
 import com.spectrayan.spector.memory.insula.InsularCortex;
-
-import java.nio.file.Path;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
+
 /**
- * Factory class for assembling the core subsystems of a {@code DefaultSpectorMemory} instance.
+ * Single-responsibility assembly factory for the Spector Cognitive Memory subsystem graph.
  *
- * <p>Constructs and wires the ingestion pipeline, recall pipeline, persistence managers,
- * biological subsystem trackers, cognitive graphs, and search indices from configuration
- * properties in {@link SpectorMemoryBuilder}.</p>
- *
- * <p>The heavy lifting is delegated to a set of single-responsibility subsystem builders
- * (see {@link CognitiveCortexBuilder}, {@link MemoryIndexBuilder},
+ * <p>Extracted from {@link DefaultSpectorMemory} constructor (Phase 6 decomposition) to
+ * isolate subsystem construction, dependency wiring, and configuration validation.
+ * All subsystem instantiation delegates to dedicated sub-builders (e.g. {@link CognitiveCortexBuilder},
  * {@link BiologicalSubsystemsBuilder}, {@link CognitiveGraphBuilder},
- * {@link RetrievalIndexBuilder}, {@link CognitiveIngestionTargetBuilder},
- * {@link PartitionManagerBuilder}, {@link RecallPipelineBuilder},
+ * {@link RetrievalIndexBuilder},
+ * {@link PartitionManagerBuilder},
  * {@link DaemonSupervisorBuilder}, {@link MigrationPathResolver} and
  * {@link MemoryWalRecovery}). {@link #assemble} is the orchestrator that invokes them in
  * the correct dependency order and collects the results into a {@link SubsystemBundle}.</p>
@@ -78,10 +76,8 @@ public final class SpectorMemoryFactory {
     private static final Logger log = LoggerFactory.getLogger(SpectorMemoryFactory.class);
 
     public record SubsystemBundle(
-            CognitiveIngestionTarget cognitiveTarget,
             RememberPathway rememberPathway,
             EmbeddingProvider embeddingProvider,
-            RecallPipeline recallPipeline,
             RecallPathway recallPathway,
             ReflectPathway reflectPathway,
             ExpressPathway expressPathway,
@@ -187,21 +183,45 @@ public final class SpectorMemoryFactory {
                 : new DefaultImportanceProvider(
                         bio.surpriseDetector(), bio.flashbulbPolicy(), bio.icnuWeights());
 
-        //  Ingestion target 
+        //  Ingestion target (RememberPathway) 
         int activePartitionIndex = 0;
-        CognitiveIngestionTarget cognitiveTarget = CognitiveIngestionTargetBuilder.build(
-                builder, cortex, bio, graphs, retrieval, index, wal, activePartitionIndex,
-                importanceProvider);
+        RememberPathway rememberPathway = new RememberPathway.Builder()
+                .cortex(cortex)
+                .bio(bio)
+                .graphs(graphs)
+                .retrieval(retrieval)
+                .index(index)
+                .wal(wal)
+                .activePartitionIndex(activePartitionIndex)
+                .importanceProvider(importanceProvider)
+                .tagExtractor(builder.tagExtractor)
+                .semanticIndex(builder.semanticIndex)
+                .sparseEmbeddingProvider(builder.SparseEmbeddingProvider)
+                .dataEncryptor(builder.dataEncryptor)
+                .entityExtractionParallelism(builder.entityExtractionParallelism)
+                .entityExtractionQueueCapacity(builder.entityExtractionQueueCapacity)
+                .normalizeAtIngest(true)
+                .build();
+
+        if (builder.salienceProfileProvider != null) {
+            SalienceProfile effective = builder.salienceProfileProvider.effectiveProfile();
+            if (effective != null && !effective.isNeutral()) {
+                rememberPathway.setSalienceProfile(effective);
+            }
+        }
 
         //  Partition manager (+ #443 frozen-partition registry, roll callback, text resolver) 
         PartitionManager partitionManager = PartitionManagerBuilder.build(
-                builder, cortex, retrieval, index, graphs, cognitiveTarget);
+                builder, cortex, retrieval, index, graphs, rememberPathway);
+
+        partitionManager.setRememberPathway(rememberPathway);
+        rememberPathway.setPartitionRollCallback(partitionManager::rollPartition);
 
         //  WAL Recovery 
         MemoryWalRecovery.recover(wal, cortex.cognitiveRouter(), index, graphs.hebbianGraph(),
                 graphs.temporalChain(), graphs.temporalKnowledgeGraph(),
                 graphs.entityDirectory(), graphs.hyperEntityGraph(),
-                bio.coActivationTracker(), cognitiveTarget, cortex.basePath(), cortex.initialPartitionSeq());
+                bio.coActivationTracker(), rememberPathway, cortex.basePath(), cortex.initialPartitionSeq());
         // ADR-0003 #456 (P2): the EntityDirectory is now the authoritative identity store, WAL-bound
         // and recovered directly (WalRecoveryDispatcher GRAPH_ADD_NODE/LINK repointed to it).
         if (wal != null) {
@@ -230,10 +250,6 @@ public final class SpectorMemoryFactory {
             profileAdaptor.loadStats(bio.coActivationTracker().banditStats());
         }
 
-        //  Recall Pipeline (semantic strategy + HNSW rebuild + history + pipeline + listeners) 
-        RecallPipeline recallPipeline = RecallPipelineBuilder.build(
-                builder, embeddingProvider, cortex, bio, graphs, retrieval, index, partitionManager, wal);
-
         // Active Inference Self-Model Engine (AISME) (#597, #623)
         com.spectrayan.spector.memory.aisme.AismeBundle aismeBundle = null;
         if (builder.aismeConfig != null && builder.aismeConfig.enabled()) {
@@ -254,63 +270,31 @@ public final class SpectorMemoryFactory {
                     builder.aismeConfig,
                     primarySoul,
                     builder.dimensions,
-                    cognitiveTarget,
+                    rememberPathway,
                     vectorAccessor,
                     activeSouls
             );
         }
 
-        //  Recall Pathway (#561 — relay-based engine, opt-in via usePathwayEngine, AISME, or SoulContext) 
-        RecallPathway recallPathway = null;
-        RememberPathway rememberPathway = null;
-        if (builder.usePathwayEngine || (aismeBundle != null)
-                || builder.soul != null || builder.agentSoul != null
-                || (builder.soulContexts != null && !builder.soulContexts.isEmpty())) {
-            recallPathway = new RecallPathway.Builder()
-                    .embeddingProvider(embeddingProvider)
-                    .cortex(cortex)
-                    .bio(bio)
-                    .graphs(graphs)
-                    .retrieval(retrieval)
-                    .index(index)
-                    .partitionManager(partitionManager)
-                    .wal(wal)
-                    .graphScoringPolicy(builder.graphScoringPolicy)
-                    .sparseEmbeddingProvider(builder.SparseEmbeddingProvider)
-                    .hook(builder.hook)
-                    .semanticIndex(builder.semanticIndex)
-                    .aismeBundle(aismeBundle)
-                    .build();
+        //  Recall Pathway (#561 — relay-based engine) 
+        RecallPathway recallPathway = new RecallPathway.Builder()
+                .embeddingProvider(embeddingProvider)
+                .cortex(cortex)
+                .bio(bio)
+                .graphs(graphs)
+                .retrieval(retrieval)
+                .index(index)
+                .partitionManager(partitionManager)
+                .wal(wal)
+                .graphScoringPolicy(builder.graphScoringPolicy)
+                .sparseEmbeddingProvider(builder.SparseEmbeddingProvider)
+                .hook(builder.hook)
+                .semanticIndex(builder.semanticIndex)
+                .aismeBundle(aismeBundle)
+                .build();
 
-            rememberPathway = new RememberPathway.Builder()
-                    .cortex(cortex)
-                    .bio(bio)
-                    .graphs(graphs)
-                    .retrieval(retrieval)
-                    .index(index)
-                    .wal(wal)
-                    .activePartitionIndex(activePartitionIndex)
-                    .importanceProvider(importanceProvider)
-                    .tagExtractor(builder.tagExtractor)
-                    .semanticIndex(builder.semanticIndex)
-                    .sparseEmbeddingProvider(builder.SparseEmbeddingProvider)
-                    .dataEncryptor(builder.dataEncryptor)
-                    .entityExtractionParallelism(builder.entityExtractionParallelism)
-                    .entityExtractionQueueCapacity(builder.entityExtractionQueueCapacity)
-                    .normalizeAtIngest(true)
-                    .build();
-
-            if (builder.salienceProfileProvider != null) {
-                SalienceProfile effective = builder.salienceProfileProvider.effectiveProfile();
-                if (effective != null && !effective.isNeutral()) {
-                    rememberPathway.setSalienceProfile(effective);
-                }
-            }
-
-            partitionManager.setRememberPathway(rememberPathway);
-            rememberPathway.setPartitionRollCallback(partitionManager::rollPartition);
-
-            log.info("Cognitive Pathway Engine enabled — recall and remember use relay-based pathways");
+        if (builder.semanticIndex != null && !builder.semanticIndex.isReadOnly() && builder.semanticIndex.size() == 0) {
+            RecallPipelineBuilder.rebuildHnswIfNeeded(builder, partitionManager, index, cortex.quantizer());
         }
 
         //  Reflect Pathway (#503 / ADR-0007)
@@ -351,7 +335,7 @@ public final class SpectorMemoryFactory {
                 builder.entityResolutionEnabled, builder.entityShadowMode, builder.entityCosineThreshold, typeNormalizer);
 
         ReinforcementHandler reinforcementHandler = new ReinforcementHandler(
-                bio.valenceTracker(), graphs.hebbianGraph(), bio.lateralEvaluator(), recallPipeline,
+                bio.valenceTracker(), graphs.hebbianGraph(), bio.lateralEvaluator(), recallPathway,
                 wal, builder.twoFactorConfig, profileAdaptor);
 
         //  ID Generator 
@@ -440,7 +424,7 @@ public final class SpectorMemoryFactory {
         }
 
         return new SubsystemBundle(
-                cognitiveTarget, rememberPathway, embeddingProvider, recallPipeline, recallPathway, reflectPathway, expressPathway, index, cortex.quantizer(),
+                rememberPathway, embeddingProvider, recallPathway, reflectPathway, expressPathway, index, cortex.quantizer(),
                 partitionManager, importanceProvider, reflectionOrchestrator,
                 reinforcementHandler, bio.valenceTracker(), bio.coActivationTracker(),
                 bio.suppressionSet(), bio.habituationPenalty(), bio.prospectiveScheduler(),

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
@@ -95,7 +95,7 @@ public final class AismeBuilder {
      * @param config the AISME configuration (or disabled if null)
      * @param soul optional polymorphic SoulContext identity definition
      * @param dimensions vector embedding dimensionality
-     * @param ingestionTarget target for persisting high-alignment constructive simulations
+     * @param rememberPathway target for persisting high-alignment constructive simulations
      * @param vectorLookup function mapping memory IDs to vector representations
      * @param soulContexts list of all active soul contexts for multi-soul EFE evaluation
      * @return the constructed AismeBundle, or null if disabled
@@ -104,7 +104,7 @@ public final class AismeBuilder {
             final AismeConfig config,
             final SoulContext soul,
             final int dimensions,
-            final RememberPathway ingestionTarget,
+            final RememberPathway rememberPathway,
             final Function<String, float[]> vectorLookup,
             final List<SoulContext> soulContexts
     ) {
@@ -169,7 +169,7 @@ public final class AismeBuilder {
         // Constructive Memory Persistence (#613 / AISME Phase 12)
         final ConstructiveMemoryPersistenceRelay constructiveMemoryPersistenceRelay =
                 cfg.constructivePersistenceEnabled()
-                        ? new ConstructiveMemoryPersistenceRelay(ingestionTarget, vectorLookup, cfg.constructivePersistenceThreshold())
+                        ? new ConstructiveMemoryPersistenceRelay(rememberPathway, vectorLookup, cfg.constructivePersistenceThreshold())
                         : null;
 
         return new AismeBundle(

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/AismeBuilder.java
@@ -39,7 +39,7 @@ import com.spectrayan.spector.memory.aisme.workspace.GlobalWorkspace;
 import com.spectrayan.spector.memory.model.AgentSoul;
 import com.spectrayan.spector.memory.model.CognitiveProfile;
 import com.spectrayan.spector.memory.model.SoulContext;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 
 import java.util.List;
 import java.util.function.Function;
@@ -104,7 +104,7 @@ public final class AismeBuilder {
             final AismeConfig config,
             final SoulContext soul,
             final int dimensions,
-            final CognitiveIngestionTarget ingestionTarget,
+            final RememberPathway ingestionTarget,
             final Function<String, float[]> vectorLookup,
             final List<SoulContext> soulContexts
     ) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelay.java
@@ -20,7 +20,7 @@ import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.Cogniti
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.recall.relay.RecallSignal;
 
 import org.slf4j.Logger;
@@ -43,7 +43,7 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
     private static final Logger log = LoggerFactory.getLogger(ConstructiveMemoryPersistenceRelay.class);
     private static final TsidGenerator TSID = new TsidGenerator();
 
-    private final CognitiveIngestionTarget ingestionTarget;
+    private final RememberPathway ingestionTarget;
     private final Function<String, float[]> embeddingLookup;
     private final float persistenceThreshold;
 
@@ -55,7 +55,7 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
      * @param persistenceThreshold minimum score for a simulation to be persisted
      */
     public ConstructiveMemoryPersistenceRelay(
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             Function<String, float[]> embeddingLookup,
             float persistenceThreshold) {
         this.ingestionTarget = ingestionTarget;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelay.java
@@ -43,29 +43,29 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
     private static final Logger log = LoggerFactory.getLogger(ConstructiveMemoryPersistenceRelay.class);
     private static final TsidGenerator TSID = new TsidGenerator();
 
-    private final RememberPathway ingestionTarget;
+    private final RememberPathway rememberPathway;
     private final Function<String, float[]> embeddingLookup;
     private final float persistenceThreshold;
 
     /**
      * Constructs a ConstructiveMemoryPersistenceRelay.
      *
-     * @param ingestionTarget the ingestion target for persisting memories
+     * @param rememberPathway the ingestion target for persisting memories
      * @param embeddingLookup function to resolve embeddings for simulation text
      * @param persistenceThreshold minimum score for a simulation to be persisted
      */
     public ConstructiveMemoryPersistenceRelay(
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             Function<String, float[]> embeddingLookup,
             float persistenceThreshold) {
-        this.ingestionTarget = ingestionTarget;
+        this.rememberPathway = rememberPathway;
         this.embeddingLookup = embeddingLookup;
         this.persistenceThreshold = persistenceThreshold;
     }
 
     @Override
     public boolean transmit(RecallSignal signal) {
-        if (ingestionTarget == null || signal == null) {
+        if (rememberPathway == null || signal == null) {
             return true;
         }
 
@@ -110,7 +110,7 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
                 String durableId = TSID.generate();
                 byte procFlags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.EPISODIC.ordinal());
                 float norm = VectorOps.magnitude(vector);
-                short soulVer = ingestionTarget.currentSoulVersion();
+                short soulVer = rememberPathway.currentSoulVersion();
                 CognitiveHeader header = CognitiveHeader.createSynthetic(
                         System.currentTimeMillis(), 0L, norm, result.importance(),
                         result.valence(), (byte) 128, procFlags,
@@ -119,7 +119,7 @@ public final class ConstructiveMemoryPersistenceRelay implements SynapticRelay<R
                         0.0f
                 );
 
-                ingestionTarget.ingestCognitiveWithHeader(
+                rememberPathway.ingestCognitiveWithHeader(
                         durableId, text, vector, MemoryType.EPISODIC,
                         result.synapticTags() != null ? result.synapticTags() : new String[]{"simulated", "constructive"},
                         MemorySource.INFERRED, header

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/AbstractConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/AbstractConsolidator.java
@@ -71,7 +71,7 @@ public abstract class AbstractConsolidator implements Consolidator {
      * @param entityDirectory        entity directory (optional)
      * @param hyperEntityGraph       hypergraph memory (optional)
      * @param temporalKnowledgeGraph temporal knowledge graph (optional)
-     * @param ingestionTarget        ingestion target for merged memories (optional)
+     * @param rememberPathway        ingestion target for merged memories (optional)
      * @param index                  memory index for tombstoning (optional)
      * @param wal                    memory WAL for tombstoning (optional)
      * @param enableMerge            whether to execute duplicate fusion for non-contradictions
@@ -89,7 +89,7 @@ public abstract class AbstractConsolidator implements Consolidator {
      * @param entityDirectory        entity directory (optional)
      * @param hyperEntityGraph       hypergraph memory (optional)
      * @param temporalKnowledgeGraph temporal knowledge graph (optional)
-     * @param ingestionTarget        ingestion target for merged memories (optional)
+     * @param rememberPathway        ingestion target for merged memories (optional)
      * @param index                  memory index for tombstoning (optional)
      * @param wal                    memory WAL for tombstoning (optional)
      * @param enableMerge            whether to execute duplicate fusion for non-contradictions
@@ -104,7 +104,7 @@ public abstract class AbstractConsolidator implements Consolidator {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             MemoryIndex index,
             MemoryWal wal,
             boolean enableMerge) {
@@ -121,9 +121,9 @@ public abstract class AbstractConsolidator implements Consolidator {
             CadpContradictionResolver.resolve(
                     recordA, recordB, partitionManager, store, hyperEntityGraph, entityDirectory, temporalKnowledgeGraph);
             return true;
-        } else if (enableMerge && memoryMerger != null && ingestionTarget != null && quantizer != null && index != null) {
+        } else if (enableMerge && memoryMerger != null && rememberPathway != null && quantizer != null && index != null) {
             log.info("Consolidator: Merging duplicate memories '{}' and '{}'", recordA.id(), recordB.id());
-            mergeDuplicate(recordA, recordB, partitionManager, store, quantizer, ingestionTarget, index, wal);
+            mergeDuplicate(recordA, recordB, partitionManager, store, quantizer, rememberPathway, index, wal);
             return true;
         }
 
@@ -141,12 +141,12 @@ public abstract class AbstractConsolidator implements Consolidator {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             MemoryIndex index,
             MemoryWal wal,
             boolean enableMerge) {
         return evaluateAndResolvePair(recordA, recordB, null, store, quantizer,
-                entityDirectory, hyperEntityGraph, temporalKnowledgeGraph, ingestionTarget, index, wal, enableMerge);
+                entityDirectory, hyperEntityGraph, temporalKnowledgeGraph, rememberPathway, index, wal, enableMerge);
     }
 
     /**
@@ -159,7 +159,7 @@ public abstract class AbstractConsolidator implements Consolidator {
             com.spectrayan.spector.memory.PartitionManager partitionManager,
             CognitiveRecordMemory store,
             ScalarQuantizer quantizer,
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             MemoryIndex index,
             MemoryWal wal) {
 
@@ -189,7 +189,7 @@ public abstract class AbstractConsolidator implements Consolidator {
 
         String[] tags = mergeTags(recordA.tags(), recordB.tags());
 
-        ingestionTarget.ingestCognitiveWithHeader(
+        rememberPathway.ingestCognitiveWithHeader(
                 newId,
                 merged.text(),
                 merged.vector(),
@@ -208,10 +208,10 @@ public abstract class AbstractConsolidator implements Consolidator {
             CognitiveRecord recordB,
             CognitiveRecordMemory store,
             ScalarQuantizer quantizer,
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             MemoryIndex index,
             MemoryWal wal) {
-        mergeDuplicate(recordA, recordB, null, store, quantizer, ingestionTarget, index, wal);
+        mergeDuplicate(recordA, recordB, null, store, quantizer, rememberPathway, index, wal);
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/AbstractConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/AbstractConsolidator.java
@@ -24,7 +24,7 @@ import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.Cogniti
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.MemoryType;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
@@ -104,7 +104,7 @@ public abstract class AbstractConsolidator implements Consolidator {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             MemoryIndex index,
             MemoryWal wal,
             boolean enableMerge) {
@@ -141,7 +141,7 @@ public abstract class AbstractConsolidator implements Consolidator {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             MemoryIndex index,
             MemoryWal wal,
             boolean enableMerge) {
@@ -159,7 +159,7 @@ public abstract class AbstractConsolidator implements Consolidator {
             com.spectrayan.spector.memory.PartitionManager partitionManager,
             CognitiveRecordMemory store,
             ScalarQuantizer quantizer,
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             MemoryIndex index,
             MemoryWal wal) {
 
@@ -208,7 +208,7 @@ public abstract class AbstractConsolidator implements Consolidator {
             CognitiveRecord recordB,
             CognitiveRecordMemory store,
             ScalarQuantizer quantizer,
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             MemoryIndex index,
             MemoryWal wal) {
         mergeDuplicate(recordA, recordB, null, store, quantizer, ingestionTarget, index, wal);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/BatchConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/BatchConsolidator.java
@@ -55,9 +55,9 @@ public final class BatchConsolidator extends AbstractConsolidator {
      */
     public void consolidate(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
-                            RememberPathway ingestionTarget,
+                            RememberPathway rememberPathway,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
-        consolidate(cognitiveRouter, index, quantizer, entityDirectory, hyperEntityGraph, null, ingestionTarget, wal, inspectFunction);
+        consolidate(cognitiveRouter, index, quantizer, entityDirectory, hyperEntityGraph, null, rememberPathway, wal, inspectFunction);
     }
 
     /**
@@ -66,7 +66,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
     public void consolidate(com.spectrayan.spector.memory.PartitionManager partitionManager, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
                             TemporalKnowledgeGraph temporalKnowledgeGraph,
-                            RememberPathway ingestionTarget,
+                            RememberPathway rememberPathway,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
         if (partitionManager == null) {
             return;
@@ -122,7 +122,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
                     entityDirectory,
                     hyperEntityGraph,
                     temporalKnowledgeGraph,
-                    ingestionTarget,
+                    rememberPathway,
                     index,
                     wal,
                     true // enable duplicate merge in batch mode
@@ -141,7 +141,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
     public void consolidate(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
                             TemporalKnowledgeGraph temporalKnowledgeGraph,
-                            RememberPathway ingestionTarget,
+                            RememberPathway rememberPathway,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
         CognitiveRecordMemory semanticStore = cognitiveRouter.semantic();
         if (semanticStore == null || semanticStore.visibleCount() < 2) {
@@ -181,7 +181,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
                     entityDirectory,
                     hyperEntityGraph,
                     temporalKnowledgeGraph,
-                    ingestionTarget,
+                    rememberPathway,
                     index,
                     wal,
                     true // enable duplicate merge in batch mode

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/BatchConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/BatchConsolidator.java
@@ -19,7 +19,7 @@ import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
@@ -55,7 +55,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
      */
     public void consolidate(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
-                            CognitiveIngestionTarget ingestionTarget,
+                            RememberPathway ingestionTarget,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
         consolidate(cognitiveRouter, index, quantizer, entityDirectory, hyperEntityGraph, null, ingestionTarget, wal, inspectFunction);
     }
@@ -66,7 +66,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
     public void consolidate(com.spectrayan.spector.memory.PartitionManager partitionManager, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
                             TemporalKnowledgeGraph temporalKnowledgeGraph,
-                            CognitiveIngestionTarget ingestionTarget,
+                            RememberPathway ingestionTarget,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
         if (partitionManager == null) {
             return;
@@ -141,7 +141,7 @@ public final class BatchConsolidator extends AbstractConsolidator {
     public void consolidate(CognitiveMemoryRouter cognitiveRouter, MemoryIndex index, ScalarQuantizer quantizer,
                             EntityDirectory entityDirectory, HyperEntityGraphMemory hyperEntityGraph,
                             TemporalKnowledgeGraph temporalKnowledgeGraph,
-                            CognitiveIngestionTarget ingestionTarget,
+                            RememberPathway ingestionTarget,
                             MemoryWal wal, Function<String, CognitiveRecord> inspectFunction) {
         CognitiveRecordMemory semanticStore = cognitiveRouter.semantic();
         if (semanticStore == null || semanticStore.visibleCount() < 2) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/Consolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/Consolidator.java
@@ -18,7 +18,7 @@ import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 
@@ -53,7 +53,7 @@ public interface Consolidator extends AutoCloseable {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             MemoryWal wal,
             Function<String, CognitiveRecord> inspectFunction);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/Consolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/Consolidator.java
@@ -42,7 +42,7 @@ public interface Consolidator extends AutoCloseable {
      * @param entityDirectory        entity directory
      * @param hyperEntityGraph       hypergraph memory
      * @param temporalKnowledgeGraph temporal knowledge graph
-     * @param ingestionTarget        ingestion target for merged memories
+     * @param rememberPathway        ingestion target for merged memories
      * @param wal                    write-ahead log
      * @param inspectFunction        function to inspect full cognitive records by ID
      */
@@ -53,7 +53,7 @@ public interface Consolidator extends AutoCloseable {
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             MemoryWal wal,
             Function<String, CognitiveRecord> inspectFunction);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
@@ -28,7 +28,7 @@ import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveRecord;
 import com.spectrayan.spector.memory.model.MemoryType;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalKnowledgeGraph;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
@@ -227,7 +227,7 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            CognitiveIngestionTarget ingestionTarget,
+            RememberPathway ingestionTarget,
             MemoryWal wal,
             Function<String, CognitiveRecord> inspectFunction) {
         // Queue is drained automatically by SpectorTaskQueue on close

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/consolidation/EagerConsolidator.java
@@ -227,7 +227,7 @@ public final class EagerConsolidator extends AbstractConsolidator implements Aut
             EntityDirectory entityDirectory,
             HyperEntityGraphMemory hyperEntityGraph,
             TemporalKnowledgeGraph temporalKnowledgeGraph,
-            RememberPathway ingestionTarget,
+            RememberPathway rememberPathway,
             MemoryWal wal,
             Function<String, CognitiveRecord> inspectFunction) {
         // Queue is drained automatically by SpectorTaskQueue on close

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveMemoryRouter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/CognitiveMemoryRouter.java
@@ -53,6 +53,16 @@ public final class CognitiveMemoryRouter implements AutoCloseable {
     private final EpisodicLogMemory episodicLogStore;
 
     /**
+     * Creates a CognitiveMemoryRouter with the modern log-structured episodic store.
+     */
+    public CognitiveMemoryRouter(WorkingRecordMemory workingStore,
+                                 SemanticRecordMemory semanticStore,
+                                 ProceduralRecordMemory proceduralStore,
+                                 EpisodicLogMemory episodicLogStore) {
+        this(workingStore, null, semanticStore, proceduralStore, episodicLogStore);
+    }
+
+    /**
      * Creates a CognitiveMemoryRouter with all four cognitive memory stores.
      */
     public CognitiveMemoryRouter(WorkingRecordMemory workingStore,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ContinuityRecordMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ContinuityRecordMemory.java
@@ -108,7 +108,8 @@ public final class ContinuityRecordMemory implements Memory<ContinuityLayout>, A
             throw new SpectorMemoryException(ErrorCode.RECORD_CRC_CORRUPTED, "Region slice too small for ContinuityRecordMemory");
         }
 
-        if (isNew) {
+        boolean effectivelyNew = isNew || !MemoryHeader.isValid(regionSlice, 0L);
+        if (effectivelyNew) {
             long now = System.currentTimeMillis();
             MemoryHeader.write(regionSlice, 0L, ContinuityLayout.SCHEMA_VERSION, MemoryShape.RECORD, 1,
                     ContinuityLayout.RECORD_STRIDE, recordCapacity, 0, ContinuityLayout.LAYOUT_ID, now, now);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicLogMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicLogMemory.java
@@ -88,6 +88,20 @@ public final class EpisodicLogMemory extends AbstractAppendMemory<EpisodicLogLay
     }
 
     /**
+     * Creates a volatile (heap-backed) episodic log with a default 16MB buffer.
+     */
+    public static EpisodicLogMemory heap() {
+        return new EpisodicLogMemory(16 * 1024 * 1024L);
+    }
+
+    /**
+     * Creates a volatile (heap-backed) episodic log with specified capacity.
+     */
+    public static EpisodicLogMemory heap(long capacityBytes) {
+        return new EpisodicLogMemory(capacityBytes);
+    }
+
+    /**
      * Creates a bundle-backed episodic log from a pre-sliced region segment.
      *
      * @param arena        the shared arena from the owning bundle

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityRelation.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/EntityRelation.java
@@ -16,7 +16,7 @@ package com.spectrayan.spector.memory.graph;
  * A typed relation between two entities extracted from memory text.
  *
  * <p><b>Open-schema types:</b> The relation type is a free-form string,
- * not constrained to the well-known {@link RelationType} enum values. Any
+ * not constrained to the canonical {@link OntologyConfig#canonicalPredicates()} ontology values. Any
  * type string is accepted and auto-registered in the {@link TypeRegistryMemory}
  * at graph population time.</p>
  *

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/ExtractedEntity.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/ExtractedEntity.java
@@ -21,7 +21,7 @@ import java.util.List;
  * is case-insensitive (normalized during graph population).</p>
  *
  * <p><b>Open-schema types:</b> The type field is a free-form string, not
- * constrained to the well-known {@link EntityType} enum values. Any type
+ * constrained to the canonical {@link OntologyConfig#canonicalTypes()} ontology values. Any type
  * string is accepted and auto-registered in the {@link TypeRegistryMemory} at
  * graph population time. This allows domain-specific types (e.g., VEHICLE,
  * RECIPE, MEDICAL_CONDITION) to flow through without being collapsed to OTHER.</p>

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/graph/HyperEntityGraphMemory.java
@@ -194,12 +194,15 @@ public final class HyperEntityGraphMemory extends AbstractGraphMemory<HyperEntit
               true, bundlePath, null, true); // bundleManaged=true
         this.bundleManaged = true;
         this.entityCapacity = entityCapacity;
-        this.hyperedgeCapacity = hyperedgeCapacity;
-        this.vertexCapacity = hyperedgeCapacity * HyperEntityLayout.MAX_VERTICES_PER_EDGE;
+        long availableBytes = Math.max(0L, regionSlice.byteSize() - DATA_START);
+        long bytesPerHedge = HyperEntityLayout.HEDGE_BYTES + (long) HyperEntityLayout.VERTEX_BYTES * HyperEntityLayout.MAX_VERTICES_PER_EDGE;
+        int availableHedgeCap = (int) (availableBytes / bytesPerHedge);
+        this.hyperedgeCapacity = Math.min(hyperedgeCapacity, availableHedgeCap);
+        this.vertexCapacity = this.hyperedgeCapacity * HyperEntityLayout.MAX_VERTICES_PER_EDGE;
         this.incidenceCapacity = entityCapacity * HyperEntityLayout.MAX_HYPEREDGES_PER_ENTITY;
 
-        long hedgeBytes = (long) HyperEntityLayout.HEDGE_BYTES * hyperedgeCapacity;
-        long vertexBytes = (long) HyperEntityLayout.VERTEX_BYTES * vertexCapacity;
+        long hedgeBytes = (long) HyperEntityLayout.HEDGE_BYTES * this.hyperedgeCapacity;
+        long vertexBytes = (long) HyperEntityLayout.VERTEX_BYTES * this.vertexCapacity;
 
         this.hedges = regionSlice.asSlice(DATA_START, hedgeBytes);
         this.vertices = regionSlice.asSlice(DATA_START + hedgeBytes, vertexBytes);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/DecayModulator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/DecayModulator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.hebbian;
+
+/**
+ * Per-node decay rate modifier for arousal-modulated Hebbian edge decay.
+ *
+ * <p>Implementations return a multiplier in [0.5, 2.0] applied to the decay factor
+ * per node. Values &gt; 1.0 = slower decay (high importance), &lt; 1.0 = faster decay
+ * (low importance). A null modulator means uniform decay (no modulation).</p>
+ *
+ * <p>Typical usage: the cortex layer reads synaptic header importance/arousal
+ * values and provides a modulator that maps node indices to decay multipliers.</p>
+ *
+ * @see SynapticDecayModulator
+ * @see HebbianGraphBase#setDecayModulator(DecayModulator)
+ */
+@FunctionalInterface
+public interface DecayModulator {
+    /**
+     * Returns a decay rate modifier for the given memory node.
+     *
+     * @param nodeIndex memory slot index
+     * @return multiplier applied to decay factor (e.g., 1.2 = 20% slower decay)
+     */
+    float modulateDecay(int nodeIndex);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianEdge.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianEdge.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.hebbian;
+
+/**
+ * A weighted edge in the Hebbian associative graph connecting two memory nodes.
+ *
+ * @param neighborIndex index of the connected memory node
+ * @param weight        association strength (higher = stronger co-activation)
+ * @param bridgeScore   structural importance score (0-255, unsigned byte range)
+ *
+ * @see HebbianGraphBase#neighbors(int)
+ * @see HebbianGraphMemory
+ */
+public record HebbianEdge(int neighborIndex, float weight, int bridgeScore) {
+
+    /** Backward-compatible constructor (bridgeScore defaults to 0). */
+    public HebbianEdge(int neighborIndex, float weight) {
+        this(neighborIndex, weight, 0);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraph.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraph.java
@@ -123,25 +123,14 @@ public final class HebbianGraph implements HebbianGraphBase {
     private final EdgeImportance edgeImportance;
 
     /**
-     * Optional per-node decay modulator — allows the cortex layer to inject
-     * synaptic importance/arousal signals without HebbianGraph knowing the header layout.
-     *
-     * <p>Returns a multiplier in [0.5, 2.0] applied to the decay factor per node.
-     * Values > 1.0 = slower decay (high importance), &lt; 1.0 = faster decay (low importance).
-     * Null means uniform decay (no modulation).</p>
+     * @deprecated Use top-level {@link com.spectrayan.spector.memory.hebbian.DecayModulator} directly.
      */
+    @Deprecated(since = "1.0.0", forRemoval = true)
     @FunctionalInterface
-    public interface DecayModulator {
-        /**
-         * Returns a decay rate modifier for the given memory node.
-         *
-         * @param nodeIndex memory slot index
-         * @return multiplier applied to decay factor (e.g., 1.2 = 20% slower decay)
-         */
-        float modulateDecay(int nodeIndex);
+    public interface DecayModulator extends com.spectrayan.spector.memory.hebbian.DecayModulator {
     }
 
-    private volatile DecayModulator decayModulator;
+    private volatile com.spectrayan.spector.memory.hebbian.DecayModulator decayModulator;
 
     private final Arena arena;
     private final MemorySegment segment;
@@ -521,25 +510,6 @@ public final class HebbianGraph implements HebbianGraphBase {
     }
 
     /**
-     * Immutable Hebbian edge record.
-     *
-     * <p><b>TODO (JDK 28+ / Project Valhalla):</b> Convert to {@code value record}.
-     * As a value class, HebbianEdge would be scalarized in the caller's stack frame
-     * instead of heap-allocated. With specialized generics, {@code List<HebbianEdge>}
-     * would store flattened values instead of boxed pointers.</p>
-     *
-     * @param neighborIndex index of the connected memory
-     * @param weight        association strength
-     */
-    public record HebbianEdge(int neighborIndex, float weight, int bridgeScore) {
-
-        /** Backward-compatible constructor (bridgeScore defaults to 0). */
-        public HebbianEdge(int neighborIndex, float weight) {
-            this(neighborIndex, weight, 0);
-        }
-    }
-
-    /**
      * Sets the per-node decay modulator for arousal-modulated edge decay.
      *
      * <p>Typical usage: the cortex layer reads synaptic header importance/arousal
@@ -547,7 +517,7 @@ public final class HebbianGraph implements HebbianGraphBase {
      *
      * @param modulator per-node modifier (null = uniform decay)
      */
-    public void setDecayModulator(DecayModulator modulator) {
+    public void setDecayModulator(com.spectrayan.spector.memory.hebbian.DecayModulator modulator) {
         this.decayModulator = modulator;
     }
 
@@ -612,7 +582,7 @@ public final class HebbianGraph implements HebbianGraphBase {
             currentCycle++;
             int removed = 0;
             float removalThreshold = 0.01f;
-            DecayModulator mod = this.decayModulator; // snapshot volatile
+            com.spectrayan.spector.memory.hebbian.DecayModulator mod = this.decayModulator; // snapshot volatile
             int activeNodes = 0;
 
             for (int node = 0; node < capacity; node++) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphBase.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphBase.java
@@ -13,8 +13,6 @@
 package com.spectrayan.spector.memory.hebbian;
 
 import com.spectrayan.spector.memory.graph.GraphHealthMetrics;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.DecayModulator;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -31,7 +29,6 @@ import java.util.List;
  * <p>All implementations are thread-safe for concurrent reads. Structural mutations
  * (strengthen, decay) are synchronized via {@link java.util.concurrent.locks.ReentrantLock}.</p>
  *
- * @see HebbianGraph The original V2 fixed-width implementation (deprecated)
  * @see HebbianGraphMemory The CSR V3 sparse implementation (preferred)
  */
 public sealed interface HebbianGraphBase extends AutoCloseable

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
@@ -16,7 +16,6 @@ import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
 import com.spectrayan.spector.memory.graph.BridgeDetector;
 import com.spectrayan.spector.memory.graph.EdgeImportance;
 import com.spectrayan.spector.memory.graph.GraphHealthMetrics;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.MemoryShape;
@@ -123,7 +122,7 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
     private final ReentrantLock graphLock = new ReentrantLock();
     private volatile long lastActivityMs = System.currentTimeMillis();
     private volatile long sessionBoundaryMs = SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_SESSION_BOUNDARY_MS;
-    private volatile HebbianGraph.DecayModulator decayModulator;
+    private volatile DecayModulator decayModulator;
     private volatile long lastCompactionEpochMs = 0L;
     private volatile long bytesReclaimedLastCycle = 0L;
 
@@ -225,7 +224,7 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
     }
 
     public HebbianGraphMemory(int capacity) {
-        this(capacity, capacity * HebbianLayout.DEFAULT_EDGE_CAPACITY_FACTOR, HebbianGraph.DEFAULT_MAX_DEGREE, EdgeImportance.DEFAULT);
+        this(capacity, capacity * HebbianLayout.DEFAULT_EDGE_CAPACITY_FACTOR, SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE, EdgeImportance.DEFAULT);
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -304,7 +303,7 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
     }
 
     @Override
-    public void setDecayModulator(HebbianGraph.DecayModulator modulator) {
+    public void setDecayModulator(DecayModulator modulator) {
         this.decayModulator = modulator;
     }
 
@@ -328,7 +327,7 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
         graphLock.lock();
         try {
             currentCycle++;
-            HebbianGraph.DecayModulator mod = this.decayModulator;
+            DecayModulator mod = this.decayModulator;
             int removed = 0;
             int activeNodes = 0;
 
@@ -578,7 +577,7 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
     }
 
     public static HebbianGraphMemory load(Path filePath, int defaultCapacity) {
-        return load(filePath, defaultCapacity, HebbianGraph.DEFAULT_MAX_DEGREE, EdgeImportance.DEFAULT);
+        return load(filePath, defaultCapacity, SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE, EdgeImportance.DEFAULT);
     }
 
     public static HebbianGraphMemory load(Path filePath, int defaultCapacity,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemory.java
@@ -173,12 +173,14 @@ public final class HebbianGraphMemory extends AbstractGraphMemory<HebbianLayout>
               isNew ? 0 : (int) MemoryHeader.readCount(regionSlice, 0L),
               true, bundlePath, null, true); // bundleManaged=true
         this.bundleManaged = true;
-        this.edgeCapacity = edgeCapacity;
         this.maxDegree = maxDegree;
         this.edgeImportance = edgeImportance;
 
         long offsetBytes = (long) (capacity + 1) * Integer.BYTES;
-        long edgeBytes = (long) edgeCapacity * EDGE_BYTES;
+        long maxEdgeBytes = Math.max(0L, regionSlice.byteSize() - DATA_START - offsetBytes);
+        int availableEdgeCap = (int) (maxEdgeBytes / EDGE_BYTES);
+        this.edgeCapacity = Math.min(edgeCapacity, availableEdgeCap);
+        long edgeBytes = (long) this.edgeCapacity * EDGE_BYTES;
 
         this.offsets = segment().asSlice(DATA_START, offsetBytes);
         this.edges = segment().asSlice(DATA_START + offsetBytes, edgeBytes);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HgphToCsrStep.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/HgphToCsrStep.java
@@ -51,15 +51,17 @@ public final class HgphToCsrStep extends RewriteFileStep {
         return TO_FORMAT;
     }
 
+    @SuppressWarnings("deprecation") // HebbianGraph.load() required for legacy V2 HGPH migration
     @Override
     protected void rewrite(Path source, Path target, MigrationContext ctx) throws IOException {
         // Decode the legacy fixed-width HGPH graph, rebuild it as a CSR graph, and write
         // the result as an SMKM container to the migration target.
+        int maxDegree = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_MEMORY_HEBBIAN_MAX_DEGREE;
         HebbianGraph legacy = HebbianGraph.load(source, 1024,
-                HebbianGraph.DEFAULT_MAX_DEGREE, EdgeImportance.DEFAULT);
+                maxDegree, EdgeImportance.DEFAULT);
         try {
             HebbianGraphMemory csr = HebbianGraphMemory.fromNeighbors(
-                    legacy, HebbianGraph.DEFAULT_MAX_DEGREE, EdgeImportance.DEFAULT);
+                    legacy, maxDegree, EdgeImportance.DEFAULT);
             try {
                 csr.save(target);
             } finally {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/SynapticDecayModulator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hebbian/SynapticDecayModulator.java
@@ -43,9 +43,9 @@ import java.lang.foreign.MemorySegment;
  * <p><b>Usage:</b> Created once before each decay cycle by {@link com.spectrayan.spector.memory.ReflectionOrchestrator},
  * then discarded. Captures a snapshot of the partition state at creation time.</p>
  *
- * @see HebbianGraph.DecayModulator
+ * @see DecayModulator
  */
-public final class SynapticDecayModulator implements HebbianGraph.DecayModulator {
+public final class SynapticDecayModulator implements DecayModulator {
 
     private final float[] modifiers;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
@@ -191,19 +191,19 @@ public final class ReflectDaemon {
      * text lookup (falls back to basic behavior).</p>
      *
      * @param episodicStore the episodic memory store to scan
-     * @param ingestionTarget the cognitive ingestion target to promote into
+     * @param rememberPathway the cognitive ingestion target to promote into
      * @return report summarizing what was done
      */
     /**
      * Runs a single synchronous reflection cycle across all frozen and active partitions (#446).
      *
      * @param partitionManager the partition manager providing frozen and active partition handles
-     * @param ingestionTarget the cognitive ingestion target to promote into (active partition)
+     * @param rememberPathway the cognitive ingestion target to promote into (active partition)
      * @param index memory index for text lookup
      * @return report summarizing what was done
      */
     public ReflectReport runCycle(PartitionManager partitionManager,
-                                   RememberPathway ingestionTarget,
+                                   RememberPathway rememberPathway,
                                    MemoryIndex index) {
         if (partitionManager == null) {
             return ReflectReport.EMPTY;
@@ -227,7 +227,7 @@ public final class ReflectDaemon {
                 if (handle.router() != null && handle.router().isEpisodicLogMode()) {
                     var logStore = handle.router().episodicLog();
                     if (logStore != null) {
-                        int consolidatedTurns = reflectEpisodicLog(logStore, ingestionTarget);
+                        int consolidatedTurns = reflectEpisodicLog(logStore, rememberPathway);
                         totalConsolidated += consolidatedTurns;
                     }
                 }
@@ -249,8 +249,8 @@ public final class ReflectDaemon {
                 for (EpisodicPartition partition : allLegacyPartitions) {
                     totalTombstoned += compactor.pruneDecayed(partition, policy.decayPruneThreshold(), nowMs);
                     int promoted = centroidRouter != null
-                            ? clusterAndSynthesize(partition, ingestionTarget, offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null)
-                            : promoteHighestImportance(partition, ingestionTarget, offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null);
+                            ? clusterAndSynthesize(partition, rememberPathway, offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null)
+                            : promoteHighestImportance(partition, rememberPathway, offset -> index != null ? index.findTextByOffset(MemoryType.EPISODIC, offset) : null);
                     totalConsolidated += promoted;
                 }
             }
@@ -265,8 +265,8 @@ public final class ReflectDaemon {
         }
     }
 
-    private int reflectEpisodicLog(EpisodicLogMemory logStore, RememberPathway ingestionTarget) {
-        if (logStore == null || ingestionTarget == null) return 0;
+    private int reflectEpisodicLog(EpisodicLogMemory logStore, RememberPathway rememberPathway) {
+        if (logStore == null || rememberPathway == null) return 0;
         List<Long> unconsolidatedOffsets = logStore.unconsolidatedTurnOffsets();
         if (unconsolidatedOffsets.isEmpty()) return 0;
 
@@ -308,7 +308,7 @@ public final class ReflectDaemon {
                 if (joinedText.length() > 500) {
                     joinedText = joinedText.substring(0, 500);
                 }
-                float[] vec = embeddingProvider != null ? embeddingProvider.embed(joinedText).vector() : new float[ingestionTarget.quantizer().dimensions()];
+                float[] vec = embeddingProvider != null ? embeddingProvider.embed(joinedText).vector() : new float[rememberPathway.quantizer().dimensions()];
                 CognitiveHeader header = new CognitiveHeader(
                         System.currentTimeMillis(),
                         0L,
@@ -326,7 +326,7 @@ public final class ReflectDaemon {
 
             if (promoted != null && promoted.header() != null) {
                 String newId = "rem-log-" + new com.spectrayan.spector.memory.id.TsidGenerator().generate();
-                ingestionTarget.ingestCognitiveWithHeader(
+                rememberPathway.ingestCognitiveWithHeader(
                         newId,
                         promoted.text(),
                         promoted.vector(),
@@ -360,12 +360,12 @@ public final class ReflectDaemon {
     }
 
     public ReflectReport runCycle(EpisodicRecordMemory episodicStore,
-                                   RememberPathway ingestionTarget) {
-        return runCycle(episodicStore, ingestionTarget, null);
+                                   RememberPathway rememberPathway) {
+        return runCycle(episodicStore, rememberPathway, null);
     }
 
     public ReflectReport runCycle(EpisodicRecordMemory episodicStore,
-                                   RememberPathway ingestionTarget,
+                                   RememberPathway rememberPathway,
                                    Function<Long, String> textLookup) {
         if (!running.compareAndSet(false, true)) {
             log.warn("Reflection cycle already in progress  --  skipping");
@@ -440,9 +440,9 @@ public final class ReflectDaemon {
                 for (EpisodicPartition partition : episodicStore.partitions()) {
                     remTasks.add(() -> {
                         if (centroidRouter != null) {
-                            return clusterAndSynthesize(partition, ingestionTarget, textLookup);
+                            return clusterAndSynthesize(partition, rememberPathway, textLookup);
                         } else {
-                            return promoteHighestImportance(partition, ingestionTarget, textLookup);
+                            return promoteHighestImportance(partition, rememberPathway, textLookup);
                         }
                     });
                 }
@@ -453,8 +453,8 @@ public final class ReflectDaemon {
                 log.warn("Parallel REM failed, falling back to sequential: {}", e.getMessage());
                 for (EpisodicPartition partition : episodicStore.partitions()) {
                     int promoted = centroidRouter != null
-                            ? clusterAndSynthesize(partition, ingestionTarget, textLookup)
-                            : promoteHighestImportance(partition, ingestionTarget, textLookup);
+                            ? clusterAndSynthesize(partition, rememberPathway, textLookup)
+                            : promoteHighestImportance(partition, rememberPathway, textLookup);
                     totalConsolidated += promoted;
                 }
             }
@@ -501,9 +501,9 @@ public final class ReflectDaemon {
     private record PromotedFact(String text, float[] vector, CognitiveHeader header) {}
 
     private int clusterAndSynthesize(EpisodicPartition partition,
-                                      RememberPathway ingestionTarget,
+                                      RememberPathway rememberPathway,
                                       Function<Long, String> textLookup) {
-        if (ingestionTarget == null || partition.count() == 0) return 0;
+        if (rememberPathway == null || partition.count() == 0) return 0;
 
         CognitiveRecordLayout layout = partition.layout();
         var segment = partition.segment();
@@ -589,14 +589,14 @@ public final class ReflectDaemon {
                 int vecBytes = layout.quantizedVecBytes();
                 byte[] quantized = new byte[vecBytes];
                 java.lang.foreign.MemorySegment.copy(segment, layout.vectorOffset(bestOffset), java.lang.foreign.MemorySegment.ofArray(quantized), 0, vecBytes);
-                float[] decodedVector = ingestionTarget.quantizer().decode(quantized);
+                float[] decodedVector = rememberPathway.quantizer().decode(quantized);
                 
                 promotedFact = new PromotedFact(bestText, decodedVector, promotedHeader);
             }
 
             if (promotedFact != null && promotedFact.header() != null) {
                 String newId = "rem-" + new com.spectrayan.spector.memory.id.TsidGenerator().generate();
-                ingestionTarget.ingestCognitiveWithHeader(
+                rememberPathway.ingestCognitiveWithHeader(
                         newId,
                         promotedFact.text(),
                         promotedFact.vector(),
@@ -812,9 +812,9 @@ public final class ReflectDaemon {
      * into the semantic store. Used as fallback when clustering is not configured.
      */
     private int promoteHighestImportance(EpisodicPartition partition,
-                                          RememberPathway ingestionTarget,
+                                          RememberPathway rememberPathway,
                                           Function<Long, String> textLookup) {
-        if (ingestionTarget == null || partition.count() == 0) return 0;
+        if (rememberPathway == null || partition.count() == 0) return 0;
 
         CognitiveRecordLayout layout = partition.layout();
         var segment = partition.segment();
@@ -851,10 +851,10 @@ public final class ReflectDaemon {
             int vecBytes = layout.quantizedVecBytes();
             byte[] quantized = new byte[vecBytes];
             java.lang.foreign.MemorySegment.copy(segment, layout.vectorOffset(offset), java.lang.foreign.MemorySegment.ofArray(quantized), 0, vecBytes);
-            float[] decodedVector = ingestionTarget.quantizer().decode(quantized);
+            float[] decodedVector = rememberPathway.quantizer().decode(quantized);
 
             String newId = "rem-" + new com.spectrayan.spector.memory.id.TsidGenerator().generate();
-            ingestionTarget.ingestCognitiveWithHeader(
+            rememberPathway.ingestCognitiveWithHeader(
                     newId,
                     bestText,
                     decodedVector,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemon.java
@@ -31,7 +31,7 @@ import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.provider.generation.GenerationOptions;
 import com.spectrayan.spector.core.similarity.VectorOps;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.cortex.MemorySource;
 
 import org.slf4j.Logger;
@@ -203,7 +203,7 @@ public final class ReflectDaemon {
      * @return report summarizing what was done
      */
     public ReflectReport runCycle(PartitionManager partitionManager,
-                                   CognitiveIngestionTarget ingestionTarget,
+                                   RememberPathway ingestionTarget,
                                    MemoryIndex index) {
         if (partitionManager == null) {
             return ReflectReport.EMPTY;
@@ -265,7 +265,7 @@ public final class ReflectDaemon {
         }
     }
 
-    private int reflectEpisodicLog(EpisodicLogMemory logStore, CognitiveIngestionTarget ingestionTarget) {
+    private int reflectEpisodicLog(EpisodicLogMemory logStore, RememberPathway ingestionTarget) {
         if (logStore == null || ingestionTarget == null) return 0;
         List<Long> unconsolidatedOffsets = logStore.unconsolidatedTurnOffsets();
         if (unconsolidatedOffsets.isEmpty()) return 0;
@@ -360,12 +360,12 @@ public final class ReflectDaemon {
     }
 
     public ReflectReport runCycle(EpisodicRecordMemory episodicStore,
-                                   CognitiveIngestionTarget ingestionTarget) {
+                                   RememberPathway ingestionTarget) {
         return runCycle(episodicStore, ingestionTarget, null);
     }
 
     public ReflectReport runCycle(EpisodicRecordMemory episodicStore,
-                                   CognitiveIngestionTarget ingestionTarget,
+                                   RememberPathway ingestionTarget,
                                    Function<Long, String> textLookup) {
         if (!running.compareAndSet(false, true)) {
             log.warn("Reflection cycle already in progress  --  skipping");
@@ -501,7 +501,7 @@ public final class ReflectDaemon {
     private record PromotedFact(String text, float[] vector, CognitiveHeader header) {}
 
     private int clusterAndSynthesize(EpisodicPartition partition,
-                                      CognitiveIngestionTarget ingestionTarget,
+                                      RememberPathway ingestionTarget,
                                       Function<Long, String> textLookup) {
         if (ingestionTarget == null || partition.count() == 0) return 0;
 
@@ -812,7 +812,7 @@ public final class ReflectDaemon {
      * into the semantic store. Used as fallback when clustering is not configured.
      */
     private int promoteHighestImportance(EpisodicPartition partition,
-                                          CognitiveIngestionTarget ingestionTarget,
+                                          RememberPathway ingestionTarget,
                                           Function<Long, String> textLookup) {
         if (ingestionTarget == null || partition.count() == 0) return 0;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/insula/InsularCortex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/insula/InsularCortex.java
@@ -58,7 +58,8 @@ public final class InsularCortex implements Memory<InsularLayout>, AutoCloseable
      */
     public static InsularCortex fromBundle(Arena arena, MemorySegment regionSlice, boolean isNew) {
         MemoryId memoryId = SystemMemoryId.INSULA.id();
-        if (isNew) {
+        boolean effectivelyNew = isNew || !MemoryHeader.isValid(regionSlice, 0L);
+        if (effectivelyNew) {
             long now = System.currentTimeMillis();
             MemoryHeader.write(regionSlice, 0L, InsularLayout.SCHEMA_VERSION, MemoryShape.INSULAR, 1,
                     1, 0, 0, InsularLayout.LAYOUT_ID, now, now);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/ContentTagExtractor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/ContentTagExtractor.java
@@ -82,7 +82,7 @@ public final class ContentTagExtractor implements TagExtractor {
      * Examples:
      *   WhatsAppTelegram  → Whats-App-Telegram  → whatsapp-telegram (after lowercase + clean)
      *   profileAdaptorSuggest → profile-Adaptor-Suggest → profile-adaptor-suggest
-     *   CognitiveIngestionTarget → Cognitive-Ingestion-Target
+     *   RememberPathway → Cognitive-Ingestion-Target
      *   BM25Index → BM25-Index
      *
      * Three patterns:

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -40,7 +40,6 @@ import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.config.model.TextSearchMode;
-import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory.EpisodicPartition;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index;
 import com.spectrayan.spector.memory.cortex.MemoryBM25Index.BM25Candidate;
 import com.spectrayan.spector.memory.cortex.MemorySpladeIndex;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/scan/TierScanStrategy.java
@@ -48,6 +48,7 @@ public interface TierScanStrategy {
         @Override
         public void contribute(ScanContext ctx, PartitionHandle handle, ScanEmitter emitter) {
             if (!CognitiveMemoryRouter.shouldScan(MemoryType.EPISODIC, ctx.targetTypes())) return;
+            if (handle.router() == null || handle.router().episodic() == null) return;
             for (EpisodicPartition partition : handle.router().episodic().partitions()) {
                 if (partition.visibleCount() > 0) {
                     emitter.emitSlabScan(partition::segment, partition::visibleCount,

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/EpisodicLogConsolidationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/EpisodicLogConsolidationRelay.java
@@ -107,17 +107,6 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                 }
 
                 if (signal.rememberPathway() != null) {
-                    signal.rememberPathway().ingestCognitive(
-                            memoryId,
-                            factText,
-                            vector,
-                            MemoryType.SEMANTIC,
-                            tags,
-                            MemorySource.REFLECTED,
-                            (com.spectrayan.spector.memory.neurodivergent.IngestionHints) null
-                    );
-                    signal.addConsolidated(1);
-                } else if (signal.ingestionTarget() != null) {
                     float exactNorm = vector != null ? VectorOps.magnitude(vector) : 1.0f;
                     byte semanticFlags = SynapticHeaderConstants.withMemoryType(
                             SynapticHeaderConstants.FLAG_CONSOLIDATED, MemoryType.SEMANTIC.ordinal());
@@ -125,7 +114,7 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                             System.currentTimeMillis(), 0L, exactNorm, 1.0f, 1,
                             (short) 0, (byte) 0, semanticFlags, (byte) 0, 1.0f
                     );
-                    signal.ingestionTarget().ingestCognitiveWithHeader(
+                    signal.rememberPathway().ingestCognitiveWithHeader(
                             memoryId, factText, vector, MemoryType.SEMANTIC, tags, MemorySource.REFLECTED, header
                     );
                     signal.addConsolidated(1);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/ProceduralCrystallizationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/ProceduralCrystallizationRelay.java
@@ -105,28 +105,17 @@ public final class ProceduralCrystallizationRelay implements SynapticRelay<Refle
 
                 String[] tags = new String[]{"procedural", "crystallized", "skill"};
                 if (signal.rememberPathway() != null) {
-                    try {
-                        signal.rememberPathway().ingestCognitive(
-                                skillId, skillText, vector, MemoryType.PROCEDURAL, tags,
-                                MemorySource.REFLECTED,
-                                (com.spectrayan.spector.memory.neurodivergent.IngestionHints) null
-                        );
-                        signal.addProceduralCrystallized(1);
-                    } catch (Exception e) {
-                        log.warn("Failed to remember procedural skill: {}", e.getMessage());
-                    }
-                } else if (signal.ingestionTarget() != null) {
                     float exactNorm = vector != null ? VectorOps.magnitude(vector) : 1.0f;
                     byte procFlags = SynapticHeaderConstants.withMemoryType(
                             (byte) 0, MemoryType.PROCEDURAL.ordinal());
-                    short soulVer = signal.ingestionTarget().currentSoulVersion();
+                    short soulVer = signal.rememberPathway().currentSoulVersion();
                     CognitiveHeader header = CognitiveHeader.createSynthetic(
                             System.currentTimeMillis(), 0L, exactNorm, 1.0f,
                             (byte) 0, (byte) 0, procFlags,
                             SynapticHeaderConstants.FLAG_CRYSTALLIZED,
                             soulVer, 0.0f
                     );
-                    signal.ingestionTarget().ingestCognitiveWithHeader(
+                    signal.rememberPathway().ingestCognitiveWithHeader(
                             skillId, skillText, vector, MemoryType.PROCEDURAL, tags, MemorySource.REFLECTED, header
                     );
                     signal.addProceduralCrystallized(1);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/ReflectSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/ReflectSignal.java
@@ -48,7 +48,6 @@ public final class ReflectSignal {
     private final MemoryIndex index;
     private final ScalarQuantizer quantizer;
     private final RememberPathway rememberPathway;
-    private final RememberPathway ingestionTarget;
     private final EmbeddingProvider embeddingProvider;
     private final LlmProvider textGenerator;
     private final ImportanceProvider importanceProvider;
@@ -108,7 +107,6 @@ public final class ReflectSignal {
         this.index = builder.index;
         this.quantizer = builder.quantizer;
         this.rememberPathway = builder.rememberPathway;
-        this.ingestionTarget = builder.ingestionTarget;
         this.embeddingProvider = builder.embeddingProvider;
         this.textGenerator = builder.textGenerator;
         this.importanceProvider = builder.importanceProvider != null ? builder.importanceProvider : ImportanceProvider.baseline();
@@ -169,7 +167,6 @@ public final class ReflectSignal {
     public MemoryIndex index() { return index; }
     public ScalarQuantizer quantizer() { return quantizer; }
     public RememberPathway rememberPathway() { return rememberPathway; }
-    public RememberPathway ingestionTarget() { return ingestionTarget; }
     public EmbeddingProvider embeddingProvider() { return embeddingProvider; }
     public LlmProvider textGenerator() { return textGenerator; }
     public ImportanceProvider importanceProvider() { return importanceProvider; }
@@ -279,7 +276,6 @@ public final class ReflectSignal {
         private MemoryIndex index;
         private ScalarQuantizer quantizer;
         private RememberPathway rememberPathway;
-        private RememberPathway ingestionTarget;
         private EmbeddingProvider embeddingProvider;
         private LlmProvider textGenerator;
         private ImportanceProvider importanceProvider;
@@ -316,7 +312,6 @@ public final class ReflectSignal {
         public Builder index(MemoryIndex idx) { this.index = idx; return this; }
         public Builder quantizer(ScalarQuantizer q) { this.quantizer = q; return this; }
         public Builder rememberPathway(RememberPathway rp) { this.rememberPathway = rp; return this; }
-        public Builder ingestionTarget(RememberPathway cit) { this.ingestionTarget = cit; return this; }
         public Builder embeddingProvider(EmbeddingProvider ep) { this.embeddingProvider = ep; return this; }
         public Builder textGenerator(LlmProvider tg) { this.textGenerator = tg; return this; }
         public Builder importanceProvider(ImportanceProvider ip) { this.importanceProvider = ip; return this; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/ReflectSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/ReflectSignal.java
@@ -27,7 +27,7 @@ import com.spectrayan.spector.memory.hippocampus.CircadianPolicy;
 import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.model.SalienceProfile;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
@@ -48,7 +48,7 @@ public final class ReflectSignal {
     private final MemoryIndex index;
     private final ScalarQuantizer quantizer;
     private final RememberPathway rememberPathway;
-    private final CognitiveIngestionTarget ingestionTarget;
+    private final RememberPathway ingestionTarget;
     private final EmbeddingProvider embeddingProvider;
     private final LlmProvider textGenerator;
     private final ImportanceProvider importanceProvider;
@@ -169,7 +169,7 @@ public final class ReflectSignal {
     public MemoryIndex index() { return index; }
     public ScalarQuantizer quantizer() { return quantizer; }
     public RememberPathway rememberPathway() { return rememberPathway; }
-    public CognitiveIngestionTarget ingestionTarget() { return ingestionTarget; }
+    public RememberPathway ingestionTarget() { return ingestionTarget; }
     public EmbeddingProvider embeddingProvider() { return embeddingProvider; }
     public LlmProvider textGenerator() { return textGenerator; }
     public ImportanceProvider importanceProvider() { return importanceProvider; }
@@ -279,7 +279,7 @@ public final class ReflectSignal {
         private MemoryIndex index;
         private ScalarQuantizer quantizer;
         private RememberPathway rememberPathway;
-        private CognitiveIngestionTarget ingestionTarget;
+        private RememberPathway ingestionTarget;
         private EmbeddingProvider embeddingProvider;
         private LlmProvider textGenerator;
         private ImportanceProvider importanceProvider;
@@ -316,7 +316,7 @@ public final class ReflectSignal {
         public Builder index(MemoryIndex idx) { this.index = idx; return this; }
         public Builder quantizer(ScalarQuantizer q) { this.quantizer = q; return this; }
         public Builder rememberPathway(RememberPathway rp) { this.rememberPathway = rp; return this; }
-        public Builder ingestionTarget(CognitiveIngestionTarget cit) { this.ingestionTarget = cit; return this; }
+        public Builder ingestionTarget(RememberPathway cit) { this.ingestionTarget = cit; return this; }
         public Builder embeddingProvider(EmbeddingProvider ep) { this.embeddingProvider = ep; return this; }
         public Builder textGenerator(LlmProvider tg) { this.textGenerator = tg; return this; }
         public Builder importanceProvider(ImportanceProvider ip) { this.importanceProvider = ip; return this; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/SoulDriftRefusionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/SoulDriftRefusionRelay.java
@@ -71,8 +71,6 @@ public final class SoulDriftRefusionRelay implements SynapticRelay<ReflectSignal
         short currentSoulVersion = 0;
         if (signal.rememberPathway() != null) {
             currentSoulVersion = signal.rememberPathway().currentSoulVersion();
-        } else if (signal.ingestionTarget() != null) {
-            currentSoulVersion = signal.ingestionTarget().currentSoulVersion();
         }
 
         if (currentSoulVersion > 0) {
@@ -108,8 +106,8 @@ public final class SoulDriftRefusionRelay implements SynapticRelay<ReflectSignal
     private float[] computeAutobiographicalCentroid(ReflectSignal signal) {
         if (signal.partitionManager() == null) return null;
         ScalarQuantizer quantizer = signal.quantizer();
-        if (quantizer == null && signal.ingestionTarget() != null) {
-            quantizer = signal.ingestionTarget().quantizer();
+        if (quantizer == null && signal.rememberPathway() != null) {
+            quantizer = signal.rememberPathway().quantizer();
         }
         if (quantizer == null) return null;
 
@@ -199,8 +197,8 @@ public final class SoulDriftRefusionRelay implements SynapticRelay<ReflectSignal
         MemorySegment.copy(segment, layout.vectorOffset(offset), MemorySegment.ofArray(quantized), 0, vecBytes);
 
         ScalarQuantizer quantizer = signal.quantizer();
-        if (quantizer == null && signal.ingestionTarget() != null) {
-            quantizer = signal.ingestionTarget().quantizer();
+        if (quantizer == null && signal.rememberPathway() != null) {
+            quantizer = signal.rememberPathway().quantizer();
         }
         float[] vector = (quantizer != null) ? quantizer.decode(quantized) : new float[vecBytes];
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/SpectralSparsificationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/reflect/relay/SpectralSparsificationRelay.java
@@ -17,7 +17,7 @@ import com.spectrayan.spector.config.SpectorPropertyConstants;
 import com.spectrayan.spector.memory.graph.BridgeDetector;
 import com.spectrayan.spector.memory.graph.SparsificationPlan;
 import com.spectrayan.spector.memory.graph.SpectralSparsifier;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/CorticalWriteTransactionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/CorticalWriteTransactionRelay.java
@@ -103,47 +103,71 @@ public final class CorticalWriteTransactionRelay implements SynapticRelay<Rememb
         final IngestionHints hints = signal.hints();
         final IngestionContext context = signal.context();
         final SalienceProfile salienceProfile = signal.salienceProfile();
-
-        byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, type.ordinal());
-        if (signal.isFlashbulb()) {
-            flags = (byte) (flags | SynapticHeaderConstants.FLAG_PINNED);
-        }
-        if (context != null) {
-            final SourceModality modality = context.sourceModality();
-            if (modality != null && modality != SourceModality.TEXT) {
-                flags = SynapticHeaderConstants.withSourceModality(flags, modality.ordinal());
-            }
-        }
-
         final float l2Norm = (vector != null) ? VectorOps.magnitude(vector) : 0.0f;
-        final byte rawValence = (hints != null) ? hints.valence() : (byte) 0;
-        final byte rawArousal = (hints != null) ? hints.effectiveArousal() : (byte) 0;
-        final byte valence = salienceProfile.modulateValence(rawValence);
-        final byte arousal = salienceProfile.modulateArousal(rawArousal);
 
-        final float surpriseZScore = (float) surpriseDetector.stats().zScore(signal.nearestDist());
-        final byte encodingProfile = computeEncodingProfile(salienceProfile);
-        final byte encodingAlpha = computeEncodingAlpha(salienceProfile);
-        final byte encodingBeta = computeEncodingBeta(salienceProfile);
+        final CognitiveHeader preserved = signal.header();
+        final CognitiveHeader header;
+        if (preserved != null) {
+            long synapticTags = signal.synapticTags() != 0 ? signal.synapticTags() : preserved.synapticTags();
+            header = new CognitiveHeader(
+                    preserved.timestampMs(),
+                    synapticTags,
+                    l2Norm,
+                    preserved.importance(),
+                    preserved.agentRecallCount(),
+                    (short) 0,
+                    preserved.valence(),
+                    preserved.flags(),
+                    preserved.arousal(),
+                    preserved.storageStrength(),
+                    preserved.encodingProfile(),
+                    preserved.encodingAlpha(),
+                    preserved.encodingBeta(),
+                    preserved.soulVersion(),
+                    preserved.encodingSurprise(),
+                    preserved.consolidationFlags()
+            );
+        } else {
+            byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, type.ordinal());
+            if (signal.isFlashbulb()) {
+                flags = (byte) (flags | SynapticHeaderConstants.FLAG_PINNED);
+            }
+            if (context != null) {
+                final SourceModality modality = context.sourceModality();
+                if (modality != null && modality != SourceModality.TEXT) {
+                    flags = SynapticHeaderConstants.withSourceModality(flags, modality.ordinal());
+                }
+            }
 
-        final CognitiveHeader header = new CognitiveHeader(
-                signal.timestampMs(),
-                signal.synapticTags(),
-                l2Norm,
-                signal.importance(),
-                0,
-                (short) 0,
-                valence,
-                flags,
-                arousal,
-                1.0f,
-                encodingProfile,
-                encodingAlpha,
-                encodingBeta,
-                signal.soulVersion(),
-                surpriseZScore,
-                (byte) 0
-        );
+            final byte rawValence = (hints != null) ? hints.valence() : (byte) 0;
+            final byte rawArousal = (hints != null) ? hints.effectiveArousal() : (byte) 0;
+            final byte valence = salienceProfile.modulateValence(rawValence);
+            final byte arousal = salienceProfile.modulateArousal(rawArousal);
+
+            final float surpriseZScore = (float) surpriseDetector.stats().zScore(signal.nearestDist());
+            final byte encodingProfile = computeEncodingProfile(salienceProfile);
+            final byte encodingAlpha = computeEncodingAlpha(salienceProfile);
+            final byte encodingBeta = computeEncodingBeta(salienceProfile);
+
+            header = new CognitiveHeader(
+                    signal.timestampMs(),
+                    signal.synapticTags(),
+                    l2Norm,
+                    signal.importance(),
+                    0,
+                    (short) 0,
+                    valence,
+                    flags,
+                    arousal,
+                    1.0f,
+                    encodingProfile,
+                    encodingAlpha,
+                    encodingBeta,
+                    signal.soulVersion(),
+                    surpriseZScore,
+                    (byte) 0
+            );
+        }
         signal.header(header);
 
         // 3. Off-Heap Slab Write (with partition roll support)
@@ -209,6 +233,10 @@ public final class CorticalWriteTransactionRelay implements SynapticRelay<Rememb
 
     public PostIngestSync postIngestSync() {
         return postIngestSync;
+    }
+
+    public com.spectrayan.spector.core.quantization.ScalarQuantizer quantizer() {
+        return quantizer;
     }
 
     private static float[] l2Normalize(final float[] vector) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/DopaminergicSurpriseRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/DopaminergicSurpriseRelay.java
@@ -47,6 +47,11 @@ public final class DopaminergicSurpriseRelay implements SynapticRelay<RememberSi
 
     @Override
     public boolean transmit(final RememberSignal signal) {
+        if (signal.header() != null) {
+            signal.importance(signal.header().importance());
+            signal.flashbulb((signal.header().flags() & com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.FLAG_PINNED) != 0);
+            return true;
+        }
         final float[] vector = signal.vector();
         final float nearestDist;
         if (workingStore != null && workingStore.count() > 0 && vector != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/RememberSignal.java
@@ -73,7 +73,7 @@ public final class RememberSignal {
         this.text = Objects.requireNonNull(text, "text cannot be null");
         this.vector = vector;
         this.type = type != null ? type : MemoryType.SEMANTIC;
-        this.tags = tags != null ? tags : new String[0];
+        this.tags = tags;
         this.source = source != null ? source : MemorySource.OBSERVED;
         this.hints = hints;
         this.context = context;
@@ -122,6 +122,25 @@ public final class RememberSignal {
                 salienceProfile, soulVersion, ts);
     }
 
+    /**
+     * Factory for cognitive remember requests preserving an existing header.
+     */
+    public static RememberSignal forCognitiveWithHeader(
+            final String id,
+            final String text,
+            final float[] vector,
+            final MemoryType type,
+            final String[] tags,
+            final MemorySource source,
+            final CognitiveHeader header) {
+        final RememberSignal signal = new RememberSignal(
+                id, text, vector, type, tags, source, null, null,
+                SalienceProfile.NEUTRAL, header != null ? header.soulVersion() : 0,
+                header != null ? header.timestampMs() : System.currentTimeMillis());
+        signal.header(header);
+        return signal;
+    }
+
     // ── Getters & Setters ──────────────────────────────────────────
 
     public String id() { return id; }
@@ -145,7 +164,7 @@ public final class RememberSignal {
     public long timestampMs() { return timestampMs; }
 
     public String[] tags() { return tags; }
-    public void tags(final String[] tags) { this.tags = tags != null ? tags : new String[0]; }
+    public void tags(final String[] tags) { this.tags = tags; }
 
     public long synapticTags() { return synapticTags; }
     public void synapticTags(final long synapticTags) { this.synapticTags = synapticTags; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/SynapticTagTransductionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/remember/relay/SynapticTagTransductionRelay.java
@@ -49,7 +49,7 @@ public final class SynapticTagTransductionRelay implements SynapticRelay<Remembe
         }
 
         String[] tags = signal.tags();
-        if ((tags == null || tags.length == 0) && tagExtractor != null) {
+        if (tags == null && tagExtractor != null) {
             tags = tagExtractor.extract(signal.id(), signal.text());
             signal.tags(tags);
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/sync/CheckpointDaemon.java
@@ -211,23 +211,24 @@ public final class CheckpointDaemon {
             }
         }
 
-        // Step 3: Persist cognitive graphs to runtime/ directory (V3 layout)
+        // Step 3: Persist cognitive graphs
         if (basePath != null) {
+            Path bundlePath = StorageLayout.runtimeBundleFile(basePath);
             saveGraph("HebbianGraph", () ->
-                    hebbianGraph.save(StorageLayout.hebbianGraphRuntime(basePath)));
+                    hebbianGraph.save(bundlePath));
             saveGraph("TemporalChain", () ->
-                    temporalChain.save(StorageLayout.temporalChainRuntime(basePath)));
+                    temporalChain.save(bundlePath));
 
             if (hyperEntityGraph != null) {
                 saveGraph("HyperEntityGraph", () ->
-                        hyperEntityGraph.save(StorageLayout.hyperEntityGraphRuntime(basePath)));
+                        hyperEntityGraph.save(bundlePath));
             }
             if (entityDirectory != null) {
                 saveGraph("EntityDirectory", () ->
-                        entityDirectory.save(StorageLayout.entityDirectoryRuntime(basePath)));
+                        entityDirectory.save(bundlePath));
                 saveGraph("EntityTypeRegistry", () -> {
                     try {
-                        entityDirectory.entityTypeRegistry().save(StorageLayout.entityTypesRuntime(basePath));
+                        entityDirectory.entityTypeRegistry().save(bundlePath);
                     } catch (java.io.IOException e) {
                         throw new java.io.UncheckedIOException(e);
                     }
@@ -236,19 +237,16 @@ public final class CheckpointDaemon {
             if (temporalKnowledgeGraph != null) {
                 saveGraph("RelationTypeRegistry", () -> {
                     try {
-                        temporalKnowledgeGraph.predicateRegistry().save(StorageLayout.relationTypesRuntime(basePath));
+                        temporalKnowledgeGraph.predicateRegistry().save(bundlePath);
                     } catch (java.io.IOException e) {
                         throw new java.io.UncheckedIOException(e);
                     }
                 });
             }
-        }
-
-        // Step 4: Persist CoActivationTracker (global, not partitioned)
-        if (coActivationTracker != null && basePath != null) {
-            saveGraph("CoActivationTracker", () ->
-                    coActivationTracker.save(
-                            StorageLayout.coactivationTracker(basePath)));
+            if (coActivationTracker != null) {
+                saveGraph("CoActivationTracker", () ->
+                        coActivationTracker.save(bundlePath));
+            }
         }
 
         // Step 5: Read the WAL high-water mark

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
@@ -24,7 +24,7 @@ import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.model.MemoryType;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 
 import org.junit.jupiter.api.AfterEach;
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.mock;
  * {@link PartitionManager} is package-private.</p>
  *
  * <p>The tier stores, {@link CognitiveMemoryRouter}, and filesystem are REAL. Only
- * {@link CognitiveIngestionTarget} is mocked — {@code PartitionManager} calls just
+ * {@link RememberPathway} is mocked — {@code PartitionManager} calls just
  * {@code updateCognitiveRouter(...)} on it during a roll, and its full construction
  * is prohibitively heavy. Index / Hebbian / Temporal collaborators are real so the
  * {@code flushGlobalState()} behaviour is exercised end-to-end.</p>
@@ -71,7 +71,7 @@ class PartitionManagerTest {
     private MemoryIndex index;
     private HebbianGraphMemory hebbian;
     private TemporalChainMemory temporal;
-    private CognitiveIngestionTarget cognitiveTarget;
+    private RememberPathway cognitiveTarget;
 
     private final List<CognitiveMemoryRouter> routersToClose = new ArrayList<>();
 
@@ -81,7 +81,7 @@ class PartitionManagerTest {
         hebbian = new HebbianGraphMemory(128);
         // Persistent backing so save() (a copy-on-differ) actually materialises a file.
         temporal = new TemporalChainMemory(basePath.resolve("temporal-backing.chain"), 128);
-        cognitiveTarget = mock(CognitiveIngestionTarget.class);
+        cognitiveTarget = mock(RememberPathway.class);
     }
 
     @AfterEach

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PartitionManagerTest.java
@@ -13,7 +13,7 @@
 package com.spectrayan.spector.memory;
 
 import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
-import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory;
+import com.spectrayan.spector.memory.cortex.EpisodicLogMemory;
 import com.spectrayan.spector.memory.cortex.PartitionHandle;
 import com.spectrayan.spector.memory.cortex.ProceduralRecordMemory;
 import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
@@ -61,8 +61,8 @@ import static org.mockito.Mockito.mock;
 class PartitionManagerTest {
 
     private static final int VEC_BYTES = 16;
-    private static final int SEMANTIC_CAP = 64;
-    private static final int EPISODIC_CAP = 4;   // small → easy to drive to tier-full
+    private static final int SEMANTIC_CAP = 4;   // small → easy to drive to tier-full
+    private static final int EPISODIC_CAP = 64;
     private static final int PROCEDURAL_CAP = 64;
 
     @TempDir
@@ -107,13 +107,12 @@ class PartitionManagerTest {
     /** Builds a real router with fresh tier stores rooted in the given partition dir. */
     private CognitiveMemoryRouter newRouter(Path partitionDir) {
         WorkingRecordMemory working = new WorkingRecordMemory(VEC_BYTES, 64);
-        EpisodicRecordMemory episodic = new EpisodicRecordMemory(
-                StorageLayout.episodicMem(partitionDir), VEC_BYTES, EPISODIC_CAP);
         SemanticRecordMemory semantic = new SemanticRecordMemory(
                 VEC_BYTES, SEMANTIC_CAP, StorageLayout.semanticMem(partitionDir));
         ProceduralRecordMemory procedural = new ProceduralRecordMemory(
                 VEC_BYTES, PROCEDURAL_CAP, StorageLayout.proceduralMem(partitionDir));
-        CognitiveMemoryRouter router = new CognitiveMemoryRouter(working, episodic, semantic, procedural);
+        EpisodicLogMemory episodicLog = EpisodicLogMemory.heap();
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(working, semantic, procedural, episodicLog);
         routersToClose.add(router);
         return router;
     }
@@ -128,8 +127,8 @@ class PartitionManagerTest {
                 /* useBundleMode */ false, /* activePartitionBundle */ null);
     }
 
-    private static CognitiveHeader episodicHeader(long timestampMs) {
-        return CognitiveHeader.create(timestampMs, 0L, 1.0f, 0.5f, (short) 0, MemoryType.EPISODIC);
+    private static CognitiveHeader semanticHeader(long timestampMs) {
+        return CognitiveHeader.create(timestampMs, 0L, 1.0f, 0.5f, (short) 0, MemoryType.SEMANTIC);
     }
 
     private static byte[] vec() {
@@ -141,43 +140,27 @@ class PartitionManagerTest {
     // ──────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("discovery: fresh base creates partition 000 as active")
-    void discoveryCreatesInitialPartitionWhenNoneExist() throws Exception {
-        Path active = PartitionManager.discoverOrCreatePartition(basePath);
-
-        assertThat(Files.isDirectory(active)).isTrue();
-        assertThat(active.getParent()).isEqualTo(StorageLayout.partitionsDir(basePath));
-        assertThat(StorageLayout.isPartitionDir(active.getFileName().toString())).isTrue();
-        assertThat(StorageLayout.parsePartitionSeqNo(active.getFileName().toString())).isZero();
+    @DisplayName("discovery: empty base dir creates p000 partition on load")
+    void emptyBaseDirDiscoversAndCreatesPartitionZero() throws Exception {
+        List<Path> discovered = PartitionManager.discoverAllPartitions(basePath);
+        assertThat(discovered).hasSize(1);
+        Path p0 = discovered.get(0);
+        assertThat(p0.getFileName().toString()).startsWith("000_");
+        assertThat(Files.isDirectory(p0)).isTrue();
     }
 
     @Test
-    @DisplayName("discovery: newest NNN_EPOCH selected as active, prior dirs left frozen (not written)")
-    void discoverySelectsNewestPartitionAsActive() throws Exception {
-        // Pre-seed three partition dirs; the highest seq (002) must become active.
-        Path p0 = StorageLayout.partitionDir(basePath, 0, 1_717_430_400L);
-        Path p1 = StorageLayout.partitionDir(basePath, 1, 1_717_516_800L);
-        Path p2 = StorageLayout.partitionDir(basePath, 2, 1_717_603_200L);
-        Files.createDirectories(p0);
-        Files.createDirectories(p1);
-        Files.createDirectories(p2);
-        // A non-partition directory must be ignored.
-        Files.createDirectories(StorageLayout.partitionsDir(basePath).resolve("not-a-partition"));
+    @DisplayName("discovery: existing partition dirs are sorted ascending by seq on load")
+    void existingPartitionDirsAreDiscoveredAscendingBySeq() throws Exception {
+        Files.createDirectories(StorageLayout.partitionDir(basePath, 0, 1_000L));
+        Files.createDirectories(StorageLayout.partitionDir(basePath, 2, 3_000L));
+        Files.createDirectories(StorageLayout.partitionDir(basePath, 1, 2_000L));
 
-        Path active = PartitionManager.discoverOrCreatePartition(basePath);
-
-        assertThat(active).isEqualTo(p2);
-        assertThat(StorageLayout.parsePartitionSeqNo(active.getFileName().toString())).isEqualTo(2);
-        // No new partition dir was created — the prior partitions are simply frozen (never re-selected).
-        try (var stream = Files.newDirectoryStream(StorageLayout.partitionsDir(basePath))) {
-            long partitionDirs = 0;
-            for (Path entry : stream) {
-                if (Files.isDirectory(entry) && StorageLayout.isPartitionDir(entry.getFileName().toString())) {
-                    partitionDirs++;
-                }
-            }
-            assertThat(partitionDirs).isEqualTo(3);
-        }
+        List<Path> discovered = PartitionManager.discoverAllPartitions(basePath);
+        assertThat(discovered).hasSize(3);
+        assertThat(discovered.get(0).getFileName().toString()).startsWith("000_");
+        assertThat(discovered.get(1).getFileName().toString()).startsWith("001_");
+        assertThat(discovered.get(2).getFileName().toString()).startsWith("002_");
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -191,16 +174,16 @@ class PartitionManagerTest {
         CognitiveMemoryRouter router0 = newRouter(p0);
         PartitionManager pm = newManager(router0, p0);
 
-        // Fill the active episodic store to capacity.
-        EpisodicRecordMemory episodic0 = router0.episodic();
-        for (int i = 0; i < EPISODIC_CAP; i++) {
-            episodic0.append(episodicHeader(1_000L + i), vec());
+        // Fill the active semantic store to capacity.
+        SemanticRecordMemory semantic0 = router0.semantic();
+        for (int i = 0; i < SEMANTIC_CAP; i++) {
+            semantic0.append(semanticHeader(1_000L + i), vec());
         }
-        assertThat(episodic0.totalRecords()).isEqualTo(EPISODIC_CAP);
+        assertThat(semantic0.size()).isEqualTo(SEMANTIC_CAP);
 
         // The next write must overflow the tier — this is what the ingestion pipeline
         // catches to trigger PartitionManager::rollPartition.
-        assertThatThrownBy(() -> episodic0.append(episodicHeader(9_999L), vec()))
+        assertThatThrownBy(() -> semantic0.append(semanticHeader(9_999L), vec()))
                 .isInstanceOf(SpectorMemoryTierFullException.class);
 
         pm.rollPartition();
@@ -215,13 +198,12 @@ class PartitionManagerTest {
         CognitiveMemoryRouter rolled = pm.cognitiveRouter();
         routersToClose.add(rolled);
         assertThat(rolled).isNotSameAs(router0);
-        assertThat(rolled.episodic().totalRecords()).isZero();
         assertThat(rolled.semantic().size()).isZero();
         assertThat(rolled.procedural().size()).isZero();
 
-        // The new active episodic store accepts writes again.
-        rolled.episodic().append(episodicHeader(2_000L), vec());
-        assertThat(rolled.episodic().totalRecords()).isEqualTo(1);
+        // The new active semantic store accepts writes again.
+        rolled.semantic().append(semanticHeader(2_000L), vec());
+        assertThat(rolled.semantic().size()).isEqualTo(1);
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -235,9 +217,9 @@ class PartitionManagerTest {
         CognitiveMemoryRouter router0 = newRouter(p0);
         PartitionManager pm = newManager(router0, p0);
 
-        EpisodicRecordMemory episodic0 = router0.episodic();
-        for (int i = 0; i < EPISODIC_CAP; i++) {
-            episodic0.append(episodicHeader(1_000L + i), vec());
+        SemanticRecordMemory semantic0 = router0.semantic();
+        for (int i = 0; i < SEMANTIC_CAP; i++) {
+            semantic0.append(semanticHeader(1_000L + i), vec());
         }
 
         AtomicBoolean stop = new AtomicBoolean(false);
@@ -248,10 +230,10 @@ class PartitionManagerTest {
         Thread reader = new Thread(() -> {
             try {
                 while (!stop.get()) {
-                    int visible = episodic0.visibleCount();
-                    assertThat(visible).isEqualTo(EPISODIC_CAP);
+                    int visible = semantic0.visibleCount();
+                    assertThat(visible).isEqualTo(SEMANTIC_CAP);
                     // Read record 0 — must remain the value written before the roll.
-                    CognitiveHeader h = episodic0.readHeader(0);
+                    CognitiveHeader h = semantic0.readHeader(0);
                     assertThat(h.timestampMs()).isEqualTo(1_000L);
                     sawData.set(true);
                 }
@@ -276,9 +258,9 @@ class PartitionManagerTest {
         // Router was swapped away from router0 …
         assertThat(pm.cognitiveRouter()).isNotSameAs(router0);
         // … yet the OLD partition's Arena was NOT unmapped: reads on router0 still succeed.
-        assertThat(episodic0.totalRecords()).isEqualTo(EPISODIC_CAP);
-        assertThat(episodic0.readHeader(EPISODIC_CAP - 1).timestampMs())
-                .isEqualTo(1_000L + (EPISODIC_CAP - 1));
+        assertThat(semantic0.size()).isEqualTo(SEMANTIC_CAP);
+        assertThat(semantic0.readHeader(SEMANTIC_CAP - 1).timestampMs())
+                .isEqualTo(1_000L + (SEMANTIC_CAP - 1));
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -320,9 +302,9 @@ class PartitionManagerTest {
         PartitionManager pm = newManager(router0, p0);
 
         // Seed the initial (soon-to-be-frozen) partition with readable records.
-        EpisodicRecordMemory episodic0 = router0.episodic();
-        for (int i = 0; i < EPISODIC_CAP; i++) {
-            episodic0.append(episodicHeader(1_000L + i), vec());
+        SemanticRecordMemory semantic0 = router0.semantic();
+        for (int i = 0; i < SEMANTIC_CAP; i++) {
+            semantic0.append(semanticHeader(1_000L + i), vec());
         }
 
         final int rolls = 5;
@@ -339,17 +321,17 @@ class PartitionManagerTest {
         }
 
         // FROZEN handles remain OPEN and readable (this is the leak fix — old Arenas kept mapped).
-        assertThat(episodic0.totalRecords()).isEqualTo(EPISODIC_CAP);
-        assertThat(episodic0.readHeader(0).timestampMs()).isEqualTo(1_000L);
-        assertThat(episodic0.readHeader(EPISODIC_CAP - 1).timestampMs())
-                .isEqualTo(1_000L + (EPISODIC_CAP - 1));
+        assertThat(semantic0.size()).isEqualTo(SEMANTIC_CAP);
+        assertThat(semantic0.readHeader(0).timestampMs()).isEqualTo(1_000L);
+        assertThat(semantic0.readHeader(SEMANTIC_CAP - 1).timestampMs())
+                .isEqualTo(1_000L + (SEMANTIC_CAP - 1));
 
         // Ensure the active roll-created router is closed by tearDown.
         routersToClose.add(pm.cognitiveRouter());
 
         // Close once: frozen handles' stores are released (reads now throw on closed Arena).
         pm.close();
-        assertThatThrownBy(() -> episodic0.readHeader(0))
+        assertThatThrownBy(() -> semantic0.readHeader(0))
                 .as("frozen store's arena is closed after component close()")
                 .isInstanceOf(RuntimeException.class);
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PerformanceBenchmarkTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/PerformanceBenchmarkTest.java
@@ -213,13 +213,10 @@ class PerformanceBenchmarkTest {
     void p12_totalCountDirectSum() {
         int quantizedVecBytes = 32;
         var working = new WorkingRecordMemory(quantizedVecBytes, 10);
-        var episodic = new com.spectrayan.spector.memory.cortex.EpisodicRecordMemory(
-                java.nio.file.Path.of(System.getProperty("java.io.tmpdir"),
-                        "perf-test-p12-" + System.nanoTime()),
-                quantizedVecBytes, 100);
+        var episodicLog = com.spectrayan.spector.memory.cortex.EpisodicLogMemory.heap(100 * 256L);
         var semantic = new com.spectrayan.spector.memory.cortex.SemanticRecordMemory(quantizedVecBytes, 10);
         var procedural = new com.spectrayan.spector.memory.cortex.ProceduralRecordMemory(quantizedVecBytes, 10);
-        var router = new CognitiveMemoryRouter(working, episodic, semantic, procedural);
+        var router = new CognitiveMemoryRouter(working, semantic, procedural, episodicLog);
 
         try {
             // Warm up

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructiveMemoryPersistenceRelayTest.java
@@ -26,7 +26,7 @@ import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.recall.relay.RecallSignal;
 
 import org.junit.jupiter.api.Test;
@@ -58,7 +58,7 @@ class ConstructiveMemoryPersistenceRelayTest {
 
     @Test
     void highAlignmentSimulation_isPersisted() {
-        CognitiveIngestionTarget target = mock(CognitiveIngestionTarget.class);
+        RememberPathway target = mock(RememberPathway.class);
         org.mockito.Mockito.when(target.currentSoulVersion()).thenReturn((short) 5);
         Map<String, float[]> vectors = new HashMap<>();
         vectors.put("0123456789ABC", new float[]{1.0f, 0.0f});
@@ -85,7 +85,7 @@ class ConstructiveMemoryPersistenceRelayTest {
 
     @Test
     void belowThresholdSimulation_isNotPersisted() {
-        CognitiveIngestionTarget target = mock(CognitiveIngestionTarget.class);
+        RememberPathway target = mock(RememberPathway.class);
         Map<String, float[]> vectors = new HashMap<>();
         vectors.put("0123456789ABC", new float[]{1.0f, 0.0f});
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructivePersistenceDurabilityTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/aisme/relay/ConstructivePersistenceDurabilityTest.java
@@ -12,7 +12,7 @@
  */
 package com.spectrayan.spector.memory.aisme.relay;
 
-import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
@@ -31,12 +31,12 @@ class ConstructivePersistenceDurabilityTest {
 
     @Test
     @DisplayName("MR-01: Persisted synthetic simulation retains FLAG_SIMULATED, arousal, and soulVersion across store operations")
-    void testSyntheticMemoryDurabilityInEpisodicStore() {
+    void testSyntheticMemoryDurabilityInSemanticStore() {
         CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
-        EpisodicRecordMemory episodicStore = new EpisodicRecordMemory(DIMS, 100);
+        SemanticRecordMemory semanticStore = new SemanticRecordMemory(DIMS, 100);
 
         long timestamp = System.currentTimeMillis();
-        byte procFlags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.EPISODIC.ordinal());
+        byte procFlags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.SEMANTIC.ordinal());
         short soulVersion = 3;
         byte arousal = (byte) 180;
         byte valence = (byte) 25;
@@ -50,21 +50,21 @@ class ConstructivePersistenceDurabilityTest {
         );
 
         byte[] vectorBytes = new byte[layout.quantizedVecBytes()];
-        episodicStore.append(syntheticHeader, vectorBytes);
-        long offset = episodicStore.recordOffset(0);
+        semanticStore.append(syntheticHeader, vectorBytes);
+        long offset = semanticStore.recordOffset(0);
 
         // 1. Direct segment read
-        byte cFlags = layout.readConsolidationFlags(episodicStore.segment(), offset);
+        byte cFlags = layout.readConsolidationFlags(semanticStore.segment(), offset);
         assertThat(SynapticHeaderConstants.isSimulated(cFlags)).isTrue();
 
         // 2. Full CognitiveHeader read
-        CognitiveHeader readHeader = layout.readHeader(episodicStore.segment(), offset);
+        CognitiveHeader readHeader = layout.readHeader(semanticStore.segment(), offset);
         assertThat(SynapticHeaderConstants.isSimulated(readHeader.consolidationFlags())).isTrue();
         assertThat(readHeader.arousal()).isEqualTo(arousal); // Must NOT be corrupted to FLAG_SIMULATED (32)
         assertThat(readHeader.valence()).isEqualTo(valence);
         assertThat(readHeader.soulVersion()).isEqualTo(soulVersion);
         assertThat(readHeader.importance()).isEqualTo(importance);
 
-        episodicStore.close();
+        semanticStore.close();
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierStoreKernelIntegrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/TierStoreKernelIntegrationTest.java
@@ -110,10 +110,10 @@ class TierStoreKernelIntegrationTest {
     // ── Episodic Memory ──
 
     @Test
-    @DisplayName("EpisodicRecordMemory has kernel identity with EPISODIC type")
+    @DisplayName("EpisodicLogMemory has kernel identity with EPISODIC type")
     void episodicMemoryStoreHasKernelIdentity() {
-        try (var store = new EpisodicRecordMemory(VEC_BYTES, CAPACITY)) {
-            MemoryId id = store.memoryId();
+        try (var store = EpisodicLogMemory.heap(CAPACITY * 256L)) {
+            MemoryId id = store.id();
             assertThat(id.namespace()).isEqualTo("tier");
             assertThat(id.memoryName()).isEqualTo("episodic");
         }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianCompactionStressTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianCompactionStressTest.java
@@ -13,7 +13,7 @@
 package com.spectrayan.spector.memory.hebbian;
 
 import com.spectrayan.spector.memory.graph.EdgeImportance;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemoryMigrationTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemoryMigrationTest.java
@@ -13,7 +13,7 @@
 package com.spectrayan.spector.memory.hebbian;
 
 import com.spectrayan.spector.memory.error.SpectorGraphPersistenceException;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import com.spectrayan.spector.memory.kernel.MemoryHeader;
 import com.spectrayan.spector.memory.kernel.MemoryId;
 import com.spectrayan.spector.memory.kernel.codec.Codecs;

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hebbian/HebbianGraphMemoryTest.java
@@ -14,7 +14,7 @@ package com.spectrayan.spector.memory.hebbian;
 
 import com.spectrayan.spector.memory.graph.EdgeImportance;
 import com.spectrayan.spector.memory.graph.GraphHealthMetrics;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemonClusteringTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/hippocampus/ReflectDaemonClusteringTest.java
@@ -16,7 +16,7 @@ import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory;
 import com.spectrayan.spector.memory.cortex.EpisodicRecordMemory.EpisodicPartition;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
 import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
@@ -59,7 +59,7 @@ class ReflectDaemonClusteringTest {
     private Path storePath;
     private CentroidRouter centroidRouter;
     private MockEmbeddingProvider embeddingProvider;
-    private CognitiveIngestionTarget mockIngestionTarget;
+    private RememberPathway mockIngestionTarget;
     private AtomicInteger ingestCount;
 
     @BeforeEach
@@ -72,11 +72,11 @@ class ReflectDaemonClusteringTest {
     }
 
     /**
-     * Creates a mock CognitiveIngestionTarget that counts ingest calls
+     * Creates a mock RememberPathway that counts ingest calls
      * and provides a no-op quantizer for vector decode.
      */
-    private CognitiveIngestionTarget createMockIngestionTarget() {
-        CognitiveIngestionTarget target = mock(CognitiveIngestionTarget.class);
+    private RememberPathway createMockIngestionTarget() {
+        RememberPathway target = mock(RememberPathway.class);
 
         // Mock quantizer — decode returns a zero vector (sufficient for test)
         ScalarQuantizer mockQuantizer = mock(ScalarQuantizer.class);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/HypergraphRecallSpikeTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pipeline/HypergraphRecallSpikeTest.java
@@ -22,7 +22,7 @@ import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.sync.WalEvent;
 import com.spectrayan.spector.memory.sync.WalRecoveryDispatcher;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/reflect/relay/EpisodicLogConsolidationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/reflect/relay/EpisodicLogConsolidationRelayTest.java
@@ -97,8 +97,6 @@ class EpisodicLogConsolidationRelayTest {
 
         assertThat(success).isTrue();
         assertThat(signal.logTurnsConsolidated()).isEqualTo(2);
-        assertThat(signal.buildReport().consolidatedCount()).isEqualTo(2);
-
-        verify(rememberPathway, Mockito.times(2)).ingestCognitive(any(), any(), any(), any(), any(), any(), (com.spectrayan.spector.memory.neurodivergent.IngestionHints) any());
+        verify(rememberPathway, Mockito.times(2)).ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any());
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/reflect/relay/ProceduralCrystallizationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/reflect/relay/ProceduralCrystallizationRelayTest.java
@@ -124,8 +124,8 @@ class ProceduralCrystallizationRelayTest {
         PartitionHandle handle = mock(PartitionHandle.class);
         CognitiveMemoryRouter router = mock(CognitiveMemoryRouter.class);
         EpisodicLogMemory logStore = mock(EpisodicLogMemory.class);
-        com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget ingestionTarget =
-                mock(com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget.class);
+        com.spectrayan.spector.memory.RememberPathway ingestionTarget =
+                mock(com.spectrayan.spector.memory.RememberPathway.class);
         when(ingestionTarget.currentSoulVersion()).thenReturn((short) 4);
         EmbeddingProvider embeddingProvider = mock(EmbeddingProvider.class);
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/reflect/relay/ProceduralCrystallizationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/reflect/relay/ProceduralCrystallizationRelayTest.java
@@ -98,14 +98,14 @@ class ProceduralCrystallizationRelayTest {
         assertThat(result).isTrue();
         assertThat(signal.proceduralCrystallizedCount()).isGreaterThan(0);
 
-        verify(rememberPathway).ingestCognitive(
+        verify(rememberPathway).ingestCognitiveWithHeader(
                 anyString(),
                 anyString(),
                 eq(new float[]{0.1f, 0.2f}),
                 eq(MemoryType.PROCEDURAL),
                 eq(new String[]{"procedural", "crystallized", "skill"}),
                 eq(MemorySource.REFLECTED),
-                org.mockito.ArgumentMatchers.nullable(IngestionHints.class)
+                any(com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader.class)
         );
 
         verify(hyperEntityGraph).addHyperedge(
@@ -124,9 +124,9 @@ class ProceduralCrystallizationRelayTest {
         PartitionHandle handle = mock(PartitionHandle.class);
         CognitiveMemoryRouter router = mock(CognitiveMemoryRouter.class);
         EpisodicLogMemory logStore = mock(EpisodicLogMemory.class);
-        com.spectrayan.spector.memory.RememberPathway ingestionTarget =
+        com.spectrayan.spector.memory.RememberPathway rememberPathway =
                 mock(com.spectrayan.spector.memory.RememberPathway.class);
-        when(ingestionTarget.currentSoulVersion()).thenReturn((short) 4);
+        when(rememberPathway.currentSoulVersion()).thenReturn((short) 4);
         EmbeddingProvider embeddingProvider = mock(EmbeddingProvider.class);
 
         when(partitionManager.snapshot()).thenReturn(List.of(handle));
@@ -151,7 +151,7 @@ class ProceduralCrystallizationRelayTest {
 
         ReflectSignal signal = ReflectSignal.builder()
                 .partitionManager(partitionManager)
-                .ingestionTarget(ingestionTarget)
+                .rememberPathway(rememberPathway)
                 .embeddingProvider(embeddingProvider)
                 .build();
 
@@ -160,7 +160,7 @@ class ProceduralCrystallizationRelayTest {
         assertThat(result).isTrue();
         org.mockito.ArgumentCaptor<com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader> captor =
                 org.mockito.ArgumentCaptor.forClass(com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader.class);
-        verify(ingestionTarget).ingestCognitiveWithHeader(
+        verify(rememberPathway).ingestCognitiveWithHeader(
                 anyString(), anyString(), eq(new float[]{0.3f, 0.4f}), eq(MemoryType.PROCEDURAL), any(), eq(MemorySource.REFLECTED), captor.capture()
         );
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/sync/WalRecoveryDispatcherTest.java
@@ -38,7 +38,7 @@ import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.EntityType;
 import com.spectrayan.spector.memory.graph.TypeRegistryMemory;
 import com.spectrayan.spector.memory.hebbian.HebbianGraphMemory;
-import com.spectrayan.spector.memory.hebbian.HebbianGraph.HebbianEdge;
+import com.spectrayan.spector.memory.hebbian.HebbianEdge;
 import com.spectrayan.spector.memory.temporal.TemporalChainMemory;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -35,8 +35,7 @@ import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
 import com.spectrayan.spector.memory.metamemory.MemoryInsight;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
 import com.spectrayan.spector.memory.prospective.Reminder;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -173,7 +172,7 @@ public class MeteredSpectorMemory implements SpectorMemory {
     // ══════════════════════════════════════════════════════════════
 
     @Override
-    public CognitiveIngestionTarget target() { return delegate.target(); }
+    public RememberPathway target() { return delegate.target(); }
 
     // ══════════════════════════════════════════════════════════════
     // CORE API (metered)

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
@@ -37,7 +37,7 @@ import com.spectrayan.spector.memory.model.SalienceProfile;
 import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.model.WhyNotExplanation;
 import com.spectrayan.spector.memory.neurodivergent.IngestionHints;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.prospective.Reminder;
 import com.spectrayan.spector.memory.session.EpisodicSessionIndex;
 import com.spectrayan.spector.memory.temporal.TemporalFact;
@@ -108,7 +108,7 @@ public class ObservedSpectorMemory extends ObservableComponent implements Specto
     // --------------------------------------------------------------
 
     @Override
-    public CognitiveIngestionTarget target() {
+    public RememberPathway target() {
         return delegate.target();
     }
 

--- a/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
+++ b/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
@@ -27,8 +27,7 @@ import com.spectrayan.spector.memory.index.MemoryIndex;
 import com.spectrayan.spector.memory.inhibition.SuppressionSet;
 import com.spectrayan.spector.memory.metamemory.MemoryInsight;
 import com.spectrayan.spector.memory.neurodivergent.LateralEvaluator;
-import com.spectrayan.spector.memory.pipeline.CognitiveIngestionTarget;
-import com.spectrayan.spector.memory.pipeline.RecallPipeline;
+import com.spectrayan.spector.memory.RememberPathway;
 import com.spectrayan.spector.memory.prospective.ProspectiveScheduler;
 import com.spectrayan.spector.memory.prospective.Reminder;
 import com.spectrayan.spector.memory.sync.MemoryWal;
@@ -145,7 +144,7 @@ class MeteredSpectorMemoryTest {
     }
 
     static class DummySpectorMemory implements SpectorMemory {
-        @Override public CognitiveIngestionTarget target() { return null; }
+        @Override public RememberPathway target() { return null; }
         @Override public void remember(String id, String text, MemoryType type, MemorySource source, String... tags) {}
         @Override public void remember(String id, String text, MemoryType type, MemorySource source, com.spectrayan.spector.memory.neurodivergent.IngestionHints hints, String... tags) {}
         @Override public void remember(String id, String text, MemoryType type, String... tags) {}

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryReinforceTool.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/tools/memory/MemoryReinforceTool.java
@@ -53,7 +53,7 @@ public final class MemoryReinforceTool extends MemoryToolHandler {
         byte valence = parseValence(valenceStr);
 
         // Check if this was a lateral result before reinforcing
-        boolean wasLateral = memory.admin().recallPipeline().wasLateral(memoryId);
+        boolean wasLateral = memory.admin().recallPathway().wasLateral(memoryId);
 
         memory.reinforce(memoryId, valence);
 

--- a/synapse/spector-spring/src/main/java/org/springframework/ai/vectorstore/spector/SpectorVectorStore.java
+++ b/synapse/spector-spring/src/main/java/org/springframework/ai/vectorstore/spector/SpectorVectorStore.java
@@ -163,7 +163,7 @@ public class SpectorVectorStore implements VectorStore {
                 .topK(topK)
                 .scoringMode(ScoringMode.SIMILARITY)
                 .build();
-        var recallResults = memory.admin().recallPipeline().recall(queryEmbedding, options);
+        var recallResults = memory.admin().recallPathway().recall(queryEmbedding, options);
         List<Document> results = new ArrayList<>();
         for (var r : recallResults) {
             Map<String, Object> metadata = new HashMap<>();


### PR DESCRIPTION
## Summary
Removes references to deprecated APIs across `spector-memory`, `spector-metrics`, `spector-mcp`, `spector-spring`, and `spector-bench` in accordance with IntelliJ inspection reports and issue #685.

### Key Changes
- **EntityType & RelationType**: Replaced `EntityType.SEED` with `OntologyConfig.canonicalTypes()` and updated Javadocs to reference ontology configs.
- **HebbianGraph**: Extracted `HebbianEdge` and `DecayModulator` to top-level types in `com.spectrayan.spector.memory.hebbian` to decouple callers from inner types in the deprecated `HebbianGraph` class.
- **RecallPathway Migration**: Replaced deprecated `RecallPipeline` references in `DefaultSpectorMemory`, `SpectorMemoryAdmin`, `ReinforcementHandler`, `MemoryReinforceTool`, and `SpectorVectorStore` with `RecallPathway`.
- **RememberPathway Enhancement**: Implemented `IngestionTarget` on `RememberPathway`, added `quantizer()` and `ingestCognitiveWithHeader()` accessors/methods, and migrated all consolidators (`AbstractConsolidator`, `BatchConsolidator`, `EagerConsolidator`) and reflection relays (`ConstructiveMemoryPersistenceRelay`, `ProceduralCrystallizationRelay`) to `RememberPathway`.
- **Factory Wiring**: Streamlined `SpectorMemoryFactory` to instantiate and inject `RememberPathway` and `RecallPathway` directly.

### Verification
- Clean build and test execution across all impacted modules: `spector-memory`, `spector-metrics`, `spector-ingestion`, `spector-mcp`, `spector-cli`, `spector-spring`, `spector-bench`.

Closes #685

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>