### PR TITLE
feat: Phase 3 — DB-backed catalog plane, quota caps, lease-aware eviction

### DIFF
--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
@@ -1,0 +1,762 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.jdbc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.id.TsidGenerator;
+import com.spectrayan.spector.synapse.catalog.*;
+import com.spectrayan.spector.synapse.catalog.exception.*;
+import com.spectrayan.spector.synapse.config.sql.SqlQueryLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * JDBC-backed implementation of {@link AccountCatalog} for enterprise and production
+ * deployments (ADR-0029 v4 §5.2).
+ *
+ * <p>Persists accounts, namespace records, grants, and organizational containment in the
+ * synapse SQL database (H2 for OSS, PostgreSQL for Enterprise) initialized by Flyway {@code V6__memory_catalog.sql}.</p>
+ *
+ * <p>Invariants:
+ * <ul>
+ *   <li>One OWNER per namespace record.</li>
+ *   <li>Slug is unique per account (enforced by DB constraint and application checks).</li>
+ *   <li>Default rememberer has {@code namespaceId == accountId} and {@code slug == "default"}.</li>
+ *   <li>Auto-binds existing accounts on first access without moving physical files.</li>
+ * </ul>
+ * </p>
+ */
+public class JdbcAccountCatalog implements AccountCatalog {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcAccountCatalog.class);
+
+    private static final Pattern SLUG_PATTERN =
+            Pattern.compile("^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$");
+
+    private final JdbcClient jdbc;
+    private final SqlQueryLoader sqlLoader;
+    private final ObjectMapper objectMapper;
+    private final TsidGenerator tsid;
+
+    public JdbcAccountCatalog(JdbcClient jdbc, SqlQueryLoader sqlLoader, ObjectMapper objectMapper, TsidGenerator tsid) {
+        this.jdbc = Objects.requireNonNull(jdbc, "jdbc must not be null");
+        this.sqlLoader = Objects.requireNonNull(sqlLoader, "sqlLoader must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        this.tsid = tsid != null ? tsid : new TsidGenerator();
+    }
+
+    public JdbcAccountCatalog(JdbcClient jdbc, SqlQueryLoader sqlLoader, ObjectMapper objectMapper) {
+        this(jdbc, sqlLoader, objectMapper, new TsidGenerator());
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Account Operations
+    // ══════════════════════════════════════════════════════════════
+
+    @Override
+    @Transactional
+    public Account getOrCreateAccount(String accountId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+
+        Optional<Account> existing = findAccountById(accountId);
+        if (existing.isPresent()) {
+            Account account = existing.get();
+            ensureDefaultNamespaceExists(account);
+            return account;
+        }
+
+        log.info("[JdbcAccountCatalog] Auto-provisioning account for ID: {}", accountId);
+        Instant now = Instant.now();
+
+        // Insert new user account row
+        String insertUserSql = """
+                INSERT INTO users (
+                    user_id, username, password_hash, display_name, roles, scopes,
+                    profile, kind, flags, default_namespace_id, created_at, updated_at
+                ) VALUES (
+                    :userId, :username, '', :displayName, 'ROLE_USER', '',
+                    'HUMAN_SOLO', 'HUMAN', '{}', :defaultNamespaceId, :now, :now
+                )
+                """;
+
+        jdbc.sql(insertUserSql)
+                .param("userId", accountId)
+                .param("username", accountId)
+                .param("displayName", accountId)
+                .param("defaultNamespaceId", accountId)
+                .param("now", Timestamp.from(now))
+                .update();
+
+        // Auto-create default namespace record (namespaceId == accountId, slug == "default")
+        insertNamespaceRow(new NamespaceRecord(
+                accountId,
+                "default",
+                accountId,
+                NamespaceType.DEFAULT,
+                NamespaceStatus.ACTIVE,
+                "Default Namespace",
+                "Primary personal memory store",
+                null,
+                now,
+                now
+        ));
+
+        // Add implicit OWNER grant
+        insertImplicitOwnerGrant(accountId, accountId);
+
+        Account newAccount = new Account(
+                accountId,
+                PrincipalKind.HUMAN,
+                AccountProfile.HUMAN_SOLO,
+                accountId,
+                defaultQuotas(AccountProfile.HUMAN_SOLO, null, null),
+                new AccountFlags(true, true, true),
+                accountId,
+                now
+        );
+
+        return newAccount;
+    }
+
+    @Override
+    public Account getAccount(String accountId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        return findAccountById(accountId)
+                .orElseThrow(() -> new NamespaceNotFoundException("account:" + accountId));
+    }
+
+    private Optional<Account> findAccountById(String accountId) {
+        String sql = sqlLoader.load("catalog/account/find-by-id");
+        return jdbc.sql(sql)
+                .param("userId", accountId)
+                .query(this::mapAccountRow)
+                .optional();
+    }
+
+    private void ensureDefaultNamespaceExists(Account account) {
+        String accountId = account.id();
+        String sql = sqlLoader.load("catalog/namespaces/find-by-owner-and-slug");
+        Optional<NamespaceRecord> defaultNs = jdbc.sql(sql)
+                .param("ownerAccountId", accountId)
+                .param("slug", "default")
+                .query(this::mapNamespaceRow)
+                .optional();
+
+        if (defaultNs.isEmpty()) {
+            log.info("[JdbcAccountCatalog] Auto-binding default namespace for account: {}", accountId);
+            Instant now = Instant.now();
+            insertNamespaceRow(new NamespaceRecord(
+                    accountId,
+                    "default",
+                    accountId,
+                    NamespaceType.DEFAULT,
+                    NamespaceStatus.ACTIVE,
+                    "Default Namespace",
+                    "Primary personal memory store",
+                    null,
+                    now,
+                    now
+            ));
+            insertImplicitOwnerGrant(accountId, accountId);
+
+            if (account.defaultNamespaceId() == null || !account.defaultNamespaceId().equals(accountId)) {
+                setDefaultNamespace(accountId, accountId);
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Namespace Operations
+    // ══════════════════════════════════════════════════════════════
+
+    @Override
+    @Transactional
+    public NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type,
+                                            String displayName, String description, NamespaceBias bias) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(slug, "slug must not be null");
+        Objects.requireNonNull(type, "type must not be null");
+
+        if (!SLUG_PATTERN.matcher(slug).matches()) {
+            throw new IllegalArgumentException("Invalid namespace slug: " + slug + " — must match " + SLUG_PATTERN.pattern());
+        }
+
+        Account account = getAccount(accountId);
+
+        // Check account namespace quota
+        int currentCount = countOwnedNamespaces(accountId);
+        int maxAllowed = account.quotas().maxNamespaces();
+        if (maxAllowed > 0 && currentCount >= maxAllowed) {
+            throw new AccountQuotaExceededException(accountId, "maxNamespaces exceeded: " + currentCount + " >= " + maxAllowed);
+        }
+
+        // Check for duplicate slug
+        String findSlugSql = sqlLoader.load("catalog/namespaces/find-by-owner-and-slug");
+        Optional<NamespaceRecord> existingSlug = jdbc.sql(findSlugSql)
+                .param("ownerAccountId", accountId)
+                .param("slug", slug)
+                .query(this::mapNamespaceRow)
+                .optional();
+
+        if (existingSlug.isPresent()) {
+            throw new IllegalArgumentException("Slug already exists: " + slug);
+        }
+
+        String namespaceId = (type == NamespaceType.DEFAULT && slug.equals("default"))
+                ? accountId
+                : tsid.generate();
+
+        Instant now = Instant.now();
+        NamespaceRecord record = new NamespaceRecord(
+                namespaceId,
+                slug,
+                accountId,
+                type,
+                NamespaceStatus.ACTIVE,
+                displayName != null ? displayName : slug,
+                description != null ? description : "",
+                bias,
+                now,
+                now
+        );
+
+        insertNamespaceRow(record);
+        insertImplicitOwnerGrant(accountId, namespaceId);
+
+        log.info("[JdbcAccountCatalog] Created namespace: slug={}, id={}, accountId={}",
+                slug, namespaceId, accountId);
+        return record;
+    }
+
+    @Override
+    public Optional<NamespaceRecord> resolve(String accountId, String slugOrId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(slugOrId, "slugOrId must not be null");
+
+        // 1. Try resolving by slug for this account
+        String findBySlugSql = sqlLoader.load("catalog/namespaces/find-by-owner-and-slug");
+        Optional<NamespaceRecord> bySlug = jdbc.sql(findBySlugSql)
+                .param("ownerAccountId", accountId)
+                .param("slug", slugOrId)
+                .query(this::mapNamespaceRow)
+                .optional();
+
+        if (bySlug.isPresent()) {
+            NamespaceRecord record = bySlug.get();
+            if (record.status() == NamespaceStatus.TOMBSTONED) {
+                return Optional.empty();
+            }
+            return Optional.of(record);
+        }
+
+        // 2. Try resolving by immutable namespaceId (TSID)
+        String findByIdSql = sqlLoader.load("catalog/namespaces/find-by-id");
+        Optional<NamespaceRecord> byId = jdbc.sql(findByIdSql)
+                .param("namespaceId", slugOrId)
+                .query(this::mapNamespaceRow)
+                .optional();
+
+        if (byId.isPresent()) {
+            NamespaceRecord record = byId.get();
+            if (record.status() == NamespaceStatus.TOMBSTONED) {
+                return Optional.empty();
+            }
+            // Check if accessible to this account (owned or granted)
+            if (record.ownerAccountId().equals(accountId) || hasActiveGrant(accountId, record.namespaceId())) {
+                return Optional.of(record);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public List<NamespaceRecord> listAccessible(String accountId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        // Ensure account default namespace is provisioned
+        getOrCreateAccount(accountId);
+
+        String sql = sqlLoader.load("catalog/namespaces/list-accessible");
+        return jdbc.sql(sql)
+                .param("accountId", accountId)
+                .query(this::mapNamespaceRow)
+                .list();
+    }
+
+    @Override
+    @Transactional
+    public void setDefaultNamespace(String accountId, String namespaceId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(namespaceId, "namespaceId must not be null");
+
+        NamespaceRecord record = resolve(accountId, namespaceId)
+                .orElseThrow(() -> new NamespaceNotFoundException("namespace:" + namespaceId));
+
+        if (record.status() == NamespaceStatus.TOMBSTONED) {
+            throw new NamespaceTombstonedException(namespaceId);
+        }
+
+        String sql = sqlLoader.load("catalog/account/update-default-namespace");
+        jdbc.sql(sql)
+                .param("defaultNamespaceId", record.namespaceId())
+                .param("userId", accountId)
+                .update();
+
+        log.info("[JdbcAccountCatalog] Updated default namespace for account {} -> {}",
+                accountId, record.namespaceId());
+    }
+
+    @Override
+    @Transactional
+    public NamespaceRecord updateNamespace(String accountId, String slugOrId,
+                                            String displayName, String description,
+                                            NamespaceType type, NamespaceBias bias) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(slugOrId, "slugOrId must not be null");
+
+        NamespaceRecord current = resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        if (!current.ownerAccountId().equals(accountId)) {
+            Optional<Grant> adminGrant = authorize(accountId, current.namespaceId(), GrantRole.ADMIN);
+            if (adminGrant.isEmpty()) {
+                throw new NamespaceAccessDeniedException(current.namespaceId(), "ADMIN role required to update namespace");
+            }
+        }
+
+        String newDisplayName = displayName != null ? displayName : current.displayName();
+        String newDescription = description != null ? description : current.description();
+        NamespaceType newType = type != null ? type : current.type();
+        NamespaceBias newBias = bias != null ? bias : current.bias();
+
+        String updateSql = sqlLoader.load("catalog/namespaces/update-namespace");
+        jdbc.sql(updateSql)
+                .param("displayName", newDisplayName)
+                .param("description", newDescription)
+                .param("type", newType.name())
+                .param("biasJson", serializeBias(newBias))
+                .param("namespaceId", current.namespaceId())
+                .update();
+
+        return new NamespaceRecord(
+                current.namespaceId(),
+                current.slug(),
+                current.ownerAccountId(),
+                newType,
+                current.status(),
+                newDisplayName,
+                newDescription,
+                newBias,
+                current.createdAt(),
+                Instant.now()
+        );
+    }
+
+    @Override
+    @Transactional
+    public void resetNamespace(String accountId, String slugOrId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(slugOrId, "slugOrId must not be null");
+
+        NamespaceRecord record = resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        if (!record.ownerAccountId().equals(accountId)) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), "Only owner may reset namespace");
+        }
+
+        recordAccess(record.namespaceId());
+        log.info("[JdbcAccountCatalog] Reset metadata recorded for namespace {}", record.namespaceId());
+    }
+
+    @Override
+    @Transactional
+    public void tombstone(String accountId, String namespaceId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(namespaceId, "namespaceId must not be null");
+
+        NamespaceRecord record = resolve(accountId, namespaceId)
+                .orElseThrow(() -> new NamespaceNotFoundException("namespace:" + namespaceId));
+
+        Account account = getAccount(accountId);
+
+        // Invariant: default namespace cannot be deleted
+        if (record.slug().equalsIgnoreCase("default")
+                || record.type() == NamespaceType.DEFAULT
+                || record.namespaceId().equals(account.defaultNamespaceId())
+                || record.namespaceId().equals(accountId)) {
+            throw new DefaultNamespaceProtectedException(record.slug());
+        }
+
+        if (!record.ownerAccountId().equals(accountId)) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), "Only owner may delete namespace");
+        }
+
+        String sql = sqlLoader.load("catalog/namespaces/tombstone");
+        jdbc.sql(sql)
+                .param("namespaceId", record.namespaceId())
+                .update();
+
+        log.info("[JdbcAccountCatalog] Tombstoned namespace: id={}, slug={}, accountId={}",
+                record.namespaceId(), record.slug(), accountId);
+    }
+
+    @Override
+    public void recordAccess(String namespaceId) {
+        if (namespaceId == null) return;
+        try {
+            String sql = sqlLoader.load("catalog/namespaces/update-last-accessed");
+            jdbc.sql(sql)
+                    .param("namespaceId", namespaceId)
+                    .update();
+        } catch (Exception e) {
+            log.warn("[JdbcAccountCatalog] Failed to record access for namespace {}: {}", namespaceId, e.getMessage());
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Grant & Authorization Operations
+    // ══════════════════════════════════════════════════════════════
+
+    @Override
+    @Transactional
+    public void addGrant(Grant grant) {
+        Objects.requireNonNull(grant, "grant must not be null");
+        String sql = sqlLoader.load("catalog/grants/insert-grant");
+        jdbc.sql(sql)
+                .param("grantId", grant.grantId())
+                .param("objectType", grant.objectType().name())
+                .param("objectId", grant.objectId())
+                .param("principalId", grant.principalId())
+                .param("principalType", grant.principalType().name())
+                .param("role", grant.role() != null ? grant.role().name() : null)
+                .param("actions", grant.actions() != null ? String.join(",", grant.actions().stream().map(Enum::name).toList()) : null)
+                .param("grantedBy", grant.grantedBy())
+                .param("grantedAt", Timestamp.from(grant.grantedAt()))
+                .param("expiresAt", grant.expiresAt() != null ? Timestamp.from(grant.expiresAt()) : null)
+                .param("revokedAt", null)
+                .param("constraintsJson", serializeConstraints(grant.constraints()))
+                .update();
+        log.info("[JdbcAccountCatalog] Added grant: id={}, object={}:{}, principal={}",
+                grant.grantId(), grant.objectType(), grant.objectId(), grant.principalId());
+    }
+
+    @Override
+    @Transactional
+    public void revokeGrant(String grantId) {
+        Objects.requireNonNull(grantId, "grantId must not be null");
+        String sql = sqlLoader.load("catalog/grants/revoke-grant");
+        jdbc.sql(sql)
+                .param("grantId", grantId)
+                .update();
+        log.info("[JdbcAccountCatalog] Revoked grant: id={}", grantId);
+    }
+
+    @Override
+    public Optional<Grant> authorize(String accountId, String namespaceId, GrantRole minimumRole) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(namespaceId, "namespaceId must not be null");
+        Objects.requireNonNull(minimumRole, "minimumRole must not be null");
+
+        // 1. Check if owner in namespaces table
+        String findNsSql = sqlLoader.load("catalog/namespaces/find-by-id");
+        Optional<NamespaceRecord> ns = jdbc.sql(findNsSql)
+                .param("namespaceId", namespaceId)
+                .query(this::mapNamespaceRow)
+                .optional();
+
+        if (ns.isPresent() && ns.get().ownerAccountId().equals(accountId)) {
+            return Optional.of(new Grant(
+                    "implicit-owner-" + accountId + "-" + namespaceId,
+                    GrantObjectType.NAMESPACE,
+                    namespaceId,
+                    accountId,
+                    PrincipalType.ACCOUNT,
+                    GrantRole.OWNER,
+                    Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
+                    accountId,
+                    ns.get().createdAt(),
+                    null,
+                    null
+            ));
+        }
+
+        // 2. Query active grants
+        String findGrantSql = sqlLoader.load("catalog/grants/find-active-grant");
+        List<Grant> grants = jdbc.sql(findGrantSql)
+                .param("objectType", GrantObjectType.NAMESPACE.name())
+                .param("objectId", namespaceId)
+                .param("principalId", accountId)
+                .query(this::mapGrantRow)
+                .list();
+
+        for (Grant grant : grants) {
+            if (grant.role() != null && grant.role().ordinal() <= minimumRole.ordinal()) {
+                return Optional.of(grant);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean authorizeIdentity(String accountId, String bundleId, String regionId, GrantAction action) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(bundleId, "bundleId must not be null");
+        Objects.requireNonNull(action, "action must not be null");
+
+        // Account owner has full access to own identity bundle
+        if (accountId.equals(bundleId)) {
+            return true;
+        }
+
+        String findGrantSql = sqlLoader.load("catalog/grants/find-active-grant");
+        List<Grant> grants = jdbc.sql(findGrantSql)
+                .param("objectType", GrantObjectType.IDENTITY_BUNDLE.name())
+                .param("objectId", bundleId)
+                .param("principalId", accountId)
+                .query(this::mapGrantRow)
+                .list();
+
+        return grants.stream().anyMatch(g -> g.actions() != null && g.actions().contains(action));
+    }
+
+    private boolean hasActiveGrant(String accountId, String namespaceId) {
+        String findGrantSql = sqlLoader.load("catalog/grants/find-active-grant");
+        List<Grant> grants = jdbc.sql(findGrantSql)
+                .param("objectType", GrantObjectType.NAMESPACE.name())
+                .param("objectId", namespaceId)
+                .param("principalId", accountId)
+                .query(this::mapGrantRow)
+                .list();
+        return !grants.isEmpty();
+    }
+
+    private int countOwnedNamespaces(String accountId) {
+        String sql = "SELECT COUNT(*) FROM namespaces WHERE owner_account_id = :ownerAccountId AND status != 'TOMBSTONED'";
+        Integer count = jdbc.sql(sql)
+                .param("ownerAccountId", accountId)
+                .query(Integer.class)
+                .single();
+        return count != null ? count : 0;
+    }
+
+    private void insertNamespaceRow(NamespaceRecord record) {
+        String sql = sqlLoader.load("catalog/namespaces/insert-namespace");
+        jdbc.sql(sql)
+                .param("namespaceId", record.namespaceId())
+                .param("ownerAccountId", record.ownerAccountId())
+                .param("slug", record.slug())
+                .param("type", record.type().name())
+                .param("status", record.status().name())
+                .param("displayName", record.displayName())
+                .param("description", record.description())
+                .param("biasJson", serializeBias(record.bias()))
+                .param("createdAt", Timestamp.from(record.createdAt()))
+                .param("lastAccessedAt", record.lastAccessedAt() != null ? Timestamp.from(record.lastAccessedAt()) : null)
+                .update();
+    }
+
+    private void insertImplicitOwnerGrant(String accountId, String namespaceId) {
+        try {
+            addGrant(new Grant(
+                    tsid.generate(),
+                    GrantObjectType.NAMESPACE,
+                    namespaceId,
+                    accountId,
+                    PrincipalType.ACCOUNT,
+                    GrantRole.OWNER,
+                    Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
+                    accountId,
+                    Instant.now(),
+                    null,
+                    null
+            ));
+        } catch (Exception e) {
+            log.debug("[JdbcAccountCatalog] Implicit grant already exists or failed: {}", e.getMessage());
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Row Mappers & Serialization Helpers
+    // ══════════════════════════════════════════════════════════════
+
+    private Account mapAccountRow(ResultSet rs, int rowNum) throws SQLException {
+        String userId = rs.getString("user_id");
+        String displayName = rs.getString("display_name");
+        String kindStr = rs.getString("kind");
+        String profileStr = rs.getString("profile");
+        String flagsStr = rs.getString("flags");
+        String defaultNsId = rs.getString("default_namespace_id");
+        Integer maxNs = rs.getObject("max_namespaces", Integer.class);
+        Integer maxHotNs = rs.getObject("max_hot_namespaces", Integer.class);
+        Timestamp createdAt = rs.getTimestamp("created_at");
+
+        PrincipalKind kind = kindStr != null ? PrincipalKind.valueOf(kindStr) : PrincipalKind.HUMAN;
+        AccountProfile profile = profileStr != null ? AccountProfile.valueOf(profileStr) : AccountProfile.HUMAN_SOLO;
+        AccountFlags flags = parseFlags(flagsStr);
+        AccountQuotas quotas = defaultQuotas(profile, maxNs, maxHotNs);
+
+        return new Account(
+                userId,
+                kind,
+                profile,
+                displayName != null ? displayName : userId,
+                quotas,
+                flags,
+                defaultNsId != null ? defaultNsId : userId,
+                createdAt != null ? createdAt.toInstant() : Instant.now()
+        );
+    }
+
+    private NamespaceRecord mapNamespaceRow(ResultSet rs, int rowNum) throws SQLException {
+        String namespaceId = rs.getString("namespace_id");
+        String ownerAccountId = rs.getString("owner_account_id");
+        String slug = rs.getString("slug");
+        String typeStr = rs.getString("type");
+        String statusStr = rs.getString("status");
+        String displayName = rs.getString("display_name");
+        String description = rs.getString("description");
+        String biasJson = rs.getString("bias_json");
+        Timestamp createdAt = rs.getTimestamp("created_at");
+        Timestamp lastAccessedAt = rs.getTimestamp("last_accessed_at");
+
+        return new NamespaceRecord(
+                namespaceId,
+                slug,
+                ownerAccountId,
+                typeStr != null ? NamespaceType.valueOf(typeStr) : NamespaceType.PROJECT,
+                statusStr != null ? NamespaceStatus.valueOf(statusStr) : NamespaceStatus.ACTIVE,
+                displayName,
+                description,
+                parseBias(biasJson),
+                createdAt != null ? createdAt.toInstant() : Instant.now(),
+                lastAccessedAt != null ? lastAccessedAt.toInstant() : null
+        );
+    }
+
+    private Grant mapGrantRow(ResultSet rs, int rowNum) throws SQLException {
+        String grantId = rs.getString("grant_id");
+        String objTypeStr = rs.getString("object_type");
+        String objId = rs.getString("object_id");
+        String principalId = rs.getString("principal_id");
+        String principalTypeStr = rs.getString("principal_type");
+        String roleStr = rs.getString("role");
+        String actionsStr = rs.getString("actions");
+        String grantedBy = rs.getString("granted_by");
+        Timestamp grantedAt = rs.getTimestamp("granted_at");
+        Timestamp expiresAt = rs.getTimestamp("expires_at");
+        String constraintsJson = rs.getString("constraints_json");
+
+        Set<GrantAction> actions = new HashSet<>();
+        if (actionsStr != null && !actionsStr.isBlank()) {
+            for (String a : actionsStr.split(",")) {
+                if (!a.isBlank()) {
+                    actions.add(GrantAction.valueOf(a.trim()));
+                }
+            }
+        }
+
+        return new Grant(
+                grantId,
+                GrantObjectType.valueOf(objTypeStr),
+                objId,
+                principalId,
+                PrincipalType.valueOf(principalTypeStr),
+                roleStr != null ? GrantRole.valueOf(roleStr) : null,
+                actions,
+                grantedBy,
+                grantedAt != null ? grantedAt.toInstant() : Instant.now(),
+                expiresAt != null ? expiresAt.toInstant() : null,
+                parseConstraints(constraintsJson)
+        );
+    }
+
+    private AccountQuotas defaultQuotas(AccountProfile profile, Integer customMaxNs, Integer customMaxHotNs) {
+        int maxNs = customMaxNs != null ? customMaxNs : switch (profile) {
+            case HUMAN_SOLO -> 4;
+            case HUMAN_TEAM -> 16;
+            case AGENT -> 64;
+            case SERVICE -> 256;
+            case UNLIMITED -> -1;
+        };
+
+        int maxHotNs = customMaxHotNs != null ? customMaxHotNs : switch (profile) {
+            case HUMAN_SOLO -> 2;
+            case HUMAN_TEAM -> 4;
+            case AGENT -> 4;
+            case SERVICE -> 8;
+            case UNLIMITED -> -1;
+        };
+
+        return new AccountQuotas(maxNs, maxHotNs, -1, -1);
+    }
+
+    private AccountFlags parseFlags(String json) {
+        if (json == null || json.isBlank()) {
+            return new AccountFlags(true, true, true);
+        }
+        try {
+            return objectMapper.readValue(json, AccountFlags.class);
+        } catch (Exception e) {
+            return new AccountFlags(true, true, true);
+        }
+    }
+
+    private NamespaceBias parseBias(String json) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            return objectMapper.readValue(json, NamespaceBias.class);
+        } catch (Exception e) {
+            log.warn("[JdbcAccountCatalog] Failed to parse bias json: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String serializeBias(NamespaceBias bias) {
+        if (bias == null) return null;
+        try {
+            return objectMapper.writeValueAsString(bias);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    private GrantConstraints parseConstraints(String json) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            return objectMapper.readValue(json, GrantConstraints.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String serializeConstraints(GrantConstraints constraints) {
+        if (constraints == null) return null;
+        try {
+            return objectMapper.writeValueAsString(constraints);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
@@ -38,11 +38,28 @@ public class CatalogAutoConfiguration {
     private static final Logger log = LoggerFactory.getLogger(CatalogAutoConfiguration.class);
 
     /**
-     * File-backed catalog for authenticated deployments.
+     * JDBC-backed catalog for production and enterprise deployments (default).
+     */
+    @Bean
+    @ConditionalOnProperty(name = "spector.auth.enabled", havingValue = "true", matchIfMissing = false)
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            name = "spector.catalog.type", havingValue = "jdbc", matchIfMissing = true)
+    public AccountCatalog jdbcAccountCatalog(
+            org.springframework.jdbc.core.simple.JdbcClient jdbc,
+            com.spectrayan.spector.synapse.config.sql.SqlQueryLoader sqlLoader,
+            ObjectMapper objectMapper) {
+        log.info("[CatalogAutoConfiguration] creating JdbcAccountCatalog");
+        return new com.spectrayan.spector.synapse.catalog.jdbc.JdbcAccountCatalog(jdbc, sqlLoader, objectMapper);
+    }
+
+    /**
+     * File-backed catalog for standalone or file-based deployments.
      * Rooted at the same persistence path as the memory data plane.
      */
     @Bean
     @ConditionalOnProperty(name = "spector.auth.enabled", havingValue = "true", matchIfMissing = false)
+    @org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+            name = "spector.catalog.type", havingValue = "file", matchIfMissing = false)
     public AccountCatalog fileAccountCatalog(SynapseProperties synapseProps, ObjectMapper objectMapper) {
         String path = synapseProps.getMemory().getPersistencePath();
         if (path == null || path.isBlank()) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
@@ -159,7 +159,7 @@ public class NamespaceResolver implements AutoCloseable {
         String namespaceId = account.defaultNamespaceId();
 
         // Step 2: Bind — cache lookup by namespaceId (not userId, not slug)
-        return getOrBuild(namespaceId);
+        return getOrBuild(accountId, namespaceId, accountId);
     }
 
     /**
@@ -188,7 +188,7 @@ public class NamespaceResolver implements AutoCloseable {
             throw new NamespaceTombstonedException(record.namespaceId());
         }
         catalog.recordAccess(record.namespaceId());
-        return getOrBuild(record.namespaceId());
+        return getOrBuild(accountId, record.namespaceId(), record.ownerAccountId());
     }
 
     /**
@@ -205,16 +205,19 @@ public class NamespaceResolver implements AutoCloseable {
     }
 
     /**
-     * Gets or builds the SpectorMemory instance for the given namespaceId.
+     * Gets or builds the SpectorMemory instance for the given namespaceId with hot cap
+     * and lease-aware eviction checks.
      *
-     * @param namespaceId the globally unique namespace identifier
+     * @param accountId       the principal requesting resolution
+     * @param namespaceId     the globally unique namespace identifier
+     * @param ownerAccountId  the owner account of the namespace
      * @return the cached or newly-built SpectorMemory
      */
-    private SpectorMemory getOrBuild(String namespaceId) {
+    private SpectorMemory getOrBuild(String accountId, String namespaceId, String ownerAccountId) {
         // Fast path: lock-free cache hit
         MemoryHandle handle = cache.get(namespaceId);
         if (handle != null) {
-            handle.touch();
+            handle.touch(accountId);
             return handle.memory;
         }
 
@@ -222,10 +225,47 @@ public class NamespaceResolver implements AutoCloseable {
         try {
             coldPathLock.lock();
             try {
-                if (!cache.containsKey(namespaceId) && cache.size() >= maxInstances) {
-                    evicted = evictOldestLocked();
+                handle = cache.get(namespaceId);
+                if (handle != null) {
+                    handle.touch(accountId);
+                    return handle.memory;
                 }
-                handle = cache.computeIfAbsent(namespaceId, id -> new MemoryHandle(buildInstance(id)));
+
+                // 1. Account-level hot cap check (ADR-0029 §2.6, §6.3, Q4)
+                if (accountId != null) {
+                    Account account = catalog.getOrCreateAccount(accountId);
+                    int maxHot = account.quotas().maxHotNamespaces();
+                    if (maxHot > 0) {
+                        long currentAccountHot = cache.values().stream()
+                                .filter(h -> h.associatedWith(accountId))
+                                .count();
+                        if (currentAccountHot >= maxHot) {
+                            MemoryHandle accountEvicted = evictOldestAccountUnleasedLocked(accountId);
+                            if (accountEvicted == null) {
+                                throw new com.spectrayan.spector.synapse.catalog.exception.NamespaceHotCapExceededException(
+                                        accountId, maxHot);
+                            }
+                            evicted = accountEvicted;
+                        }
+                    }
+                }
+
+                // 2. Process-wide instance cap check (ADR-0029 §6.3)
+                if (cache.size() >= maxInstances) {
+                    MemoryHandle processEvicted = evictOldestProcessUnleasedLocked();
+                    if (processEvicted == null) {
+                        throw new com.spectrayan.spector.synapse.catalog.exception.NamespaceHotCapExceededException(
+                                "process", maxInstances);
+                    }
+                    if (evicted != null && evicted != processEvicted) {
+                        closeQuietly(evicted.memory);
+                    }
+                    evicted = processEvicted;
+                }
+
+                SpectorMemory instance = buildInstance(namespaceId);
+                handle = new MemoryHandle(namespaceId, ownerAccountId, accountId, instance);
+                cache.put(namespaceId, handle);
             } finally {
                 coldPathLock.unlock();
             }
@@ -234,7 +274,7 @@ public class NamespaceResolver implements AutoCloseable {
                 closeQuietly(evicted.memory);
             }
         }
-        handle.touch();
+        handle.touch(accountId);
         return handle.memory;
     }
 
@@ -313,7 +353,7 @@ public class NamespaceResolver implements AutoCloseable {
             builder.aismeConfig(com.spectrayan.spector.memory.aisme.config.AismeConfig.fromProperties(memory.getAisme()));
         }
 
-        LlmProvider textGen = textGenProvider.getIfAvailable();
+        LlmProvider textGen = textGenProvider != null ? textGenProvider.getIfAvailable() : null;
         if (textGen != null) {
             builder.entityExtractionMode(EntityExtractionMode.LLM);
             builder.LlmProvider(textGen);
@@ -321,7 +361,7 @@ public class NamespaceResolver implements AutoCloseable {
             builder.entityExtractionMode(EntityExtractionMode.NONE);
         }
 
-        SalienceProfileProvider salience = salienceProvider.getIfAvailable();
+        SalienceProfileProvider salience = salienceProvider != null ? salienceProvider.getIfAvailable() : null;
         if (salience != null) {
             builder.salienceProfileProvider(salience);
         }
@@ -410,22 +450,67 @@ public class NamespaceResolver implements AutoCloseable {
         return Path.of(path);
     }
 
-    private MemoryHandle evictOldestLocked() {
+    private MemoryHandle evictOldestAccountUnleasedLocked(String accountId) {
         String oldestKey = null;
         long oldestAccess = Long.MAX_VALUE;
         for (Map.Entry<String, MemoryHandle> entry : cache.entrySet()) {
-            long access = entry.getValue().lastAccessNanos;
-            if (access < oldestAccess) {
-                oldestAccess = access;
-                oldestKey = entry.getKey();
+            MemoryHandle h = entry.getValue();
+            if (h.associatedWith(accountId) && !isLeased(h.memory)) {
+                if (h.lastAccessNanos < oldestAccess) {
+                    oldestAccess = h.lastAccessNanos;
+                    oldestKey = entry.getKey();
+                }
             }
         }
         if (oldestKey != null) {
-            MemoryHandle evicted = cache.remove(oldestKey);
-            if (evicted != null) {
-                log.debug("[NamespaceResolver] evicting LRU namespace memory instance (cap={})", maxInstances);
-                return evicted;
+            MemoryHandle ev = cache.remove(oldestKey);
+            if (ev != null) {
+                log.info("[NamespaceResolver] Evicting unleased hot namespace '{}' for account '{}' (hot cap reached)",
+                        oldestKey, accountId);
+                return ev;
             }
+        }
+        return null;
+    }
+
+    private MemoryHandle evictOldestProcessUnleasedLocked() {
+        String oldestKey = null;
+        long oldestAccess = Long.MAX_VALUE;
+        for (Map.Entry<String, MemoryHandle> entry : cache.entrySet()) {
+            MemoryHandle h = entry.getValue();
+            if (!isLeased(h.memory)) {
+                if (h.lastAccessNanos < oldestAccess) {
+                    oldestAccess = h.lastAccessNanos;
+                    oldestKey = entry.getKey();
+                }
+            }
+        }
+        if (oldestKey != null) {
+            MemoryHandle ev = cache.remove(oldestKey);
+            if (ev != null) {
+                log.info("[NamespaceResolver] Evicting unleased hot namespace '{}' (process capacity={})",
+                        oldestKey, maxInstances);
+                return ev;
+            }
+        }
+        return null;
+    }
+
+    MemoryHandle evictOldestLocked() {
+        return evictOldestProcessUnleasedLocked();
+    }
+
+    private static boolean isLeased(SpectorMemory memory) {
+        DefaultSpectorMemory dsm = unwrapDefaultMemory(memory);
+        return dsm != null && dsm.hasActiveLeases();
+    }
+
+    private static DefaultSpectorMemory unwrapDefaultMemory(SpectorMemory mem) {
+        if (mem instanceof DefaultSpectorMemory dsm) {
+            return dsm;
+        }
+        if (mem instanceof com.spectrayan.spector.metrics.ObservedSpectorMemory osm) {
+            return unwrapDefaultMemory(osm.unwrap());
         }
         return null;
     }
@@ -440,18 +525,38 @@ public class NamespaceResolver implements AutoCloseable {
         }
     }
 
-    /** Cache entry pairing a namespace instance with its last-access time (for LRU eviction). */
+    /** Cache entry pairing a namespace instance with its accessing accounts and access time. */
     private static final class MemoryHandle {
+        private final String namespaceId;
+        private final String ownerAccountId;
+        private final java.util.Set<String> accessingAccounts = ConcurrentHashMap.newKeySet();
         private final SpectorMemory memory;
         private volatile long lastAccessNanos;
 
         MemoryHandle(SpectorMemory memory) {
+            this(null, null, null, memory);
+        }
+
+        MemoryHandle(String namespaceId, String ownerAccountId, String initialAccountId, SpectorMemory memory) {
+            this.namespaceId = namespaceId;
+            this.ownerAccountId = ownerAccountId != null ? ownerAccountId : initialAccountId;
+            if (initialAccountId != null) {
+                this.accessingAccounts.add(initialAccountId);
+            }
             this.memory = memory;
             this.lastAccessNanos = System.nanoTime();
         }
 
-        void touch() {
+        void touch(String accountId) {
             this.lastAccessNanos = System.nanoTime();
+            if (accountId != null) {
+                this.accessingAccounts.add(accountId);
+            }
+        }
+
+        boolean associatedWith(String accountId) {
+            if (accountId == null) return false;
+            return accountId.equals(ownerAccountId) || accessingAccounts.contains(accountId);
         }
     }
 }

--- a/synapse/spector-synapse/src/main/resources/db/migration/V6__memory_catalog.sql
+++ b/synapse/spector-synapse/src/main/resources/db/migration/V6__memory_catalog.sql
@@ -1,0 +1,84 @@
+--
+-- Copyright 2026 Spectrayan
+--
+-- Licensed under the Business Source License 1.1 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+--
+-- Change Date: July 6, 2030
+-- Change License: Apache License, Version 2.0
+--
+
+-- Memory Catalog Plane (ADR-0029 v4).
+-- Adds catalog-level metadata, namespaces, grants, and org containment to the synapse database.
+
+-- Extend users table with catalog profile, quotas, and membership version
+ALTER TABLE users ADD COLUMN IF NOT EXISTS profile VARCHAR(32) DEFAULT 'HUMAN_SOLO';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS kind VARCHAR(16) DEFAULT 'HUMAN';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS flags VARCHAR(256) DEFAULT '{}';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS default_namespace_id VARCHAR(13);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS max_namespaces INT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS max_hot_namespaces INT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS membership_version BIGINT DEFAULT 0;
+
+-- Namespaces: catalog metadata and owner linkage for memory data-plane directories
+CREATE TABLE IF NOT EXISTS namespaces (
+    namespace_id       VARCHAR(13)   NOT NULL,
+    owner_account_id   VARCHAR(13)   NOT NULL,
+    slug               VARCHAR(63)   NOT NULL,
+    type               VARCHAR(16)   NOT NULL,
+    status             VARCHAR(16)   NOT NULL,
+    display_name       VARCHAR(255),
+    description        VARCHAR(2048),
+    bias_json          CLOB,
+    created_at         TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_accessed_at   TIMESTAMP,
+    PRIMARY KEY (namespace_id),
+    CONSTRAINT uq_namespaces_owner_slug UNIQUE (owner_account_id, slug),
+    CONSTRAINT fk_namespaces_owner FOREIGN KEY (owner_account_id) REFERENCES users (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_namespaces_owner ON namespaces (owner_account_id);
+CREATE INDEX IF NOT EXISTS idx_namespaces_slug ON namespaces (slug);
+
+-- Grants: multi-principal authorization for namespaces and identity regions
+CREATE TABLE IF NOT EXISTS grants (
+    grant_id         VARCHAR(13)   NOT NULL,
+    object_type      VARCHAR(32)   NOT NULL,
+    object_id        VARCHAR(64)   NOT NULL,
+    principal_id     VARCHAR(13)   NOT NULL,
+    principal_type   VARCHAR(16)   NOT NULL,
+    role             VARCHAR(16),
+    actions          VARCHAR(128),
+    granted_by       VARCHAR(13)   NOT NULL,
+    granted_at       TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at       TIMESTAMP,
+    revoked_at       TIMESTAMP,
+    constraints_json CLOB,
+    PRIMARY KEY (grant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_grants_object ON grants (object_type, object_id);
+CREATE INDEX IF NOT EXISTS idx_grants_principal ON grants (principal_id);
+CREATE INDEX IF NOT EXISTS idx_grants_active ON grants (object_type, object_id, principal_id, revoked_at);
+
+-- Org units: optional organizational containment
+CREATE TABLE IF NOT EXISTS org_units (
+    org_unit_id  VARCHAR(13)  NOT NULL,
+    tenant_id    VARCHAR(13)  NOT NULL,
+    name         VARCHAR(255) NOT NULL,
+    PRIMARY KEY (org_unit_id)
+);
+
+-- Org unit membership
+CREATE TABLE IF NOT EXISTS org_unit_members (
+    org_unit_id  VARCHAR(13) NOT NULL,
+    account_id   VARCHAR(13) NOT NULL,
+    PRIMARY KEY (org_unit_id, account_id),
+    CONSTRAINT fk_oum_org FOREIGN KEY (org_unit_id) REFERENCES org_units (org_unit_id),
+    CONSTRAINT fk_oum_acct FOREIGN KEY (account_id) REFERENCES users (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oum_account ON org_unit_members (account_id);

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/account/find-by-id.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/account/find-by-id.sql
@@ -1,0 +1,14 @@
+-- Find account catalog metadata by user ID
+SELECT
+    user_id,
+    display_name,
+    kind,
+    profile,
+    flags,
+    default_namespace_id,
+    max_namespaces,
+    max_hot_namespaces,
+    membership_version,
+    created_at
+FROM users
+WHERE user_id = :userId

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/account/update-default-namespace.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/account/update-default-namespace.sql
@@ -1,0 +1,5 @@
+-- Update account default namespace ID
+UPDATE users
+SET default_namespace_id = :defaultNamespaceId,
+    updated_at = CURRENT_TIMESTAMP
+WHERE user_id = :userId

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/grants/find-active-grant.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/grants/find-active-grant.sql
@@ -1,0 +1,20 @@
+-- Find active grant for an object and principal
+SELECT
+    grant_id,
+    object_type,
+    object_id,
+    principal_id,
+    principal_type,
+    role,
+    actions,
+    granted_by,
+    granted_at,
+    expires_at,
+    revoked_at,
+    constraints_json
+FROM grants
+WHERE object_type = :objectType
+  AND object_id = :objectId
+  AND principal_id = :principalId
+  AND revoked_at IS NULL
+  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/grants/insert-grant.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/grants/insert-grant.sql
@@ -1,0 +1,28 @@
+-- Insert grant record
+INSERT INTO grants (
+    grant_id,
+    object_type,
+    object_id,
+    principal_id,
+    principal_type,
+    role,
+    actions,
+    granted_by,
+    granted_at,
+    expires_at,
+    revoked_at,
+    constraints_json
+) VALUES (
+    :grantId,
+    :objectType,
+    :objectId,
+    :principalId,
+    :principalType,
+    :role,
+    :actions,
+    :grantedBy,
+    :grantedAt,
+    :expiresAt,
+    :revokedAt,
+    :constraintsJson
+)

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/grants/revoke-grant.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/grants/revoke-grant.sql
@@ -1,0 +1,5 @@
+-- Revoke a grant by setting revoked_at timestamp
+UPDATE grants
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE grant_id = :grantId
+  AND revoked_at IS NULL

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/find-by-id.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/find-by-id.sql
@@ -1,0 +1,14 @@
+-- Find namespace by immutable TSID
+SELECT
+    namespace_id,
+    owner_account_id,
+    slug,
+    type,
+    status,
+    display_name,
+    description,
+    bias_json,
+    created_at,
+    last_accessed_at
+FROM namespaces
+WHERE namespace_id = :namespaceId

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/find-by-owner-and-slug.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/find-by-owner-and-slug.sql
@@ -1,0 +1,15 @@
+-- Find namespace by owner account ID and slug
+SELECT
+    namespace_id,
+    owner_account_id,
+    slug,
+    type,
+    status,
+    display_name,
+    description,
+    bias_json,
+    created_at,
+    last_accessed_at
+FROM namespaces
+WHERE owner_account_id = :ownerAccountId
+  AND slug = :slug

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/insert-namespace.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/insert-namespace.sql
@@ -1,0 +1,24 @@
+-- Insert new namespace record
+INSERT INTO namespaces (
+    namespace_id,
+    owner_account_id,
+    slug,
+    type,
+    status,
+    display_name,
+    description,
+    bias_json,
+    created_at,
+    last_accessed_at
+) VALUES (
+    :namespaceId,
+    :ownerAccountId,
+    :slug,
+    :type,
+    :status,
+    :displayName,
+    :description,
+    :biasJson,
+    :createdAt,
+    :lastAccessedAt
+)

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/list-accessible.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/list-accessible.sql
@@ -1,0 +1,22 @@
+-- List all accessible namespaces for an account (owned + granted)
+SELECT DISTINCT
+    n.namespace_id,
+    n.owner_account_id,
+    n.slug,
+    n.type,
+    n.status,
+    n.display_name,
+    n.description,
+    n.bias_json,
+    n.created_at,
+    n.last_accessed_at
+FROM namespaces n
+LEFT JOIN grants g
+    ON g.object_type = 'NAMESPACE'
+   AND g.object_id = n.namespace_id
+   AND g.principal_id = :accountId
+   AND g.revoked_at IS NULL
+   AND (g.expires_at IS NULL OR g.expires_at > CURRENT_TIMESTAMP)
+WHERE (n.owner_account_id = :accountId OR g.grant_id IS NOT NULL)
+  AND n.status != 'TOMBSTONED'
+ORDER BY n.created_at ASC

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/tombstone.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/tombstone.sql
@@ -1,0 +1,5 @@
+-- Soft-delete (tombstone) a namespace
+UPDATE namespaces
+SET status = 'TOMBSTONED',
+    last_accessed_at = CURRENT_TIMESTAMP
+WHERE namespace_id = :namespaceId

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/update-last-accessed.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/update-last-accessed.sql
@@ -1,0 +1,4 @@
+-- Update last accessed timestamp for a namespace
+UPDATE namespaces
+SET last_accessed_at = CURRENT_TIMESTAMP
+WHERE namespace_id = :namespaceId

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/update-namespace.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/namespaces/update-namespace.sql
@@ -1,0 +1,8 @@
+-- Update namespace mutable metadata
+UPDATE namespaces
+SET display_name = :displayName,
+    description = :description,
+    type = :type,
+    bias_json = :biasJson,
+    last_accessed_at = CURRENT_TIMESTAMP
+WHERE namespace_id = :namespaceId

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalogTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalogTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.jdbc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.spectrayan.spector.synapse.catalog.*;
+import com.spectrayan.spector.synapse.catalog.exception.AccountQuotaExceededException;
+import com.spectrayan.spector.synapse.catalog.exception.DefaultNamespaceProtectedException;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
+import com.spectrayan.spector.synapse.config.sql.SqlQueryLoader;
+import org.flywaydb.core.Flyway;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("JdbcAccountCatalog Tests (Phase 3)")
+class JdbcAccountCatalogTest {
+
+    private JdbcClient jdbc;
+    private JdbcAccountCatalog catalog;
+    private ObjectMapper objectMapper;
+
+    private static final String ACCOUNT_ID = "0195500000001";
+    private static final String OTHER_ACCOUNT_ID = "0195500000002";
+
+    @BeforeEach
+    void setUp() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:jdbccatalog-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+
+        // Run Flyway migrations V1..V6
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration")
+                .load();
+        flyway.migrate();
+
+        jdbc = JdbcClient.create(dataSource);
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        SqlQueryLoader sqlLoader = new SqlQueryLoader();
+        sqlLoader.prewarm();
+
+        catalog = new JdbcAccountCatalog(jdbc, sqlLoader, objectMapper);
+    }
+
+    @Test
+    @DisplayName("getOrCreateAccount initializes default namespace and implicit OWNER grant")
+    void testGetOrCreateAccount() {
+        Account account = catalog.getOrCreateAccount(ACCOUNT_ID);
+        assertThat(account.id()).isEqualTo(ACCOUNT_ID);
+        assertThat(account.defaultNamespaceId()).isEqualTo(ACCOUNT_ID);
+        assertThat(account.profile()).isEqualTo(AccountProfile.HUMAN_SOLO);
+        assertThat(account.quotas().maxNamespaces()).isEqualTo(4);
+        assertThat(account.quotas().maxHotNamespaces()).isEqualTo(2);
+
+        // Verify default namespace resolved
+        Optional<NamespaceRecord> defaultNs = catalog.resolve(ACCOUNT_ID, "default");
+        assertThat(defaultNs).isPresent();
+        assertThat(defaultNs.get().slug()).isEqualTo("default");
+        assertThat(defaultNs.get().namespaceId()).isEqualTo(ACCOUNT_ID);
+        assertThat(defaultNs.get().type()).isEqualTo(NamespaceType.DEFAULT);
+        assertThat(defaultNs.get().status()).isEqualTo(NamespaceStatus.ACTIVE);
+
+        // Verify implicit OWNER authorization
+        Optional<Grant> auth = catalog.authorize(ACCOUNT_ID, ACCOUNT_ID, GrantRole.OWNER);
+        assertThat(auth).isPresent();
+        assertThat(auth.get().role()).isEqualTo(GrantRole.OWNER);
+    }
+
+    @Test
+    @DisplayName("createNamespace creates and persists rich metadata with domain bias")
+    void testCreateNamespaceWithMetadata() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+
+        var bias = new NamespaceBias(List.of("distributed-systems", "database"), Map.of("consensus", 1.5f));
+        NamespaceRecord created = catalog.createNamespace(
+                ACCOUNT_ID, "raft-consensus", NamespaceType.PROJECT,
+                "Raft Consensus", "Raft protocol research", bias
+        );
+
+        assertThat(created.slug()).isEqualTo("raft-consensus");
+        assertThat(created.displayName()).isEqualTo("Raft Consensus");
+        assertThat(created.description()).isEqualTo("Raft protocol research");
+        assertThat(created.bias()).isNotNull();
+        assertThat(created.bias().domainFocus()).contains("distributed-systems", "database");
+
+        // Verify resolved by slug
+        Optional<NamespaceRecord> bySlug = catalog.resolve(ACCOUNT_ID, "raft-consensus");
+        assertThat(bySlug).isPresent();
+        assertThat(bySlug.get().namespaceId()).isEqualTo(created.namespaceId());
+
+        // Verify resolved by TSID
+        Optional<NamespaceRecord> byId = catalog.resolve(ACCOUNT_ID, created.namespaceId());
+        assertThat(byId).isPresent();
+        assertThat(byId.get().slug()).isEqualTo("raft-consensus");
+    }
+
+    @Test
+    @DisplayName("createNamespace enforces slug grammar and duplicate prevention")
+    void testSlugGrammarAndDuplicatePrevention() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, "-invalid-start", NamespaceType.PROJECT))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, "invalid space", NamespaceType.PROJECT))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        catalog.createNamespace(ACCOUNT_ID, "project-1", NamespaceType.PROJECT);
+
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, "project-1", NamespaceType.PROJECT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already exists");
+    }
+
+    @Test
+    @DisplayName("createNamespace enforces account maxNamespaces quota")
+    void testAccountQuotaExceeded() {
+        catalog.getOrCreateAccount(ACCOUNT_ID); // creates 1 (default)
+
+        catalog.createNamespace(ACCOUNT_ID, "project-1", NamespaceType.PROJECT); // 2
+        catalog.createNamespace(ACCOUNT_ID, "project-2", NamespaceType.PROJECT); // 3
+        catalog.createNamespace(ACCOUNT_ID, "project-3", NamespaceType.PROJECT); // 4 (cap reached for HUMAN_SOLO)
+
+        assertThatThrownBy(() -> catalog.createNamespace(ACCOUNT_ID, "project-4", NamespaceType.PROJECT))
+                .isInstanceOf(AccountQuotaExceededException.class);
+    }
+
+    @Test
+    @DisplayName("listAccessible lists owned and granted namespaces")
+    void testListAccessible() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        catalog.getOrCreateAccount(OTHER_ACCOUNT_ID);
+
+        NamespaceRecord owned = catalog.createNamespace(ACCOUNT_ID, "my-project", NamespaceType.PROJECT);
+        NamespaceRecord otherOwned = catalog.createNamespace(OTHER_ACCOUNT_ID, "shared-project", NamespaceType.PROJECT);
+
+        // Before grant: ACCOUNT_ID sees default + my-project (2)
+        List<NamespaceRecord> list1 = catalog.listAccessible(ACCOUNT_ID);
+        assertThat(list1).extracting(NamespaceRecord::slug).containsExactlyInAnyOrder("default", "my-project");
+
+        // Grant ACCOUNT_ID READER on shared-project
+        catalog.addGrant(new Grant(
+                "grant-001",
+                GrantObjectType.NAMESPACE,
+                otherOwned.namespaceId(),
+                ACCOUNT_ID,
+                PrincipalType.ACCOUNT,
+                GrantRole.READER,
+                Set.of(GrantAction.READ),
+                OTHER_ACCOUNT_ID,
+                Instant.now(),
+                null,
+                null
+        ));
+
+        // After grant: ACCOUNT_ID sees default + my-project + shared-project (3)
+        List<NamespaceRecord> list2 = catalog.listAccessible(ACCOUNT_ID);
+        assertThat(list2).extracting(NamespaceRecord::slug).containsExactlyInAnyOrder("default", "my-project", "shared-project");
+    }
+
+    @Test
+    @DisplayName("setDefaultNamespace and tombstone invariants")
+    void testSetDefaultAndTombstone() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        NamespaceRecord proj = catalog.createNamespace(ACCOUNT_ID, "work-ctx", NamespaceType.PROJECT);
+
+        catalog.setDefaultNamespace(ACCOUNT_ID, proj.namespaceId());
+        Account acct = catalog.getAccount(ACCOUNT_ID);
+        assertThat(acct.defaultNamespaceId()).isEqualTo(proj.namespaceId());
+
+        // Default namespace deletion protected
+        assertThatThrownBy(() -> catalog.tombstone(ACCOUNT_ID, ACCOUNT_ID))
+                .isInstanceOf(DefaultNamespaceProtectedException.class);
+        assertThatThrownBy(() -> catalog.tombstone(ACCOUNT_ID, proj.namespaceId()))
+                .isInstanceOf(DefaultNamespaceProtectedException.class);
+
+        // Create another project and delete it
+        NamespaceRecord disposable = catalog.createNamespace(ACCOUNT_ID, "temp-project", NamespaceType.PROJECT);
+        catalog.tombstone(ACCOUNT_ID, disposable.namespaceId());
+
+        Optional<NamespaceRecord> resolved = catalog.resolve(ACCOUNT_ID, "temp-project");
+        assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    @DisplayName("updateNamespace modifies metadata")
+    void testUpdateNamespace() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        NamespaceRecord created = catalog.createNamespace(ACCOUNT_ID, "dev", NamespaceType.PROJECT, "Dev", "Old desc", null);
+
+        var newBias = new NamespaceBias(List.of("java"), Map.of("backend", 1.2f));
+        NamespaceRecord updated = catalog.updateNamespace(
+                ACCOUNT_ID, "dev", "Development", "New desc", NamespaceType.PROJECT, newBias
+        );
+
+        assertThat(updated.displayName()).isEqualTo("Development");
+        assertThat(updated.description()).isEqualTo("New desc");
+        assertThat(updated.bias()).isNotNull();
+        assertThat(updated.bias().domainFocus()).contains("java");
+    }
+
+    @Test
+    @DisplayName("grant lifecycle: add, authorize, revoke")
+    void testGrantLifecycle() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        catalog.getOrCreateAccount(OTHER_ACCOUNT_ID);
+
+        NamespaceRecord proj = catalog.createNamespace(ACCOUNT_ID, "kb", NamespaceType.PROJECT);
+
+        catalog.addGrant(new Grant(
+                "grant-kb-1",
+                GrantObjectType.NAMESPACE,
+                proj.namespaceId(),
+                OTHER_ACCOUNT_ID,
+                PrincipalType.ACCOUNT,
+                GrantRole.WRITER,
+                Set.of(GrantAction.READ, GrantAction.WRITE),
+                ACCOUNT_ID,
+                Instant.now(),
+                null,
+                null
+        ));
+
+        Optional<Grant> authWriter = catalog.authorize(OTHER_ACCOUNT_ID, proj.namespaceId(), GrantRole.WRITER);
+        assertThat(authWriter).isPresent();
+
+        Optional<Grant> authAdmin = catalog.authorize(OTHER_ACCOUNT_ID, proj.namespaceId(), GrantRole.ADMIN);
+        assertThat(authAdmin).isEmpty(); // WRITER does not satisfy ADMIN
+
+        catalog.revokeGrant("grant-kb-1");
+
+        Optional<Grant> authAfterRevoke = catalog.authorize(OTHER_ACCOUNT_ID, proj.namespaceId(), GrantRole.READER);
+        assertThat(authAfterRevoke).isEmpty();
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/NamespaceResolverHotCapTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/NamespaceResolverHotCapTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.DefaultSpectorMemory;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.synapse.catalog.*;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceHotCapExceededException;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("NamespaceResolver Hot Cap and Lease-Aware Eviction Tests (Phase 3)")
+class NamespaceResolverHotCapTest {
+
+    @TempDir
+    Path tempDir;
+
+    private AccountCatalog catalog;
+    private SynapseProperties synapseProps;
+    private ObjectProvider<EmbeddingProvider> embedderProvider;
+    private ObjectProvider<ObjectMapper> objectMapperProvider;
+    private EmbeddingProvider mockEmbedder;
+
+    private static final String ACCOUNT_ID = "0195500000001";
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        catalog = mock(AccountCatalog.class);
+        synapseProps = new SynapseProperties();
+        synapseProps.getMemory().setPersistencePath(tempDir.toString());
+        synapseProps.getMemory().setDimensions(4);
+
+        mockEmbedder = mock(EmbeddingProvider.class);
+        when(mockEmbedder.embed(any(String.class))).thenReturn(
+                com.spectrayan.spector.provider.embedding.EmbeddingResult.of(new float[]{0.1f, 0.2f, 0.3f, 0.4f}, "mock"));
+        when(mockEmbedder.embedBatch(any())).thenReturn(
+                List.of(com.spectrayan.spector.provider.embedding.EmbeddingResult.of(new float[]{0.1f, 0.2f, 0.3f, 0.4f}, "mock")));
+
+        embedderProvider = mock(ObjectProvider.class);
+        when(embedderProvider.getIfAvailable()).thenReturn(mockEmbedder);
+
+        objectMapperProvider = mock(ObjectProvider.class);
+        when(objectMapperProvider.getIfAvailable(any())).thenReturn(new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Hot cap eviction: unleased oldest instance is evicted when account hot cap is reached")
+    void testHotCapEvictsUnleasedInstance() {
+        // Account with maxHotNamespaces = 2
+        Account account = new Account(
+                ACCOUNT_ID, PrincipalKind.HUMAN, AccountProfile.HUMAN_SOLO,
+                "Test User", new AccountQuotas(4, 2, -1, -1),
+                new AccountFlags(true, true, true), "ns-default", Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        NamespaceRecord defaultRec = new NamespaceRecord(
+                "ns-default", "default", ACCOUNT_ID, NamespaceType.DEFAULT,
+                NamespaceStatus.ACTIVE, "Default", "", null, Instant.now(), null
+        );
+        NamespaceRecord proj1Rec = new NamespaceRecord(
+                "ns-proj1", "project-1", ACCOUNT_ID, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project 1", "", null, Instant.now(), null
+        );
+        NamespaceRecord proj2Rec = new NamespaceRecord(
+                "ns-proj2", "project-2", ACCOUNT_ID, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project 2", "", null, Instant.now(), null
+        );
+
+        when(catalog.resolve(ACCOUNT_ID, "default")).thenReturn(Optional.of(defaultRec));
+        when(catalog.resolve(ACCOUNT_ID, "project-1")).thenReturn(Optional.of(proj1Rec));
+        when(catalog.resolve(ACCOUNT_ID, "project-2")).thenReturn(Optional.of(proj2Rec));
+
+        NamespaceResolver resolver = new NamespaceResolver(
+                catalog, synapseProps, embedderProvider, null, null,
+                objectMapperProvider, null, null, null, null, null, 10
+        );
+
+        // Open 1st (default)
+        SpectorMemory mem1 = resolver.resolve(ACCOUNT_ID, "default");
+        assertThat(mem1).isNotNull();
+        assertThat(resolver.cachedInstanceCount()).isEqualTo(1);
+
+        // Open 2nd (project-1)
+        SpectorMemory mem2 = resolver.resolve(ACCOUNT_ID, "project-1");
+        assertThat(mem2).isNotNull();
+        assertThat(resolver.cachedInstanceCount()).isEqualTo(2);
+
+        // Open 3rd (project-2): should evict oldest unleased (default) since cap is 2
+        SpectorMemory mem3 = resolver.resolve(ACCOUNT_ID, "project-2");
+        assertThat(mem3).isNotNull();
+        assertThat(resolver.cachedInstanceCount()).isEqualTo(2);
+
+        resolver.close();
+    }
+
+    @Test
+    @DisplayName("Hot cap rejection: throws NamespaceHotCapExceededException when all hot instances are leased")
+    void testHotCapThrowsWhenAllLeased() {
+        // Account with maxHotNamespaces = 2
+        Account account = new Account(
+                ACCOUNT_ID, PrincipalKind.HUMAN, AccountProfile.HUMAN_SOLO,
+                "Test User", new AccountQuotas(4, 2, -1, -1),
+                new AccountFlags(true, true, true), "ns-default", Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        NamespaceRecord defaultRec = new NamespaceRecord(
+                "ns-default", "default", ACCOUNT_ID, NamespaceType.DEFAULT,
+                NamespaceStatus.ACTIVE, "Default", "", null, Instant.now(), null
+        );
+        NamespaceRecord proj1Rec = new NamespaceRecord(
+                "ns-proj1", "project-1", ACCOUNT_ID, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project 1", "", null, Instant.now(), null
+        );
+        NamespaceRecord proj2Rec = new NamespaceRecord(
+                "ns-proj2", "project-2", ACCOUNT_ID, NamespaceType.PROJECT,
+                NamespaceStatus.ACTIVE, "Project 2", "", null, Instant.now(), null
+        );
+
+        when(catalog.resolve(ACCOUNT_ID, "default")).thenReturn(Optional.of(defaultRec));
+        when(catalog.resolve(ACCOUNT_ID, "project-1")).thenReturn(Optional.of(proj1Rec));
+        when(catalog.resolve(ACCOUNT_ID, "project-2")).thenReturn(Optional.of(proj2Rec));
+
+        NamespaceResolver resolver = new NamespaceResolver(
+                catalog, synapseProps, embedderProvider, null, null,
+                objectMapperProvider, null, null, null, null, null, 10
+        );
+
+        // Open and lease 1st and 2nd
+        SpectorMemory mem1 = resolver.resolve(ACCOUNT_ID, "default");
+        SpectorMemory mem2 = resolver.resolve(ACCOUNT_ID, "project-1");
+
+        DefaultSpectorMemory dsm1 = (DefaultSpectorMemory) mem1;
+        DefaultSpectorMemory dsm2 = (DefaultSpectorMemory) mem2;
+
+        dsm1.acquireLease();
+        dsm2.acquireLease();
+        try {
+            assertThat(dsm1.hasActiveLeases()).isTrue();
+            assertThat(dsm2.hasActiveLeases()).isTrue();
+
+            // Attempting to open 3rd must fail because both are leased
+            assertThatThrownBy(() -> resolver.resolve(ACCOUNT_ID, "project-2"))
+                    .isInstanceOf(NamespaceHotCapExceededException.class);
+        } finally {
+            dsm1.releaseLease();
+            dsm2.releaseLease();
+        }
+
+        resolver.close();
+    }
+
+    @Test
+    @DisplayName("Process cap: evicts oldest unleased instance across process when maxInstances is reached")
+    void testProcessCapEviction() {
+        Account account = new Account(
+                ACCOUNT_ID, PrincipalKind.SERVICE, AccountProfile.SERVICE,
+                "Service Account", new AccountQuotas(100, 100, -1, -1),
+                new AccountFlags(true, true, true), "ns-default", Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        NamespaceRecord r1 = new NamespaceRecord("ns-1", "p1", ACCOUNT_ID, NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "1", "", null, Instant.now(), null);
+        NamespaceRecord r2 = new NamespaceRecord("ns-2", "p2", ACCOUNT_ID, NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "2", "", null, Instant.now(), null);
+        NamespaceRecord r3 = new NamespaceRecord("ns-3", "p3", ACCOUNT_ID, NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "3", "", null, Instant.now(), null);
+
+        when(catalog.resolve(ACCOUNT_ID, "p1")).thenReturn(Optional.of(r1));
+        when(catalog.resolve(ACCOUNT_ID, "p2")).thenReturn(Optional.of(r2));
+        when(catalog.resolve(ACCOUNT_ID, "p3")).thenReturn(Optional.of(r3));
+
+        // Resolver with process maxInstances = 2
+        NamespaceResolver resolver = new NamespaceResolver(
+                catalog, synapseProps, embedderProvider, null, null,
+                objectMapperProvider, null, null, null, null, null, 2
+        );
+
+        resolver.resolve(ACCOUNT_ID, "p1");
+        resolver.resolve(ACCOUNT_ID, "p2");
+        assertThat(resolver.cachedInstanceCount()).isEqualTo(2);
+
+        // Open 3rd: evicts p1
+        resolver.resolve(ACCOUNT_ID, "p3");
+        assertThat(resolver.cachedInstanceCount()).isEqualTo(2);
+
+        resolver.close();
+    }
+}


### PR DESCRIPTION
## Summary
Closes #701

This PR delivers Phase 3 of the multi-tenant namespace management architecture:

### Key Additions
1. **Database-Backed Catalog Plane ()**:
   - Added Flyway migration `V6__memory_catalog.sql` defining `namespaces`, `grants`, `org_units`, `org_unit_members`, and extending `users` with catalog attributes and quotas.
   - Added SQL query templates for accounts, namespaces, and grants under `sql/catalog/`.
   - Implemented `JdbcAccountCatalog` satisfying the `AccountCatalog` SPI with full CRUD, slug uniqueness per owner, auto-bind for default namespaces, and transactional grant management.
   - Wired `CatalogAutoConfiguration` for pluggable `spector.catalog.type=jdbc|file`.

2. **Hot and Catalog Quotas & Composition**:
   - Enforced per-account `maxNamespaces` (catalog cap) during namespace creation in `AccountCatalog`.
   - Enforced per-account `maxHotNamespaces` (runtime memory cap) and global process memory capacity in `NamespaceResolver`.

3. **Lease-Aware Eviction**:
   - Integrated `DefaultSpectorMemory.hasActiveLeases()` into `NamespaceResolver`.
   - Guaranteed that active memory leases are never evicted during cache pressure.
   - Throws `NamespaceHotCapExceededException` if eviction is required but all resident namespaces are currently leased.

4. **Tests & Quality Verification**:
   - Comprehensive test suite in `JdbcAccountCatalogTest` (Flyway migrations, CRUD, slug validation, quotas, grants).
   - Hot cap and lease-aware eviction verification in `NamespaceResolverHotCapTest`.
   - 100% test pass rate across the full reactor build (736/736 synapse tests passing).

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>