### PR TITLE
feat(synapse): multi-namespace foundation types, AccountCatalog SPI, and failure codes (#698)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/StorageLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/StorageLayout.java
@@ -458,6 +458,83 @@ public final class StorageLayout {
         return namespacesDir(basePath).resolve(l1).resolve(l2).resolve(tenantId).resolve(namespaceId);
     }
 
+    // ── Catalog and identity plane resolvers (ADR-0029) ──
+
+    /** Directory name for account catalog entries. */
+    public static final String DIR_ACCOUNTS = "accounts";
+
+    /** Directory name for tenant catalog/identity entries. */
+    public static final String DIR_TENANTS = "tenants";
+
+    /** Filename for account identity bundles. */
+    public static final String FILE_IDENTITY_BUNDLE = "identity.bundle";
+
+    /**
+     * Resolves the catalog directory for an account.
+     *
+     * <p>Sharded by SHA-256 of the accountId, same 2-level scheme
+     * as namespace directories:</p>
+     * <pre>
+     *   basePath/accounts/XX/YY/accountId/
+     * </pre>
+     *
+     * @param basePath  root persistence path
+     * @param accountId the account identifier (TSID from JWT {@code sub})
+     * @return sharded account catalog directory
+     * @throws SpectorValidationException if {@code accountId} is invalid
+     */
+    public static Path accountDir(Path basePath, String accountId) {
+        validateNamespaceId(accountId);
+        String hash = sha256Hex(accountId);
+        String l1 = hash.substring(0, SHARD_HEX_DIGITS);
+        String l2 = hash.substring(SHARD_HEX_DIGITS, SHARD_HEX_DIGITS * SHARD_LEVELS);
+        return basePath.resolve(DIR_ACCOUNTS).resolve(l1).resolve(l2).resolve(accountId);
+    }
+
+    /**
+     * Resolves the identity bundle file for an account.
+     *
+     * <pre>
+     *   basePath/accounts/XX/YY/accountId/identity.bundle
+     * </pre>
+     *
+     * <p>The identity bundle is a small mmap file (1 FD) containing the account's
+     * primary soul, salience profile, and continuity trajectory. It is separate
+     * from any data-plane rememberer.</p>
+     *
+     * @param basePath  root persistence path
+     * @param accountId the account identifier (TSID)
+     * @return path to the account identity bundle file
+     * @throws SpectorValidationException if {@code accountId} is invalid
+     */
+    public static Path accountIdentityBundle(Path basePath, String accountId) {
+        return accountDir(basePath, accountId).resolve(FILE_IDENTITY_BUNDLE);
+    }
+
+    /**
+     * Resolves the identity bundle file for a tenant.
+     *
+     * <pre>
+     *   basePath/tenants/XX/YY/tenantId/identity.bundle
+     * </pre>
+     *
+     * <p>The tenant identity bundle stores the {@code TenantSoul}, compliance
+     * policy floors, and the org-unit directory. It is 1 FD when hot.</p>
+     *
+     * @param basePath root persistence path
+     * @param tenantId the tenant identifier (TSID)
+     * @return path to the tenant identity bundle file
+     * @throws SpectorValidationException if {@code tenantId} is invalid
+     */
+    public static Path tenantIdentityBundle(Path basePath, String tenantId) {
+        validateNamespaceId(tenantId);
+        String hash = sha256Hex(tenantId);
+        String l1 = hash.substring(0, SHARD_HEX_DIGITS);
+        String l2 = hash.substring(SHARD_HEX_DIGITS, SHARD_HEX_DIGITS * SHARD_LEVELS);
+        return basePath.resolve(DIR_TENANTS).resolve(l1).resolve(l2).resolve(tenantId)
+                .resolve(FILE_IDENTITY_BUNDLE);
+    }
+
     /**
      * Computes the hex-encoded SHA-256 hash of the input string.
      *

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/error/ErrorCategory.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/error/ErrorCategory.java
@@ -77,7 +77,10 @@ public enum ErrorCategory {
     CLUSTER     ("Cluster",        700, 709),
 
     /** Internal bugs, invariant violations, and unreachable code paths. */
-    INTERNAL    ("Internal",       900, 909);
+    INTERNAL    ("Internal",       900, 909),
+
+    /** Namespace catalog, identity, and authorization errors. */
+    NAMESPACE   ("Namespace",      800, 809);
 
     private final String displayName;
     private final int rangeStart;

--- a/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/error/ErrorCode.java
+++ b/nucleus/spector-commons/src/main/java/com/spectrayan/spector/commons/error/ErrorCode.java
@@ -526,7 +526,63 @@ public enum ErrorCode {
 
     /** A concurrent execution subtask failed. */
     CONCURRENT_EXECUTION_FAILED(900_004, ErrorCategory.INTERNAL,
-            "Concurrent execution failed: {}");
+            "Concurrent execution failed: {}"),
+
+    // ══════════════════════════════════════════════════════════════════════
+    // NAMESPACE (SPE-800-xxx)
+    // ══════════════════════════════════════════════════════════════════════
+
+    /** The requested namespace does not exist in the catalog. */
+    NAMESPACE_NOT_FOUND           (800_001, ErrorCategory.NAMESPACE,
+            "Namespace not found: {}"),
+
+    /** The principal does not have sufficient access to the namespace. */
+    NAMESPACE_ACCESS_DENIED       (800_002, ErrorCategory.NAMESPACE,
+            "Access denied to namespace '{}' for principal '{}'"),
+
+    /** Namespace-level quota exceeded (maxMemories, maxStorageBytes). */
+    NAMESPACE_QUOTA_EXCEEDED      (800_003, ErrorCategory.NAMESPACE,
+            "Namespace quota exceeded for '{}': {}"),
+
+    /** Account-level quota exceeded (maxNamespaces, maxTotalStorageBytes). */
+    ACCOUNT_QUOTA_EXCEEDED        (800_004, ErrorCategory.NAMESPACE,
+            "Account quota exceeded for '{}': {}"),
+
+    /** Tenant-level quota exceeded. */
+    TENANT_QUOTA_EXCEEDED         (800_005, ErrorCategory.NAMESPACE,
+            "Tenant quota exceeded for '{}': {}"),
+
+    /** Hot namespace cap exhausted — no idle instances to evict. */
+    NAMESPACE_HOT_CAP_EXCEEDED    (800_006, ErrorCategory.NAMESPACE,
+            "Hot namespace cap exceeded for account '{}': max {} mapped instances"),
+
+    /** Operation on a tombstoned namespace. */
+    NAMESPACE_TOMBSTONED          (800_007, ErrorCategory.NAMESPACE,
+            "Namespace '{}' is tombstoned and cannot be accessed"),
+
+    /** Operation blocked by legal hold on the namespace. */
+    NAMESPACE_LEGAL_HOLD          (800_008, ErrorCategory.NAMESPACE,
+            "Namespace '{}' is under legal hold — modification blocked"),
+
+    /** Federated recall attempted on an account without federation enabled. */
+    FEDERATION_DISABLED           (800_009, ErrorCategory.NAMESPACE,
+            "Federation is not enabled for account '{}'"),
+
+    /** Token-locked namespace cannot be widened by client signals. */
+    TOKEN_NAMESPACE_LOCKED        (800_010, ErrorCategory.NAMESPACE,
+            "Token is locked to namespace(s) '{}' — cannot switch to '{}'"),
+
+    /** Attempt to delete or tombstone the default namespace. */
+    DEFAULT_NAMESPACE_PROTECTED   (800_011, ErrorCategory.NAMESPACE,
+            "Default namespace '{}' cannot be deleted — use reset instead"),
+
+    /** Access denied to an identity bundle region. */
+    IDENTITY_REGION_DENIED        (800_012, ErrorCategory.NAMESPACE,
+            "Access denied to identity region '{}' on bundle '{}'"),
+
+    /** Soul stack could not be assembled for the request. */
+    SOUL_STACK_UNAVAILABLE        (800_013, ErrorCategory.NAMESPACE,
+            "Soul stack unavailable for account '{}': {}");
 
     // ══════════════════════════════════════════════════════════════════════
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/Account.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/Account.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.time.Instant;
+
+/**
+ * Catalog representation of an authenticated principal. The account is NOT a namespace — it owns namespaces.
+ * The default namespace has namespaceId equal to accountId.
+ *
+ * @param id the unique account identifier
+ * @param kind the kind of principal (human, agent, service)
+ * @param profile the account profile metadata
+ * @param displayName the human-readable display name
+ * @param quotas the resource and rate quotas assigned to the account
+ * @param flags the feature flags and account-level overrides
+ * @param defaultNamespaceId the identifier of the default namespace owned by this account
+ * @param createdAt the timestamp when the account was created
+ */
+public record Account(
+        String id,
+        PrincipalKind kind,
+        AccountProfile profile,
+        String displayName,
+        AccountQuotas quotas,
+        AccountFlags flags,
+        String defaultNamespaceId,
+        Instant createdAt
+) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service provider interface for the catalog plane. Manages accounts, namespace records,
+ * grants, and access authorization. OSS uses a file-backed implementation (account.json,
+ * slugs.json, grants.jsonl). Enterprise uses a DB-backed implementation. Both share the
+ * same interface and invariants: one OWNER per namespace, slug unique per account, default
+ * namespaceId equals accountId.
+ */
+public interface AccountCatalog {
+
+    /**
+     * Gets an existing account or creates a new one if it does not exist for the given account ID.
+     *
+     * @param accountId the account identifier
+     * @return the existing or newly created account
+     */
+    Account getOrCreateAccount(String accountId);
+
+    /**
+     * Retrieves an account by its account identifier.
+     *
+     * @param accountId the account identifier
+     * @return the account matching the identifier
+     */
+    Account getAccount(String accountId);
+
+    /**
+     * Creates a new namespace record for the given account with the specified slug and type.
+     *
+     * @param accountId the account identifier
+     * @param slug      the human-readable slug for the namespace, unique within the account
+     * @param type      the namespace type
+     * @return the newly created namespace record
+     */
+    NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type);
+
+    /**
+     * Resolves a namespace record by account ID and slug or namespace ID.
+     *
+     * @param accountId the account identifier
+     * @param slugOrId  the namespace slug or namespace identifier
+     * @return an {@link Optional} containing the namespace record if resolved, or empty otherwise
+     */
+    Optional<NamespaceRecord> resolve(String accountId, String slugOrId);
+
+    /**
+     * Lists all accessible namespace records for a given account.
+     *
+     * @param accountId the account identifier
+     * @return a list of accessible namespace records
+     */
+    List<NamespaceRecord> listAccessible(String accountId);
+
+    /**
+     * Sets the default namespace ID for the specified account.
+     *
+     * @param accountId   the account identifier
+     * @param namespaceId the namespace identifier to set as default
+     */
+    void setDefaultNamespace(String accountId, String namespaceId);
+
+    /**
+     * Adds an access grant.
+     *
+     * @param grant the grant to add
+     */
+    void addGrant(Grant grant);
+
+    /**
+     * Revokes a grant by its grant identifier.
+     *
+     * @param grantId the identifier of the grant to revoke
+     */
+    void revokeGrant(String grantId);
+
+    /**
+     * Checks authorization for an account on a namespace requiring at least the minimum grant role.
+     *
+     * @param accountId   the account identifier
+     * @param namespaceId the namespace identifier
+     * @param minimum     the minimum grant role required
+     * @return an {@link Optional} containing the matching {@link Grant} if authorized, or empty otherwise
+     */
+    Optional<Grant> authorize(String accountId, String namespaceId, GrantRole minimum);
+
+    /**
+     * Checks authorization for an account on an identity bundle and region for a specific grant action.
+     *
+     * @param accountId the account identifier
+     * @param bundleId  the identity bundle identifier
+     * @param regionId  the region identifier
+     * @param action    the grant action to check
+     * @return {@code true} if authorized; {@code false} otherwise
+     */
+    boolean authorizeIdentity(String accountId, String bundleId, String regionId, GrantAction action);
+
+    /**
+     * Marks a namespace as tombstoned (soft-deleted) for an account.
+     *
+     * @param accountId   the account identifier
+     * @param namespaceId the namespace identifier to tombstone
+     */
+    void tombstone(String accountId, String namespaceId);
+
+    /**
+     * Records access for the given namespace ID, updating last-accessed timestamps and metrics.
+     *
+     * @param namespaceId the namespace identifier
+     */
+    void recordAccess(String namespaceId);
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountFlags.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountFlags.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.Objects;
+
+/**
+ * Feature flags for an account. Controlled by AccountProfile packaging, not the identity model.
+ *
+ * @param multiNamespace whether the account can create and manage multiple namespaces
+ * @param sharing        whether the account can share namespaces across principals
+ * @param federation     whether the account can participate in cross-instance federation
+ */
+public record AccountFlags(
+        boolean multiNamespace,
+        boolean sharing,
+        boolean federation
+) {
+
+    /**
+     * Resolves default feature flags for a given account packaging profile.
+     *
+     * @param profile the account profile to look up flags for
+     * @return the resolved {@link AccountFlags}
+     * @throws NullPointerException if {@code profile} is null
+     */
+    public static AccountFlags forProfile(AccountProfile profile) {
+        Objects.requireNonNull(profile, "profile must not be null");
+        return switch (profile) {
+            case HUMAN_SOLO -> new AccountFlags(true, false, false);
+            case HUMAN_TEAM -> new AccountFlags(true, true, false);
+            case AGENT      -> new AccountFlags(true, false, false);
+            case SERVICE    -> new AccountFlags(true, true, true);
+            case UNLIMITED  -> new AccountFlags(true, true, true);
+        };
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountProfile.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountProfile.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Packaging profile that assigns default quotas and feature flags to an account.
+ */
+public enum AccountProfile {
+
+    /**
+     * Individual human developer or user profile.
+     */
+    HUMAN_SOLO,
+
+    /**
+     * Collaborative human team profile.
+     */
+    HUMAN_TEAM,
+
+    /**
+     * Dedicated autonomous agent profile.
+     */
+    AGENT,
+
+    /**
+     * Automated service or integration profile.
+     */
+    SERVICE,
+
+    /**
+     * Uncapped profile with unlimited quotas and all feature flags enabled.
+     */
+    UNLIMITED
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountQuotas.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountQuotas.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.Objects;
+
+/**
+ * Quota limits for an account. Profile-based defaults; tenant plans may override. A value of -1 means unlimited.
+ *
+ * @param maxNamespaces         maximum number of total namespaces allowed for the account (-1 for unlimited)
+ * @param maxHotNamespaces      maximum number of concurrently active (hot) namespaces (-1 for unlimited)
+ * @param maxTotalStorageBytes  maximum total storage in bytes allowed across all namespaces (-1 for unlimited)
+ * @param maxTotalMemories      maximum total memories allowed across all namespaces (-1 for unlimited)
+ */
+public record AccountQuotas(
+        int maxNamespaces,
+        int maxHotNamespaces,
+        long maxTotalStorageBytes,
+        long maxTotalMemories
+) {
+
+    /**
+     * Uncapped quota instance with unlimited limits for all dimensions.
+     */
+    public static final AccountQuotas UNLIMITED = new AccountQuotas(-1, -1, -1, -1);
+
+    /**
+     * Resolves default quota limits for a given account packaging profile.
+     *
+     * @param profile the account profile to look up quotas for
+     * @return the resolved {@link AccountQuotas}
+     * @throws NullPointerException if {@code profile} is null
+     */
+    public static AccountQuotas forProfile(AccountProfile profile) {
+        Objects.requireNonNull(profile, "profile must not be null");
+        return switch (profile) {
+            case HUMAN_SOLO -> new AccountQuotas(4, 2, -1, -1);
+            case HUMAN_TEAM -> new AccountQuotas(16, 4, -1, -1);
+            case AGENT      -> new AccountQuotas(64, 4, -1, -1);
+            case SERVICE    -> new AccountQuotas(256, 8, -1, -1);
+            case UNLIMITED  -> new AccountQuotas(-1, -1, -1, -1);
+        };
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/Grant.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/Grant.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.time.Instant;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Authorization grant on a namespace, identity bundle, or identity region. Exactly one OWNER
+ * per namespace. INJECT on IDENTITY_REGION(SOUL) does NOT imply READ on any NAMESPACE traces.
+ * ExpiresAt null means no expiry. Role is used when objectType is NAMESPACE; actions are used
+ * when objectType is IDENTITY_BUNDLE or IDENTITY_REGION.
+ *
+ * @param grantId unique grant identifier
+ * @param objectType type of object being granted access to
+ * @param objectId identifier of the target object
+ * @param principalId identifier of the principal receiving the grant
+ * @param principalType type of principal (account, org unit, etc.)
+ * @param role role-based access level when objectType is NAMESPACE, nullable otherwise
+ * @param actions set of fine-grained actions when objectType is IDENTITY_BUNDLE or IDENTITY_REGION, nullable otherwise
+ * @param grantedBy identifier of the principal that created this grant
+ * @param grantedAt timestamp when the grant was created
+ * @param expiresAt timestamp when the grant expires, or null if it does not expire
+ * @param constraints optional additional constraints restricting this grant, nullable
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record Grant(
+        String grantId,
+        GrantObjectType objectType,
+        String objectId,
+        String principalId,
+        PrincipalType principalType,
+        GrantRole role,
+        Set<GrantAction> actions,
+        String grantedBy,
+        Instant grantedAt,
+        Instant expiresAt,
+        GrantConstraints constraints
+) {
+
+    /**
+     * Checks if this grant is expired based on current time.
+     *
+     * @return {@code true} if an expiry timestamp is set and is before the current instant, {@code false} otherwise
+     */
+    public boolean isExpired() {
+        return expiresAt != null && Instant.now().isAfter(expiresAt);
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantAction.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantAction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Fine-grained actions for identity region and namespace grants. INJECT on a soul region is NOT equivalent to READ on traces.
+ */
+public enum GrantAction {
+
+    /**
+     * Read action allowing inspection or querying of the target object.
+     */
+    READ,
+
+    /**
+     * Write action allowing modifications or appends to the target object.
+     */
+    WRITE,
+
+    /**
+     * Administrative action allowing grant management and policy configuration.
+     */
+    ADMIN,
+
+    /**
+     * Injection action allowing prompt/context injection into agent execution without exposing raw data.
+     */
+    INJECT
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantConstraints.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantConstraints.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Optional constraints on a grant. All fields are nullable. Empty tierMask means all cognitive tiers.
+ * Constraints are intersected with the role — a READER cannot be granted remember.
+ *
+ * @param tierMask set of cognitive tier identifiers allowed by this grant, or null/empty for all tiers
+ * @param tagPrefix prefix filter for tags accessible under this grant, nullable
+ * @param operations set of specific permitted operations, nullable
+ * @param regionIds set of identity region identifiers permitted by this grant, nullable
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GrantConstraints(
+        Set<String> tierMask,
+        String tagPrefix,
+        Set<String> operations,
+        Set<String> regionIds
+) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantObjectType.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantObjectType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Type of object targeted by a grant.
+ */
+public enum GrantObjectType {
+
+    /**
+     * Namespace resource grant target.
+     */
+    NAMESPACE,
+
+    /**
+     * Identity bundle grant target containing cohesive identity configuration and soul states.
+     */
+    IDENTITY_BUNDLE,
+
+    /**
+     * Identity region grant target representing a specific section of an agent soul.
+     */
+    IDENTITY_REGION
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantRole.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/GrantRole.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.Objects;
+
+/**
+ * Role-based grant level for namespace trace access. OWNER &gt; ADMIN &gt; WRITER &gt; READER.
+ */
+public enum GrantRole {
+
+    /**
+     * Full ownership role with permission to manage lifecycle, grants, and data.
+     */
+    OWNER,
+
+    /**
+     * Administrative role with permission to manage grants and data.
+     */
+    ADMIN,
+
+    /**
+     * Write role with permission to read and append trace records.
+     */
+    WRITER,
+
+    /**
+     * Read-only role with permission to view trace records.
+     */
+    READER;
+
+    /**
+     * Checks if this role is at least as privileged as the specified minimum role.
+     *
+     * @param minimum the minimum required role
+     * @return {@code true} if this role is greater than or equal to the minimum role in privilege
+     * @throws NullPointerException if {@code minimum} is null
+     */
+    public boolean isAtLeast(GrantRole minimum) {
+        Objects.requireNonNull(minimum, "minimum role must not be null");
+        return this.ordinal() <= minimum.ordinal();
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/IdentityRegionId.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/IdentityRegionId.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Identity plane region identifiers. These are separate from data-plane RegionId — they live
+ * in identity.bundle files, not runtime.bundle. Region authorization is keyed on this enum,
+ * never on byte offsets.
+ */
+public enum IdentityRegionId {
+
+    /**
+     * Magic, version, and region directory.
+     */
+    HEADER(0),
+
+    /**
+     * UserSoul / AgentSoul / TenantSoul.
+     */
+    SOUL(1),
+
+    /**
+     * SalienceProfile.
+     */
+    SALIENCE(2),
+
+    /**
+     * Identity trajectory.
+     */
+    CONTINUITY(3),
+
+    /**
+     * Compliance floors, domain focus (tenant only).
+     */
+    POLICY(4),
+
+    /**
+     * OrgUnitId to soul offset map (tenant only).
+     */
+    ORG_DIR(5);
+
+    private final int id;
+
+    IdentityRegionId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the integer region identifier.
+     *
+     * @return the numeric identifier for this identity region
+     */
+    public int id() {
+        return id;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceBias.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceBias.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Optional soft domain tilt for a namespace. This is NOT a SoulContext — it adjusts the account
+ * salience profile at bind time via a request-scoped overlay. Empty bias has no effect on scoring.
+ *
+ * @param domainFocus list of domain identifiers to prioritize in scoring
+ * @param tagWeights mapping of tag names to their scoring weight multipliers
+ */
+public record NamespaceBias(
+        List<String> domainFocus,
+        Map<String, Float> tagWeights
+) {
+
+    /**
+     * An empty namespace bias with no domain focus and no tag weights.
+     */
+    public static final NamespaceBias EMPTY = new NamespaceBias(List.of(), Map.of());
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceRecord.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceRecord.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Catalog entry for a namespace (rememberer ρ). The slug is an account-scoped mutable alias.
+ * The namespaceId is a globally unique immutable TSID that names the data-plane directory.
+ * Bias is nullable.
+ *
+ * @param namespaceId globally unique immutable TSID naming the data-plane directory
+ * @param slug account-scoped mutable alias for the namespace
+ * @param ownerAccountId identifier of the owning account
+ * @param type type of namespace
+ * @param status operational status of the namespace
+ * @param displayName human-readable display name
+ * @param description detailed description of the namespace
+ * @param bias optional soft domain tilt for salience scoring, nullable
+ * @param createdAt timestamp when the namespace was created
+ * @param lastAccessedAt timestamp when the namespace was last accessed
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NamespaceRecord(
+        String namespaceId,
+        String slug,
+        String ownerAccountId,
+        NamespaceType type,
+        NamespaceStatus status,
+        String displayName,
+        String description,
+        NamespaceBias bias,
+        Instant createdAt,
+        Instant lastAccessedAt
+) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceStatus.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceStatus.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Lifecycle status of a namespace in the catalog.
+ */
+public enum NamespaceStatus {
+
+    /**
+     * Active namespace available for standard read and write operations.
+     */
+    ACTIVE,
+
+    /**
+     * Tombstoned namespace marked for asynchronous garbage collection and cleanup.
+     */
+    TOMBSTONED,
+
+    /**
+     * Archived namespace preserved in read-only mode.
+     */
+    ARCHIVED,
+
+    /**
+     * Namespace under legal hold preventing modification, archiving, or deletion.
+     */
+    LEGAL_HOLD
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceType.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/NamespaceType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Type of namespace in the catalog.
+ */
+public enum NamespaceType {
+
+    /**
+     * Unique autobiographical namespace, one per account.
+     */
+    DEFAULT,
+
+    /**
+     * Project-scoped isolated context.
+     */
+    PROJECT,
+
+    /**
+     * Agent-specific workspace.
+     */
+    AGENT,
+
+    /**
+     * Shared knowledge base with grant-based access.
+     */
+    SHARED,
+
+    /**
+     * Read-only archived namespace (sets readOnly=true on kernel NamespaceConfig).
+     */
+    ARCHIVE
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/OrgUnit.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/OrgUnit.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.List;
+
+/**
+ * Organizational unit within a tenant. Catalog membership is authoritative — JWT org claims
+ * only narrow, never widen. Each OrgUnit may have an OrgUnitSoul stored in the tenant identity bundle.
+ *
+ * @param orgUnitId unique organizational unit identifier
+ * @param tenantId identifier of the owning tenant
+ * @param name human-readable name of the organizational unit
+ * @param memberAccountIds list of account identifiers belonging to this organizational unit
+ */
+public record OrgUnit(
+        String orgUnitId,
+        String tenantId,
+        String name,
+        List<String> memberAccountIds
+) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/PrincipalKind.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/PrincipalKind.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Kind of principal that authenticates with Spector.
+ */
+public enum PrincipalKind {
+
+    /**
+     * Human user principal.
+     */
+    HUMAN,
+
+    /**
+     * Autonomous agent principal.
+     */
+    AGENT,
+
+    /**
+     * Service or system principal.
+     */
+    SERVICE
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/PrincipalType.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/PrincipalType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+/**
+ * Type of grantee principal. GROUP resolves through tenant group directory (enterprise only).
+ */
+public enum PrincipalType {
+
+    /**
+     * Individual account principal.
+     */
+    ACCOUNT,
+
+    /**
+     * Group principal that resolves through tenant group directory (enterprise only).
+     */
+    GROUP,
+
+    /**
+     * Automated service principal.
+     */
+    SERVICE
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/RequestMemoryContext.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/RequestMemoryContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog;
+
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Per-request binding context assembled during the resolution chain. Contains the authenticated
+ * principal identity, the resolved namespace, the effective grant role, and the token allow-set.
+ * Soul stack assembly happens downstream in the memory layer after catalog resolution.
+ *
+ * @param tenantId    tenant identifier (nullable on OSS)
+ * @param orgUnitIds  list of organizational unit identifiers
+ * @param accountId   account identifier
+ * @param namespaceId resolved namespace identifier
+ * @param slug        namespace slug
+ * @param role        effective grant role
+ * @param allowSet    action allow-set from token (empty implies all granted)
+ * @param sessionId   optional session identifier (nullable; MCP connection ID)
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RequestMemoryContext(
+        String tenantId,
+        List<String> orgUnitIds,
+        String accountId,
+        String namespaceId,
+        String slug,
+        GrantRole role,
+        Set<String> allowSet,
+        String sessionId
+) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/AccountQuotaExceededException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/AccountQuotaExceededException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when an operation exceeds an account-level quota.
+ */
+public class AccountQuotaExceededException extends NamespaceException {
+
+    private final String accountId;
+    private final String detail;
+
+    /**
+     * Creates a new account quota exceeded exception.
+     *
+     * @param accountId the identifier of the account
+     * @param detail    details regarding the exceeded quota
+     */
+    public AccountQuotaExceededException(String accountId, String detail) {
+        super(ErrorCode.ACCOUNT_QUOTA_EXCEEDED, "AccountQuotaExceeded", accountId, detail);
+        this.accountId = accountId;
+        this.detail = detail;
+    }
+
+    /**
+     * Gets the account identifier.
+     *
+     * @return the account ID
+     */
+    public String getAccountId() {
+        return accountId;
+    }
+
+    /**
+     * Gets the quota violation details.
+     *
+     * @return the violation detail message
+     */
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/DefaultNamespaceProtectedException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/DefaultNamespaceProtectedException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when an attempt is made to delete or tombstone the protected default namespace.
+ */
+public class DefaultNamespaceProtectedException extends NamespaceException {
+
+    private final String namespaceId;
+
+    /**
+     * Creates a new default namespace protected exception.
+     *
+     * @param namespaceId the identifier of the default namespace
+     */
+    public DefaultNamespaceProtectedException(String namespaceId) {
+        super(ErrorCode.DEFAULT_NAMESPACE_PROTECTED, "DefaultNamespaceProtected", namespaceId);
+        this.namespaceId = namespaceId;
+    }
+
+    /**
+     * Gets the namespace identifier.
+     *
+     * @return the namespace ID
+     */
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/FederationDisabledException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/FederationDisabledException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when federated recall is attempted on an account that does not have federation enabled.
+ */
+public class FederationDisabledException extends NamespaceException {
+
+    private final String accountId;
+
+    /**
+     * Creates a new federation disabled exception.
+     *
+     * @param accountId the identifier of the account
+     */
+    public FederationDisabledException(String accountId) {
+        super(ErrorCode.FEDERATION_DISABLED, "FederationDisabled", accountId);
+        this.accountId = accountId;
+    }
+
+    /**
+     * Gets the account identifier.
+     *
+     * @return the account ID
+     */
+    public String getAccountId() {
+        return accountId;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/IdentityRegionDeniedException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/IdentityRegionDeniedException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when access is denied to a specific identity bundle region.
+ */
+public class IdentityRegionDeniedException extends NamespaceException {
+
+    private final String regionId;
+    private final String bundleId;
+
+    /**
+     * Creates a new identity region denied exception.
+     *
+     * @param regionId the identifier of the identity region
+     * @param bundleId the identifier of the identity bundle
+     */
+    public IdentityRegionDeniedException(String regionId, String bundleId) {
+        super(ErrorCode.IDENTITY_REGION_DENIED, "IdentityRegionDenied", regionId, bundleId);
+        this.regionId = regionId;
+        this.bundleId = bundleId;
+    }
+
+    /**
+     * Gets the identity region identifier.
+     *
+     * @return the region ID
+     */
+    public String getRegionId() {
+        return regionId;
+    }
+
+    /**
+     * Gets the identity bundle identifier.
+     *
+     * @return the bundle ID
+     */
+    public String getBundleId() {
+        return bundleId;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceAccessDeniedException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceAccessDeniedException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when a principal does not have sufficient access permissions for a namespace.
+ */
+public class NamespaceAccessDeniedException extends NamespaceException {
+
+    private final String namespaceId;
+    private final String principalId;
+
+    /**
+     * Creates a new namespace access denied exception.
+     *
+     * @param namespaceId the identifier of the namespace
+     * @param principalId the identifier of the principal attempting access
+     */
+    public NamespaceAccessDeniedException(String namespaceId, String principalId) {
+        super(ErrorCode.NAMESPACE_ACCESS_DENIED, "NamespaceAccessDenied", namespaceId, principalId);
+        this.namespaceId = namespaceId;
+        this.principalId = principalId;
+    }
+
+    /**
+     * Gets the namespace identifier.
+     *
+     * @return the namespace ID
+     */
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+
+    /**
+     * Gets the principal identifier.
+     *
+     * @return the principal ID
+     */
+    public String getPrincipalId() {
+        return principalId;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.synapse.error.SynapseException;
+
+/**
+ * Base exception for all namespace catalog operations.
+ */
+public abstract class NamespaceException extends SynapseException {
+
+    private final String errorCodeName;
+
+    /**
+     * Creates a new namespace exception.
+     *
+     * @param errorCode     the stable error code identifying this condition
+     * @param errorCodeName the name identifier of the error code
+     * @param args          values to substitute into the template's {@code {}} placeholders
+     */
+    protected NamespaceException(ErrorCode errorCode, String errorCodeName, Object... args) {
+        super(errorCode, args);
+        this.errorCodeName = errorCodeName;
+    }
+
+    /**
+     * Gets the error code name identifier.
+     *
+     * @return the error code name
+     */
+    public String getErrorCodeName() {
+        return errorCodeName;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceHotCapExceededException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceHotCapExceededException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when the number of concurrently active hot namespaces exceeds the configured cap.
+ */
+public class NamespaceHotCapExceededException extends NamespaceException {
+
+    private final String accountId;
+    private final int maxHotNamespaces;
+
+    /**
+     * Creates a new namespace hot cap exceeded exception.
+     *
+     * @param accountId        the identifier of the account
+     * @param maxHotNamespaces the maximum number of hot namespace instances permitted
+     */
+    public NamespaceHotCapExceededException(String accountId, int maxHotNamespaces) {
+        super(ErrorCode.NAMESPACE_HOT_CAP_EXCEEDED, "NamespaceHotCapExceeded", accountId, maxHotNamespaces);
+        this.accountId = accountId;
+        this.maxHotNamespaces = maxHotNamespaces;
+    }
+
+    /**
+     * Gets the account identifier.
+     *
+     * @return the account ID
+     */
+    public String getAccountId() {
+        return accountId;
+    }
+
+    /**
+     * Gets the maximum permitted hot namespaces.
+     *
+     * @return the hot namespace cap
+     */
+    public int getMaxHotNamespaces() {
+        return maxHotNamespaces;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceLegalHoldException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceLegalHoldException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when an operation is blocked due to a legal hold placed on the namespace.
+ */
+public class NamespaceLegalHoldException extends NamespaceException {
+
+    private final String namespaceId;
+
+    /**
+     * Creates a new namespace legal hold exception.
+     *
+     * @param namespaceId the identifier of the namespace under legal hold
+     */
+    public NamespaceLegalHoldException(String namespaceId) {
+        super(ErrorCode.NAMESPACE_LEGAL_HOLD, "NamespaceLegalHold", namespaceId);
+        this.namespaceId = namespaceId;
+    }
+
+    /**
+     * Gets the namespace identifier.
+     *
+     * @return the namespace ID
+     */
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceNotFoundException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceNotFoundException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when a requested namespace does not exist in the catalog.
+ */
+public class NamespaceNotFoundException extends NamespaceException {
+
+    private final String namespaceIdOrSlug;
+
+    /**
+     * Creates a new namespace not found exception.
+     *
+     * @param namespaceIdOrSlug the namespace ID or slug that could not be found
+     */
+    public NamespaceNotFoundException(String namespaceIdOrSlug) {
+        super(ErrorCode.NAMESPACE_NOT_FOUND, "NamespaceNotFound", namespaceIdOrSlug);
+        this.namespaceIdOrSlug = namespaceIdOrSlug;
+    }
+
+    /**
+     * Gets the namespace ID or slug.
+     *
+     * @return the namespace ID or slug
+     */
+    public String getNamespaceIdOrSlug() {
+        return namespaceIdOrSlug;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceQuotaExceededException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceQuotaExceededException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when an operation exceeds a namespace-level quota.
+ */
+public class NamespaceQuotaExceededException extends NamespaceException {
+
+    private final String namespaceId;
+    private final String detail;
+
+    /**
+     * Creates a new namespace quota exceeded exception.
+     *
+     * @param namespaceId the identifier of the namespace
+     * @param detail      details regarding the exceeded quota
+     */
+    public NamespaceQuotaExceededException(String namespaceId, String detail) {
+        super(ErrorCode.NAMESPACE_QUOTA_EXCEEDED, "NamespaceQuotaExceeded", namespaceId, detail);
+        this.namespaceId = namespaceId;
+        this.detail = detail;
+    }
+
+    /**
+     * Gets the namespace identifier.
+     *
+     * @return the namespace ID
+     */
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+
+    /**
+     * Gets the quota violation details.
+     *
+     * @return the violation detail message
+     */
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceTombstonedException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/NamespaceTombstonedException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when an operation is attempted on a tombstoned namespace.
+ */
+public class NamespaceTombstonedException extends NamespaceException {
+
+    private final String namespaceId;
+
+    /**
+     * Creates a new namespace tombstoned exception.
+     *
+     * @param namespaceId the identifier of the tombstoned namespace
+     */
+    public NamespaceTombstonedException(String namespaceId) {
+        super(ErrorCode.NAMESPACE_TOMBSTONED, "NamespaceTombstoned", namespaceId);
+        this.namespaceId = namespaceId;
+    }
+
+    /**
+     * Gets the namespace identifier.
+     *
+     * @return the namespace ID
+     */
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/SoulStackUnavailableException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/SoulStackUnavailableException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when a soul stack cannot be assembled or is unavailable for an account.
+ */
+public class SoulStackUnavailableException extends NamespaceException {
+
+    private final String accountId;
+    private final String reason;
+
+    /**
+     * Creates a new soul stack unavailable exception.
+     *
+     * @param accountId the identifier of the account
+     * @param reason    the reason why the soul stack is unavailable
+     */
+    public SoulStackUnavailableException(String accountId, String reason) {
+        super(ErrorCode.SOUL_STACK_UNAVAILABLE, "SoulStackUnavailable", accountId, reason);
+        this.accountId = accountId;
+        this.reason = reason;
+    }
+
+    /**
+     * Gets the account identifier.
+     *
+     * @return the account ID
+     */
+    public String getAccountId() {
+        return accountId;
+    }
+
+    /**
+     * Gets the reason for unavailability.
+     *
+     * @return the failure reason
+     */
+    public String getReason() {
+        return reason;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TenantQuotaExceededException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TenantQuotaExceededException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when an operation exceeds a tenant-level quota.
+ */
+public class TenantQuotaExceededException extends NamespaceException {
+
+    private final String tenantId;
+    private final String detail;
+
+    /**
+     * Creates a new tenant quota exceeded exception.
+     *
+     * @param tenantId the identifier of the tenant
+     * @param detail   details regarding the exceeded quota
+     */
+    public TenantQuotaExceededException(String tenantId, String detail) {
+        super(ErrorCode.TENANT_QUOTA_EXCEEDED, "TenantQuotaExceeded", tenantId, detail);
+        this.tenantId = tenantId;
+        this.detail = detail;
+    }
+
+    /**
+     * Gets the tenant identifier.
+     *
+     * @return the tenant ID
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the quota violation details.
+     *
+     * @return the violation detail message
+     */
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TokenNamespaceLockedException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TokenNamespaceLockedException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.exception;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+
+/**
+ * Thrown when a token is locked to specific namespaces and a request attempts to switch to an unauthorized namespace.
+ */
+public class TokenNamespaceLockedException extends NamespaceException {
+
+    private final String allowSet;
+    private final String requestedSlug;
+
+    /**
+     * Creates a new token namespace locked exception.
+     *
+     * @param allowSet      the set or pattern of allowed namespaces
+     * @param requestedSlug the requested namespace slug
+     */
+    public TokenNamespaceLockedException(String allowSet, String requestedSlug) {
+        super(ErrorCode.TOKEN_NAMESPACE_LOCKED, "TokenNamespaceLocked", allowSet, requestedSlug);
+        this.allowSet = allowSet;
+        this.requestedSlug = requestedSlug;
+    }
+
+    /**
+     * Gets the allowed namespaces pattern or set.
+     *
+     * @return the allowed namespace set
+     */
+    public String getAllowSet() {
+        return allowSet;
+    }
+
+    /**
+     * Gets the requested namespace slug.
+     *
+     * @return the requested slug
+     */
+    public String getRequestedSlug() {
+        return requestedSlug;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 of the multi-namespace architecture — pure foundation types with zero behavioral changes.

Closes #698

## Changes

### `spector-commons` (nucleus)
- Add `ErrorCategory.NAMESPACE` (SPE-800-xxx)
- Add 13 `ErrorCode` entries covering the full namespace failure vocabulary

### `spector-memory` (memory)
- Add `StorageLayout.accountDir()`, `accountIdentityBundle()`, `tenantIdentityBundle()` — catalog/identity plane path resolvers only
- Data-plane `namespaceDirSharded()` is **unchanged**
- Kernel `NamespaceConfig` is **unchanged**

### `spector-synapse` (synapse)
New package `com.spectrayan.spector.synapse.catalog`:

**Enums (8):** `PrincipalKind`, `AccountProfile`, `NamespaceType`, `NamespaceStatus`, `GrantRole`, `GrantAction`, `GrantObjectType`, `PrincipalType`

**Records (9):** `Account`, `AccountFlags`, `AccountQuotas`, `NamespaceBias`, `NamespaceRecord`, `OrgUnit`, `GrantConstraints`, `Grant`, `RequestMemoryContext`

**SPI (1):** `AccountCatalog` — 12-method interface for account CRUD, namespace resolution, grant management, and access authorization

**Identity (1):** `IdentityRegionId` enum — identity plane region IDs separate from data-plane `RegionId`

**Exceptions (14):** `NamespaceException` base + 13 specific exceptions matching the failure vocabulary

## Key Design Decisions

1. **Three-plane separation**: Catalog (principals, slugs, grants) · Identity (soul stack in mmap bundles) · Data (rememberer ρ)
2. **Kernel unchanged**: `NamespaceConfig` does not gain owner, grants, soul, or account fields
3. **Slug ≠ directory name**: `namespaceId` is a globally unique immutable TSID; slugs are account-scoped aliases
4. **Profile defaults**: `HUMAN_SOLO(4/2)`, `HUMAN_TEAM(16/4)`, `AGENT(64/4)`, `SERVICE(256/8)`
5. **INJECT ≠ READ**: Soul grants and trace grants are separate objects

## Testing

- `mvn compile` — BUILD SUCCESS (all 19 modules)
- `mvn test` — 1635 tests run; 6 pre-existing failures on `main` (unrelated `SpectorPropertyConstants` reflection error), 0 new failures
- Zero behavioral changes — no existing code paths are modified