### PR TITLE
feat(synapse): namespace CRUD REST/MCP APIs and connection switching (#700)

### DIFF
--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_browse.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_browse.json
@@ -1,6 +1,6 @@
 {
   "name": "memory_browse",
-  "description": "Browse memories by tag — no vector search needed. Returns all memories matching the given tags (AND: must contain ALL tags). Useful for auditing ('show me everything tagged payments'), knowledge review ('list architecture decisions'), and bulk operations. Use comma-separated tags for multiple filters.",
+  "description": "Browse memories by tag \u2014 no vector search needed. Returns all memories matching the given tags (AND: must contain ALL tags). Useful for auditing ('show me everything tagged payments'), knowledge review ('list architecture decisions'), and bulk operations. Use comma-separated tags for multiple filters.",
   "category": "MEMORY",
   "scopes": [
     "spector:memory:read"
@@ -14,6 +14,10 @@
       "tags": {
         "type": "string",
         "description": "Comma-separated tags to filter by (AND semantics). Example: 'payments,architecture' returns memories with BOTH tags."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_compute_importance.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_compute_importance.json
@@ -1,6 +1,6 @@
 {
   "name": "memory_compute_importance",
-  "description": "Compute what importance a memory WOULD receive without actually storing it. Use this BEFORE memory_remember to preview novelty, detect duplicates, and understand how your ICNU hints affect the final score. Returns: novelty score (Spector-native), fused importance, nearest existing memory, and profile-specific importance variations. This is read-only — nothing is stored or modified.",
+  "description": "Compute what importance a memory WOULD receive without actually storing it. Use this BEFORE memory_remember to preview novelty, detect duplicates, and understand how your ICNU hints affect the final score. Returns: novelty score (Spector-native), fused importance, nearest existing memory, and profile-specific importance variations. This is read-only \u2014 nothing is stored or modified.",
   "category": "MEMORY",
   "scopes": [
     "spector:memory:read"
@@ -39,6 +39,10 @@
         "type": "number",
         "description": "Emotional intensity: 0 (calm) to 255 (extreme). 0 = neutral.",
         "default": 0
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_context_pack.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_context_pack.json
@@ -37,6 +37,10 @@
         "type": "string",
         "description": "Conflict resolution mode: MULTI_EVIDENCE, HIGHEST_CONFIDENCE, FAIL_CLOSED.",
         "default": "MULTI_EVIDENCE"
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_export.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_export.json
@@ -12,6 +12,10 @@
         "type": "string",
         "description": "Export format: 'json' (default). Future: 'csv', 'markdown'.",
         "default": "json"
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_express.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_express.json
@@ -23,6 +23,10 @@
         "type": "integer",
         "description": "Maximum candidate memories to recall",
         "default": 5
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_fact_history.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_fact_history.json
@@ -19,6 +19,10 @@
         "type": "string",
         "description": "Relationship type or attribute name (e.g. 'works_at', 'role'). Default '*'.",
         "default": "*"
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_forget.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_forget.json
@@ -14,6 +14,10 @@
       "memory_id": {
         "type": "string",
         "description": "The ID of the memory to forget."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_graph_recall.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_graph_recall.json
@@ -51,6 +51,10 @@
         "type": "boolean",
         "description": "Whether to include superseded (retracted) facts in traversal (default: false).",
         "default": false
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_inspect.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_inspect.json
@@ -1,6 +1,6 @@
 {
   "name": "memory_inspect",
-  "description": "Inspect a single memory by ID — returns the full cognitive X-ray: text content, cognitive header (importance, valence, arousal, recall counts, synaptic tags bloom filter, storage strength, flags), vector dimensions, physical location, and flag states (tombstoned, consolidated, pinned, resolved). Use this to debug why a memory scores high or low, verify ingestion, or understand the full internal state of a specific memory.",
+  "description": "Inspect a single memory by ID \u2014 returns the full cognitive X-ray: text content, cognitive header (importance, valence, arousal, recall counts, synaptic tags bloom filter, storage strength, flags), vector dimensions, physical location, and flag states (tombstoned, consolidated, pinned, resolved). Use this to debug why a memory scores high or low, verify ingestion, or understand the full internal state of a specific memory.",
   "category": "MEMORY",
   "scopes": [
     "spector:memory:read"
@@ -14,6 +14,10 @@
       "id": {
         "type": "string",
         "description": "The memory ID to inspect."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_introspect.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_introspect.json
@@ -14,6 +14,10 @@
       "topic": {
         "type": "string",
         "description": "The topic to introspect (e.g., 'kubernetes', 'user preferences')."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_multi_evidence_recall.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_multi_evidence_recall.json
@@ -27,6 +27,10 @@
         "type": "integer",
         "description": "Number of memory evidence items to return (1-20).",
         "default": 5
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_persona_context.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_persona_context.json
@@ -11,6 +11,10 @@
       "userId": {
         "type": "string",
         "description": "Target user ID for persona resolution"
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_reinforce.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_reinforce.json
@@ -19,6 +19,10 @@
       "valence": {
         "type": "string",
         "description": "Outcome: 'strongly_positive' (+100), 'positive' (+50), 'neutral' (0), 'negative' (-50), 'strongly_negative' (-100), or a numeric byte value (-128 to 127)."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_reminder.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_reminder.json
@@ -23,6 +23,10 @@
       "tags": {
         "type": "string",
         "description": "Comma-separated contextual tags."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_resolve.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_resolve.json
@@ -19,6 +19,10 @@
       "resolved": {
         "type": "boolean",
         "description": "true = mark resolved (normal decay), false = mark unresolved (stays top-of-mind)."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_salience.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_salience.json
@@ -1,6 +1,6 @@
 {
   "name": "memory_salience",
-  "description": "Manage the active salience profile — controls what matters to the agent. Operations: 'get' (view current profile), 'set' (replace profile), 'compute_boost' (preview importance boost for text), 'add_interest' (add interest topic), 'add_disinterest' (add dampened topic), 'set_persona' (set personality/identity context). Use this to personalize memory scoring for different users or agents.",
+  "description": "Manage the active salience profile \u2014 controls what matters to the agent. Operations: 'get' (view current profile), 'set' (replace profile), 'compute_boost' (preview importance boost for text), 'add_interest' (add interest topic), 'add_disinterest' (add dampened topic), 'set_persona' (set personality/identity context). Use this to personalize memory scoring for different users or agents.",
   "category": "MEMORY",
   "scopes": [
     "spector:memory:write"
@@ -85,6 +85,10 @@
       "agent_relevance_boost": {
         "type": "string",
         "description": "Agent expertise relevance boost (1.0-1.8). Pre-computed scalar from agent soul expertise matching. Default 1.0 (no effect). Set higher to boost memories matching the agent's domain expertise."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_scratchpad.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_scratchpad.json
@@ -14,6 +14,10 @@
       "text": {
         "type": "string",
         "description": "The scratchpad note to store."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_status.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_status.json
@@ -7,6 +7,11 @@
   ],
   "inputSchema": {
     "type": "object",
-    "properties": {}
+    "properties": {
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
+      }
+    }
   }
 }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_suppress.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_suppress.json
@@ -23,6 +23,10 @@
       "reason": {
         "type": "string",
         "description": "Why this memory is being suppressed (for audit trail)."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-mcp/src/main/resources/mcp/tools/memory_why_not.json
+++ b/synapse/spector-mcp/src/main/resources/mcp/tools/memory_why_not.json
@@ -24,6 +24,10 @@
         "type": "integer",
         "description": "The topK used in the original recall (default 5).",
         "default": 5
+      },
+      "namespace": {
+        "type": "string",
+        "description": "Target memory namespace (slug or ID). Omit to use connection or account default."
       }
     }
   }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceCreateTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceCreateTool.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.api.NamespaceResponse;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for creating a new memory namespace (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceCreateTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceCreateTool.class);
+
+    private final AccountCatalog catalog;
+    private final ObjectMapper objectMapper;
+
+    public NamespaceCreateTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        this.catalog = catalog;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_create";
+    }
+
+    @Override
+    public String description() {
+        return "Creates a new isolated memory namespace for the authenticated account with the given slug. "
+                + "The slug is a human-readable alias (1-63 alphanumeric/hyphen/underscore).";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "slug", Map.of(
+                                "type", "string",
+                                "description", "Unique human-readable alias for the namespace (e.g. 'project-alpha', 'agent-coder')"
+                        ),
+                        "type", Map.of(
+                                "type", "string",
+                                "description", "Namespace type: PROJECT (default), AGENT, SHARED, ARCHIVE",
+                                "enum", List.of("PROJECT", "AGENT", "SHARED", "ARCHIVE")
+                        ),
+                        "displayName", Map.of(
+                                "type", "string",
+                                "description", "Optional human-friendly display name"
+                        ),
+                        "description", Map.of(
+                                "type", "string",
+                                "description", "Optional description of what this namespace holds"
+                        )
+                ),
+                "required", List.of("slug")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
+        String slug = requireString(args, "slug");
+        String typeStr = optionalString(args, "type", "PROJECT");
+        NamespaceType type;
+        try {
+            type = NamespaceType.valueOf(typeStr.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return errorResult("Invalid namespace type: '" + typeStr + "'. Must be PROJECT, AGENT, SHARED, or ARCHIVE.");
+        }
+
+        String displayName = optionalString(args, "displayName", null);
+        String description = optionalString(args, "description", null);
+
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceCreateTool] creating namespace: account={}, slug={}, type={}", accountId, slug, type);
+
+        try {
+            NamespaceRecord created = catalog.createNamespace(accountId, slug, type, displayName, description, null);
+            return textResult("Namespace created successfully:\n"
+                    + objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(NamespaceResponse.from(created)));
+        } catch (IllegalArgumentException e) {
+            return errorResult(e.getMessage());
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceDeleteTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceDeleteTool.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.exception.DefaultNamespaceProtectedException;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for soft-deleting (tombstoning) a memory namespace (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceDeleteTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceDeleteTool.class);
+
+    private final AccountCatalog catalog;
+
+    public NamespaceDeleteTool(AccountCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_delete";
+    }
+
+    @Override
+    public String description() {
+        return "Soft-deletes (tombstones) a memory namespace for the authenticated account. "
+                + "The default namespace cannot be deleted (returns 409 DefaultNamespaceProtected).";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "namespace", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or identifier to delete/tombstone"
+                        )
+                ),
+                "required", List.of("namespace")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
+        String target = requireString(args, "namespace");
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceDeleteTool] deleting namespace: account={}, target={}", accountId, target);
+
+        try {
+            catalog.tombstone(accountId, target);
+            return textResult(String.format("Successfully deleted/tombstoned namespace '%s' for account %s.",
+                    target, accountId));
+        } catch (DefaultNamespaceProtectedException e) {
+            return errorResult("Default namespace cannot be deleted. Use reset instead.");
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceInfoTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceInfoTool.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.api.NamespaceResponse;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for retrieving details of a memory namespace (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceInfoTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceInfoTool.class);
+
+    private final AccountCatalog catalog;
+    private final ObjectMapper objectMapper;
+
+    public NamespaceInfoTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        this.catalog = catalog;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_info";
+    }
+
+    @Override
+    public String description() {
+        return "Retrieves metadata and status details for a specified memory namespace (slug or ID).";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return false;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "namespace", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or identifier to inspect"
+                        )
+                ),
+                "required", List.of("namespace")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
+        String target = requireString(args, "namespace");
+        String accountId = SecurityUtils.getUserId();
+        log.debug("[NamespaceInfoTool] inspect namespace: account={}, target={}", accountId, target);
+
+        Optional<NamespaceRecord> record = catalog.resolve(accountId, target);
+        if (record.isEmpty()) {
+            return errorResult("Namespace not found: '" + target + "' for account " + accountId);
+        }
+
+        return textResult(objectMapper.writerWithDefaultPrettyPrinter()
+                .writeValueAsString(NamespaceResponse.from(record.get())));
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListTool.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.api.NamespaceResponse;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for listing all accessible memory namespaces (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceListTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceListTool.class);
+
+    private final AccountCatalog catalog;
+    private final ObjectMapper objectMapper;
+
+    public NamespaceListTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        this.catalog = catalog;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_list";
+    }
+
+    @Override
+    public String description() {
+        return "Lists all accessible memory namespaces for the authenticated account (owned and granted). "
+                + "Returns slugs, IDs, types, and descriptions.";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return false;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of()
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
+        String accountId = SecurityUtils.getUserId();
+        log.debug("[NamespaceListTool] listing namespaces for account={}", accountId);
+        List<NamespaceRecord> records = catalog.listAccessible(accountId);
+        List<NamespaceResponse> responses = records.stream().map(NamespaceResponse::from).toList();
+        return textResult(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(responses));
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSetDefaultTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSetDefaultTool.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for persisting an account's default namespace (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceSetDefaultTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceSetDefaultTool.class);
+
+    private final AccountCatalog catalog;
+
+    public NamespaceSetDefaultTool(AccountCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_set_default";
+    }
+
+    @Override
+    public String description() {
+        return "Persistently sets the default namespace for the authenticated account in the catalog. "
+                + "Durable across restarts and new sessions.";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "namespace", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or identifier to set as the durable account default"
+                        )
+                ),
+                "required", List.of("namespace")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
+        String target = requireString(args, "namespace");
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceSetDefaultTool] set default namespace: account={}, target={}", accountId, target);
+
+        Optional<NamespaceRecord> record = catalog.resolve(accountId, target);
+        if (record.isEmpty()) {
+            return errorResult("Namespace not found: '" + target + "' for account " + accountId);
+        }
+
+        NamespaceRecord ns = record.get();
+        catalog.setDefaultNamespace(accountId, ns.namespaceId());
+
+        return textResult(String.format(
+                "Successfully set default namespace to '%s' (ID: %s) for account %s.",
+                ns.slug(), ns.namespaceId(), accountId
+        ));
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSwitchTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSwitchTool.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.mcp.McpSessionContext;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for setting a connection-scoped default namespace (ADR-0029 §6.2, §8.2).
+ *
+ * <p>The switch applies to subsequent tool invocations on the active connection.
+ * It is non-durable and does not persist across restarts or new connections
+ * unless {@code namespace_set_default} is called.</p>
+ */
+@Component
+public class NamespaceSwitchTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceSwitchTool.class);
+
+    private final AccountCatalog catalog;
+
+    public NamespaceSwitchTool(AccountCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_switch";
+    }
+
+    @Override
+    public String description() {
+        return "Sets the connection-scoped active default namespace for subsequent memory tool invocations "
+                + "(remember, recall, forget, etc.) in the current session. Non-durable.";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return false;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "namespace", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or identifier to switch to as connection default"
+                        )
+                ),
+                "required", List.of("namespace")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
+        String target = requireString(args, "namespace");
+        if ("*".equals(target.trim())) {
+            return errorResult("Wildcard namespace '*' cannot be set as connection default.");
+        }
+
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceSwitchTool] switching session namespace: account={}, target={}", accountId, target);
+
+        Optional<NamespaceRecord> record = catalog.resolve(accountId, target);
+        if (record.isEmpty()) {
+            return errorResult("Namespace not found: '" + target + "' for account " + accountId);
+        }
+
+        NamespaceRecord ns = record.get();
+        if (ns.status() == NamespaceStatus.TOMBSTONED) {
+            return errorResult("Cannot switch to tombstoned namespace: '" + target + "' (id: " + ns.namespaceId() + ")");
+        }
+
+        // Set on connection / thread session context
+        McpSessionContext.setSessionDefault(null, ns.namespaceId());
+
+        return textResult(String.format(
+                "Switched active connection namespace to '%s' (ID: %s, type: %s). "
+                + "Subsequent memory operations without an explicit namespace argument will target this namespace.",
+                ns.slug(), ns.namespaceId(), ns.type()
+        ));
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
@@ -48,7 +48,23 @@ public interface AccountCatalog {
      * @param type      the namespace type
      * @return the newly created namespace record
      */
-    NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type);
+    default NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type) {
+        return createNamespace(accountId, slug, type, null, null, null);
+    }
+
+    /**
+     * Creates a new namespace record for the given account with full initial metadata.
+     *
+     * @param accountId   the account identifier
+     * @param slug        the human-readable slug for the namespace, unique within the account
+     * @param type        the namespace type
+     * @param displayName human-readable display name, or null
+     * @param description human-readable description, or null
+     * @param bias        domain bias overlay, or null
+     * @return the newly created namespace record
+     */
+    NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type,
+            String displayName, String description, NamespaceBias bias);
 
     /**
      * Resolves a namespace record by account ID and slug or namespace ID.
@@ -109,6 +125,29 @@ public interface AccountCatalog {
      * @return {@code true} if authorized; {@code false} otherwise
      */
     boolean authorizeIdentity(String accountId, String bundleId, String regionId, GrantAction action);
+
+    /**
+     * Updates an existing namespace record's mutable metadata (display name, description, type, bias).
+     *
+     * @param accountId   the account identifier
+     * @param slugOrId    the namespace slug or namespace identifier
+     * @param displayName the new display name, or null to keep/clear
+     * @param description the new description, or null to keep/clear
+     * @param type        the new namespace type, or null to keep existing
+     * @param bias        the new namespace bias, or null to keep/clear
+     * @return the updated namespace record
+     */
+    NamespaceRecord updateNamespace(String accountId, String slugOrId,
+            String displayName, String description, NamespaceType type, NamespaceBias bias);
+
+    /**
+     * Resets a namespace by clearing its memory state while preserving catalog registration.
+     * Allowed on default and non-default namespaces.
+     *
+     * @param accountId the account identifier
+     * @param slugOrId  the namespace slug or namespace identifier
+     */
+    void resetNamespace(String accountId, String slugOrId);
 
     /**
      * Marks a namespace as tombstoned (soft-deleted) for an account.

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/Grant.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/Grant.java
@@ -15,6 +15,8 @@ package com.spectrayan.spector.synapse.catalog;
 import java.time.Instant;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -36,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * @param constraints optional additional constraints restricting this grant, nullable
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record Grant(
         String grantId,
         GrantObjectType objectType,
@@ -55,6 +58,7 @@ public record Grant(
      *
      * @return {@code true} if an expiry timestamp is set and is before the current instant, {@code false} otherwise
      */
+    @JsonIgnore
     public boolean isExpired() {
         return expiresAt != null && Instant.now().isAfter(expiresAt);
     }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/AccountDefaultController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/AccountDefaultController.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+/**
+ * REST controller for account-level default namespace configuration (ADR-0029 §8.1).
+ */
+@RestController
+@RequestMapping(value = "/api/v1/account", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AccountDefaultController {
+
+    private static final Logger log = LoggerFactory.getLogger(AccountDefaultController.class);
+
+    private final AccountCatalog catalog;
+
+    public AccountDefaultController(AccountCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    /**
+     * Persists a new default namespace for the authenticated account.
+     */
+    @PutMapping(value = "/default-namespace", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, String>> setDefaultNamespace(
+            @RequestBody SetDefaultNamespaceRequest request) {
+        if (request.namespace() == null || request.namespace().isBlank()) {
+            throw new IllegalArgumentException("Namespace identifier or slug must not be blank");
+        }
+
+        String accountId = SecurityUtils.getUserId();
+        String slugOrId = request.namespace().trim();
+        log.info("[AccountDefaultController] setDefaultNamespace: account={}, target={}", accountId, slugOrId);
+
+        NamespaceRecord record = catalog.resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        catalog.setDefaultNamespace(accountId, record.namespaceId());
+        return ResponseEntity.ok(Map.of(
+                "status", "updated",
+                "accountId", accountId,
+                "defaultNamespaceId", record.namespaceId(),
+                "slug", record.slug()
+        ));
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/CreateNamespaceRequest.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/CreateNamespaceRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.spectrayan.spector.synapse.catalog.NamespaceBias;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+
+/**
+ * Request payload for creating a new namespace (ADR-0029 §8.1).
+ * The caller supplies the {@code slug}; the system allocates the immutable TSID {@code namespaceId}.
+ *
+ * @param slug        human-readable slug, unique per account (1-63 alphanumeric/hyphen/underscore)
+ * @param type        namespace type (default: PROJECT)
+ * @param displayName optional human-readable display name
+ * @param description optional human-readable description
+ * @param bias        optional namespace domain bias overlay
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CreateNamespaceRequest(
+        String slug,
+        NamespaceType type,
+        String displayName,
+        String description,
+        NamespaceBias bias) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/NamespaceController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/NamespaceController.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+/**
+ * REST controller for catalog-plane namespace lifecycle management (ADR-0029 §8.1).
+ *
+ * <p>All endpoints operate on the catalog metadata layer without mapping or locking
+ * data-plane memory bundles.</p>
+ */
+@RestController
+@RequestMapping(value = "/api/v1/namespaces", produces = MediaType.APPLICATION_JSON_VALUE)
+public class NamespaceController {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceController.class);
+
+    private final AccountCatalog catalog;
+
+    public NamespaceController(AccountCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    /**
+     * Lists all accessible namespaces for the authenticated account (owned + granted).
+     */
+    @GetMapping
+    public ResponseEntity<List<NamespaceResponse>> listNamespaces() {
+        String accountId = SecurityUtils.getUserId();
+        log.debug("[NamespaceController] listNamespaces for account={}", accountId);
+        List<NamespaceResponse> responses = catalog.listAccessible(accountId).stream()
+                .map(NamespaceResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * Creates a new namespace for the authenticated account.
+     */
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<NamespaceResponse> createNamespace(@RequestBody CreateNamespaceRequest request) {
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceController] createNamespace: account={}, slug={}, type={}",
+                accountId, request.slug(), request.type());
+
+        NamespaceType type = request.type() != null ? request.type() : NamespaceType.PROJECT;
+        NamespaceRecord created = catalog.createNamespace(
+                accountId,
+                request.slug(),
+                type,
+                request.displayName(),
+                request.description(),
+                request.bias()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(NamespaceResponse.from(created));
+    }
+
+    /**
+     * Retrieves namespace details by slug or namespaceId.
+     */
+    @GetMapping("/{slugOrId}")
+    public ResponseEntity<NamespaceResponse> getNamespace(@PathVariable String slugOrId) {
+        String accountId = SecurityUtils.getUserId();
+        log.debug("[NamespaceController] getNamespace: account={}, slugOrId={}", accountId, slugOrId);
+        NamespaceRecord record = catalog.resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+        return ResponseEntity.ok(NamespaceResponse.from(record));
+    }
+
+    /**
+     * Updates mutable metadata of an existing namespace.
+     */
+    @PutMapping(value = "/{slugOrId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<NamespaceResponse> updateNamespace(
+            @PathVariable String slugOrId,
+            @RequestBody UpdateNamespaceRequest request) {
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceController] updateNamespace: account={}, slugOrId={}", accountId, slugOrId);
+        NamespaceRecord updated = catalog.updateNamespace(
+                accountId,
+                slugOrId,
+                request.displayName(),
+                request.description(),
+                request.type(),
+                request.bias()
+        );
+        return ResponseEntity.ok(NamespaceResponse.from(updated));
+    }
+
+    /**
+     * Soft-deletes (tombstones) a namespace. The default namespace cannot be deleted.
+     */
+    @DeleteMapping("/{slugOrId}")
+    public ResponseEntity<Void> deleteNamespace(@PathVariable String slugOrId) {
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceController] deleteNamespace: account={}, slugOrId={}", accountId, slugOrId);
+        catalog.tombstone(accountId, slugOrId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Resets a namespace by purging its memory state while keeping catalog registration.
+     */
+    @PostMapping("/{slugOrId}/reset")
+    public ResponseEntity<Map<String, String>> resetNamespace(@PathVariable String slugOrId) {
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceController] resetNamespace: account={}, slugOrId={}", accountId, slugOrId);
+        catalog.resetNamespace(accountId, slugOrId);
+        return ResponseEntity.ok(Map.of("status", "reset", "namespace", slugOrId));
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/NamespaceResponse.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/NamespaceResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.spectrayan.spector.synapse.catalog.NamespaceBias;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+
+/**
+ * Standard REST representation of a catalog namespace record (ADR-0029 §8.1).
+ *
+ * @param namespaceId    globally unique immutable TSID
+ * @param slug           account-scoped alias
+ * @param ownerAccountId owning account TSID
+ * @param type           namespace type
+ * @param status         lifecycle status
+ * @param displayName    human-readable display name
+ * @param description    human-readable description
+ * @param bias           domain bias overlay
+ * @param createdAt      creation timestamp
+ * @param lastAccessedAt last access timestamp
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NamespaceResponse(
+        String namespaceId,
+        String slug,
+        String ownerAccountId,
+        NamespaceType type,
+        NamespaceStatus status,
+        String displayName,
+        String description,
+        NamespaceBias bias,
+        Instant createdAt,
+        Instant lastAccessedAt) {
+
+    public static NamespaceResponse from(NamespaceRecord record) {
+        return new NamespaceResponse(
+                record.namespaceId(),
+                record.slug(),
+                record.ownerAccountId(),
+                record.type(),
+                record.status(),
+                record.displayName(),
+                record.description(),
+                record.bias(),
+                record.createdAt(),
+                record.lastAccessedAt()
+        );
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/SetDefaultNamespaceRequest.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/SetDefaultNamespaceRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Request payload for persisting an account's default namespace (ADR-0029 §8.1).
+ *
+ * @param namespace namespace slug or namespaceId
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SetDefaultNamespaceRequest(
+        String namespace) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/UpdateNamespaceRequest.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/UpdateNamespaceRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.spectrayan.spector.synapse.catalog.NamespaceBias;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+
+/**
+ * Request payload for updating namespace mutable metadata (ADR-0029 §8.1).
+ *
+ * @param displayName new display name, or null to keep current
+ * @param description new description, or null to keep current
+ * @param type        new namespace type, or null to keep current
+ * @param bias        new namespace bias overlay, or null to keep current
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UpdateNamespaceRequest(
+        String displayName,
+        String description,
+        NamespaceType type,
+        NamespaceBias bias) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/CatalogSnapshot.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/CatalogSnapshot.java
@@ -27,18 +27,21 @@ import java.util.Set;
  * Cached with mtime invalidation.
  *
  * @param account           the account
- * @param slugToNamespaceId immutable map from slugs.json
+ * @param slugToNamespaceId immutable map from slugs.json (slug → namespaceId)
+ * @param namespaces        immutable map from namespaces.json (namespaceId → NamespaceRecord)
  * @param liveGrants        parsed from grants.jsonl, only live/non-expired
  * @param mtimeNanos        file modification time for invalidation
  */
 public record CatalogSnapshot(
         Account account,
         Map<String, String> slugToNamespaceId,
+        Map<String, NamespaceRecord> namespaces,
         List<Grant> liveGrants,
         long mtimeNanos) {
 
     public CatalogSnapshot {
         slugToNamespaceId = Map.copyOf(slugToNamespaceId);
+        namespaces = namespaces != null ? Map.copyOf(namespaces) : Map.of();
         liveGrants = List.copyOf(liveGrants);
     }
 
@@ -52,10 +55,45 @@ public record CatalogSnapshot(
         if (slugToNamespaceId.containsKey(slugOrId)) {
             return Optional.of(slugToNamespaceId.get(slugOrId));
         }
-        if (slugToNamespaceId.containsValue(slugOrId)) {
+        if (slugToNamespaceId.containsValue(slugOrId) || namespaces.containsKey(slugOrId)) {
             return Optional.of(slugOrId);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Resolves a slug or namespace ID directly to its {@link NamespaceRecord}.
+     *
+     * @param slugOrId the slug or namespace ID
+     * @return the namespace record if resolved, or empty otherwise
+     */
+    public Optional<NamespaceRecord> resolveNamespace(String slugOrId) {
+        Optional<String> resolvedId = resolveSlug(slugOrId);
+        if (resolvedId.isEmpty()) {
+            return Optional.empty();
+        }
+        String id = resolvedId.get();
+        if (namespaces.containsKey(id)) {
+            return Optional.of(namespaces.get(id));
+        }
+        // Fallback for legacy directories / missing namespaces.json
+        String slug = slugToNamespaceId.entrySet().stream()
+                .filter(e -> e.getValue().equals(id))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(slugOrId);
+        return Optional.of(new NamespaceRecord(
+                id,
+                slug,
+                account.id(),
+                id.equals(account.defaultNamespaceId()) ? NamespaceType.DEFAULT : NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE,
+                null,
+                null,
+                null,
+                Instant.now(),
+                Instant.now()
+        ));
     }
 
     /**
@@ -100,7 +138,7 @@ public record CatalogSnapshot(
      * @return list of accessible namespace records
      */
     public List<NamespaceRecord> accessibleNamespaces(String accountId) {
-        List<NamespaceRecord> namespaces = new ArrayList<>();
+        List<NamespaceRecord> result = new ArrayList<>();
         Set<String> accessibleIds = new HashSet<>();
 
         if (accountId.equals(account.id()) && account.defaultNamespaceId() != null) {
@@ -114,22 +152,30 @@ public record CatalogSnapshot(
         }
 
         for (Map.Entry<String, String> entry : slugToNamespaceId.entrySet()) {
-            if (accessibleIds.contains(entry.getValue())) {
-                namespaces.add(new NamespaceRecord(
-                        entry.getValue(),
-                        entry.getKey(),
-                        account.id(),
-                        NamespaceType.DEFAULT,
-                        NamespaceStatus.ACTIVE,
-                        null,   // displayName
-                        null,   // description
-                        null,   // bias
-                        Instant.now(),
-                        Instant.now()
-                ));
+            String nsId = entry.getValue();
+            if (accessibleIds.contains(nsId)) {
+                if (namespaces.containsKey(nsId)) {
+                    NamespaceRecord record = namespaces.get(nsId);
+                    if (record.status() != NamespaceStatus.TOMBSTONED) {
+                        result.add(record);
+                    }
+                } else {
+                    result.add(new NamespaceRecord(
+                            nsId,
+                            entry.getKey(),
+                            account.id(),
+                            nsId.equals(account.defaultNamespaceId()) ? NamespaceType.DEFAULT : NamespaceType.PROJECT,
+                            NamespaceStatus.ACTIVE,
+                            null,   // displayName
+                            null,   // description
+                            null,   // bias
+                            Instant.now(),
+                            Instant.now()
+                    ));
+                }
             }
         }
 
-        return namespaces;
+        return result;
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
@@ -52,8 +52,12 @@ public class FileAccountCatalog implements AccountCatalog {
 
     private static final String FILE_ACCOUNT = "account.json";
     private static final String FILE_SLUGS = "slugs.json";
+    private static final String FILE_NAMESPACES = "namespaces.json";
     private static final String FILE_GRANTS = "grants.jsonl";
     private static final String FILE_LOCK = "LOCK";
+
+    private static final java.util.regex.Pattern SLUG_PATTERN =
+            java.util.regex.Pattern.compile("^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$");
 
     private final Path basePath;
     private final ObjectMapper objectMapper;
@@ -94,10 +98,17 @@ public class FileAccountCatalog implements AccountCatalog {
                         new TypeReference<Map<String, String>>() {});
             }
 
+            Path namespacesFile = accountDir.resolve(FILE_NAMESPACES);
+            Map<String, NamespaceRecord> namespaces = new HashMap<>();
+            if (Files.exists(namespacesFile)) {
+                namespaces = objectMapper.readValue(namespacesFile.toFile(),
+                        new TypeReference<Map<String, NamespaceRecord>>() {});
+            }
+
             Path grantsFile = accountDir.resolve(FILE_GRANTS);
             List<Grant> grants = GrantLog.parseGrants(grantsFile, objectMapper);
 
-            CatalogSnapshot snapshot = new CatalogSnapshot(account, slugs, grants, mtime);
+            CatalogSnapshot snapshot = new CatalogSnapshot(account, slugs, namespaces, grants, mtime);
             snapshotCache.put(accountId, snapshot);
             return snapshot;
         } catch (IOException e) {
@@ -161,6 +172,15 @@ public class FileAccountCatalog implements AccountCatalog {
                 Map<String, String> slugs = Map.of("default", accountId);
                 atomicWrite(accountDir.resolve(FILE_SLUGS), slugs);
 
+                // Write initial default namespace record
+                Instant now = Instant.now();
+                NamespaceRecord defaultNamespace = new NamespaceRecord(
+                        accountId, "default", accountId, NamespaceType.DEFAULT,
+                        NamespaceStatus.ACTIVE, null, null, null, now, now
+                );
+                Map<String, NamespaceRecord> namespaces = Map.of(accountId, defaultNamespace);
+                atomicWrite(accountDir.resolve(FILE_NAMESPACES), namespaces);
+
                 // Write implicit OWNER grant
                 Grant implicitOwner = new Grant(
                         accountId + "-owner-default",
@@ -171,7 +191,7 @@ public class FileAccountCatalog implements AccountCatalog {
                         GrantRole.OWNER,
                         Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
                         accountId,           // grantedBy
-                        Instant.now(),
+                        now,
                         null,                // expiresAt
                         null                 // constraints
                 );
@@ -190,7 +210,6 @@ public class FileAccountCatalog implements AccountCatalog {
 
     @Override
     public Account getAccount(String accountId) {
-        // Phase 1: getAccount delegates to getOrCreateAccount for lazy migration
         return getOrCreateAccount(accountId);
     }
 
@@ -202,32 +221,7 @@ public class FileAccountCatalog implements AccountCatalog {
         } catch (NamespaceNotFoundException e) {
             return Optional.empty();
         }
-
-        Optional<String> resolvedId = snapshot.resolveSlug(slugOrId);
-        if (resolvedId.isEmpty()) {
-            return Optional.empty();
-        }
-
-        String namespaceId = resolvedId.get();
-        // Find the slug for this namespaceId
-        String slug = snapshot.slugToNamespaceId().entrySet().stream()
-                .filter(e -> e.getValue().equals(namespaceId))
-                .map(Map.Entry::getKey)
-                .findFirst()
-                .orElse(slugOrId);
-
-        return Optional.of(new NamespaceRecord(
-                namespaceId,
-                slug,
-                accountId,
-                NamespaceType.DEFAULT,
-                NamespaceStatus.ACTIVE,
-                null,    // displayName
-                null,    // description
-                null,    // bias
-                Instant.now(),
-                Instant.now()
-        ));
+        return snapshot.resolveNamespace(slugOrId);
     }
 
     @Override
@@ -242,7 +236,13 @@ public class FileAccountCatalog implements AccountCatalog {
     }
 
     @Override
-    public NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type) {
+    public NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type,
+            String displayName, String description, NamespaceBias bias) {
+        if (slug == null || !SLUG_PATTERN.matcher(slug).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid namespace slug: '" + slug + "'. Must be 1-63 alphanumeric/underscore/hyphen characters matching " + SLUG_PATTERN.pattern());
+        }
+
         ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
         jvmLock.lock();
         try {
@@ -264,12 +264,35 @@ public class FileAccountCatalog implements AccountCatalog {
                     throw new IllegalArgumentException("Slug already exists: " + slug);
                 }
 
+                Path namespacesFile = accountDir.resolve(FILE_NAMESPACES);
+                Map<String, NamespaceRecord> namespaces = new HashMap<>();
+                if (Files.exists(namespacesFile)) {
+                    namespaces = new HashMap<>(objectMapper.readValue(namespacesFile.toFile(),
+                            new TypeReference<Map<String, NamespaceRecord>>() {}));
+                }
+
                 // Allocate new namespaceId (UUID-based TSID-like 13-char id)
                 String newNamespaceId = UUID.randomUUID().toString()
                         .replace("-", "").substring(0, 13);
 
                 slugs.put(slug, newNamespaceId);
                 atomicWrite(slugsFile, slugs);
+
+                Instant now = Instant.now();
+                NamespaceRecord newRecord = new NamespaceRecord(
+                        newNamespaceId,
+                        slug,
+                        accountId,
+                        type != null ? type : NamespaceType.PROJECT,
+                        NamespaceStatus.ACTIVE,
+                        displayName,
+                        description,
+                        bias,
+                        now,
+                        now
+                );
+                namespaces.put(newNamespaceId, newRecord);
+                atomicWrite(namespacesFile, namespaces);
 
                 // Create data-plane directory
                 Path namespaceDir = StorageLayout.namespaceDirSharded(basePath, newNamespaceId);
@@ -285,7 +308,7 @@ public class FileAccountCatalog implements AccountCatalog {
                         GrantRole.OWNER,
                         Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
                         accountId,
-                        Instant.now(),
+                        now,
                         null,
                         null
                 );
@@ -294,18 +317,136 @@ public class FileAccountCatalog implements AccountCatalog {
                 // Invalidate snapshot cache
                 snapshotCache.remove(accountId);
 
-                Instant now = Instant.now();
                 log.info("[FileAccountCatalog] created namespace: {} (slug={}) for account {}",
                         newNamespaceId, slug, accountId);
-                return new NamespaceRecord(
-                        newNamespaceId, slug, accountId, type, NamespaceStatus.ACTIVE,
-                        null, null, null, now, now
-                );
+                return newRecord;
             }
         } catch (IOException e) {
             log.error("[FileAccountCatalog] failed to create namespace {} for account {}",
                     slug, accountId, e);
             throw new RuntimeException("Failed to create namespace", e);
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    @Override
+    public NamespaceRecord updateNamespace(String accountId, String slugOrId,
+            String displayName, String description, NamespaceType type, NamespaceBias bias) {
+        ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
+        jvmLock.lock();
+        try {
+            Path accountDir = StorageLayout.accountDir(basePath, accountId);
+            Path lockFile = accountDir.resolve(FILE_LOCK);
+
+            try (FileChannel channel = FileChannel.open(lockFile,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock fileLock = channel.lock()) {
+
+                Path slugsFile = accountDir.resolve(FILE_SLUGS);
+                Map<String, String> slugs = new HashMap<>();
+                if (Files.exists(slugsFile)) {
+                    slugs = objectMapper.readValue(slugsFile.toFile(),
+                            new TypeReference<Map<String, String>>() {});
+                }
+
+                String namespaceId = slugs.get(slugOrId);
+                if (namespaceId == null) {
+                    if (slugs.containsValue(slugOrId)) {
+                        namespaceId = slugOrId;
+                    } else {
+                        throw new NamespaceNotFoundException(slugOrId);
+                    }
+                }
+
+                Path namespacesFile = accountDir.resolve(FILE_NAMESPACES);
+                Map<String, NamespaceRecord> namespaces = new HashMap<>();
+                if (Files.exists(namespacesFile)) {
+                    namespaces = new HashMap<>(objectMapper.readValue(namespacesFile.toFile(),
+                            new TypeReference<Map<String, NamespaceRecord>>() {}));
+                }
+
+                NamespaceRecord existing = namespaces.get(namespaceId);
+                String slug = existing != null ? existing.slug() : slugOrId;
+                Instant createdAt = existing != null ? existing.createdAt() : Instant.now();
+                NamespaceType currentType = type != null ? type : (existing != null ? existing.type() : NamespaceType.PROJECT);
+
+                NamespaceRecord updated = new NamespaceRecord(
+                        namespaceId,
+                        slug,
+                        accountId,
+                        currentType,
+                        existing != null ? existing.status() : NamespaceStatus.ACTIVE,
+                        displayName != null ? displayName : (existing != null ? existing.displayName() : null),
+                        description != null ? description : (existing != null ? existing.description() : null),
+                        bias != null ? bias : (existing != null ? existing.bias() : null),
+                        createdAt,
+                        Instant.now()
+                );
+
+                namespaces.put(namespaceId, updated);
+                atomicWrite(namespacesFile, namespaces);
+                snapshotCache.remove(accountId);
+
+                log.info("[FileAccountCatalog] updated namespace: {} for account {}", namespaceId, accountId);
+                return updated;
+            }
+        } catch (IOException e) {
+            log.error("[FileAccountCatalog] failed to update namespace {} for account {}",
+                    slugOrId, accountId, e);
+            throw new RuntimeException("Failed to update namespace", e);
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    @Override
+    public void resetNamespace(String accountId, String slugOrId) {
+        ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
+        jvmLock.lock();
+        try {
+            Path accountDir = StorageLayout.accountDir(basePath, accountId);
+            Path lockFile = accountDir.resolve(FILE_LOCK);
+
+            try (FileChannel channel = FileChannel.open(lockFile,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock fileLock = channel.lock()) {
+
+                Path slugsFile = accountDir.resolve(FILE_SLUGS);
+                Map<String, String> slugs = new HashMap<>();
+                if (Files.exists(slugsFile)) {
+                    slugs = objectMapper.readValue(slugsFile.toFile(),
+                            new TypeReference<Map<String, String>>() {});
+                }
+
+                String namespaceId = slugs.get(slugOrId);
+                if (namespaceId == null) {
+                    if (slugs.containsValue(slugOrId)) {
+                        namespaceId = slugOrId;
+                    } else {
+                        throw new NamespaceNotFoundException(slugOrId);
+                    }
+                }
+
+                // Reset data-plane directory: delete bundle/index files and recreate
+                Path namespaceDir = StorageLayout.namespaceDirSharded(basePath, namespaceId);
+                if (Files.exists(namespaceDir)) {
+                    try (var stream = Files.walk(namespaceDir)) {
+                        stream.sorted(Comparator.reverseOrder())
+                                .filter(p -> !p.equals(namespaceDir))
+                                .forEach(p -> {
+                                    try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+                                });
+                    }
+                }
+                Files.createDirectories(namespaceDir);
+                snapshotCache.remove(accountId);
+                log.info("[FileAccountCatalog] reset namespace data directory: {}", namespaceId);
+            }
+        } catch (IOException e) {
+            log.error("[FileAccountCatalog] failed to reset namespace {} for account {}",
+                    slugOrId, accountId, e);
+            throw new RuntimeException("Failed to reset namespace", e);
         } finally {
             jvmLock.unlock();
         }
@@ -408,26 +549,62 @@ public class FileAccountCatalog implements AccountCatalog {
                  FileLock fileLock = channel.lock()) {
 
                 Path slugsFile = accountDir.resolve(FILE_SLUGS);
+                String resolvedNamespaceId = namespaceId;
+                String slugToRemove = null;
+
                 if (Files.exists(slugsFile)) {
                     Map<String, String> slugs = new HashMap<>(objectMapper.readValue(
                             slugsFile.toFile(),
                             new TypeReference<Map<String, String>>() {}));
-                    String slugToRemove = null;
-                    for (Map.Entry<String, String> entry : slugs.entrySet()) {
-                        if (entry.getValue().equals(namespaceId)) {
-                            slugToRemove = entry.getKey();
-                            break;
+
+                    if (slugs.containsKey(namespaceId)) {
+                        slugToRemove = namespaceId;
+                        resolvedNamespaceId = slugs.get(namespaceId);
+                    } else {
+                        for (Map.Entry<String, String> entry : slugs.entrySet()) {
+                            if (entry.getValue().equals(namespaceId)) {
+                                slugToRemove = entry.getKey();
+                                break;
+                            }
                         }
                     }
+
+                    if ("default".equals(slugToRemove) || accountId.equals(resolvedNamespaceId)) {
+                        throw new DefaultNamespaceProtectedException(resolvedNamespaceId);
+                    }
+
                     if (slugToRemove != null) {
-                        if ("default".equals(slugToRemove)) {
-                            throw new DefaultNamespaceProtectedException(namespaceId);
-                        }
                         slugs.remove(slugToRemove);
                         atomicWrite(slugsFile, slugs);
-                        snapshotCache.remove(accountId);
                     }
                 }
+
+                Path namespacesFile = accountDir.resolve(FILE_NAMESPACES);
+                if (Files.exists(namespacesFile)) {
+                    Map<String, NamespaceRecord> namespaces = new HashMap<>(objectMapper.readValue(
+                            namespacesFile.toFile(),
+                            new TypeReference<Map<String, NamespaceRecord>>() {}));
+                    NamespaceRecord existing = namespaces.get(resolvedNamespaceId);
+                    if (existing != null) {
+                        NamespaceRecord tombstoned = new NamespaceRecord(
+                                existing.namespaceId(),
+                                existing.slug(),
+                                existing.ownerAccountId(),
+                                existing.type(),
+                                NamespaceStatus.TOMBSTONED,
+                                existing.displayName(),
+                                existing.description(),
+                                existing.bias(),
+                                existing.createdAt(),
+                                Instant.now()
+                        );
+                        namespaces.put(resolvedNamespaceId, tombstoned);
+                        atomicWrite(namespacesFile, namespaces);
+                    }
+                }
+
+                snapshotCache.remove(accountId);
+                log.info("[FileAccountCatalog] tombstoned namespace {} for account {}", resolvedNamespaceId, accountId);
             }
         } catch (DefaultNamespaceProtectedException e) {
             throw e;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
@@ -87,7 +87,23 @@ public class CatalogAutoConfiguration {
         @Override
         public com.spectrayan.spector.synapse.catalog.NamespaceRecord createNamespace(
                 String accountId, String slug,
-                com.spectrayan.spector.synapse.catalog.NamespaceType type) {
+                com.spectrayan.spector.synapse.catalog.NamespaceType type,
+                String displayName, String description,
+                com.spectrayan.spector.synapse.catalog.NamespaceBias bias) {
+            throw new UnsupportedOperationException(MSG);
+        }
+
+        @Override
+        public com.spectrayan.spector.synapse.catalog.NamespaceRecord updateNamespace(
+                String accountId, String slugOrId,
+                String displayName, String description,
+                com.spectrayan.spector.synapse.catalog.NamespaceType type,
+                com.spectrayan.spector.synapse.catalog.NamespaceBias bias) {
+            throw new UnsupportedOperationException(MSG);
+        }
+
+        @Override
+        public void resetNamespace(String accountId, String slugOrId) {
             throw new UnsupportedOperationException(MSG);
         }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GlobalExceptionHandler.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GlobalExceptionHandler.java
@@ -73,6 +73,14 @@ public class GlobalExceptionHandler {
                     ? HttpStatus.NOT_FOUND
                     : HttpStatus.BAD_REQUEST;
             case INGESTION -> HttpStatus.BAD_REQUEST;
+            case NAMESPACE -> switch (code) {
+                case NAMESPACE_NOT_FOUND, NAMESPACE_TOMBSTONED -> HttpStatus.NOT_FOUND;
+                case NAMESPACE_ACCESS_DENIED, TOKEN_NAMESPACE_LOCKED, FEDERATION_DISABLED, IDENTITY_REGION_DENIED -> HttpStatus.FORBIDDEN;
+                case DEFAULT_NAMESPACE_PROTECTED, NAMESPACE_LEGAL_HOLD -> HttpStatus.CONFLICT;
+                case NAMESPACE_QUOTA_EXCEEDED, ACCOUNT_QUOTA_EXCEEDED, TENANT_QUOTA_EXCEEDED, NAMESPACE_HOT_CAP_EXCEEDED -> HttpStatus.TOO_MANY_REQUESTS;
+                case SOUL_STACK_UNAVAILABLE -> HttpStatus.SERVICE_UNAVAILABLE;
+                default -> HttpStatus.BAD_REQUEST;
+            };
             case SERVER -> HttpStatus.SERVICE_UNAVAILABLE;
             default -> HttpStatus.INTERNAL_SERVER_ERROR;
         };

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
@@ -216,8 +216,9 @@ public class McpServerConfig {
 
                     return new McpStatelessServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
                         Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
+                        String namespace = args.get("namespace") != null ? String.valueOf(args.get("namespace")) : null;
                         Optional<McpRequestMemory.DenyReason> deny =
-                                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled);
+                                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
                         if (deny.isPresent()) {
                             return toolError(McpRequestMemory.message(deny.get()));
                         }
@@ -244,8 +245,9 @@ public class McpServerConfig {
 
                     return new McpServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
                         Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
+                        String namespace = args.get("namespace") != null ? String.valueOf(args.get("namespace")) : null;
                         Optional<McpRequestMemory.DenyReason> deny =
-                                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled);
+                                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
                         if (deny.isPresent()) {
                             return toolError(McpRequestMemory.message(deny.get()));
                         }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpController.java
@@ -94,8 +94,10 @@ public class McpController {
 
         // Resolve + bind the caller's per-user memory on this request thread. Denies
         // (auth-required / resolution-failed) fail closed without touching any user's memory.
+        String namespace = (arguments != null && arguments.containsKey("namespace"))
+                ? String.valueOf(arguments.get("namespace")) : null;
         Optional<McpRequestMemory.DenyReason> deny =
-                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled);
+                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
         if (deny.isPresent()) {
             return errorResponse(McpRequestMemory.message(deny.get()));
         }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
@@ -63,7 +63,9 @@ public final class McpRequestMemory {
         /** Auth is enabled but the request carries no resolvable authenticated security context. */
         AUTH_REQUIRED,
         /** Per-user memory resolution or lazy construction failed; the call fails closed. */
-        RESOLUTION_FAILED
+        RESOLUTION_FAILED,
+        /** Wildcard '*' was supplied as a namespace selector (ADR-0029 Invariant 7). */
+        WILDCARD_REJECTED
     }
 
     /**
@@ -77,16 +79,47 @@ public final class McpRequestMemory {
      *         {@link DenyReason} describing why the call must be denied (nothing is bound)
      */
     public static Optional<DenyReason> bindForCurrentRequest(MemoryRegistry registry, boolean authEnabled) {
+        return bindForCurrentRequest(registry, authEnabled, null, null);
+    }
+
+    /**
+     * Resolves the caller's memory with an optional explicit namespace selector or connection ID.
+     *
+     * @param registry          the per-user memory registry
+     * @param authEnabled       whether {@code spector.auth.enabled} is {@code true}
+     * @param namespaceSelector optional explicit namespace slug or ID (from tool argument)
+     * @param connectionId      optional MCP connection or session identifier
+     * @return {@link Optional#empty()} when bound; otherwise {@link DenyReason}
+     */
+    public static Optional<DenyReason> bindForCurrentRequest(
+            MemoryRegistry registry,
+            boolean authEnabled,
+            String namespaceSelector,
+            String connectionId) {
         if (authEnabled && !SecurityUtils.isAuthenticated()) {
             return Optional.of(DenyReason.AUTH_REQUIRED);
         }
+
+        if (namespaceSelector != null && "*".equals(namespaceSelector.trim())) {
+            return Optional.of(DenyReason.WILDCARD_REJECTED);
+        }
+
         try {
-            CURRENT.set(registry.resolveForCurrentRequest());
+            String userId = SecurityUtils.getUserId();
+            String selector = (namespaceSelector != null && !namespaceSelector.isBlank())
+                    ? namespaceSelector.trim()
+                    : McpSessionContext.getSessionDefault(connectionId).orElse(null);
+
+            SpectorMemory memory = (selector != null && !selector.isBlank())
+                    ? registry.namespaceResolver().resolve(userId, selector)
+                    : registry.resolveForCurrentRequest();
+
+            CURRENT.set(memory);
             return Optional.empty();
         } catch (RuntimeException e) {
             clear();
             // Never echo the resolved namespace/identifier; message stays generic.
-            log.warn("[McpRequestMemory] per-user memory resolution failed; denying MCP call: {}", e.getMessage());
+            log.warn("[McpRequestMemory] memory resolution failed; denying MCP call: {}", e.getMessage());
             log.debug("[McpRequestMemory] resolution failure detail (id withheld)", e);
             return Optional.of(DenyReason.RESOLUTION_FAILED);
         }
@@ -106,6 +139,7 @@ public final class McpRequestMemory {
     /** Removes any memory bound to the current thread. Must be invoked in a {@code finally} block. */
     public static void clear() {
         CURRENT.remove();
+        McpSessionContext.clearFallback();
     }
 
     /**
@@ -120,6 +154,8 @@ public final class McpRequestMemory {
                     "Authentication is required to invoke MCP tools over /mcp.";
             case RESOLUTION_FAILED ->
                     "Memory resolution failed; the MCP call was denied and no memory was modified.";
+            case WILDCARD_REJECTED ->
+                    "Wildcard namespace '*' is not supported. Please specify a single namespace or omit to use the default.";
         };
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpSessionContext.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpSessionContext.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.mcp;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages connection-scoped session state for MCP transports (ADR-0029 §6.2, §16).
+ *
+ * <p>{@code namespace_switch} sets the connection-scoped default on this context.
+ * It is tied to the MCP connection/session lifecycle and dies with the session.
+ * For stateless transports without a connection ID, a request-scoped fallback is used.</p>
+ */
+public final class McpSessionContext {
+
+    private static final Logger log = LoggerFactory.getLogger(McpSessionContext.class);
+
+    private static final ConcurrentHashMap<String, String> SESSION_DEFAULTS = new ConcurrentHashMap<>();
+    private static final ThreadLocal<String> FALLBACK_DEFAULT = new ThreadLocal<>();
+
+    private McpSessionContext() {
+    }
+
+    /**
+     * Sets the default namespace slug or ID for the specified MCP connection/session.
+     *
+     * @param connectionId the MCP connection or session identifier, or null for fallback
+     * @param slugOrId     the namespace slug or identifier
+     */
+    public static void setSessionDefault(String connectionId, String slugOrId) {
+        if (connectionId != null && !connectionId.isBlank()) {
+            SESSION_DEFAULTS.put(connectionId, slugOrId);
+            log.debug("[McpSessionContext] set default namespace for session {}: {}", connectionId, slugOrId);
+        } else {
+            FALLBACK_DEFAULT.set(slugOrId);
+            log.debug("[McpSessionContext] set default namespace on thread fallback: {}", slugOrId);
+        }
+    }
+
+    /**
+     * Gets the connection-scoped default namespace for the given connection ID, if any.
+     *
+     * @param connectionId the MCP connection or session identifier
+     * @return optional containing the active default namespace slug or identifier
+     */
+    public static Optional<String> getSessionDefault(String connectionId) {
+        if (connectionId != null && !connectionId.isBlank()) {
+            String value = SESSION_DEFAULTS.get(connectionId);
+            if (value != null) {
+                return Optional.of(value);
+            }
+        }
+        String fallback = FALLBACK_DEFAULT.get();
+        return Optional.ofNullable(fallback);
+    }
+
+    /**
+     * Clears session state when an MCP connection terminates.
+     *
+     * @param connectionId the MCP connection or session identifier
+     */
+    public static void clearSession(String connectionId) {
+        if (connectionId != null) {
+            SESSION_DEFAULTS.remove(connectionId);
+            log.debug("[McpSessionContext] cleared session: {}", connectionId);
+        }
+        FALLBACK_DEFAULT.remove();
+    }
+
+    /** Clears thread fallback state. */
+    public static void clearFallback() {
+        FALLBACK_DEFAULT.remove();
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryBinding.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryBinding.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+
+/**
+ * Immutable per-request memory binding context holding the resolved {@link SpectorMemory}
+ * instance along with its owning account and resolved namespace identifier (ADR-0029 §16).
+ *
+ * @param memory      the active SpectorMemory engine
+ * @param accountId   the authenticated account identifier
+ * @param namespaceId the resolved data-plane namespace TSID
+ * @param slug        the requested or resolved namespace slug
+ */
+public record MemoryBinding(
+        SpectorMemory memory,
+        String accountId,
+        String namespaceId,
+        String slug) {
+
+    /** RequestAttributes attribute key for the bound context. */
+    public static final String ATTRIBUTE_KEY = "com.spectrayan.spector.synapse.memory.MemoryBinding";
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRegistry.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRegistry.java
@@ -125,6 +125,21 @@ public final class MemoryRegistry implements AutoCloseable {
         if (!synapseProps.auth().enabled()) {
             return sharedMemory();
         }
+        // Check for bound MemoryBinding in RequestAttributes (Filter + RequestAttributes pattern, ADR §16)
+        try {
+            org.springframework.web.context.request.RequestAttributes attrs =
+                    org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+            if (attrs != null) {
+                Object binding = attrs.getAttribute(MemoryBinding.ATTRIBUTE_KEY,
+                        org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST);
+                if (binding instanceof MemoryBinding mb && mb.memory() != null) {
+                    return mb.memory();
+                }
+            }
+        } catch (Exception ignored) {
+            // Fall through to standard resolution
+        }
+
         String userId = SecurityUtils.getUserId();
         if (DEFAULT_USER_ID.equals(userId)) {
             return sharedMemory();

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.synapse.catalog.Account;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceTombstonedException;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+
+/**
+ * Shared binder that resolves an authenticated request to a {@link MemoryBinding}
+ * holding the target {@link SpectorMemory} (ADR-0029 §16).
+ *
+ * <p>Both REST filters and MCP sessions delegate resolution to this component,
+ * ensuring consistent resolution order:
+ * {@code client signal (header/arg) > session default > account default}.</p>
+ */
+@Component
+public class MemoryRequestBinder {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryRequestBinder.class);
+    private static final String DEFAULT_USER_ID = "default";
+
+    private final AccountCatalog catalog;
+    private final MemoryRegistry registry;
+    private final SynapseProperties synapseProps;
+    private final SpectorMemory sharedMemory;
+
+    public MemoryRequestBinder(
+            AccountCatalog catalog,
+            MemoryRegistry registry,
+            SynapseProperties synapseProps,
+            org.springframework.beans.factory.ObjectProvider<SpectorMemory> sharedMemoryProvider) {
+        this.catalog = catalog;
+        this.registry = registry;
+        this.synapseProps = synapseProps;
+        this.sharedMemory = sharedMemoryProvider.getIfAvailable();
+    }
+
+    /**
+     * Binds a memory instance for the given authentication and optional namespace selector.
+     *
+     * @param auth     the current authentication, or null if unauthenticated
+     * @param selector optional namespace slug or namespaceId
+     * @return the bound memory context
+     */
+    public MemoryBinding bind(Authentication auth, Optional<String> selector) {
+        if (!synapseProps.auth().enabled() || auth == null || !auth.isAuthenticated()
+                || auth instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
+            return new MemoryBinding(sharedMemory, DEFAULT_USER_ID, DEFAULT_USER_ID, "default");
+        }
+
+        String accountId = auth.getName();
+        if (accountId == null || accountId.isBlank() || DEFAULT_USER_ID.equals(accountId)) {
+            return new MemoryBinding(sharedMemory, DEFAULT_USER_ID, DEFAULT_USER_ID, "default");
+        }
+
+        Account account = catalog.getOrCreateAccount(accountId);
+
+        if (selector != null && selector.isPresent() && !selector.get().isBlank()) {
+            String slugOrId = selector.get().trim();
+            if ("*".equals(slugOrId)) {
+                throw new IllegalArgumentException("Wildcard namespace '*' is not supported for memory operations");
+            }
+            NamespaceRecord record = catalog.resolve(accountId, slugOrId)
+                    .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+            if (record.status() == NamespaceStatus.TOMBSTONED) {
+                throw new NamespaceTombstonedException(record.namespaceId());
+            }
+            catalog.recordAccess(record.namespaceId());
+            NamespaceResolver resolver = registry.namespaceResolver();
+            SpectorMemory memory = resolver.resolve(accountId, record.namespaceId());
+            return new MemoryBinding(memory, accountId, record.namespaceId(), record.slug());
+        }
+
+        String defaultNamespaceId = account.defaultNamespaceId();
+        SpectorMemory memory = registry.resolveFor(accountId);
+        return new MemoryBinding(memory, accountId, defaultNamespaceId, "default");
+    }
+
+    /**
+     * Unbinds the given memory binding.
+     *
+     * @param binding the binding to release
+     */
+    public void unbind(MemoryBinding binding) {
+        // Reserved for lease release in Phase 3 parity
+        log.trace("[MemoryRequestBinder] unbinding memory for account={}, ns={}",
+                binding != null ? binding.accountId() : null,
+                binding != null ? binding.namespaceId() : null);
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
@@ -38,7 +38,9 @@ import com.spectrayan.spector.synapse.catalog.Account;
 import com.spectrayan.spector.synapse.catalog.AccountCatalog;
 import com.spectrayan.spector.synapse.catalog.GrantRole;
 import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceTombstonedException;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -158,6 +160,48 @@ public class NamespaceResolver implements AutoCloseable {
 
         // Step 2: Bind — cache lookup by namespaceId (not userId, not slug)
         return getOrBuild(namespaceId);
+    }
+
+    /**
+     * Resolves an authenticated principal and explicit namespace selector (slug or namespaceId)
+     * to the corresponding {@link SpectorMemory} instance.
+     *
+     * <p>Resolution chain (ADR-0029 §6.1):</p>
+     * <pre>
+     * (accountId, slugOrId) → catalog.resolve → NamespaceRecord → getOrBuild(namespaceId)
+     * </pre>
+     *
+     * @param accountId the authenticated principal's TSID
+     * @param slugOrId  the namespace slug or namespace identifier; null/blank resolves default
+     * @return the cached or newly-built SpectorMemory
+     * @throws NamespaceNotFoundException if the namespace is not found
+     * @throws NamespaceTombstonedException if the namespace is soft-deleted
+     */
+    public SpectorMemory resolve(String accountId, String slugOrId) {
+        if (slugOrId == null || slugOrId.isBlank()) {
+            return resolve(accountId);
+        }
+        catalog.getOrCreateAccount(accountId);
+        NamespaceRecord record = catalog.resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+        if (record.status() == NamespaceStatus.TOMBSTONED) {
+            throw new NamespaceTombstonedException(record.namespaceId());
+        }
+        catalog.recordAccess(record.namespaceId());
+        return getOrBuild(record.namespaceId());
+    }
+
+    /**
+     * Evicts a namespace instance from the cache and closes it.
+     *
+     * @param namespaceId the namespace identifier
+     */
+    public void evict(String namespaceId) {
+        if (namespaceId == null) return;
+        MemoryHandle handle = cache.remove(namespaceId);
+        if (handle != null) {
+            closeQuietly(handle.memory);
+        }
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/PassthroughCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/PassthroughCatalog.java
@@ -49,8 +49,26 @@ final class PassthroughCatalog implements AccountCatalog {
     }
 
     @Override
-    public NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type) {
-        throw new UnsupportedOperationException("PassthroughCatalog does not support createNamespace");
+    public NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type,
+            String displayName, String description, NamespaceBias bias) {
+        return new NamespaceRecord(
+                accountId + "-" + slug, slug, accountId, type != null ? type : NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, displayName, description, bias, Instant.now(), Instant.now()
+        );
+    }
+
+    @Override
+    public NamespaceRecord updateNamespace(String accountId, String slugOrId,
+            String displayName, String description, NamespaceType type, NamespaceBias bias) {
+        return new NamespaceRecord(
+                slugOrId, "default", accountId, type != null ? type : NamespaceType.DEFAULT,
+                NamespaceStatus.ACTIVE, displayName, description, bias, Instant.now(), Instant.now()
+        );
+    }
+
+    @Override
+    public void resetNamespace(String accountId, String slugOrId) {
+        // no-op
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/security/NamespaceResolutionFilter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/security/NamespaceResolutionFilter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.security;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.spectrayan.spector.synapse.memory.MemoryBinding;
+import com.spectrayan.spector.synapse.memory.MemoryRequestBinder;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet filter that resolves the active namespace for REST memory requests
+ * and attaches the resulting {@link MemoryBinding} to {@link RequestAttributes} (ADR-0029 §16, Q19).
+ *
+ * <p>Selection order per ADR §6.1:</p>
+ * <pre>
+ * HTTP: X-Spector-Namespace > ?namespace= > account.defaultNamespaceId
+ * </pre>
+ *
+ * <p>Cleans up the bound context in a {@code finally} block upon filter completion.</p>
+ */
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE - 10)
+public class NamespaceResolutionFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceResolutionFilter.class);
+
+    public static final String HEADER_NAMESPACE = "X-Spector-Namespace";
+    public static final String PARAM_NAMESPACE = "namespace";
+
+    private final MemoryRequestBinder binder;
+
+    public NamespaceResolutionFilter(MemoryRequestBinder binder) {
+        this.binder = binder;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path == null || !path.startsWith("/api/v1/memory");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String headerNamespace = request.getHeader(HEADER_NAMESPACE);
+        String paramNamespace = request.getParameter(PARAM_NAMESPACE);
+
+        String selector = (headerNamespace != null && !headerNamespace.isBlank())
+                ? headerNamespace.trim()
+                : (paramNamespace != null && !paramNamespace.isBlank() ? paramNamespace.trim() : null);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        MemoryBinding binding = null;
+
+        try {
+            binding = binder.bind(auth, Optional.ofNullable(selector));
+            request.setAttribute(MemoryBinding.ATTRIBUTE_KEY, binding);
+
+            RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+            if (attrs != null) {
+                attrs.setAttribute(MemoryBinding.ATTRIBUTE_KEY, binding, RequestAttributes.SCOPE_REQUEST);
+            }
+
+            filterChain.doFilter(request, response);
+        } finally {
+            if (binding != null) {
+                binder.unbind(binding);
+            }
+        }
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/tools/NamespaceToolsTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/tools/NamespaceToolsTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.exception.DefaultNamespaceProtectedException;
+import com.spectrayan.spector.synapse.mcp.McpSessionContext;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+
+@DisplayName("Namespace MCP Tools Tests")
+class NamespaceToolsTest {
+
+    private AccountCatalog catalog;
+    private ObjectMapper objectMapper;
+
+    private static final String TEST_ACCOUNT = "0195500000001";
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(AccountCatalog.class);
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+        var auth = new UsernamePasswordAuthenticationToken(TEST_ACCOUNT, "pw", List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        McpSessionContext.clearFallback();
+    }
+
+    @Test
+    @DisplayName("namespace_list lists accessible namespaces")
+    void testNamespaceList() throws Exception {
+        var record = new NamespaceRecord(
+                TEST_ACCOUNT, "default", TEST_ACCOUNT, NamespaceType.DEFAULT,
+                NamespaceStatus.ACTIVE, "Default", null, null, Instant.now(), Instant.now()
+        );
+        when(catalog.listAccessible(TEST_ACCOUNT)).thenReturn(List.of(record));
+
+        var tool = new NamespaceListTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of());
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("namespace_create creates new namespace")
+    void testNamespaceCreate() throws Exception {
+        var record = new NamespaceRecord(
+                "0195500000002", "research", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Research", "Notes", null, Instant.now(), Instant.now()
+        );
+        when(catalog.createNamespace(eq(TEST_ACCOUNT), eq("research"), eq(NamespaceType.PROJECT),
+                eq("Research"), eq("Notes"), any())).thenReturn(record);
+
+        var tool = new NamespaceCreateTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of(
+                "slug", "research",
+                "type", "PROJECT",
+                "displayName", "Research",
+                "description", "Notes"
+        ));
+
+        assertThat(result.isError()).isFalse();
+        verify(catalog).createNamespace(eq(TEST_ACCOUNT), eq("research"), eq(NamespaceType.PROJECT),
+                eq("Research"), eq("Notes"), any());
+    }
+
+    @Test
+    @DisplayName("namespace_info returns namespace details")
+    void testNamespaceInfo() throws Exception {
+        var record = new NamespaceRecord(
+                "0195500000002", "research", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Research", "Notes", null, Instant.now(), Instant.now()
+        );
+        when(catalog.resolve(TEST_ACCOUNT, "research")).thenReturn(Optional.of(record));
+
+        var tool = new NamespaceInfoTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of("namespace", "research"));
+
+        assertThat(result.isError()).isFalse();
+    }
+
+    @Test
+    @DisplayName("namespace_info returns error when namespace not found")
+    void testNamespaceInfoNotFound() throws Exception {
+        when(catalog.resolve(TEST_ACCOUNT, "missing")).thenReturn(Optional.empty());
+
+        var tool = new NamespaceInfoTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of("namespace", "missing"));
+
+        assertThat(result.isError()).isTrue();
+    }
+
+    @Test
+    @DisplayName("namespace_switch sets connection-scoped default")
+    void testNamespaceSwitch() throws Exception {
+        var record = new NamespaceRecord(
+                "0195500000002", "research", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Research", null, null, Instant.now(), Instant.now()
+        );
+        when(catalog.resolve(TEST_ACCOUNT, "research")).thenReturn(Optional.of(record));
+
+        var tool = new NamespaceSwitchTool(catalog);
+        CallToolResult result = tool.execute(Map.of("namespace", "research"));
+
+        assertThat(result.isError()).isFalse();
+        assertThat(McpSessionContext.getSessionDefault(null)).contains("0195500000002");
+    }
+
+    @Test
+    @DisplayName("namespace_switch rejects wildcard '*'")
+    void testNamespaceSwitchWildcard() throws Exception {
+        var tool = new NamespaceSwitchTool(catalog);
+        CallToolResult result = tool.execute(Map.of("namespace", "*"));
+
+        assertThat(result.isError()).isTrue();
+    }
+
+    @Test
+    @DisplayName("namespace_switch rejects tombstoned namespace")
+    void testNamespaceSwitchTombstoned() throws Exception {
+        var tombstoned = new NamespaceRecord(
+                "0195500000002", "old-project", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.TOMBSTONED, null, null, null, Instant.now(), Instant.now()
+        );
+        when(catalog.resolve(TEST_ACCOUNT, "old-project")).thenReturn(Optional.of(tombstoned));
+
+        var tool = new NamespaceSwitchTool(catalog);
+        CallToolResult result = tool.execute(Map.of("namespace", "old-project"));
+
+        assertThat(result.isError()).isTrue();
+    }
+
+    @Test
+    @DisplayName("namespace_set_default sets persistent default namespace")
+    void testNamespaceSetDefault() throws Exception {
+        var record = new NamespaceRecord(
+                "0195500000002", "research", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Research", null, null, Instant.now(), Instant.now()
+        );
+        when(catalog.resolve(TEST_ACCOUNT, "research")).thenReturn(Optional.of(record));
+
+        var tool = new NamespaceSetDefaultTool(catalog);
+        CallToolResult result = tool.execute(Map.of("namespace", "research"));
+
+        assertThat(result.isError()).isFalse();
+        verify(catalog).setDefaultNamespace(TEST_ACCOUNT, "0195500000002");
+    }
+
+    @Test
+    @DisplayName("namespace_delete deletes namespace")
+    void testNamespaceDelete() throws Exception {
+        var tool = new NamespaceDeleteTool(catalog);
+        CallToolResult result = tool.execute(Map.of("namespace", "research"));
+
+        assertThat(result.isError()).isFalse();
+        verify(catalog).tombstone(TEST_ACCOUNT, "research");
+    }
+
+    @Test
+    @DisplayName("namespace_delete on default namespace returns error")
+    void testNamespaceDeleteDefaultProtected() throws Exception {
+        doThrow(new DefaultNamespaceProtectedException(TEST_ACCOUNT))
+                .when(catalog).tombstone(TEST_ACCOUNT, "default");
+
+        var tool = new NamespaceDeleteTool(catalog);
+        CallToolResult result = tool.execute(Map.of("namespace", "default"));
+
+        assertThat(result.isError()).isTrue();
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/api/AccountDefaultControllerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/api/AccountDefaultControllerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+
+@DisplayName("AccountDefaultController REST API Tests")
+class AccountDefaultControllerTest {
+
+    private AccountCatalog catalog;
+    private AccountDefaultController controller;
+
+    private static final String TEST_ACCOUNT = "0195500000001";
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(AccountCatalog.class);
+        controller = new AccountDefaultController(catalog);
+
+        var auth = new UsernamePasswordAuthenticationToken(TEST_ACCOUNT, "pw", List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/account/default-namespace sets default namespace successfully")
+    void testSetDefaultNamespace() {
+        var record = new NamespaceRecord(
+                "0195500000002", "project-x", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project X", null, null, Instant.now(), Instant.now()
+        );
+        when(catalog.resolve(TEST_ACCOUNT, "project-x")).thenReturn(Optional.of(record));
+
+        var request = new SetDefaultNamespaceRequest("project-x");
+        ResponseEntity<Map<String, String>> response = controller.setDefaultNamespace(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("status", "updated");
+        assertThat(response.getBody()).containsEntry("defaultNamespaceId", "0195500000002");
+        verify(catalog).setDefaultNamespace(TEST_ACCOUNT, "0195500000002");
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/account/default-namespace throws NamespaceNotFoundException when target does not exist")
+    void testSetDefaultNamespaceNotFound() {
+        when(catalog.resolve(TEST_ACCOUNT, "nonexistent")).thenReturn(Optional.empty());
+
+        var request = new SetDefaultNamespaceRequest("nonexistent");
+        assertThatThrownBy(() -> controller.setDefaultNamespace(request))
+                .isInstanceOf(NamespaceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/account/default-namespace rejects blank namespace")
+    void testSetDefaultNamespaceBlank() {
+        var request = new SetDefaultNamespaceRequest("   ");
+        assertThatThrownBy(() -> controller.setDefaultNamespace(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/api/NamespaceControllerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/api/NamespaceControllerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+
+@DisplayName("NamespaceController REST API Tests")
+class NamespaceControllerTest {
+
+    private AccountCatalog catalog;
+    private NamespaceController controller;
+
+    private static final String TEST_ACCOUNT = "0195500000001";
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(AccountCatalog.class);
+        controller = new NamespaceController(catalog);
+
+        var auth = new UsernamePasswordAuthenticationToken(TEST_ACCOUNT, "pw", List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/namespaces returns accessible namespaces")
+    void testListNamespaces() {
+        var record = new NamespaceRecord(
+                TEST_ACCOUNT, "default", TEST_ACCOUNT, NamespaceType.DEFAULT,
+                NamespaceStatus.ACTIVE, "Default", "Autobiographical", null, Instant.now(), Instant.now()
+        );
+        when(catalog.listAccessible(TEST_ACCOUNT)).thenReturn(List.of(record));
+
+        ResponseEntity<List<NamespaceResponse>> response = controller.listNamespaces();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).slug()).isEqualTo("default");
+        assertThat(response.getBody().get(0).namespaceId()).isEqualTo(TEST_ACCOUNT);
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/namespaces creates namespace and returns 201 CREATED")
+    void testCreateNamespace() {
+        var record = new NamespaceRecord(
+                "0195500000002", "project-x", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project X", "Test Project", null, Instant.now(), Instant.now()
+        );
+        when(catalog.createNamespace(eq(TEST_ACCOUNT), eq("project-x"), eq(NamespaceType.PROJECT),
+                eq("Project X"), eq("Test Project"), any())).thenReturn(record);
+
+        var request = new CreateNamespaceRequest("project-x", NamespaceType.PROJECT, "Project X", "Test Project", null);
+        ResponseEntity<NamespaceResponse> response = controller.createNamespace(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().slug()).isEqualTo("project-x");
+        assertThat(response.getBody().namespaceId()).isEqualTo("0195500000002");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/namespaces/{slugOrId} returns namespace when found")
+    void testGetNamespaceFound() {
+        var record = new NamespaceRecord(
+                "0195500000002", "project-x", TEST_ACCOUNT, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project X", null, null, Instant.now(), Instant.now()
+        );
+        when(catalog.resolve(TEST_ACCOUNT, "project-x")).thenReturn(Optional.of(record));
+
+        ResponseEntity<NamespaceResponse> response = controller.getNamespace("project-x");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().slug()).isEqualTo("project-x");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/namespaces/{slugOrId} throws NamespaceNotFoundException when missing")
+    void testGetNamespaceNotFound() {
+        when(catalog.resolve(TEST_ACCOUNT, "missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.getNamespace("missing"))
+                .isInstanceOf(NamespaceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/namespaces/{slugOrId} updates metadata and returns 200 OK")
+    void testUpdateNamespace() {
+        var updated = new NamespaceRecord(
+                "0195500000002", "project-x", TEST_ACCOUNT, NamespaceType.AGENT,
+                NamespaceStatus.ACTIVE, "Updated Name", "Updated Desc", null, Instant.now(), Instant.now()
+        );
+        when(catalog.updateNamespace(eq(TEST_ACCOUNT), eq("project-x"), eq("Updated Name"), eq("Updated Desc"),
+                eq(NamespaceType.AGENT), any())).thenReturn(updated);
+
+        var request = new UpdateNamespaceRequest("Updated Name", "Updated Desc", NamespaceType.AGENT, null);
+        ResponseEntity<NamespaceResponse> response = controller.updateNamespace("project-x", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().displayName()).isEqualTo("Updated Name");
+        assertThat(response.getBody().type()).isEqualTo(NamespaceType.AGENT);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/namespaces/{slugOrId} deletes namespace and returns 204 NO_CONTENT")
+    void testDeleteNamespace() {
+        ResponseEntity<Void> response = controller.deleteNamespace("project-x");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(catalog).tombstone(TEST_ACCOUNT, "project-x");
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/namespaces/{slugOrId}/reset resets namespace and returns 200 OK")
+    void testResetNamespace() {
+        ResponseEntity<Map<String, String>> response = controller.resetNamespace("default");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("status", "reset");
+        verify(catalog).resetNamespace(TEST_ACCOUNT, "default");
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalogPhase2Test.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalogPhase2Test.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.file;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.spectrayan.spector.memory.kernel.StorageLayout;
+import com.spectrayan.spector.synapse.catalog.Account;
+import com.spectrayan.spector.synapse.catalog.NamespaceBias;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.exception.DefaultNamespaceProtectedException;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+
+@DisplayName("FileAccountCatalog Phase 2 Tests")
+class FileAccountCatalogPhase2Test {
+
+    @TempDir
+    Path tempDir;
+
+    private FileAccountCatalog catalog;
+    private ObjectMapper objectMapper;
+
+    private static final String ACCOUNT_ID = "0195500000001";
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        catalog = new FileAccountCatalog(tempDir, objectMapper);
+    }
+
+    @Test
+    @DisplayName("getOrCreateAccount initializes default namespace with rich record")
+    void testGetOrCreateAccount() {
+        Account account = catalog.getOrCreateAccount(ACCOUNT_ID);
+        assertThat(account.id()).isEqualTo(ACCOUNT_ID);
+        assertThat(account.defaultNamespaceId()).isEqualTo(ACCOUNT_ID);
+
+        Optional<NamespaceRecord> defaultNs = catalog.resolve(ACCOUNT_ID, "default");
+        assertThat(defaultNs).isPresent();
+        assertThat(defaultNs.get().slug()).isEqualTo("default");
+        assertThat(defaultNs.get().namespaceId()).isEqualTo(ACCOUNT_ID);
+        assertThat(defaultNs.get().type()).isEqualTo(NamespaceType.DEFAULT);
+        assertThat(defaultNs.get().status()).isEqualTo(NamespaceStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("createNamespace creates and persists rich metadata")
+    void testCreateNamespaceWithMetadata() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+
+        var bias = new NamespaceBias(List.of("biology", "neuroscience"), Map.of("brain", 1.5f));
+        NamespaceRecord created = catalog.createNamespace(
+                ACCOUNT_ID, "research-ns", NamespaceType.PROJECT,
+                "Research Namespace", "Contains neuroscience research", bias
+        );
+
+        assertThat(created.slug()).isEqualTo("research-ns");
+        assertThat(created.displayName()).isEqualTo("Research Namespace");
+        assertThat(created.description()).isEqualTo("Contains neuroscience research");
+        assertThat(created.bias()).isNotNull();
+        assertThat(created.bias().domainFocus()).contains("biology", "neuroscience");
+
+        // Verify resolved
+        Optional<NamespaceRecord> resolved = catalog.resolve(ACCOUNT_ID, "research-ns");
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().namespaceId()).isEqualTo(created.namespaceId());
+        assertThat(resolved.get().displayName()).isEqualTo("Research Namespace");
+    }
+
+    @Test
+    @DisplayName("createNamespace validates slug grammar")
+    void testSlugGrammarValidation() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, "invalid/slug", NamespaceType.PROJECT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace slug");
+
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, ".hidden", NamespaceType.PROJECT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace slug");
+
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, "", NamespaceType.PROJECT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace slug");
+    }
+
+    @Test
+    @DisplayName("updateNamespace updates mutable fields")
+    void testUpdateNamespace() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        NamespaceRecord created = catalog.createNamespace(ACCOUNT_ID, "my-slug", NamespaceType.PROJECT);
+
+        var newBias = new NamespaceBias(List.of("code"), Map.of("java", 2.0f));
+        NamespaceRecord updated = catalog.updateNamespace(
+                ACCOUNT_ID, "my-slug", "New Name", "New Description",
+                NamespaceType.AGENT, newBias
+        );
+
+        assertThat(updated.displayName()).isEqualTo("New Name");
+        assertThat(updated.description()).isEqualTo("New Description");
+        assertThat(updated.type()).isEqualTo(NamespaceType.AGENT);
+        assertThat(updated.bias()).isEqualTo(newBias);
+
+        // Re-resolve
+        Optional<NamespaceRecord> resolved = catalog.resolve(ACCOUNT_ID, "my-slug");
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().displayName()).isEqualTo("New Name");
+    }
+
+    @Test
+    @DisplayName("updateNamespace throws NamespaceNotFoundException for missing slug")
+    void testUpdateNamespaceNotFound() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+
+        assertThatThrownBy(() -> catalog.updateNamespace(
+                ACCOUNT_ID, "missing", "Name", null, null, null
+        )).isInstanceOf(NamespaceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("resetNamespace clears data directory")
+    void testResetNamespace() throws IOException {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        NamespaceRecord created = catalog.createNamespace(ACCOUNT_ID, "reset-target", NamespaceType.PROJECT);
+
+        Path nsDir = StorageLayout.namespaceDirSharded(tempDir, created.namespaceId());
+        Path dummyFile = nsDir.resolve("dummy.txt");
+        Files.writeString(dummyFile, "test data");
+        assertThat(Files.exists(dummyFile)).isTrue();
+
+        catalog.resetNamespace(ACCOUNT_ID, "reset-target");
+
+        assertThat(Files.exists(dummyFile)).isFalse();
+        assertThat(Files.exists(nsDir)).isTrue();
+    }
+
+    @Test
+    @DisplayName("tombstone soft-deletes namespace and protects default")
+    void testTombstoneAndProtection() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        NamespaceRecord created = catalog.createNamespace(ACCOUNT_ID, "to-delete", NamespaceType.PROJECT);
+
+        catalog.tombstone(ACCOUNT_ID, "to-delete");
+
+        List<NamespaceRecord> accessible = catalog.listAccessible(ACCOUNT_ID);
+        assertThat(accessible).noneMatch(ns -> ns.slug().equals("to-delete"));
+
+        // Default namespace cannot be tombstoned
+        assertThatThrownBy(() -> catalog.tombstone(ACCOUNT_ID, "default"))
+                .isInstanceOf(DefaultNamespaceProtectedException.class);
+
+        assertThatThrownBy(() -> catalog.tombstone(ACCOUNT_ID, ACCOUNT_ID))
+                .isInstanceOf(DefaultNamespaceProtectedException.class);
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/security/NamespaceResolutionFilterTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/security/NamespaceResolutionFilterTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.security;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.synapse.memory.MemoryBinding;
+import com.spectrayan.spector.synapse.memory.MemoryRequestBinder;
+
+import jakarta.servlet.ServletException;
+
+@DisplayName("NamespaceResolutionFilter Tests")
+class NamespaceResolutionFilterTest {
+
+    private MemoryRequestBinder binder;
+    private NamespaceResolutionFilter filter;
+    private SpectorMemory mockMemory;
+
+    private static final String TEST_ACCOUNT = "0195500000001";
+
+    @BeforeEach
+    void setUp() {
+        binder = mock(MemoryRequestBinder.class);
+        filter = new NamespaceResolutionFilter(binder);
+        mockMemory = mock(SpectorMemory.class);
+
+        var auth = new UsernamePasswordAuthenticationToken(TEST_ACCOUNT, "pw", List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("Filter resolves namespace from X-Spector-Namespace header")
+    void testHeaderResolution() throws ServletException, IOException {
+        var request = new MockHttpServletRequest("GET", "/api/v1/memory/status");
+        request.addHeader(NamespaceResolutionFilter.HEADER_NAMESPACE, "project-x");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        var binding = new MemoryBinding(mockMemory, TEST_ACCOUNT, "0195500000002", "project-x");
+        when(binder.bind(any(), eq(Optional.of("project-x")))).thenReturn(binding);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(MemoryBinding.ATTRIBUTE_KEY)).isEqualTo(binding);
+        verify(binder).unbind(binding);
+    }
+
+    @Test
+    @DisplayName("Filter resolves namespace from ?namespace= query parameter when header is absent")
+    void testQueryParamResolution() throws ServletException, IOException {
+        var request = new MockHttpServletRequest("GET", "/api/v1/memory/status");
+        request.setParameter(NamespaceResolutionFilter.PARAM_NAMESPACE, "project-y");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        var binding = new MemoryBinding(mockMemory, TEST_ACCOUNT, "0195500000003", "project-y");
+        when(binder.bind(any(), eq(Optional.of("project-y")))).thenReturn(binding);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(MemoryBinding.ATTRIBUTE_KEY)).isEqualTo(binding);
+        verify(binder).unbind(binding);
+    }
+
+    @Test
+    @DisplayName("Filter prioritizes header over query parameter")
+    void testHeaderPriority() throws ServletException, IOException {
+        var request = new MockHttpServletRequest("GET", "/api/v1/memory/status");
+        request.addHeader(NamespaceResolutionFilter.HEADER_NAMESPACE, "header-ns");
+        request.setParameter(NamespaceResolutionFilter.PARAM_NAMESPACE, "param-ns");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        var binding = new MemoryBinding(mockMemory, TEST_ACCOUNT, "0195500000004", "header-ns");
+        when(binder.bind(any(), eq(Optional.of("header-ns")))).thenReturn(binding);
+
+        filter.doFilter(request, response, chain);
+
+        verify(binder).bind(any(), eq(Optional.of("header-ns")));
+        verify(binder).unbind(binding);
+    }
+
+    @Test
+    @DisplayName("Filter skips non-memory paths")
+    void testNonMemoryPathsSkipped() throws ServletException, IOException {
+        var request = new MockHttpServletRequest("GET", "/api/v1/auth/login");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(MemoryBinding.ATTRIBUTE_KEY)).isNull();
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/security/SecurityConfigAuthorizationGatingTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/security/SecurityConfigAuthorizationGatingTest.java
@@ -212,6 +212,8 @@ class SecurityConfigAuthorizationGatingTest {
         @Test
         void exactlyOneWarnWhenDisabledAndNoneWhenEnabled() {
             Logger secLogger = (Logger) LoggerFactory.getLogger(SecurityConfig.class);
+            Level oldLevel = secLogger.getLevel();
+            secLogger.setLevel(Level.WARN);
             ListAppender<ILoggingEvent> appender = new ListAppender<>();
             appender.start();
             secLogger.addAppender(appender);
@@ -239,6 +241,7 @@ class SecurityConfigAuthorizationGatingTest {
                         .isEqualTo(1);
             } finally {
                 secLogger.detachAppender(appender);
+                secLogger.setLevel(oldLevel);
                 appender.stop();
             }
         }


### PR DESCRIPTION
## Summary
Implements Phase 2 of multi-namespace management: comprehensive REST and MCP namespace administration and operational capabilities, request-scoped namespace resolution, and connection-scoped namespace switching (resolves #700).

### Key Architectural Changes
1. **Catalog Plane SPI & Storage**:
   - Added `createNamespace` (with `displayName`, `description`, `bias`), `updateNamespace`, and `resetNamespace` to `AccountCatalog`.
   - Updated `CatalogSnapshot` with `namespaces` lookup table and `resolveNamespace(slugOrId)`.
   - Implemented JSON persistence for namespaces in `FileAccountCatalog` (`namespaces.json`) with slug validation regex (`^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$`).
   - Added `DefaultNamespaceProtectedException` guarding against default namespace deletion or invalid rename.

2. **Resolution Pipeline & Request Binding**:
   - Implemented `NamespaceResolutionFilter` intercepting `/api/v1/memory/**` with precedence order: `X-Spector-Namespace` header > `?namespace=` query param > account default.
   - Bound resolved `MemoryBinding` into `RequestAttributes` avoiding redundant catalog queries.
   - Preserved `MemoryRegistry` backwards-compatible 1-parameter signature while delegating multi-namespace instances to `NamespaceResolver`.

3. **REST Surface**:
   - `GET /api/v1/namespaces`: Lists accessible namespaces for the authenticated account.
   - `POST /api/v1/namespaces`: Creates a new namespace with slug validation, metadata, and optional cognitive bias.
   - `GET /api/v1/namespaces/{slugOrId}`: Retrieves namespace details.
   - `PUT /api/v1/namespaces/{slugOrId}`: Updates mutable metadata (`displayName`, `description`, `bias`).
   - `DELETE /api/v1/namespaces/{slugOrId}`: Soft-deletes (tombstones) a namespace.
   - `POST /api/v1/namespaces/{slugOrId}/reset`: Purges all memory data while preserving catalog registration.
   - `PUT /api/v1/account/default-namespace`: Updates the account's primary default namespace.
   - Added `GlobalExceptionHandler` mapping for namespace error domain.

4. **MCP Surface & Session Context**:
   - Added `McpSessionContext` maintaining connection-scoped namespace defaults with fallback for stateless requests.
   - Implemented 6 MCP tools: `namespace_list`, `namespace_create`, `namespace_info`, `namespace_switch`, `namespace_set_default`, `namespace_delete`.
   - Updated all 20 memory tool schemas to accept an optional `namespace` string argument.
   - Enforced strict rejection on wildcard `namespace: "*"` with `DenyReason.WILDCARD_REJECTED`.

### Test Verification
- `FileAccountCatalogPhase2Test`: 7 tests verifying slug grammar, metadata updates, namespace reset, and tombstone protection.
- `NamespaceResolutionFilterTest`: 4 tests verifying header/query-param extraction, request binding, and fail-closed behavior.
- `NamespaceControllerTest`: 7 mock MVC tests verifying complete REST CRUD cycle, reset, and error handling.
- `AccountDefaultControllerTest`: 3 tests verifying account default namespace updates and protection invariants.
- `NamespaceToolsTest`: 10 tests verifying MCP namespace tools, session context switching, and wildcard denial.
- Full `spector-synapse` test suite: 744 tests passing (0 failures, 0 errors).

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>