### PR TITLE
feat(identity): implement account identity bundle and session working set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ spector-data-backup.tar.gz
 # ──────────── Python ────────────
 __pycache__/
 *.pyc
+
+# ──────────── Inspections ────────────
+code-inspection/

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1597,8 +1597,10 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         return namespaceId;
     }
 
-    public void acquireLease() {
+    @Override
+    public AutoCloseable acquireLease() {
         activeLeases.incrementAndGet();
+        return this::releaseLease;
     }
 
     public void releaseLease() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemory.java
@@ -88,6 +88,15 @@ public interface SpectorMemory extends AutoCloseable {
     /** Returns the namespace ID of this memory. */
     default String namespaceId() { return "default"; }
 
+    /**
+     * Acquires an active lease on this memory engine, preventing eviction while held.
+     *
+     * @return AutoCloseable handle that releases the lease upon close
+     */
+    default AutoCloseable acquireLease() {
+        return () -> {};
+    }
+
     // ══════════════════════════════════════════════════════════════
     // CORE API — remember / recall / forget / reflect
     // ══════════════════════════════════════════════════════════════

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityBundle.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityBundle.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.identity;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.zip.CRC32C;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorMemoryException;
+import com.spectrayan.spector.commons.error.SpectorServerException;
+import com.spectrayan.spector.commons.error.SpectorStorageException;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
+
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Manages an account or tenant identity bundle file (ADR-0029 §23).
+ *
+ * <p>An identity bundle is a lightweight mmap container (1 FD) that stores identity,
+ * salience, continuity, and policy outside the data-plane rememberer. It does not contain
+ * a full rememberer engine and does not count against {@code maxHotNamespaces}.</p>
+ */
+public final class IdentityBundle implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(IdentityBundle.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Path bundlePath;
+    private final Arena arena;
+    private final MemorySegment masterSegment;
+    private final boolean isHeap;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private IdentityBundle(Path bundlePath, Arena arena, MemorySegment masterSegment, boolean isHeap) {
+        this.bundlePath = bundlePath;
+        this.arena = arena;
+        this.masterSegment = masterSegment;
+        this.isHeap = isHeap;
+    }
+
+    /**
+     * Opens or creates an {@link IdentityBundle} at the specified path.
+     *
+     * @param bundlePath      the file path
+     * @param createIfMissing whether to create the bundle file if missing
+     * @return open IdentityBundle
+     */
+    public static IdentityBundle open(Path bundlePath, boolean createIfMissing) {
+        try {
+            boolean exists = Files.exists(bundlePath);
+            if (!exists && !createIfMissing) {
+                throw new SpectorStorageException(ErrorCode.DISK_IO_FAILED, "IdentityBundle file not found: " + bundlePath);
+            }
+
+            if (!exists) {
+                if (bundlePath.getParent() != null) {
+                    Files.createDirectories(bundlePath.getParent());
+                }
+            }
+
+            FileChannel channel = FileChannel.open(
+                    bundlePath,
+                    StandardOpenOption.READ,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE
+            );
+
+            if (channel.size() < IdentityBundleHeader.TOTAL_INITIAL_SIZE) {
+                channel.truncate(IdentityBundleHeader.TOTAL_INITIAL_SIZE);
+            }
+
+            Arena arena = Arena.ofShared();
+            MemorySegment segment = channel.map(
+                    FileChannel.MapMode.READ_WRITE,
+                    0L,
+                    IdentityBundleHeader.TOTAL_INITIAL_SIZE,
+                    arena
+            );
+            channel.close(); // MemorySegment retains the mapping
+
+            if (!exists || !MemoryHeader.isValid(segment, 0L)) {
+                IdentityBundleHeader.initialize(segment);
+                segment.force();
+            } else {
+                IdentityBundleHeader.validate(segment);
+            }
+
+            return new IdentityBundle(bundlePath, arena, segment, false);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open IdentityBundle at " + bundlePath, e);
+        }
+    }
+
+    /**
+     * Opens an existing {@link IdentityBundle}, creating it if it does not yet exist.
+     *
+     * @param bundlePath the file path
+     * @return open IdentityBundle
+     */
+    public static IdentityBundle open(Path bundlePath) {
+        return open(bundlePath, true);
+    }
+
+    /**
+     * Creates an in-memory, heap-backed {@link IdentityBundle} for unit tests.
+     *
+     * @return in-memory IdentityBundle
+     */
+    public static IdentityBundle heap() {
+        Arena arena = Arena.ofShared();
+        MemorySegment segment = arena.allocate(IdentityBundleHeader.TOTAL_INITIAL_SIZE, 4096);
+        IdentityBundleHeader.initialize(segment);
+        return new IdentityBundle(null, arena, segment, true);
+    }
+
+    // ── Public Accessors & Mutators ──
+
+    /**
+     * Reads the {@link SoulContext} from the given region (typically {@link IdentityRegionId#SOUL}).
+     *
+     * @param regionId the target region
+     * @return optional soul context DTO copy
+     */
+    public Optional<SoulContext> readSoul(IdentityRegionId regionId) {
+        return readRaw(regionId).flatMap(bytes -> {
+            try {
+                return Optional.of(MAPPER.readValue(bytes, SoulContext.class));
+            } catch (Exception e) {
+                try {
+                    return Optional.of(MAPPER.readValue(bytes, com.spectrayan.spector.memory.model.UserSoul.class));
+                } catch (Exception e1) {
+                    try {
+                        return Optional.of(MAPPER.readValue(bytes, com.spectrayan.spector.memory.model.AgentSoul.class));
+                    } catch (Exception e2) {
+                        try {
+                            return Optional.of(MAPPER.readValue(bytes, com.spectrayan.spector.memory.model.TenantSoul.class));
+                        } catch (Exception e3) {
+                            try {
+                                return Optional.of(MAPPER.readValue(bytes, com.spectrayan.spector.memory.model.OrgUnitSoul.class));
+                            } catch (Exception e4) {
+                                log.warn("Failed to deserialize SoulContext from region {}: {}", regionId, e.getMessage());
+                                return Optional.empty();
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Reads the primary {@link SoulContext} from {@link IdentityRegionId#SOUL}.
+     *
+     * @return optional primary soul context DTO copy
+     */
+    public Optional<SoulContext> readSoul() {
+        return readSoul(IdentityRegionId.SOUL);
+    }
+
+    /**
+     * Writes the {@link SoulContext} to the specified region.
+     *
+     * @param regionId the target region
+     * @param soul     the soul context to write
+     */
+    public void writeSoul(IdentityRegionId regionId, SoulContext soul) {
+        if (soul == null) {
+            clearRegion(regionId);
+            return;
+        }
+        try {
+            byte[] bytes = MAPPER.writeValueAsBytes(soul);
+            writeRaw(regionId, bytes);
+        } catch (Exception e) {
+            throw new SpectorMemoryException(ErrorCode.GRAPH_PERSISTENCE_FAILED, "IdentityBundle",
+                    "Failed to serialize SoulContext: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Writes the primary {@link SoulContext} to {@link IdentityRegionId#SOUL}.
+     *
+     * @param soul the soul context to write
+     */
+    public void writeSoul(SoulContext soul) {
+        writeSoul(IdentityRegionId.SOUL, soul);
+    }
+
+    /**
+     * Reads the {@link SalienceProfile} from {@link IdentityRegionId#SALIENCE}.
+     *
+     * @return optional salience profile DTO copy
+     */
+    public Optional<SalienceProfile> readSalience() {
+        return readRaw(IdentityRegionId.SALIENCE).flatMap(bytes -> {
+            try {
+                return Optional.of(MAPPER.readValue(bytes, SalienceProfile.class));
+            } catch (Exception e) {
+                log.warn("Failed to deserialize SalienceProfile: {}", e.getMessage());
+                return Optional.empty();
+            }
+        });
+    }
+
+    /**
+     * Writes the {@link SalienceProfile} to {@link IdentityRegionId#SALIENCE}.
+     *
+     * @param salience the salience profile to write
+     */
+    public void writeSalience(SalienceProfile salience) {
+        if (salience == null) {
+            clearRegion(IdentityRegionId.SALIENCE);
+            return;
+        }
+        try {
+            byte[] bytes = MAPPER.writeValueAsBytes(salience);
+            writeRaw(IdentityRegionId.SALIENCE, bytes);
+        } catch (Exception e) {
+            throw new SpectorMemoryException(ErrorCode.GRAPH_PERSISTENCE_FAILED, "IdentityBundle",
+                    "Failed to serialize SalienceProfile: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Reads continuity trajectory from {@link IdentityRegionId#CONTINUITY}.
+     */
+    public Optional<String> readContinuity() {
+        return readRaw(IdentityRegionId.CONTINUITY).map(bytes -> new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Writes continuity trajectory to {@link IdentityRegionId#CONTINUITY}.
+     */
+    public void writeContinuity(String continuity) {
+        if (continuity == null) {
+            clearRegion(IdentityRegionId.CONTINUITY);
+        } else {
+            writeRaw(IdentityRegionId.CONTINUITY, continuity.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Reads policy from {@link IdentityRegionId#POLICY}.
+     */
+    public Optional<String> readPolicy() {
+        return readRaw(IdentityRegionId.POLICY).map(bytes -> new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Writes policy to {@link IdentityRegionId#POLICY}.
+     */
+    public void writePolicy(String policy) {
+        if (policy == null) {
+            clearRegion(IdentityRegionId.POLICY);
+        } else {
+            writeRaw(IdentityRegionId.POLICY, policy.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Checks if the given region has no payload.
+     *
+     * @param regionId the target region
+     * @return true if empty or not present
+     */
+    public boolean isEmpty(IdentityRegionId regionId) {
+        ensureOpen();
+        IdentityRegionEntry entry = getEntry(regionId);
+        return !entry.isPresent() || entry.usedSize() == 0;
+    }
+
+    /**
+     * Returns the version counter for the specified region.
+     *
+     * @param regionId the target region
+     * @return version counter
+     */
+    public int getVersion(IdentityRegionId regionId) {
+        ensureOpen();
+        return getEntry(regionId).version();
+    }
+
+    /**
+     * Reads raw bytes from the specified region.
+     *
+     * @param regionId the target region
+     * @return raw payload bytes, or empty if region is empty
+     */
+    public Optional<byte[]> readRaw(IdentityRegionId regionId) {
+        ensureOpen();
+        lock.lock();
+        try {
+            IdentityRegionEntry entry = getEntry(regionId);
+            if (!entry.isPresent() || entry.usedSize() == 0) {
+                return Optional.empty();
+            }
+
+            int used = (int) entry.usedSize();
+            if (used < 0 || used > entry.allocatedSize()) {
+                throw new SpectorMemoryException(ErrorCode.RECORD_CRC_CORRUPTED, "IdentityBundle",
+                        "Corrupted usedSize " + used + " for region " + regionId);
+            }
+
+            byte[] data = new byte[used];
+            MemorySegment.copy(masterSegment, entry.offset(), MemorySegment.ofArray(data), 0L, used);
+
+            // Check CRC
+            CRC32C crc = new CRC32C();
+            crc.update(data, 0, used);
+            if ((int) crc.getValue() != entry.checksum()) {
+                throw new SpectorMemoryException(ErrorCode.RECORD_CRC_CORRUPTED, "IdentityBundle",
+                        "Checksum mismatch for region " + regionId);
+            }
+
+            return Optional.of(data);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Writes raw bytes to the specified region.
+     *
+     * @param regionId the target region
+     * @param payload  the byte array to write
+     */
+    public void writeRaw(IdentityRegionId regionId, byte[] payload) {
+        ensureOpen();
+        if (payload == null) {
+            clearRegion(regionId);
+            return;
+        }
+
+        lock.lock();
+        try {
+            IdentityRegionEntry entry = getEntry(regionId);
+            if (payload.length > entry.allocatedSize()) {
+                throw new SpectorMemoryException(ErrorCode.CAPACITY_EXCEEDED, "IdentityBundle",
+                        "Payload size " + payload.length + " exceeds region allocation " + entry.allocatedSize());
+            }
+
+            CRC32C crc = new CRC32C();
+            crc.update(payload, 0, payload.length);
+            int checksum = (int) crc.getValue();
+
+            long now = System.currentTimeMillis();
+            int nextVersion = entry.version() + 1;
+
+            // Copy payload into mmap region
+            MemorySegment.copy(MemorySegment.ofArray(payload), 0L, masterSegment, entry.offset(), payload.length);
+
+            // Update entry
+            IdentityRegionEntry updated = new IdentityRegionEntry(
+                    regionId,
+                    IdentityRegionEntry.FLAG_PRESENT,
+                    entry.offset(),
+                    entry.allocatedSize(),
+                    payload.length,
+                    nextVersion,
+                    checksum,
+                    now
+            );
+            putEntry(updated);
+
+            // Update MemoryHeader timestamp and CRC
+            long createdAt = MemoryHeader.readCreatedAt(masterSegment, 0L);
+            int flags = MemoryHeader.readFlags(masterSegment, 0L);
+            MemoryHeader.write(
+                    masterSegment,
+                    0L,
+                    IdentityBundleHeader.SCHEMA_VERSION,
+                    MemoryShape.BUNDLE,
+                    flags,
+                    IdentityBundleHeader.MAX_REGIONS,
+                    0,
+                    IdentityRegionEntry.ENTRY_BYTES,
+                    IdentityBundleHeader.LAYOUT_ID,
+                    createdAt,
+                    now
+            );
+
+            if (!isHeap) {
+                masterSegment.force();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Clears a region, resetting it to empty state.
+     */
+    public void clearRegion(IdentityRegionId regionId) {
+        ensureOpen();
+        lock.lock();
+        try {
+            IdentityRegionEntry entry = getEntry(regionId);
+            long now = System.currentTimeMillis();
+            IdentityRegionEntry updated = new IdentityRegionEntry(
+                    regionId,
+                    IdentityRegionEntry.FLAG_EMPTY,
+                    entry.offset(),
+                    entry.allocatedSize(),
+                    0L,
+                    entry.version() + 1,
+                    0,
+                    now
+            );
+            putEntry(updated);
+            if (!isHeap) {
+                masterSegment.force();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private IdentityRegionEntry getEntry(IdentityRegionId regionId) {
+        long offset = IdentityBundleHeader.OFF_ENTRIES + (long) regionId.id() * IdentityRegionEntry.ENTRY_BYTES;
+        return IdentityRegionEntry.read(masterSegment, offset);
+    }
+
+    private void putEntry(IdentityRegionEntry entry) {
+        long offset = IdentityBundleHeader.OFF_ENTRIES + (long) entry.regionId().id() * IdentityRegionEntry.ENTRY_BYTES;
+        IdentityRegionEntry.write(masterSegment, offset, entry);
+    }
+
+    private void ensureOpen() {
+        if (closed.get()) {
+            throw new SpectorMemoryException(ErrorCode.ENGINE_CLOSED, "IdentityBundle", "IdentityBundle is closed");
+        }
+    }
+
+    public Path bundlePath() {
+        return bundlePath;
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            lock.lock();
+            try {
+                if (!isHeap) {
+                    masterSegment.force();
+                }
+                arena.close();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityBundleHeader.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityBundleHeader.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.identity;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorServerException;
+import com.spectrayan.spector.memory.kernel.MemoryHeader;
+import com.spectrayan.spector.memory.kernel.MemoryShape;
+
+/**
+ * Constants and layout utilities for the {@link IdentityBundle} header and sub-header.
+ *
+ * <pre>
+ * ┌──────────────────────────────────────────────────┐ offset 0
+ * │ 64B MemoryHeader (SMKM, BUNDLE, layout=IDNT)     │
+ * ├──────────────────────────────────────────────────┤ offset 64
+ * │ 64B IdentitySubHeader (SIDB, version, regions)   │
+ * ├──────────────────────────────────────────────────┤ offset 128
+ * │ 16 × 64B IdentityRegionEntry directory           │ ends at 1152
+ * ├──────────────────────────────────────────────────┤ offset 4096 (page aligned)
+ * │ Region 0..15 data payloads (64KB default each)   │
+ * └──────────────────────────────────────────────────┘
+ * </pre>
+ */
+public final class IdentityBundleHeader {
+
+    public static final int LAYOUT_ID = 0x49444E54; // 'IDNT'
+    public static final int SUB_MAGIC = 0x53494442; // 'SIDB'
+    public static final int SCHEMA_VERSION = 1;
+    public static final int MAX_REGIONS = 16;
+    public static final long DATA_START_OFFSET = 4096L;
+    public static final long DEFAULT_REGION_ALLOCATION = 64 * 1024L; // 64KB per region
+    public static final long TOTAL_INITIAL_SIZE = DATA_START_OFFSET + MAX_REGIONS * DEFAULT_REGION_ALLOCATION; // 1,052,672 B
+
+    public static final long OFF_SMKM_HEADER = 0;
+    public static final long OFF_SUB_HEADER = MemoryHeader.HEADER_BYTES; // 64
+    public static final long OFF_ENTRIES = OFF_SUB_HEADER + 64; // 128
+
+    // Sub-header internal field offsets (from OFF_SUB_HEADER)
+    private static final long OFF_SUB_MAGIC = 0;
+    private static final long OFF_SUB_VERSION = 4;
+    private static final long OFF_SUB_REGIONS = 8;
+    private static final long OFF_SUB_DATA_START = 12;
+    private static final long OFF_SUB_TOTAL_SIZE = 16;
+
+    private IdentityBundleHeader() {
+    }
+
+    /**
+     * Initializes the SMKM header, sub-header, and 16 region entries on a newly created segment.
+     */
+    public static void initialize(MemorySegment segment) {
+        long now = System.currentTimeMillis();
+        MemoryHeader.write(
+                segment,
+                OFF_SMKM_HEADER,
+                SCHEMA_VERSION,
+                MemoryShape.BUNDLE,
+                1, // persistent
+                MAX_REGIONS,
+                0, // initial active count
+                IdentityRegionEntry.ENTRY_BYTES,
+                LAYOUT_ID,
+                now,
+                now
+        );
+
+        // Write SubHeader
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, OFF_SUB_HEADER + OFF_SUB_MAGIC, SUB_MAGIC);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, OFF_SUB_HEADER + OFF_SUB_VERSION, SCHEMA_VERSION);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, OFF_SUB_HEADER + OFF_SUB_REGIONS, MAX_REGIONS);
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, OFF_SUB_HEADER + OFF_SUB_DATA_START, (int) DATA_START_OFFSET);
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, OFF_SUB_HEADER + OFF_SUB_TOTAL_SIZE, TOTAL_INITIAL_SIZE);
+
+        // Write 16 Region Entries
+        for (int i = 0; i < MAX_REGIONS; i++) {
+            IdentityRegionId regionId = IdentityRegionId.fromId(i);
+            long offset = DATA_START_OFFSET + (long) i * DEFAULT_REGION_ALLOCATION;
+            IdentityRegionEntry entry = new IdentityRegionEntry(
+                    regionId,
+                    IdentityRegionEntry.FLAG_EMPTY,
+                    offset,
+                    DEFAULT_REGION_ALLOCATION,
+                    0L,
+                    0,
+                    0,
+                    now
+            );
+            IdentityRegionEntry.write(segment, OFF_ENTRIES + (long) i * IdentityRegionEntry.ENTRY_BYTES, entry);
+        }
+    }
+
+    /**
+     * Validates that the mapped memory segment has valid headers for an IdentityBundle.
+     */
+    public static void validate(MemorySegment segment) {
+        if (!MemoryHeader.isValid(segment, OFF_SMKM_HEADER)) {
+            throw new SpectorServerException(ErrorCode.RECORD_CRC_CORRUPTED, "Invalid SMKM MemoryHeader on IdentityBundle");
+        }
+        if (MemoryHeader.readLayoutId(segment, OFF_SMKM_HEADER) != LAYOUT_ID) {
+            throw new SpectorServerException(ErrorCode.ARGUMENT_INVALID, "IdentityBundle layoutId mismatch");
+        }
+        int subMagic = segment.get(ValueLayout.JAVA_INT_UNALIGNED, OFF_SUB_HEADER + OFF_SUB_MAGIC);
+        if (subMagic != SUB_MAGIC) {
+            throw new SpectorServerException(ErrorCode.ARGUMENT_INVALID, "IdentityBundle sub-header magic mismatch: 0x" + Integer.toHexString(subMagic));
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityRegionEntry.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityRegionEntry.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.identity;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * 64-byte on-disk directory entry for a region within an {@link IdentityBundle}.
+ *
+ * @param regionId      the identity region identifier
+ * @param flags         bitmask flags (FLAG_EMPTY, FLAG_PRESENT, FLAG_DIRTY)
+ * @param offset        byte offset in the identity bundle file
+ * @param allocatedSize total bytes allocated for this region
+ * @param usedSize      current bytes used by the payload
+ * @param version       incrementing mutation version
+ * @param checksum      CRC32C checksum of the payload bytes
+ * @param updatedAt     epoch millisecond timestamp of last update
+ */
+public record IdentityRegionEntry(
+        IdentityRegionId regionId,
+        short flags,
+        long offset,
+        long allocatedSize,
+        long usedSize,
+        int version,
+        int checksum,
+        long updatedAt
+) {
+    public static final int ENTRY_BYTES = 64;
+
+    public static final short FLAG_EMPTY = 0x00;
+    public static final short FLAG_PRESENT = 0x01;
+    public static final short FLAG_DIRTY = 0x02;
+
+    /**
+     * @return {@code true} if this region currently stores a valid payload
+     */
+    public boolean isPresent() {
+        return (flags & FLAG_PRESENT) != 0;
+    }
+
+    /**
+     * Reads an {@link IdentityRegionEntry} from a mapped memory segment.
+     *
+     * @param segment    the mapped segment
+     * @param baseOffset byte offset of the 64-byte entry
+     * @return the deserialized entry
+     */
+    public static IdentityRegionEntry read(MemorySegment segment, long baseOffset) {
+        short regionCode = segment.get(ValueLayout.JAVA_SHORT_UNALIGNED, baseOffset);
+        short flags = segment.get(ValueLayout.JAVA_SHORT_UNALIGNED, baseOffset + 2);
+        long offset = segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 8);
+        long allocatedSize = segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 16);
+        long usedSize = segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 24);
+        int version = segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + 32);
+        int checksum = segment.get(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + 36);
+        long updatedAt = segment.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 40);
+
+        return new IdentityRegionEntry(
+                IdentityRegionId.fromId(regionCode),
+                flags,
+                offset,
+                allocatedSize,
+                usedSize,
+                version,
+                checksum,
+                updatedAt
+        );
+    }
+
+    /**
+     * Writes this {@link IdentityRegionEntry} to a mapped memory segment.
+     *
+     * @param segment    the mapped segment
+     * @param baseOffset byte offset of the 64-byte entry
+     * @param entry      the entry to serialize
+     */
+    public static void write(MemorySegment segment, long baseOffset, IdentityRegionEntry entry) {
+        segment.set(ValueLayout.JAVA_SHORT_UNALIGNED, baseOffset, (short) entry.regionId().id());
+        segment.set(ValueLayout.JAVA_SHORT_UNALIGNED, baseOffset + 2, entry.flags());
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + 4, 0); // reserved
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 8, entry.offset());
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 16, entry.allocatedSize());
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 24, entry.usedSize());
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + 32, entry.version());
+        segment.set(ValueLayout.JAVA_INT_UNALIGNED, baseOffset + 36, entry.checksum());
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 40, entry.updatedAt());
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 48, 0L); // reserved
+        segment.set(ValueLayout.JAVA_LONG_UNALIGNED, baseOffset + 56, 0L); // reserved
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityRegionId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/identity/IdentityRegionId.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.identity;
+
+/**
+ * Stable identifiers for regions within an account or tenant {@link IdentityBundle} (ADR-0029 §23.3).
+ *
+ * <p>This enum is distinct from the data-plane {@code RegionId} and defines the identity
+ * plane's on-disk region layout.</p>
+ */
+public enum IdentityRegionId {
+
+    /** Region 0: Magic, schema version, and 16-entry region directory. */
+    HEADER(0),
+
+    /** Region 1: Self-model soul context (UserSoul, AgentSoul, or TenantSoul). */
+    SOUL(1),
+
+    /** Region 2: Salience profile (ICNU weights, interest topics, modulation constants). */
+    SALIENCE(2),
+
+    /** Region 3: Identity continuity trajectory and narrative history. */
+    CONTINUITY(3),
+
+    /** Region 4: Tenant compliance policies, governance floors, and domain constraints. */
+    POLICY(4),
+
+    /** Region 5: Tenant organizational unit directory and soul slabs. */
+    ORG_DIR(5),
+
+    RESERVED_6(6),
+    RESERVED_7(7),
+    RESERVED_8(8),
+    RESERVED_9(9),
+    RESERVED_10(10),
+    RESERVED_11(11),
+    RESERVED_12(12),
+    RESERVED_13(13),
+    RESERVED_14(14),
+    RESERVED_15(15);
+
+    private final int id;
+
+    IdentityRegionId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the numeric region ID (0..15)
+     */
+    public int id() {
+        return id;
+    }
+
+    /**
+     * Resolves an {@link IdentityRegionId} from its numeric ID.
+     *
+     * @param id numeric region ID (0..15)
+     * @return matching IdentityRegionId
+     * @throws IllegalArgumentException if id is out of range [0, 15]
+     */
+    public static IdentityRegionId fromId(int id) {
+        for (IdentityRegionId region : values()) {
+            if (region.id == id) {
+                return region;
+            }
+        }
+        throw new IllegalArgumentException("Unknown IdentityRegionId: " + id);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/SalienceProfile.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/SalienceProfile.java
@@ -77,6 +77,7 @@ import java.util.List;
  *                               a doctor's brain automatically gives higher salience to medical
  *                               information. The agent's expertise domains act the same way.</p>
  */
+@com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 public record SalienceProfile(
         List<InterestDomain> interests,
         List<InterestDomain> disinterests,
@@ -210,6 +211,7 @@ public record SalienceProfile(
     /**
      * Returns true if this profile has any configured interests or disinterests.
      */
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean hasInterests() {
         return !interests.isEmpty() || !disinterests.isEmpty();
     }
@@ -217,6 +219,7 @@ public record SalienceProfile(
     /**
      * Returns true if this profile overrides ICNU weights.
      */
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean hasIcnuOverride() {
         return icnuWeights != null;
     }
@@ -224,6 +227,7 @@ public record SalienceProfile(
     /**
      * Returns true if this profile overrides alpha/beta scoring weights.
      */
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean hasScoringOverride() {
         return alpha != null || beta != null;
     }
@@ -231,6 +235,7 @@ public record SalienceProfile(
     /**
      * Returns true if this profile has a persona set.
      */
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean hasPersona() {
         return persona != null && persona.isPresent();
     }
@@ -238,6 +243,7 @@ public record SalienceProfile(
     /**
      * Returns true if an agent relevance boost is active (> 1.0).
      */
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean hasAgentRelevanceBoost() {
         return agentRelevanceBoost > DEFAULT_AGENT_RELEVANCE_BOOST;
     }
@@ -245,6 +251,7 @@ public record SalienceProfile(
     /**
      * Returns true if this profile is effectively neutral (no effect).
      */
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean isNeutral() {
         return !hasInterests()
                 && !hasIcnuOverride()

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/UserSoul.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/UserSoul.java
@@ -28,6 +28,27 @@ public record UserSoul(
         Instant updatedAt
 ) implements SoulContext {
 
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public UserSoul(
+            @com.fasterxml.jackson.annotation.JsonProperty("id") String id,
+            @com.fasterxml.jackson.annotation.JsonProperty("name") String name,
+            @com.fasterxml.jackson.annotation.JsonProperty("description") String description,
+            @com.fasterxml.jackson.annotation.JsonProperty("persona") PersonaContext persona,
+            @com.fasterxml.jackson.annotation.JsonProperty("identityEmbedding") float[] identityEmbedding,
+            @com.fasterxml.jackson.annotation.JsonProperty("soulVersion") short soulVersion,
+            @com.fasterxml.jackson.annotation.JsonProperty("createdAt") Instant createdAt,
+            @com.fasterxml.jackson.annotation.JsonProperty("updatedAt") Instant updatedAt
+    ) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.persona = persona;
+        this.identityEmbedding = identityEmbedding;
+        this.soulVersion = soulVersion;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
     /** Backward-compatible constructor (version=0, no timestamps). */
     public UserSoul(String id, String name, String description,
                     PersonaContext persona, float[] identityEmbedding) {

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/identity/IdentityBundleTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/identity/IdentityBundleTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.spectrayan.spector.commons.error.SpectorMemoryException;
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.InterestLevel;
+import com.spectrayan.spector.memory.model.PersonaContext;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.memory.model.TenantSoul;
+import com.spectrayan.spector.memory.model.UserSoul;
+import com.spectrayan.spector.memory.neurodivergent.IcnuWeights;
+
+@DisplayName("IdentityBundle Specifications")
+class IdentityBundleTest {
+
+    @Nested
+    @DisplayName("In-Memory Heap Bundle")
+    class HeapBundleTests {
+
+        @Test
+        @DisplayName("Initial state is empty across all regions")
+        void initialEmpty() {
+            try (IdentityBundle bundle = IdentityBundle.heap()) {
+                for (IdentityRegionId region : IdentityRegionId.values()) {
+                    assertThat(bundle.isEmpty(region)).isTrue();
+                    assertThat(bundle.getVersion(region)).isZero();
+                }
+                assertThat(bundle.readSoul()).isEmpty();
+                assertThat(bundle.readSalience()).isEmpty();
+                assertThat(bundle.readContinuity()).isEmpty();
+                assertThat(bundle.readPolicy()).isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("Writes and reads UserSoul")
+        void readWriteUserSoul() {
+            try (IdentityBundle bundle = IdentityBundle.heap()) {
+                PersonaContext persona = PersonaContext.builder()
+                        .about("Security Researcher")
+                        .occupation("DevOps")
+                        .build();
+                UserSoul soul = new UserSoul("usr-1", "Alice", "Security Researcher", persona, null, (short) 1, Instant.now(), Instant.now());
+
+                bundle.writeSoul(soul);
+
+                assertThat(bundle.isEmpty(IdentityRegionId.SOUL)).isFalse();
+                assertThat(bundle.getVersion(IdentityRegionId.SOUL)).isEqualTo(1);
+
+                Optional<SoulContext> read = bundle.readSoul();
+                assertThat(read).isPresent();
+                assertThat(read.get()).isInstanceOf(UserSoul.class);
+
+                UserSoul userSoul = (UserSoul) read.get();
+                assertThat(userSoul.id()).isEqualTo("usr-1");
+                assertThat(userSoul.name()).isEqualTo("Alice");
+                assertThat(userSoul.description()).isEqualTo("Security Researcher");
+            }
+        }
+
+        @Test
+        @DisplayName("Writes and reads AgentSoul")
+        void readWriteAgentSoul() {
+            try (IdentityBundle bundle = IdentityBundle.heap()) {
+                AgentSoul agentSoul = AgentSoul.builder()
+                        .id("agent-forge")
+                        .name("Forge")
+                        .description("Senior Full-Stack Developer")
+                        .systemPrompt("You are Forge.")
+                        .purpose("Build high-performance systems")
+                        .personality("Pragmatic, rigorous")
+                        .tools(List.of("compile", "test"))
+                        .soulVersion((short) 2)
+                        .build();
+
+                bundle.writeSoul(agentSoul);
+
+                Optional<SoulContext> read = bundle.readSoul();
+                assertThat(read).isPresent();
+                assertThat(read.get()).isInstanceOf(AgentSoul.class);
+
+                AgentSoul readAgent = (AgentSoul) read.get();
+                assertThat(readAgent.id()).isEqualTo("agent-forge");
+                assertThat(readAgent.name()).isEqualTo("Forge");
+                assertThat(readAgent.tools()).containsExactly("compile", "test");
+            }
+        }
+
+        @Test
+        @DisplayName("Writes and reads TenantSoul")
+        void readWriteTenantSoul() {
+            try (IdentityBundle bundle = IdentityBundle.heap()) {
+                TenantSoul tenantSoul = new TenantSoul("ten-1", "Acme Health", "Healthcare platform",
+                        List.of("cardiology"), List.of("HIPAA"), null, (short) 1, Instant.now(), Instant.now());
+
+                bundle.writeSoul(tenantSoul);
+
+                Optional<SoulContext> read = bundle.readSoul();
+                assertThat(read).isPresent();
+                assertThat(read.get()).isInstanceOf(TenantSoul.class);
+                assertThat(read.get().name()).isEqualTo("Acme Health");
+            }
+        }
+
+        @Test
+        @DisplayName("Writes and reads SalienceProfile")
+        void readWriteSalienceProfile() {
+            try (IdentityBundle bundle = IdentityBundle.heap()) {
+                SalienceProfile profile = SalienceProfile.builder()
+                        .interest("kubernetes", InterestLevel.CRITICAL)
+                        .interest("java panama", InterestLevel.HIGH)
+                        .icnuWeights(new IcnuWeights(0.4f, 0.2f, 0.3f, 0.1f))
+                        .alpha(0.7f)
+                        .beta(0.3f)
+                        .build();
+
+                bundle.writeSalience(profile);
+
+                assertThat(bundle.isEmpty(IdentityRegionId.SALIENCE)).isFalse();
+                assertThat(bundle.getVersion(IdentityRegionId.SALIENCE)).isEqualTo(1);
+
+                Optional<SalienceProfile> read = bundle.readSalience();
+                assertThat(read).isPresent();
+                assertThat(read.get().alpha()).isEqualTo(0.7f);
+                assertThat(read.get().beta()).isEqualTo(0.3f);
+                assertThat(read.get().interests()).hasSize(2);
+            }
+        }
+
+        @Test
+        @DisplayName("Writes and reads Continuity and Policy")
+        void readWriteContinuityAndPolicy() {
+            try (IdentityBundle bundle = IdentityBundle.heap()) {
+                bundle.writeContinuity("Historical narrative v1");
+                bundle.writePolicy("HIPAA compliance floor");
+
+                assertThat(bundle.readContinuity()).contains("Historical narrative v1");
+                assertThat(bundle.readPolicy()).contains("HIPAA compliance floor");
+
+                bundle.clearRegion(IdentityRegionId.CONTINUITY);
+                assertThat(bundle.readContinuity()).isEmpty();
+                assertThat(bundle.isEmpty(IdentityRegionId.CONTINUITY)).isTrue();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("File-Backed Mmap Bundle")
+    class FileBundleTests {
+
+        @Test
+        @DisplayName("Persists data across close and reopen")
+        void persistenceAcrossReopen(@TempDir Path tempDir) {
+            Path bundlePath = tempDir.resolve("accounts/01/23/0123456789abc/identity.bundle");
+
+            try (IdentityBundle bundle = IdentityBundle.open(bundlePath, true)) {
+                UserSoul soul = new UserSoul("0123456789abc", "Bob", "Architect", null, null);
+                bundle.writeSoul(soul);
+
+                SalienceProfile profile = SalienceProfile.builder()
+                        .interest("security", InterestLevel.CRITICAL)
+                        .build();
+                bundle.writeSalience(profile);
+            }
+
+            assertThat(Files.exists(bundlePath)).isTrue();
+            assertThat(bundlePath.toFile().length()).isEqualTo(IdentityBundleHeader.TOTAL_INITIAL_SIZE);
+
+            try (IdentityBundle reopened = IdentityBundle.open(bundlePath, false)) {
+                Optional<SoulContext> soul = reopened.readSoul();
+                assertThat(soul).isPresent();
+                assertThat(soul.get().name()).isEqualTo("Bob");
+
+                Optional<SalienceProfile> salience = reopened.readSalience();
+                assertThat(salience).isPresent();
+                assertThat(salience.get().interests()).hasSize(1);
+            }
+        }
+
+        @Test
+        @DisplayName("Throws when payload exceeds region allocated capacity")
+        void capacityExceeded(@TempDir Path tempDir) {
+            Path bundlePath = tempDir.resolve("overflow/identity.bundle");
+
+            try (IdentityBundle bundle = IdentityBundle.open(bundlePath, true)) {
+                byte[] hugePayload = new byte[(int) IdentityBundleHeader.DEFAULT_REGION_ALLOCATION + 1];
+                assertThatThrownBy(() -> bundle.writeRaw(IdentityRegionId.SOUL, hugePayload))
+                        .isInstanceOf(SpectorMemoryException.class);
+            }
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.identity;
+
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.spectrayan.spector.memory.identity.IdentityBundle;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+
+/**
+ * Process cache for open {@link IdentityBundle} instances (ADR-0029 §23.7, §25).
+ *
+ * <p>Caches up to 256 accounts and 32 tenants. Identity bundles map only 1 FD each and
+ * <strong>do not</strong> count against the data-plane {@code maxHotNamespaces} quota.</p>
+ */
+@Component
+public class IdentityCache implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(IdentityCache.class);
+
+    public static final int MAX_HOT_ACCOUNTS = 256;
+    public static final int MAX_HOT_TENANTS = 32;
+
+    private final Path dataDir;
+    private final ConcurrentHashMap<String, IdentityBundle> accountBundles = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, IdentityBundle> tenantBundles = new ConcurrentHashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public IdentityCache(SynapseProperties properties) {
+        this.dataDir = properties.dataDir() != null ? Path.of(properties.dataDir()) : Path.of("./spector-data");
+    }
+
+    /**
+     * Testing constructor with explicit root data directory.
+     */
+    public IdentityCache(Path dataDir) {
+        this.dataDir = dataDir;
+    }
+
+    /**
+     * Retrieves or opens the {@link IdentityBundle} for the given account.
+     *
+     * @param accountId the unique account TSID
+     * @return the open IdentityBundle
+     */
+    public IdentityBundle getOrOpenAccount(String accountId) {
+        ensureOpen();
+        return accountBundles.computeIfAbsent(accountId, id -> {
+            if (accountBundles.size() >= MAX_HOT_ACCOUNTS) {
+                evictOldestAccount();
+            }
+            Path path = IdentityPaths.accountIdentityBundle(dataDir, id);
+            log.debug("[IdentityCache] Opening account identity bundle at {}", path);
+            return IdentityBundle.open(path, true);
+        });
+    }
+
+    /**
+     * Retrieves or opens the {@link IdentityBundle} for the given tenant.
+     *
+     * @param tenantId the unique tenant TSID
+     * @return the open IdentityBundle
+     */
+    public IdentityBundle getOrOpenTenant(String tenantId) {
+        ensureOpen();
+        return tenantBundles.computeIfAbsent(tenantId, id -> {
+            if (tenantBundles.size() >= MAX_HOT_TENANTS) {
+                evictOldestTenant();
+            }
+            Path path = IdentityPaths.tenantIdentityBundle(dataDir, id);
+            log.debug("[IdentityCache] Opening tenant identity bundle at {}", path);
+            return IdentityBundle.open(path, true);
+        });
+    }
+
+    /**
+     * Closes and removes a specific account's identity bundle from the cache.
+     *
+     * @param accountId the account identifier
+     */
+    public void invalidateAccount(String accountId) {
+        IdentityBundle bundle = accountBundles.remove(accountId);
+        if (bundle != null) {
+            try {
+                bundle.close();
+            } catch (Exception e) {
+                log.warn("[IdentityCache] Failed to close invalidated bundle for account {}: {}", accountId, e.getMessage());
+            }
+        }
+    }
+
+    private void evictOldestAccount() {
+        // Evict one arbitrary entry if cap reached
+        var it = accountBundles.keySet().iterator();
+        if (it.hasNext()) {
+            String key = it.next();
+            invalidateAccount(key);
+        }
+    }
+
+    private void evictOldestTenant() {
+        var it = tenantBundles.keySet().iterator();
+        if (it.hasNext()) {
+            String key = it.next();
+            IdentityBundle bundle = tenantBundles.remove(key);
+            if (bundle != null) {
+                try {
+                    bundle.close();
+                } catch (Exception e) {
+                    log.warn("[IdentityCache] Failed to close evicted tenant bundle {}: {}", key, e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed.get()) {
+            throw new IllegalStateException("IdentityCache is closed");
+        }
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            log.info("[IdentityCache] Closing all cached identity bundles");
+            accountBundles.forEach((id, bundle) -> {
+                try {
+                    bundle.close();
+                } catch (Exception e) {
+                    log.warn("[IdentityCache] Error closing account bundle for {}: {}", id, e.getMessage());
+                }
+            });
+            accountBundles.clear();
+
+            tenantBundles.forEach((id, bundle) -> {
+                try {
+                    bundle.close();
+                } catch (Exception e) {
+                    log.warn("[IdentityCache] Error closing tenant bundle for {}: {}", id, e.getMessage());
+                }
+            });
+            tenantBundles.clear();
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPaths.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPaths.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.identity;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Calculates sharded on-disk paths for account and tenant identity bundles (ADR-0029 §23.2).
+ *
+ * <pre>
+ * ${SPECTOR_DATA_DIR}/
+ *   db/synapse.mv.db
+ *   identity/
+ *     accounts/{aa}/{bb}/{accountId}/identity.bundle
+ *     tenants/{tt}/{uu}/{tenantId}/identity.bundle
+ *   cognitive/
+ *     namespaces/{xx}/{yy}/{namespaceId}/
+ * </pre>
+ */
+public final class IdentityPaths {
+
+    public static final String DIR_IDENTITY = "identity";
+    public static final String DIR_ACCOUNTS = "accounts";
+    public static final String DIR_TENANTS = "tenants";
+    public static final String FILE_IDENTITY_BUNDLE = "identity.bundle";
+
+    private IdentityPaths() {
+    }
+
+    /**
+     * Resolves the path to an account's {@code identity.bundle}.
+     *
+     * @param dataDir   synapse root data directory
+     * @param accountId the TSID or unique account identifier
+     * @return absolute path to the account's identity.bundle
+     */
+    public static Path accountIdentityBundle(Path dataDir, String accountId) {
+        Objects.requireNonNull(dataDir, "dataDir must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+
+        String s1 = shard1(accountId);
+        String s2 = shard2(accountId);
+
+        return dataDir.resolve(DIR_IDENTITY)
+                .resolve(DIR_ACCOUNTS)
+                .resolve(s1)
+                .resolve(s2)
+                .resolve(accountId)
+                .resolve(FILE_IDENTITY_BUNDLE);
+    }
+
+    /**
+     * Resolves the path to a tenant's {@code identity.bundle}.
+     *
+     * @param dataDir  synapse root data directory
+     * @param tenantId the unique tenant identifier
+     * @return absolute path to the tenant's identity.bundle
+     */
+    public static Path tenantIdentityBundle(Path dataDir, String tenantId) {
+        Objects.requireNonNull(dataDir, "dataDir must not be null");
+        Objects.requireNonNull(tenantId, "tenantId must not be null");
+
+        String s1 = shard1(tenantId);
+        String s2 = shard2(tenantId);
+
+        return dataDir.resolve(DIR_IDENTITY)
+                .resolve(DIR_TENANTS)
+                .resolve(s1)
+                .resolve(s2)
+                .resolve(tenantId)
+                .resolve(FILE_IDENTITY_BUNDLE);
+    }
+
+    private static String shard1(String id) {
+        if (id.length() < 2) {
+            return "00";
+        }
+        return id.substring(0, 2).toLowerCase();
+    }
+
+    private static String shard2(String id) {
+        if (id.length() < 4) {
+            return "00";
+        }
+        return id.substring(2, 4).toLowerCase();
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.identity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.identity.IdentityBundle;
+import com.spectrayan.spector.memory.identity.IdentityRegionId;
+import com.spectrayan.spector.memory.model.InsulaSelfModel;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
+
+/**
+ * Service coordinating identity bundle lifecycle, soul stack assembly, and Region 24 migration (ADR-0029 §23, §24).
+ */
+@Service
+public class IdentityPlane {
+
+    private static final Logger log = LoggerFactory.getLogger(IdentityPlane.class);
+
+    private final IdentityCache identityCache;
+    private final ObjectMapper mapper;
+
+    public IdentityPlane(IdentityCache identityCache, ObjectMapper mapper) {
+        this.identityCache = identityCache;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Reads the primary soul for the given account.
+     *
+     * @param accountId account TSID
+     * @return optional primary soul
+     */
+    public Optional<SoulContext> primarySoulFor(String accountId) {
+        if (accountId == null || accountId.isBlank() || "default".equals(accountId)) {
+            return Optional.empty();
+        }
+        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
+        return bundle.readSoul();
+    }
+
+    /**
+     * Reads the salience profile for the given account.
+     *
+     * @param accountId account TSID
+     * @return optional salience profile
+     */
+    public Optional<SalienceProfile> salienceFor(String accountId) {
+        if (accountId == null || accountId.isBlank() || "default".equals(accountId)) {
+            return Optional.empty();
+        }
+        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
+        return bundle.readSalience();
+    }
+
+    /**
+     * Assembles the hierarchical soul stack for a request context.
+     *
+     * @param tenantId   optional tenant TSID
+     * @param orgUnitIds list of organizational unit IDs
+     * @param accountId  account TSID
+     * @return ordered list of soul contexts (ancestors first, primary last)
+     */
+    public List<SoulContext> soulsFor(String tenantId, List<String> orgUnitIds, String accountId) {
+        List<SoulContext> stack = new ArrayList<>();
+
+        if (tenantId != null && !tenantId.isBlank()) {
+            IdentityBundle tenantBundle = identityCache.getOrOpenTenant(tenantId);
+            tenantBundle.readSoul().ifPresent(stack::add);
+        }
+
+        if (accountId != null && !accountId.isBlank() && !"default".equals(accountId)) {
+            primarySoulFor(accountId).ifPresent(stack::add);
+        }
+
+        return List.copyOf(stack);
+    }
+
+    /**
+     * Updates or sets the account's primary soul in {@code identity.bundle}.
+     *
+     * @param accountId account TSID
+     * @param soul      the soul context
+     */
+    public void updateAccountSoul(String accountId, SoulContext soul) {
+        if (accountId == null || accountId.isBlank()) {
+            return;
+        }
+        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
+        bundle.writeSoul(soul);
+        log.debug("[IdentityPlane] Updated primary soul for account {}", accountId);
+    }
+
+    /**
+     * Updates or sets the account's salience profile in {@code identity.bundle}.
+     *
+     * @param accountId account TSID
+     * @param salience  the salience profile
+     */
+    public void updateAccountSalience(String accountId, SalienceProfile salience) {
+        if (accountId == null || accountId.isBlank()) {
+            return;
+        }
+        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
+        bundle.writeSalience(salience);
+        log.debug("[IdentityPlane] Updated salience profile for account {}", accountId);
+    }
+
+    /**
+     * Performs copy-once migration from default rememberer Region 24 to {@code identity.bundle} (ADR-0029 §23.6).
+     *
+     * @param accountId     the account TSID
+     * @param defaultMemory the default namespace SpectorMemory instance
+     */
+    public void checkAndMigrateRegion24(String accountId, SpectorMemory defaultMemory) {
+        if (accountId == null || accountId.isBlank() || "default".equals(accountId) || defaultMemory == null) {
+            return;
+        }
+
+        try {
+            IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
+            if (!bundle.isEmpty(IdentityRegionId.SOUL)) {
+                return; // Already migrated or has soul
+            }
+
+            Optional<byte[]> insulaBytes = defaultMemory.admin().insularCortex().get();
+            if (insulaBytes.isEmpty()) {
+                return;
+            }
+
+            InsulaSelfModel model = mapper.readValue(insulaBytes.get(), InsulaSelfModel.class);
+            if (model != null) {
+                if (model.soul() != null) {
+                    bundle.writeSoul(model.soul());
+                    log.info("[IdentityPlane] Migrated Region 24 soul to identity.bundle for account {}", accountId);
+                }
+                if (model.salience() != null) {
+                    bundle.writeSalience(model.salience());
+                    log.info("[IdentityPlane] Migrated Region 24 salience to identity.bundle for account {}", accountId);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("[IdentityPlane] Non-fatal Region 24 migration check failed for account {}: {}", accountId, e.getMessage());
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.synapse.catalog.exception.TokenNamespaceLockedException;
 import com.spectrayan.spector.synapse.memory.MemoryRegistry;
 import com.spectrayan.spector.synapse.security.SecurityUtils;
 
@@ -43,6 +44,8 @@ import com.spectrayan.spector.synapse.security.SecurityUtils;
  *   <li>When per-user memory resolution fails, the call is denied with
  *       {@link DenyReason#RESOLUTION_FAILED}, nothing is bound, and no memory is modified — the
  *       registry never falls back to the shared or another user's instance.</li>
+ *   <li>When a token is locked to specific namespaces and an unauthorized namespace is requested,
+ *       the call is denied with {@link DenyReason#TOKEN_LOCKED}.</li>
  * </ul>
  *
  * <p>The bound reference is confined to the current thread. Callers <strong>must</strong>
@@ -65,7 +68,9 @@ public final class McpRequestMemory {
         /** Per-user memory resolution or lazy construction failed; the call fails closed. */
         RESOLUTION_FAILED,
         /** Wildcard '*' was supplied as a namespace selector (ADR-0029 Invariant 7). */
-        WILDCARD_REJECTED
+        WILDCARD_REJECTED,
+        /** Token namespace allow-set locked and request is outside allowed namespaces. */
+        TOKEN_LOCKED
     }
 
     /**
@@ -116,6 +121,10 @@ public final class McpRequestMemory {
 
             CURRENT.set(memory);
             return Optional.empty();
+        } catch (TokenNamespaceLockedException e) {
+            clear();
+            log.warn("[McpRequestMemory] token namespace locked: {}", e.getMessage());
+            return Optional.of(DenyReason.TOKEN_LOCKED);
         } catch (RuntimeException e) {
             clear();
             // Never echo the resolved namespace/identifier; message stays generic.
@@ -156,6 +165,8 @@ public final class McpRequestMemory {
                     "Memory resolution failed; the MCP call was denied and no memory was modified.";
             case WILDCARD_REJECTED ->
                     "Wildcard namespace '*' is not supported. Please specify a single namespace or omit to use the default.";
+            case TOKEN_LOCKED ->
+                    "Token is locked to specific namespaces and access to the requested namespace was denied.";
         };
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpSessionContext.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpSessionContext.java
@@ -12,6 +12,10 @@
  */
 package com.spectrayan.spector.synapse.mcp;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -19,17 +23,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Manages connection-scoped session state for MCP transports (ADR-0029 §6.2, §16).
+ * Manages connection-scoped session state and the volatile active working set for MCP transports (ADR-0029 §6.2, §16).
  *
- * <p>{@code namespace_switch} sets the connection-scoped default on this context.
- * It is tied to the MCP connection/session lifecycle and dies with the session.
- * For stateless transports without a connection ID, a request-scoped fallback is used.</p>
+ * <p>Key features:</p>
+ * <ul>
+ *   <li>Connection-scoped default namespace (set by {@code namespace_switch})</li>
+ *   <li>Active working set (FIFO bounded to 100 items, persists across {@code namespace_switch})</li>
+ *   <li>Thread fallback for stateless requests</li>
+ * </ul>
  */
 public final class McpSessionContext {
 
     private static final Logger log = LoggerFactory.getLogger(McpSessionContext.class);
 
+    public static final int MAX_ACTIVE_WORKING_ITEMS = 100;
+
+    /** Working memory record in the volatile session working set. */
+    public record ActiveWorkingItem(String id, String text, Map<String, Object> metadata, long timestampMs) {}
+
     private static final ConcurrentHashMap<String, String> SESSION_DEFAULTS = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, Deque<ActiveWorkingItem>> SESSION_WORKING_SETS = new ConcurrentHashMap<>();
     private static final ThreadLocal<String> FALLBACK_DEFAULT = new ThreadLocal<>();
 
     private McpSessionContext() {
@@ -69,6 +82,56 @@ public final class McpSessionContext {
     }
 
     /**
+     * Appends an item to the session's active volatile working set (FIFO bounded to 100).
+     *
+     * @param connectionId the connection or session identifier
+     * @param item         the working memory item
+     */
+    public static void addWorkingItem(String connectionId, ActiveWorkingItem item) {
+        if (connectionId == null || connectionId.isBlank()) {
+            return;
+        }
+        SESSION_WORKING_SETS.compute(connectionId, (key, queue) -> {
+            Deque<ActiveWorkingItem> q = queue != null ? queue : new ArrayDeque<>();
+            synchronized (q) {
+                if (q.size() >= MAX_ACTIVE_WORKING_ITEMS) {
+                    q.pollFirst(); // FIFO eviction
+                }
+                q.addLast(item);
+            }
+            return q;
+        });
+    }
+
+    /**
+     * Gets a snapshot of the active working set for the given connection ID.
+     *
+     * @param connectionId the connection or session identifier
+     * @return ordered list of active working items
+     */
+    public static List<ActiveWorkingItem> getWorkingItems(String connectionId) {
+        if (connectionId == null || connectionId.isBlank()) {
+            return List.of();
+        }
+        Deque<ActiveWorkingItem> q = SESSION_WORKING_SETS.get(connectionId);
+        if (q == null) {
+            return List.of();
+        }
+        synchronized (q) {
+            return List.copyOf(q);
+        }
+    }
+
+    /**
+     * Clears the active working set for the specified connection ID.
+     */
+    public static void clearWorkingItems(String connectionId) {
+        if (connectionId != null) {
+            SESSION_WORKING_SETS.remove(connectionId);
+        }
+    }
+
+    /**
      * Clears session state when an MCP connection terminates.
      *
      * @param connectionId the MCP connection or session identifier
@@ -76,6 +139,7 @@ public final class McpSessionContext {
     public static void clearSession(String connectionId) {
         if (connectionId != null) {
             SESSION_DEFAULTS.remove(connectionId);
+            SESSION_WORKING_SETS.remove(connectionId);
             log.debug("[McpSessionContext] cleared session: {}", connectionId);
         }
         FALLBACK_DEFAULT.remove();

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryBinding.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryBinding.java
@@ -16,19 +16,30 @@ import com.spectrayan.spector.memory.SpectorMemory;
 
 /**
  * Immutable per-request memory binding context holding the resolved {@link SpectorMemory}
- * instance along with its owning account and resolved namespace identifier (ADR-0029 §16).
+ * instance along with its owning account, resolved namespace identifier, lease, and context (ADR-0029 §16).
  *
- * @param memory      the active SpectorMemory engine
- * @param accountId   the authenticated account identifier
- * @param namespaceId the resolved data-plane namespace TSID
- * @param slug        the requested or resolved namespace slug
+ * @param memory               the active SpectorMemory engine
+ * @param accountId            the authenticated account identifier
+ * @param namespaceId          the resolved data-plane namespace TSID
+ * @param slug                 the requested or resolved namespace slug
+ * @param lease                the active engine lease handle (released on unbind)
+ * @param requestMemoryContext the full resolved memory request context
  */
 public record MemoryBinding(
         SpectorMemory memory,
         String accountId,
         String namespaceId,
-        String slug) {
+        String slug,
+        AutoCloseable lease,
+        RequestMemoryContext requestMemoryContext) {
 
     /** RequestAttributes attribute key for the bound context. */
     public static final String ATTRIBUTE_KEY = "com.spectrayan.spector.synapse.memory.MemoryBinding";
+
+    /**
+     * Backward-compatible constructor without lease or request context.
+     */
+    public MemoryBinding(SpectorMemory memory, String accountId, String namespaceId, String slug) {
+        this(memory, accountId, namespaceId, slug, null, null);
+    }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
@@ -12,25 +12,38 @@
  */
 package com.spectrayan.spector.synapse.memory;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.SoulContext;
 import com.spectrayan.spector.synapse.catalog.Account;
 import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
 import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
 import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceTombstonedException;
+import com.spectrayan.spector.synapse.catalog.exception.TokenNamespaceLockedException;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
+import com.spectrayan.spector.synapse.identity.IdentityPlane;
 
 /**
  * Shared binder that resolves an authenticated request to a {@link MemoryBinding}
- * holding the target {@link SpectorMemory} (ADR-0029 §16).
+ * holding the target {@link SpectorMemory}, lease, and security context (ADR-0029 §16).
  *
  * <p>Both REST filters and MCP sessions delegate resolution to this component,
  * ensuring consistent resolution order:
@@ -46,16 +59,19 @@ public class MemoryRequestBinder {
     private final MemoryRegistry registry;
     private final SynapseProperties synapseProps;
     private final SpectorMemory sharedMemory;
+    private final IdentityPlane identityPlane;
 
     public MemoryRequestBinder(
             AccountCatalog catalog,
             MemoryRegistry registry,
             SynapseProperties synapseProps,
-            org.springframework.beans.factory.ObjectProvider<SpectorMemory> sharedMemoryProvider) {
+            ObjectProvider<SpectorMemory> sharedMemoryProvider,
+            ObjectProvider<IdentityPlane> identityPlaneProvider) {
         this.catalog = catalog;
         this.registry = registry;
         this.synapseProps = synapseProps;
         this.sharedMemory = sharedMemoryProvider.getIfAvailable();
+        this.identityPlane = identityPlaneProvider.getIfAvailable();
     }
 
     /**
@@ -66,48 +82,172 @@ public class MemoryRequestBinder {
      * @return the bound memory context
      */
     public MemoryBinding bind(Authentication auth, Optional<String> selector) {
+        return bind(auth, selector, null);
+    }
+
+    /**
+     * Binds a memory instance with optional session identifier.
+     *
+     * @param auth      the current authentication
+     * @param selector  optional namespace slug or namespaceId
+     * @param sessionId optional MCP connection or session identifier
+     * @return the bound memory context
+     */
+    public MemoryBinding bind(Authentication auth, Optional<String> selector, String sessionId) {
         if (!synapseProps.auth().enabled() || auth == null || !auth.isAuthenticated()
                 || auth instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
-            return new MemoryBinding(sharedMemory, DEFAULT_USER_ID, DEFAULT_USER_ID, "default");
+            AutoCloseable lease = sharedMemory != null ? sharedMemory.acquireLease() : null;
+            RequestMemoryContext reqCtx = new RequestMemoryContext(
+                    null, List.of(), DEFAULT_USER_ID, DEFAULT_USER_ID, "default",
+                    GrantRole.OWNER, Set.of(), sessionId, List.of(), null);
+            return new MemoryBinding(sharedMemory, DEFAULT_USER_ID, DEFAULT_USER_ID, "default", lease, reqCtx);
         }
 
         String accountId = auth.getName();
         if (accountId == null || accountId.isBlank() || DEFAULT_USER_ID.equals(accountId)) {
-            return new MemoryBinding(sharedMemory, DEFAULT_USER_ID, DEFAULT_USER_ID, "default");
+            AutoCloseable lease = sharedMemory != null ? sharedMemory.acquireLease() : null;
+            RequestMemoryContext reqCtx = new RequestMemoryContext(
+                    null, List.of(), DEFAULT_USER_ID, DEFAULT_USER_ID, "default",
+                    GrantRole.OWNER, Set.of(), sessionId, List.of(), null);
+            return new MemoryBinding(sharedMemory, DEFAULT_USER_ID, DEFAULT_USER_ID, "default", lease, reqCtx);
         }
 
+        // Extract JWT claims
+        TokenClaims tokenClaims = extractTokenClaims(auth);
+
         Account account = catalog.getOrCreateAccount(accountId);
+
+        String targetSlug;
+        String targetNamespaceId;
+        NamespaceRecord record = null;
 
         if (selector != null && selector.isPresent() && !selector.get().isBlank()) {
             String slugOrId = selector.get().trim();
             if ("*".equals(slugOrId)) {
                 throw new IllegalArgumentException("Wildcard namespace '*' is not supported for memory operations");
             }
-            NamespaceRecord record = catalog.resolve(accountId, slugOrId)
+            record = catalog.resolve(accountId, slugOrId)
                     .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
             if (record.status() == NamespaceStatus.TOMBSTONED) {
                 throw new NamespaceTombstonedException(record.namespaceId());
             }
-            catalog.recordAccess(record.namespaceId());
-            NamespaceResolver resolver = registry.namespaceResolver();
-            SpectorMemory memory = resolver.resolve(accountId, record.namespaceId());
-            return new MemoryBinding(memory, accountId, record.namespaceId(), record.slug());
+            targetSlug = record.slug();
+            targetNamespaceId = record.namespaceId();
+        } else {
+            targetNamespaceId = account.defaultNamespaceId();
+            record = catalog.resolve(accountId, targetNamespaceId).orElse(null);
+            targetSlug = record != null ? record.slug() : "default";
         }
 
-        String defaultNamespaceId = account.defaultNamespaceId();
-        SpectorMemory memory = registry.resolveFor(accountId);
-        return new MemoryBinding(memory, accountId, defaultNamespaceId, "default");
+        // Validate Token Allow-Sets (ns and nsid claims)
+        validateTokenAllowSets(tokenClaims, targetSlug, targetNamespaceId);
+
+        if (record != null) {
+            catalog.recordAccess(record.namespaceId());
+        }
+
+        NamespaceResolver resolver = registry.namespaceResolver();
+        SpectorMemory memory = resolver.resolve(accountId, targetNamespaceId);
+        AutoCloseable lease = memory != null ? memory.acquireLease() : null;
+
+        // Perform Region 24 copy-once migration on default namespace bind
+        if (identityPlane != null && ("default".equals(targetSlug) || targetNamespaceId.equals(account.defaultNamespaceId()))) {
+            identityPlane.checkAndMigrateRegion24(accountId, memory);
+        }
+
+        // Assemble Soul Stack and Request Context
+        SoulContext primarySoul = identityPlane != null ? identityPlane.primarySoulFor(accountId).orElse(null) : null;
+        List<SoulContext> soulStack = identityPlane != null
+                ? identityPlane.soulsFor(tokenClaims.tenantId(), tokenClaims.orgUnitIds(), accountId)
+                : List.of();
+
+        RequestMemoryContext requestContext = new RequestMemoryContext(
+                tokenClaims.tenantId(),
+                tokenClaims.orgUnitIds(),
+                accountId,
+                targetNamespaceId,
+                targetSlug,
+                GrantRole.OWNER,
+                tokenClaims.allowSet(),
+                sessionId,
+                soulStack,
+                primarySoul
+        );
+
+        return new MemoryBinding(memory, accountId, targetNamespaceId, targetSlug, lease, requestContext);
     }
 
     /**
-     * Unbinds the given memory binding.
+     * Unbinds the given memory binding and safely releases its lease handle.
      *
      * @param binding the binding to release
      */
     public void unbind(MemoryBinding binding) {
-        // Reserved for lease release in Phase 3 parity
-        log.trace("[MemoryRequestBinder] unbinding memory for account={}, ns={}",
-                binding != null ? binding.accountId() : null,
-                binding != null ? binding.namespaceId() : null);
+        if (binding != null && binding.lease() != null) {
+            try {
+                binding.lease().close();
+                log.trace("[MemoryRequestBinder] Released memory lease for account={}, ns={}",
+                        binding.accountId(), binding.namespaceId());
+            } catch (Exception e) {
+                log.warn("[MemoryRequestBinder] Failed to release memory lease: {}", e.getMessage());
+            }
+        }
     }
+
+    private void validateTokenAllowSets(TokenClaims claims, String targetSlug, String targetNamespaceId) {
+        if (claims.nsSlugs() != null && !claims.nsSlugs().isEmpty()) {
+            if (!claims.nsSlugs().contains(targetSlug)) {
+                log.warn("[TokenLock] Slug '{}' is outside token allowed slugs {}", targetSlug, claims.nsSlugs());
+                throw new TokenNamespaceLockedException("ns=" + claims.nsSlugs(), targetSlug);
+            }
+        }
+        if (claims.nsIds() != null && !claims.nsIds().isEmpty()) {
+            if (!claims.nsIds().contains(targetNamespaceId)) {
+                log.warn("[TokenLock] NamespaceId '{}' is outside token allowed IDs {}", targetNamespaceId, claims.nsIds());
+                throw new TokenNamespaceLockedException("nsid=" + claims.nsIds(), targetSlug);
+            }
+        }
+    }
+
+    private TokenClaims extractTokenClaims(Authentication auth) {
+        Jwt jwt = null;
+        if (auth instanceof JwtAuthenticationToken jwtAuth) {
+            jwt = jwtAuth.getToken();
+        } else if (auth.getPrincipal() instanceof Jwt principalJwt) {
+            jwt = principalJwt;
+        } else if (auth.getCredentials() instanceof Jwt credJwt) {
+            jwt = credJwt;
+        }
+
+        if (jwt == null) {
+            return new TokenClaims(null, List.of(), Set.of(), null, null);
+        }
+
+        String tenantId = jwt.getClaimAsString("tid");
+        List<String> orgUnitIds = jwt.getClaimAsStringList("org");
+        if (orgUnitIds == null) {
+            orgUnitIds = List.of();
+        }
+
+        List<String> nsSlugs = jwt.getClaimAsStringList("ns");
+        List<String> nsIds = jwt.getClaimAsStringList("nsid");
+
+        Set<String> combinedAllowSet = new HashSet<>();
+        if (nsSlugs != null) {
+            combinedAllowSet.addAll(nsSlugs);
+        }
+        if (nsIds != null) {
+            combinedAllowSet.addAll(nsIds);
+        }
+
+        return new TokenClaims(tenantId, orgUnitIds, Collections.unmodifiableSet(combinedAllowSet), nsSlugs, nsIds);
+    }
+
+    private record TokenClaims(
+            String tenantId,
+            List<String> orgUnitIds,
+            Set<String> allowSet,
+            List<String> nsSlugs,
+            List<String> nsIds
+    ) {}
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/RequestMemoryContext.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/RequestMemoryContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import java.util.List;
+import java.util.Set;
+
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+
+/**
+ * Encapsulates the resolved security and memory context for an active request or session (ADR-0029 §6.1).
+ *
+ * @param tenantId     the tenant identifier (nullable on OSS)
+ * @param orgUnitIds   the effective organizational unit identifiers
+ * @param accountId    the authenticated account TSID
+ * @param namespaceId  the resolved memory namespace TSID
+ * @param slug         the requested or resolved namespace slug
+ * @param role         the principal's authorization role on this namespace
+ * @param allowSet     allowed namespace slugs / IDs from JWT claims (empty = unrestricted)
+ * @param sessionId    optional session or connection ID
+ * @param soulStack    the resolved hierarchical soul stack
+ * @param primarySoul  the primary soul context
+ */
+public record RequestMemoryContext(
+        String tenantId,
+        List<String> orgUnitIds,
+        String accountId,
+        String namespaceId,
+        String slug,
+        GrantRole role,
+        Set<String> allowSet,
+        String sessionId,
+        List<SoulContext> soulStack,
+        SoulContext primarySoul
+) {
+    public RequestMemoryContext {
+        orgUnitIds = orgUnitIds != null ? List.copyOf(orgUnitIds) : List.of();
+        allowSet = allowSet != null ? Set.copyOf(allowSet) : Set.of();
+        soulStack = soulStack != null ? List.copyOf(soulStack) : List.of();
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/security/ServerAccessTokenMinter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/security/ServerAccessTokenMinter.java
@@ -136,6 +136,29 @@ public class ServerAccessTokenMinter {
      * @return the minted token together with its {@code jti} and expiry
      */
     public MintedAccessToken mint(String userId, Collection<String> scopes, Collection<String> roles) {
+        return mintScoped(userId, scopes, roles, null, null, null, null);
+    }
+
+    /**
+     * Mints an access token with custom namespace, tenant, and organizational claims.
+     *
+     * @param userId the User_Id (TSID) to set as the {@code sub} claim
+     * @param scopes scope names
+     * @param roles  role names
+     * @param ns     allowed namespace slugs (null or empty for unrestricted)
+     * @param nsid   allowed namespace TSIDs (null or empty for unrestricted)
+     * @param tid    tenant ID (nullable)
+     * @param org    claimed org unit IDs (nullable)
+     * @return minted access token
+     */
+    public MintedAccessToken mintScoped(
+            String userId,
+            Collection<String> scopes,
+            Collection<String> roles,
+            Collection<String> ns,
+            Collection<String> nsid,
+            String tid,
+            Collection<String> org) {
         if (userId == null || userId.isBlank()) {
             throw new IllegalArgumentException("userId must not be null or blank");
         }
@@ -144,7 +167,7 @@ public class ServerAccessTokenMinter {
         Instant expiresAt = now.plus(accessTtl);
         String jti = UUID.randomUUID().toString();
 
-        JWTClaimsSet.Builder claims = new JWTClaimsSet.Builder()
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
                 .subject(userId)
                 .issuer(JwtDecoderConfig.SERVER_ISSUER)
                 .jwtID(jti)
@@ -153,7 +176,20 @@ public class ServerAccessTokenMinter {
                 .claim(CLAIM_SCOPE, joinScopes(scopes))
                 .claim(CLAIM_ROLES, sanitize(roles));
 
-        SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims.build());
+        if (ns != null && !ns.isEmpty()) {
+            builder.claim("ns", sanitize(ns));
+        }
+        if (nsid != null && !nsid.isEmpty()) {
+            builder.claim("nsid", sanitize(nsid));
+        }
+        if (tid != null && !tid.isBlank()) {
+            builder.claim("tid", tid.trim());
+        }
+        if (org != null && !org.isEmpty()) {
+            builder.claim("org", sanitize(org));
+        }
+
+        SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), builder.build());
         try {
             jwt.sign(signer);
         } catch (JOSEException e) {

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalogTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalogTest.java
@@ -37,8 +37,8 @@ import com.spectrayan.spector.synapse.catalog.NamespaceType;
 import com.spectrayan.spector.synapse.catalog.exception.DefaultNamespaceProtectedException;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
 
-@DisplayName("FileAccountCatalog Phase 2 Tests")
-class FileAccountCatalogPhase2Test {
+@DisplayName("FileAccountCatalog Specifications")
+class FileAccountCatalogTest {
 
     @TempDir
     Path tempDir;

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/IdentityPathsTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/IdentityPathsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IdentityPaths Specification")
+class IdentityPathsTest {
+
+    @Test
+    @DisplayName("Shards account identity bundle path by first 4 characters")
+    void accountIdentitySharded() {
+        Path root = Path.of("/data/spector");
+        Path path = IdentityPaths.accountIdentityBundle(root, "0123456789abc");
+
+        assertThat(path).isEqualTo(Path.of("/data/spector/identity/accounts/01/23/0123456789abc/identity.bundle"));
+    }
+
+    @Test
+    @DisplayName("Shards tenant identity bundle path by first 4 characters")
+    void tenantIdentitySharded() {
+        Path root = Path.of("/data/spector");
+        Path path = IdentityPaths.tenantIdentityBundle(root, "ten-hospital-99");
+
+        assertThat(path).isEqualTo(Path.of("/data/spector/identity/tenants/te/n-/ten-hospital-99/identity.bundle"));
+    }
+
+    @Test
+    @DisplayName("Handles short identifiers gracefully")
+    void shortIdentifiers() {
+        Path root = Path.of("/data/spector");
+        Path path = IdentityPaths.accountIdentityBundle(root, "a");
+
+        assertThat(path).isEqualTo(Path.of("/data/spector/identity/accounts/00/00/a/identity.bundle"));
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/IdentityPlaneTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/IdentityPlaneTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.SpectorMemoryAdmin;
+import com.spectrayan.spector.memory.insula.InsularCortex;
+import com.spectrayan.spector.memory.model.InsulaSelfModel;
+import com.spectrayan.spector.memory.model.InterestLevel;
+import com.spectrayan.spector.memory.model.PersonaContext;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.memory.model.TenantSoul;
+import com.spectrayan.spector.memory.model.UserSoul;
+
+@DisplayName("IdentityPlane Specifications")
+class IdentityPlaneTest {
+
+    private IdentityCache identityCache;
+    private IdentityPlane identityPlane;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) {
+        identityCache = new IdentityCache(tempDir);
+        mapper = JsonMapper.builder().findAndAddModules().build();
+        identityPlane = new IdentityPlane(identityCache, mapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        identityCache.close();
+    }
+
+    @Test
+    @DisplayName("Updates and reads account primary soul")
+    void readWritePrimarySoul() {
+        UserSoul soul = new UserSoul("acc-123", "Alice", "Security Lead", null, null, (short) 1, Instant.now(), Instant.now());
+        identityPlane.updateAccountSoul("acc-123", soul);
+
+        Optional<SoulContext> read = identityPlane.primarySoulFor("acc-123");
+        assertThat(read).isPresent();
+        assertThat(read.get().name()).isEqualTo("Alice");
+    }
+
+    @Test
+    @DisplayName("Updates and reads account salience profile")
+    void readWriteSalienceProfile() {
+        SalienceProfile profile = SalienceProfile.builder()
+                .interest("threat-intel", InterestLevel.CRITICAL)
+                .build();
+        identityPlane.updateAccountSalience("acc-123", profile);
+
+        Optional<SalienceProfile> read = identityPlane.salienceFor("acc-123");
+        assertThat(read).isPresent();
+        assertThat(read.get().interests()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Assembles soul stack across tenant and account")
+    void assembleSoulStack() {
+        TenantSoul tenantSoul = new TenantSoul("ten-hospital", "Acme Health", "HIPAA Compliant",
+                List.of("medical"), List.of("HIPAA"), null, (short) 1, Instant.now(), Instant.now());
+        identityCache.getOrOpenTenant("ten-hospital").writeSoul(tenantSoul);
+
+        UserSoul userSoul = new UserSoul("acc-doc", "Dr. Bob", "Cardiologist", null, null, (short) 1, Instant.now(), Instant.now());
+        identityPlane.updateAccountSoul("acc-doc", userSoul);
+
+        List<SoulContext> stack = identityPlane.soulsFor("ten-hospital", List.of(), "acc-doc");
+        assertThat(stack).hasSize(2);
+        assertThat(stack.get(0).name()).isEqualTo("Acme Health");
+        assertThat(stack.get(1).name()).isEqualTo("Dr. Bob");
+    }
+
+    @Test
+    @DisplayName("Region 24 migration copies soul and salience once from default memory")
+    void region24Migration() throws Exception {
+        String accountId = "acc-legacy-01";
+
+        // Setup legacy default rememberer with InsularCortex
+        UserSoul legacySoul = new UserSoul(accountId, "Charlie", "Legacy User", null, null);
+        SalienceProfile legacySalience = SalienceProfile.builder().interest("legacy", InterestLevel.HIGH).build();
+        InsulaSelfModel selfModel = new InsulaSelfModel("USER", legacySoul, legacySalience, null);
+        byte[] insulaJsonBytes = mapper.writeValueAsBytes(selfModel);
+
+        InsularCortex insularCortex = mock(InsularCortex.class);
+        when(insularCortex.get()).thenReturn(Optional.of(insulaJsonBytes));
+
+        SpectorMemoryAdmin admin = mock(SpectorMemoryAdmin.class);
+        when(admin.insularCortex()).thenReturn(insularCortex);
+
+        SpectorMemory defaultMemory = mock(SpectorMemory.class);
+        when(defaultMemory.admin()).thenReturn(admin);
+
+        // Prior to migration, identity bundle is empty
+        assertThat(identityPlane.primarySoulFor(accountId)).isEmpty();
+
+        // Perform migration
+        identityPlane.checkAndMigrateRegion24(accountId, defaultMemory);
+
+        // Identity bundle now contains the migrated soul and salience
+        Optional<SoulContext> migratedSoul = identityPlane.primarySoulFor(accountId);
+        assertThat(migratedSoul).isPresent();
+        assertThat(migratedSoul.get().name()).isEqualTo("Charlie");
+
+        Optional<SalienceProfile> migratedSalience = identityPlane.salienceFor(accountId);
+        assertThat(migratedSalience).isPresent();
+        assertThat(migratedSalience.get().interests()).hasSize(1);
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpSessionWorkingSetTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpSessionWorkingSetTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.spectrayan.spector.synapse.mcp.McpSessionContext.ActiveWorkingItem;
+
+@DisplayName("McpSessionContext Working Set Specifications")
+class McpSessionWorkingSetTest {
+
+    private static final String SESSION_1 = "sess-conn-1";
+    private static final String SESSION_2 = "sess-conn-2";
+
+    @AfterEach
+    void tearDown() {
+        McpSessionContext.clearSession(SESSION_1);
+        McpSessionContext.clearSession(SESSION_2);
+    }
+
+    @Test
+    @DisplayName("Working set items survive across namespace_switch")
+    void workingSetSurvivesNamespaceSwitch() {
+        McpSessionContext.setSessionDefault(SESSION_1, "project-alpha");
+        McpSessionContext.addWorkingItem(SESSION_1, new ActiveWorkingItem("w-1", "Task context A", Map.of(), System.currentTimeMillis()));
+        McpSessionContext.addWorkingItem(SESSION_1, new ActiveWorkingItem("w-2", "Task context B", Map.of(), System.currentTimeMillis()));
+
+        assertThat(McpSessionContext.getSessionDefault(SESSION_1)).contains("project-alpha");
+        assertThat(McpSessionContext.getWorkingItems(SESSION_1)).hasSize(2);
+
+        // Perform namespace_switch to project-beta
+        McpSessionContext.setSessionDefault(SESSION_1, "project-beta");
+
+        assertThat(McpSessionContext.getSessionDefault(SESSION_1)).contains("project-beta");
+        List<ActiveWorkingItem> items = McpSessionContext.getWorkingItems(SESSION_1);
+        assertThat(items).hasSize(2);
+        assertThat(items.get(0).text()).isEqualTo("Task context A");
+        assertThat(items.get(1).text()).isEqualTo("Task context B");
+    }
+
+    @Test
+    @DisplayName("Working set enforces FIFO eviction at 100 capacity")
+    void fifoEviction() {
+        for (int i = 0; i < 110; i++) {
+            McpSessionContext.addWorkingItem(SESSION_1, new ActiveWorkingItem("w-" + i, "Context " + i, Map.of(), System.currentTimeMillis()));
+        }
+
+        List<ActiveWorkingItem> items = McpSessionContext.getWorkingItems(SESSION_1);
+        assertThat(items).hasSize(100);
+        assertThat(items.get(0).id()).isEqualTo("w-10");
+        assertThat(items.get(99).id()).isEqualTo("w-109");
+    }
+
+    @Test
+    @DisplayName("Different sessions have isolated working sets")
+    void sessionIsolation() {
+        McpSessionContext.addWorkingItem(SESSION_1, new ActiveWorkingItem("w-1", "Session 1 item", Map.of(), System.currentTimeMillis()));
+        McpSessionContext.addWorkingItem(SESSION_2, new ActiveWorkingItem("w-2", "Session 2 item", Map.of(), System.currentTimeMillis()));
+
+        assertThat(McpSessionContext.getWorkingItems(SESSION_1)).hasSize(1);
+        assertThat(McpSessionContext.getWorkingItems(SESSION_1).get(0).text()).isEqualTo("Session 1 item");
+
+        assertThat(McpSessionContext.getWorkingItems(SESSION_2)).hasSize(1);
+        assertThat(McpSessionContext.getWorkingItems(SESSION_2).get(0).text()).isEqualTo("Session 2 item");
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinderTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.UserSoul;
+import com.spectrayan.spector.synapse.catalog.Account;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.AccountFlags;
+import com.spectrayan.spector.synapse.catalog.AccountProfile;
+import com.spectrayan.spector.synapse.catalog.AccountQuotas;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.PrincipalKind;
+import com.spectrayan.spector.synapse.catalog.exception.TokenNamespaceLockedException;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import com.spectrayan.spector.synapse.identity.IdentityPlane;
+
+@DisplayName("MemoryRequestBinder Specifications")
+class MemoryRequestBinderTest {
+
+    private AccountCatalog catalog;
+    private MemoryRegistry registry;
+    private NamespaceResolver resolver;
+    private SynapseProperties synapseProps;
+    private IdentityPlane identityPlane;
+    private SpectorMemory memory;
+    private AutoCloseable lease;
+    private MemoryRequestBinder binder;
+
+    @BeforeEach
+    void setUp() {
+        catalog = mock(AccountCatalog.class);
+        registry = mock(MemoryRegistry.class);
+        resolver = mock(NamespaceResolver.class);
+        when(registry.namespaceResolver()).thenReturn(resolver);
+
+        synapseProps = mock(SynapseProperties.class);
+        var authProps = mock(com.spectrayan.spector.config.properties.AuthProperties.class);
+        when(authProps.enabled()).thenReturn(true);
+        when(synapseProps.auth()).thenReturn(authProps);
+
+        identityPlane = mock(IdentityPlane.class);
+        memory = mock(SpectorMemory.class);
+        lease = mock(AutoCloseable.class);
+        when(memory.acquireLease()).thenReturn(lease);
+
+        ObjectProvider<SpectorMemory> sharedProvider = mock(ObjectProvider.class);
+        when(sharedProvider.getIfAvailable()).thenReturn(memory);
+
+        ObjectProvider<IdentityPlane> identityProvider = mock(ObjectProvider.class);
+        when(identityProvider.getIfAvailable()).thenReturn(identityPlane);
+
+        binder = new MemoryRequestBinder(catalog, registry, synapseProps, sharedProvider, identityProvider);
+    }
+
+    @Test
+    @DisplayName("Binds memory with lease and request context, and unbind releases lease")
+    void bindAndUnbindWithLease() throws Exception {
+        String accountId = "0123456789abc";
+        Account account = new Account(accountId, PrincipalKind.HUMAN, AccountProfile.HUMAN_SOLO,
+                "Alice", AccountQuotas.forProfile(AccountProfile.HUMAN_SOLO), AccountFlags.forProfile(AccountProfile.HUMAN_SOLO), "default-ns-id", Instant.now());
+        when(catalog.getOrCreateAccount(accountId)).thenReturn(account);
+        when(registry.resolveFor(accountId)).thenReturn(memory);
+        when(resolver.resolve(accountId, "default-ns-id")).thenReturn(memory);
+
+        Authentication auth = mock(Authentication.class);
+        when(auth.isAuthenticated()).thenReturn(true);
+        when(auth.getName()).thenReturn(accountId);
+
+        UserSoul soul = new UserSoul(accountId, "Alice", "Researcher", null, null);
+        when(identityPlane.primarySoulFor(accountId)).thenReturn(Optional.of(soul));
+        when(identityPlane.soulsFor(null, List.of(), accountId)).thenReturn(List.of(soul));
+
+        MemoryBinding binding = binder.bind(auth, Optional.empty());
+
+        assertThat(binding.memory()).isEqualTo(memory);
+        assertThat(binding.accountId()).isEqualTo(accountId);
+        assertThat(binding.lease()).isEqualTo(lease);
+        assertThat(binding.requestMemoryContext()).isNotNull();
+        assertThat(binding.requestMemoryContext().primarySoul()).isEqualTo(soul);
+
+        // Verify unbind releases the lease
+        binder.unbind(binding);
+        verify(lease).close();
+    }
+
+    @Test
+    @DisplayName("Enforces token allow-set on slugs and rejects unauthorized slug with TokenNamespaceLockedException")
+    void tokenNamespaceSlugLock() {
+        String accountId = "0123456789abc";
+        Account account = new Account(accountId, PrincipalKind.HUMAN, AccountProfile.HUMAN_SOLO,
+                "Alice", AccountQuotas.forProfile(AccountProfile.HUMAN_SOLO), AccountFlags.forProfile(AccountProfile.HUMAN_SOLO), "ns-default", Instant.now());
+        when(catalog.getOrCreateAccount(accountId)).thenReturn(account);
+
+        NamespaceRecord projectAlpha = new NamespaceRecord("ns-alpha", "project-alpha", accountId,
+                NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "Alpha", "Project Alpha", null, Instant.now(), Instant.now());
+        when(catalog.resolve(accountId, "project-alpha")).thenReturn(Optional.of(projectAlpha));
+        when(resolver.resolve(accountId, "ns-alpha")).thenReturn(memory);
+
+        NamespaceRecord projectBeta = new NamespaceRecord("ns-beta", "project-beta", accountId,
+                NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "Beta", "Project Beta", null, Instant.now(), Instant.now());
+        when(catalog.resolve(accountId, "project-beta")).thenReturn(Optional.of(projectBeta));
+
+        // Token locked to [project-alpha]
+        Jwt jwt = Jwt.withTokenValue("mock-token")
+                .header("alg", "none")
+                .subject(accountId)
+                .claim("ns", List.of("project-alpha"))
+                .build();
+        Authentication auth = new JwtAuthenticationToken(jwt, List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_USER")));
+
+        // Binding to project-alpha succeeds
+        MemoryBinding binding = binder.bind(auth, Optional.of("project-alpha"));
+        assertThat(binding.slug()).isEqualTo("project-alpha");
+
+        // Binding to project-beta fails with TokenNamespaceLockedException
+        assertThatThrownBy(() -> binder.bind(auth, Optional.of("project-beta")))
+                .isInstanceOf(TokenNamespaceLockedException.class);
+    }
+}


### PR DESCRIPTION
## Summary
Implements account and tenant identity bundles, session working sets, JWT allow-set enforcement, and Region 24 migration.

## Changes
- **`spector-memory`**:
  - Added `IdentityRegionId` enum (regions 0..15).
  - Added `IdentityRegionEntry` (64-byte directory entry record with CRC32C, version, offsets).
  - Added `IdentityBundleHeader` constants and initializers (4KB header, 64KB per region allocation).
  - Added `IdentityBundle` container using Java FFM / Panama with DTO accessors and Jackson serialization for `SoulContext` and `SalienceProfile`.
  - Added `acquireLease()` method to `SpectorMemory` and `DefaultSpectorMemory` returning `AutoCloseable`.
- **`spector-synapse`**:
  - Added `IdentityPaths` with sharded path calculation (`${SPECTOR_DATA_DIR}/identity/accounts/{s1}/{s2}/{accountId}/identity.bundle`).
  - Added `IdentityCache` for managing open `IdentityBundle` instances (max 256 accounts, 32 tenants).
  - Added `IdentityPlane` for soul stack assembly, primary soul lookup, salience retrieval, and Region 24 copy-once migration.
  - Added `RequestMemoryContext` for thread-safe contextual dispatch.
  - Enhanced `MemoryRequestBinder` with JWT `ns`/`nsid` allow-set enforcement, `TokenNamespaceLockedException`, engine lease management, and migration triggers.
  - Enhanced `McpSessionContext` with connection-scoped volatile active working set (FIFO bounded to 100 items, preserved across namespace switch).
  - Updated `ServerAccessTokenMinter` to support `ns`, `nsid`, `tid`, and `org` claims.
- **Tests**:
  - Clean domain-centric test naming: `IdentityBundleTest`, `IdentityPathsTest`, `IdentityPlaneTest`, `MemoryRequestBinderTest`, `McpSessionWorkingSetTest`, `FileAccountCatalogTest`.

Closes #702

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>