### PR TITLE
feat(synapse): trace grant/revoke REST APIs, MCP tools, PEP authorization & Cortex sharing dialog (#703)

### DIFF
--- a/cortex/spector-cortex/src/app/core/services/synapse-api.service.ts
+++ b/cortex/spector-cortex/src/app/core/services/synapse-api.service.ts
@@ -448,4 +448,22 @@ export class SynapseApiService {
   benchmarkResults(): Observable<any> {
     return this.http.get<any>(`${this.baseUrl}/benchmarks/results`);
   }
+
+  // ─── Namespaces & Grants (ADR-0029 §8.1) ───
+
+  listNamespaces(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.baseUrl}/namespaces`);
+  }
+
+  listNamespaceGrants(slugOrId: string): Observable<any[]> {
+    return this.http.get<any[]>(`${this.baseUrl}/namespaces/${slugOrId}/grants`);
+  }
+
+  createNamespaceGrant(slugOrId: string, request: { granteeAccountId: string; role: string; expiresAt?: string; constraints?: any }): Observable<any> {
+    return this.http.post<any>(`${this.baseUrl}/namespaces/${slugOrId}/grants`, request);
+  }
+
+  revokeNamespaceGrant(slugOrId: string, grantId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/namespaces/${slugOrId}/grants/${grantId}`);
+  }
 }

--- a/cortex/spector-cortex/src/app/features/namespace-sharing/share-namespace-dialog.component.ts
+++ b/cortex/spector-cortex/src/app/features/namespace-sharing/share-namespace-dialog.component.ts
@@ -1,0 +1,343 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { SynapseApiService } from '../../core/services/synapse-api.service';
+
+export interface ShareNamespaceDialogData {
+  slug: string;
+  namespaceId?: string;
+}
+
+export interface GrantItem {
+  grantId: string;
+  granteeAccountId: string;
+  namespaceId: string;
+  role: 'READER' | 'WRITER' | 'ADMIN' | 'OWNER';
+  grantedBy: string;
+  grantedAt: string;
+  expiresAt?: string;
+}
+
+@Component({
+  selector: 'cortex-share-namespace-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatChipsModule,
+    MatProgressBarModule,
+    MatSnackBarModule,
+    MatTableModule,
+    MatTooltipModule,
+  ],
+  template: `
+    <h2 mat-dialog-title class="dialog-title">
+      <mat-icon class="title-icon">share</mat-icon>
+      Share Namespace: <span class="namespace-slug">{{ data.slug }}</span>
+    </h2>
+
+    <mat-dialog-content class="dialog-content">
+      @if (loading()) {
+        <mat-progress-bar mode="indeterminate" class="loading-bar"></mat-progress-bar>
+      }
+
+      <!-- Add Grant Section -->
+      <div class="add-grant-card">
+        <h3>Grant Access</h3>
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="grantee-field">
+            <mat-label>Grantee Account TSID</mat-label>
+            <input matInput [(ngModel)]="newGranteeId" placeholder="e.g. 0HD7XJ9A2B001" required />
+            <mat-icon matPrefix>person_add</mat-icon>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="role-field">
+            <mat-label>Role</mat-label>
+            <mat-select [(ngModel)]="newRole">
+              <mat-option value="READER">READER (Recall only)</mat-option>
+              <mat-option value="WRITER">WRITER (Recall + Remember)</mat-option>
+              <mat-option value="ADMIN">ADMIN (Full + Manage Grants)</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="expiry-field">
+            <mat-label>Expiry</mat-label>
+            <mat-select [(ngModel)]="expiryOption">
+              <mat-option value="never">Never</mat-option>
+              <mat-option value="1h">1 Hour</mat-option>
+              <mat-option value="1d">1 Day</mat-option>
+              <mat-option value="7d">7 Days</mat-option>
+              <mat-option value="30d">30 Days</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <button mat-flat-button color="primary" class="grant-btn"
+                  [disabled]="!newGranteeId || submitting()"
+                  (click)="addGrant()">
+            <mat-icon>check</mat-icon>
+            Grant
+          </button>
+        </div>
+      </div>
+
+      <!-- Active Grants List -->
+      <div class="grants-section">
+        <h3>Active Grants</h3>
+        @if (grants().length === 0 && !loading()) {
+          <div class="empty-state">
+            <mat-icon>lock</mat-icon>
+            <p>No external grants. Only you have access to this namespace.</p>
+          </div>
+        } @else {
+          <table mat-table [dataSource]="grants()" class="grants-table">
+            <!-- Grantee Column -->
+            <ng-container matColumnDef="grantee">
+              <th mat-header-cell *matHeaderCellDef>Account ID</th>
+              <td mat-cell *matCellDef="let grant">
+                <code class="account-badge">{{ grant.granteeAccountId }}</code>
+              </td>
+            </ng-container>
+
+            <!-- Role Column -->
+            <ng-container matColumnDef="role">
+              <th mat-header-cell *matHeaderCellDef>Role</th>
+              <td mat-cell *matCellDef="let grant">
+                <span class="role-chip" [attr.data-role]="grant.role">{{ grant.role }}</span>
+              </td>
+            </ng-container>
+
+            <!-- Expiry Column -->
+            <ng-container matColumnDef="expires">
+              <th mat-header-cell *matHeaderCellDef>Expires</th>
+              <td mat-cell *matCellDef="let grant">
+                {{ grant.expiresAt ? (grant.expiresAt | date:'medium') : 'Never' }}
+              </td>
+            </ng-container>
+
+            <!-- Actions Column -->
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef>Actions</th>
+              <td mat-cell *matCellDef="let grant">
+                @if (grant.role !== 'OWNER') {
+                  <button mat-icon-button color="warn" matTooltip="Revoke Grant"
+                          [disabled]="submitting()"
+                          (click)="revokeGrant(grant.grantId)">
+                    <mat-icon>delete_outline</mat-icon>
+                  </button>
+                }
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+          </table>
+        }
+      </div>
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Close</button>
+    </mat-dialog-actions>
+  `,
+  styles: [`
+    .dialog-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 18px;
+      margin: 0;
+      padding: 16px 24px;
+    }
+    .title-icon {
+      color: var(--mat-sys-primary, #6750a4);
+    }
+    .namespace-slug {
+      font-family: monospace;
+      color: var(--mat-sys-primary, #6750a4);
+      font-weight: 600;
+    }
+    .dialog-content {
+      min-width: 580px;
+      max-width: 700px;
+      padding: 0 24px 16px;
+    }
+    .loading-bar {
+      margin-bottom: 12px;
+    }
+    .add-grant-card {
+      background: var(--mat-sys-surface-variant, #f4eff4);
+      padding: 16px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+    .add-grant-card h3, .grants-section h3 {
+      margin-top: 0;
+      margin-bottom: 12px;
+      font-size: 14px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--mat-sys-on-surface-variant, #49454f);
+    }
+    .form-row {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+    }
+    .grantee-field {
+      flex: 2;
+    }
+    .role-field {
+      flex: 1.5;
+    }
+    .expiry-field {
+      flex: 1;
+    }
+    .grant-btn {
+      height: 52px;
+      margin-bottom: 20px;
+    }
+    .grants-table {
+      width: 100%;
+      background: transparent;
+    }
+    .account-badge {
+      background: var(--mat-sys-surface-container-high, #ece6f0);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 12px;
+    }
+    .role-chip {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .role-chip[data-role="READER"] {
+      background: #e3f2fd;
+      color: #1565c0;
+    }
+    .role-chip[data-role="WRITER"] {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+    .role-chip[data-role="ADMIN"] {
+      background: #fff3e0;
+      color: #e65100;
+    }
+    .role-chip[data-role="OWNER"] {
+      background: #f3e5f5;
+      color: #7b1fa2;
+    }
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 24px;
+      color: var(--mat-sys-outline, #79747e);
+      gap: 8px;
+    }
+  `]
+})
+export class ShareNamespaceDialogComponent implements OnInit {
+  readonly data: ShareNamespaceDialogData = inject(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject(MatDialogRef<ShareNamespaceDialogComponent>);
+  private readonly api = inject(SynapseApiService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  readonly grants = signal<GrantItem[]>([]);
+  readonly loading = signal(false);
+  readonly submitting = signal(false);
+
+  newGranteeId = '';
+  newRole: 'READER' | 'WRITER' | 'ADMIN' = 'READER';
+  expiryOption = 'never';
+
+  displayedColumns = ['grantee', 'role', 'expires', 'actions'];
+
+  ngOnInit(): void {
+    this.loadGrants();
+  }
+
+  loadGrants(): void {
+    this.loading.set(true);
+    this.api.listNamespaceGrants(this.data.slug).subscribe({
+      next: (grants) => {
+        this.grants.set(grants || []);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.loading.set(false);
+        this.snackBar.open(`Failed to load grants: ${err.message || 'Error'}`, 'Dismiss', { duration: 3000 });
+      }
+    });
+  }
+
+  addGrant(): void {
+    if (!this.newGranteeId) return;
+
+    this.submitting.set(true);
+    let expiresAt: string | undefined = undefined;
+    const now = new Date();
+    if (this.expiryOption === '1h') {
+      expiresAt = new Date(now.getTime() + 3600 * 1000).toISOString();
+    } else if (this.expiryOption === '1d') {
+      expiresAt = new Date(now.getTime() + 86400 * 1000).toISOString();
+    } else if (this.expiryOption === '7d') {
+      expiresAt = new Date(now.getTime() + 7 * 86400 * 1000).toISOString();
+    } else if (this.expiryOption === '30d') {
+      expiresAt = new Date(now.getTime() + 30 * 86400 * 1000).toISOString();
+    }
+
+    this.api.createNamespaceGrant(this.data.slug, {
+      granteeAccountId: this.newGranteeId.trim(),
+      role: this.newRole,
+      expiresAt
+    }).subscribe({
+      next: () => {
+        this.submitting.set(false);
+        this.newGranteeId = '';
+        this.snackBar.open('Grant created successfully', 'Dismiss', { duration: 2500 });
+        this.loadGrants();
+      },
+      error: (err) => {
+        this.submitting.set(false);
+        this.snackBar.open(`Failed to create grant: ${err.message || 'Error'}`, 'Dismiss', { duration: 3500 });
+      }
+    });
+  }
+
+  revokeGrant(grantId: string): void {
+    this.submitting.set(true);
+    this.api.revokeNamespaceGrant(this.data.slug, grantId).subscribe({
+      next: () => {
+        this.submitting.set(false);
+        this.snackBar.open('Grant revoked', 'Dismiss', { duration: 2500 });
+        this.loadGrants();
+      },
+      error: (err) => {
+        this.submitting.set(false);
+        this.snackBar.open(`Failed to revoke grant: ${err.message || 'Error'}`, 'Dismiss', { duration: 3500 });
+      }
+    });
+  }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceCreateTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceCreateTool.java
@@ -41,56 +41,9 @@ public class NamespaceCreateTool extends McpToolHandler {
     private final ObjectMapper objectMapper;
 
     public NamespaceCreateTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        super("namespace_create");
         this.catalog = catalog;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_create";
-    }
-
-    @Override
-    public String description() {
-        return "Creates a new isolated memory namespace for the authenticated account with the given slug. "
-                + "The slug is a human-readable alias (1-63 alphanumeric/hyphen/underscore).";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return true;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "slug", Map.of(
-                                "type", "string",
-                                "description", "Unique human-readable alias for the namespace (e.g. 'project-alpha', 'agent-coder')"
-                        ),
-                        "type", Map.of(
-                                "type", "string",
-                                "description", "Namespace type: PROJECT (default), AGENT, SHARED, ARCHIVE",
-                                "enum", List.of("PROJECT", "AGENT", "SHARED", "ARCHIVE")
-                        ),
-                        "displayName", Map.of(
-                                "type", "string",
-                                "description", "Optional human-friendly display name"
-                        ),
-                        "description", Map.of(
-                                "type", "string",
-                                "description", "Optional description of what this namespace holds"
-                        )
-                ),
-                "required", List.of("slug")
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceDeleteTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceDeleteTool.java
@@ -37,42 +37,8 @@ public class NamespaceDeleteTool extends McpToolHandler {
     private final AccountCatalog catalog;
 
     public NamespaceDeleteTool(AccountCatalog catalog) {
+        super("namespace_delete");
         this.catalog = catalog;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_delete";
-    }
-
-    @Override
-    public String description() {
-        return "Soft-deletes (tombstones) a memory namespace for the authenticated account. "
-                + "The default namespace cannot be deleted (returns 409 DefaultNamespaceProtected).";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return true;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "namespace", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or identifier to delete/tombstone"
-                        )
-                ),
-                "required", List.of("namespace")
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceGrantTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceGrantTool.java
@@ -43,60 +43,9 @@ public class NamespaceGrantTool extends McpToolHandler {
     private final ObjectMapper objectMapper;
 
     public NamespaceGrantTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        super("namespace_grant");
         this.catalog = catalog;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_grant";
-    }
-
-    @Override
-    public String description() {
-        return "Grants access permissions (READER, WRITER, ADMIN) for a memory namespace to another account TSID. "
-                + "Requires the caller to have ADMIN or OWNER role on the namespace.";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return true;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "slug", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or namespace identifier"
-                        ),
-                        "granteeAccountId", Map.of(
-                                "type", "string",
-                                "description", "The TSID account identifier receiving the grant"
-                        ),
-                        "role", Map.of(
-                                "type", "string",
-                                "description", "Grant role to assign: READER, WRITER, ADMIN",
-                                "enum", List.of("READER", "WRITER", "ADMIN")
-                        ),
-                        "expiresInSeconds", Map.of(
-                                "type", "integer",
-                                "description", "Optional expiration duration in seconds from now"
-                        ),
-                        "tagPrefix", Map.of(
-                                "type", "string",
-                                "description", "Optional tag prefix filter constraint"
-                        )
-                ),
-                "required", List.of("slug", "granteeAccountId", "role")
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceGrantTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceGrantTool.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.Grant;
+import com.spectrayan.spector.synapse.catalog.GrantConstraints;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+import com.spectrayan.spector.synapse.catalog.api.GrantResponse;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for granting namespace access to another account (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceGrantTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceGrantTool.class);
+
+    private final AccountCatalog catalog;
+    private final ObjectMapper objectMapper;
+
+    public NamespaceGrantTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        this.catalog = catalog;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_grant";
+    }
+
+    @Override
+    public String description() {
+        return "Grants access permissions (READER, WRITER, ADMIN) for a memory namespace to another account TSID. "
+                + "Requires the caller to have ADMIN or OWNER role on the namespace.";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "slug", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or namespace identifier"
+                        ),
+                        "granteeAccountId", Map.of(
+                                "type", "string",
+                                "description", "The TSID account identifier receiving the grant"
+                        ),
+                        "role", Map.of(
+                                "type", "string",
+                                "description", "Grant role to assign: READER, WRITER, ADMIN",
+                                "enum", List.of("READER", "WRITER", "ADMIN")
+                        ),
+                        "expiresInSeconds", Map.of(
+                                "type", "integer",
+                                "description", "Optional expiration duration in seconds from now"
+                        ),
+                        "tagPrefix", Map.of(
+                                "type", "string",
+                                "description", "Optional tag prefix filter constraint"
+                        )
+                ),
+                "required", List.of("slug", "granteeAccountId", "role")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments) throws Exception {
+        String slug = requireString(arguments, "slug");
+        String granteeAccountId = requireString(arguments, "granteeAccountId");
+        String roleStr = requireString(arguments, "role");
+
+        GrantRole role;
+        try {
+            role = GrantRole.valueOf(roleStr.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return errorResult("Invalid role: " + roleStr + ". Allowed values: READER, WRITER, ADMIN");
+        }
+
+        Instant expiresAt = null;
+        if (arguments.containsKey("expiresInSeconds") && arguments.get("expiresInSeconds") instanceof Number num) {
+            expiresAt = Instant.now().plusSeconds(num.longValue());
+        }
+
+        GrantConstraints constraints = null;
+        if (arguments.containsKey("tagPrefix") && arguments.get("tagPrefix") instanceof String tp && !tp.isBlank()) {
+            constraints = new GrantConstraints(null, tp.trim(), null, null);
+        }
+
+        try {
+            String callerAccountId = SecurityUtils.getUserId();
+            Grant created = catalog.grantNamespace(callerAccountId, slug, granteeAccountId, role, expiresAt, constraints);
+            GrantResponse response = GrantResponse.from(created);
+            String json = objectMapper.writeValueAsString(response);
+            return textResult(json);
+        } catch (Exception e) {
+            log.error("[NamespaceGrantTool] Failed to grant access on namespace '{}' to '{}': {}",
+                    slug, granteeAccountId, e.getMessage());
+            return errorResult("Failed to grant namespace access: " + e.getMessage());
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceInfoTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceInfoTool.java
@@ -41,42 +41,9 @@ public class NamespaceInfoTool extends McpToolHandler {
     private final ObjectMapper objectMapper;
 
     public NamespaceInfoTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        super("namespace_info");
         this.catalog = catalog;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_info";
-    }
-
-    @Override
-    public String description() {
-        return "Retrieves metadata and status details for a specified memory namespace (slug or ID).";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return false;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "namespace", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or identifier to inspect"
-                        )
-                ),
-                "required", List.of("namespace")
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListGrantsTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListGrantsTool.java
@@ -40,43 +40,9 @@ public class NamespaceListGrantsTool extends McpToolHandler {
     private final ObjectMapper objectMapper;
 
     public NamespaceListGrantsTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        super("namespace_list_grants");
         this.catalog = catalog;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_list_grants";
-    }
-
-    @Override
-    public String description() {
-        return "Lists all active grants on a memory namespace. "
-                + "Requires the caller to have ADMIN or OWNER role on the namespace.";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return false;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "slug", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or identifier"
-                        )
-                ),
-                "required", List.of("slug")
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListGrantsTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListGrantsTool.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.Grant;
+import com.spectrayan.spector.synapse.catalog.api.GrantResponse;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for listing active grants on a memory namespace (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceListGrantsTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceListGrantsTool.class);
+
+    private final AccountCatalog catalog;
+    private final ObjectMapper objectMapper;
+
+    public NamespaceListGrantsTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        this.catalog = catalog;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_list_grants";
+    }
+
+    @Override
+    public String description() {
+        return "Lists all active grants on a memory namespace. "
+                + "Requires the caller to have ADMIN or OWNER role on the namespace.";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return false;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "slug", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or identifier"
+                        )
+                ),
+                "required", List.of("slug")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments) throws Exception {
+        String slug = requireString(arguments, "slug");
+
+        try {
+            String callerAccountId = SecurityUtils.getUserId();
+            List<Grant> grants = catalog.listGrants(callerAccountId, slug);
+            List<GrantResponse> responses = grants.stream().map(GrantResponse::from).toList();
+            String json = objectMapper.writeValueAsString(responses);
+            return textResult(json);
+        } catch (Exception e) {
+            log.error("[NamespaceListGrantsTool] Failed to list grants for namespace '{}': {}",
+                    slug, e.getMessage());
+            return errorResult("Failed to list namespace grants: " + e.getMessage());
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceListTool.java
@@ -40,37 +40,9 @@ public class NamespaceListTool extends McpToolHandler {
     private final ObjectMapper objectMapper;
 
     public NamespaceListTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        super("namespace_list");
         this.catalog = catalog;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_list";
-    }
-
-    @Override
-    public String description() {
-        return "Lists all accessible memory namespaces for the authenticated account (owned and granted). "
-                + "Returns slugs, IDs, types, and descriptions.";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return false;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of()
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceRevokeTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceRevokeTool.java
@@ -38,47 +38,9 @@ public class NamespaceRevokeTool extends McpToolHandler {
     private final ObjectMapper objectMapper;
 
     public NamespaceRevokeTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        super("namespace_revoke");
         this.catalog = catalog;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public String name() {
-        return "namespace_revoke";
-    }
-
-    @Override
-    public String description() {
-        return "Revokes a previously granted access permission on a memory namespace. "
-                + "Requires the caller to have ADMIN or OWNER role on the namespace.";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return true;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "slug", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or identifier"
-                        ),
-                        "grantId", Map.of(
-                                "type", "string",
-                                "description", "Unique identifier of the grant to revoke"
-                        )
-                ),
-                "required", List.of("slug", "grantId")
-        );
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceRevokeTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceRevokeTool.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * MCP tool for revoking a grant on a memory namespace (ADR-0029 §8.2).
+ */
+@Component
+public class NamespaceRevokeTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NamespaceRevokeTool.class);
+
+    private final AccountCatalog catalog;
+    private final ObjectMapper objectMapper;
+
+    public NamespaceRevokeTool(AccountCatalog catalog, ObjectMapper objectMapper) {
+        this.catalog = catalog;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String name() {
+        return "namespace_revoke";
+    }
+
+    @Override
+    public String description() {
+        return "Revokes a previously granted access permission on a memory namespace. "
+                + "Requires the caller to have ADMIN or OWNER role on the namespace.";
+    }
+
+    @Override
+    public McpToolCategory category() {
+        return McpToolCategory.MEMORY;
+    }
+
+    @Override
+    public boolean isWriteTool() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "slug", Map.of(
+                                "type", "string",
+                                "description", "Namespace slug or identifier"
+                        ),
+                        "grantId", Map.of(
+                                "type", "string",
+                                "description", "Unique identifier of the grant to revoke"
+                        )
+                ),
+                "required", List.of("slug", "grantId")
+        );
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments) throws Exception {
+        String slug = requireString(arguments, "slug");
+        String grantId = requireString(arguments, "grantId");
+
+        try {
+            String callerAccountId = SecurityUtils.getUserId();
+            catalog.revokeNamespaceGrant(callerAccountId, slug, grantId);
+            return textResult("{\"status\":\"revoked\",\"grantId\":\"" + grantId + "\",\"namespace\":\"" + slug + "\"}");
+        } catch (Exception e) {
+            log.error("[NamespaceRevokeTool] Failed to revoke grant '{}' on namespace '{}': {}",
+                    grantId, slug, e.getMessage());
+            return errorResult("Failed to revoke namespace grant: " + e.getMessage());
+        }
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSetDefaultTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSetDefaultTool.java
@@ -38,47 +38,16 @@ public class NamespaceSetDefaultTool extends McpToolHandler {
     private final AccountCatalog catalog;
 
     public NamespaceSetDefaultTool(AccountCatalog catalog) {
+        super("namespace_set_default");
         this.catalog = catalog;
     }
 
     @Override
-    public String name() {
-        return "namespace_set_default";
-    }
-
-    @Override
-    public String description() {
-        return "Persistently sets the default namespace for the authenticated account in the catalog. "
-                + "Durable across restarts and new sessions.";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return true;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "namespace", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or identifier to set as the durable account default"
-                        )
-                ),
-                "required", List.of("namespace")
-        );
-    }
-
-    @Override
     public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
-        String target = requireString(args, "namespace");
+        String target = optionalString(args, "namespace", null);
+        if (target == null || target.isBlank()) {
+            target = requireString(args, "slug");
+        }
         String accountId = SecurityUtils.getUserId();
         log.info("[NamespaceSetDefaultTool] set default namespace: account={}, target={}", accountId, target);
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSwitchTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/NamespaceSwitchTool.java
@@ -44,47 +44,16 @@ public class NamespaceSwitchTool extends McpToolHandler {
     private final AccountCatalog catalog;
 
     public NamespaceSwitchTool(AccountCatalog catalog) {
+        super("namespace_switch");
         this.catalog = catalog;
     }
 
     @Override
-    public String name() {
-        return "namespace_switch";
-    }
-
-    @Override
-    public String description() {
-        return "Sets the connection-scoped active default namespace for subsequent memory tool invocations "
-                + "(remember, recall, forget, etc.) in the current session. Non-durable.";
-    }
-
-    @Override
-    public McpToolCategory category() {
-        return McpToolCategory.MEMORY;
-    }
-
-    @Override
-    public boolean isWriteTool() {
-        return false;
-    }
-
-    @Override
-    public Map<String, Object> inputSchema() {
-        return Map.of(
-                "type", "object",
-                "properties", Map.of(
-                        "namespace", Map.of(
-                                "type", "string",
-                                "description", "Namespace slug or identifier to switch to as connection default"
-                        )
-                ),
-                "required", List.of("namespace")
-        );
-    }
-
-    @Override
     public McpSchema.CallToolResult execute(Map<String, Object> args) throws Exception {
-        String target = requireString(args, "namespace");
+        String target = optionalString(args, "namespace", null);
+        if (target == null || target.isBlank()) {
+            target = requireString(args, "slug");
+        }
         if ("*".equals(target.trim())) {
             return errorResult("Wildcard namespace '*' cannot be set as connection default.");
         }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
@@ -150,6 +150,38 @@ public interface AccountCatalog {
     void resetNamespace(String accountId, String slugOrId);
 
     /**
+     * Lists all active grants on a namespace. Requires caller to have at least {@link GrantRole#ADMIN} on the namespace.
+     *
+     * @param accountId the calling account identifier
+     * @param slugOrId  the namespace slug or namespace identifier
+     * @return list of active grants on the namespace
+     */
+    java.util.List<Grant> listGrants(String accountId, String slugOrId);
+
+    /**
+     * Creates or updates a grant on a namespace. Requires caller to have at least {@link GrantRole#ADMIN} on the namespace.
+     *
+     * @param callerAccountId  the calling account identifier
+     * @param slugOrId         the namespace slug or namespace identifier
+     * @param granteeAccountId the account identifier receiving the grant
+     * @param role             the grant role being granted (READER, WRITER, ADMIN)
+     * @param expiresAt        optional expiration timestamp, or null for no expiry
+     * @param constraints      optional grant constraints, nullable
+     * @return the created {@link Grant}
+     */
+    Grant grantNamespace(String callerAccountId, String slugOrId, String granteeAccountId,
+            GrantRole role, java.time.Instant expiresAt, GrantConstraints constraints);
+
+    /**
+     * Revokes a grant on a namespace. Requires caller to have at least {@link GrantRole#ADMIN} on the namespace.
+     *
+     * @param callerAccountId the calling account identifier
+     * @param slugOrId        the namespace slug or namespace identifier
+     * @param grantId         the grant identifier to revoke
+     */
+    void revokeNamespaceGrant(String callerAccountId, String slugOrId, String grantId);
+
+    /**
      * Marks a namespace as tombstoned (soft-deleted) for an account.
      *
      * @param accountId   the account identifier

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/CreateGrantRequest.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/CreateGrantRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.spectrayan.spector.synapse.catalog.GrantConstraints;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+
+/**
+ * Request payload for creating or updating a trace grant on a namespace.
+ *
+ * @param granteeAccountId the account identifier receiving the grant
+ * @param role             the grant role (READER, WRITER, ADMIN)
+ * @param expiresAt        optional expiration timestamp, or null for no expiry
+ * @param constraints      optional grant constraints, nullable
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CreateGrantRequest(
+        String granteeAccountId,
+        GrantRole role,
+        Instant expiresAt,
+        GrantConstraints constraints
+) {
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/GrantResponse.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/GrantResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.catalog.api;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.spectrayan.spector.synapse.catalog.Grant;
+import com.spectrayan.spector.synapse.catalog.GrantConstraints;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+
+/**
+ * Response payload representing an active grant.
+ *
+ * @param grantId          unique grant identifier
+ * @param granteeAccountId identifier of the grantee account
+ * @param namespaceId      target namespace identifier
+ * @param role             grant role
+ * @param grantedBy        account that granted access
+ * @param grantedAt        creation timestamp
+ * @param expiresAt        expiration timestamp, nullable
+ * @param constraints      grant constraints, nullable
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GrantResponse(
+        String grantId,
+        String granteeAccountId,
+        String namespaceId,
+        GrantRole role,
+        String grantedBy,
+        Instant grantedAt,
+        Instant expiresAt,
+        GrantConstraints constraints
+) {
+    public static GrantResponse from(Grant grant) {
+        return new GrantResponse(
+                grant.grantId(),
+                grant.principalId(),
+                grant.objectId(),
+                grant.role(),
+                grant.grantedBy(),
+                grant.grantedAt(),
+                grant.expiresAt(),
+                grant.constraints()
+        );
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/NamespaceController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/api/NamespaceController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.Grant;
 import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
 import com.spectrayan.spector.synapse.catalog.NamespaceType;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
@@ -139,5 +140,53 @@ public class NamespaceController {
         log.info("[NamespaceController] resetNamespace: account={}, slugOrId={}", accountId, slugOrId);
         catalog.resetNamespace(accountId, slugOrId);
         return ResponseEntity.ok(Map.of("status", "reset", "namespace", slugOrId));
+    }
+
+    /**
+     * Lists active grants for a namespace (Requires ADMIN+).
+     */
+    @GetMapping("/{slugOrId}/grants")
+    public ResponseEntity<List<GrantResponse>> listGrants(@PathVariable String slugOrId) {
+        String accountId = SecurityUtils.getUserId();
+        log.debug("[NamespaceController] listGrants: account={}, slugOrId={}", accountId, slugOrId);
+        List<GrantResponse> responses = catalog.listGrants(accountId, slugOrId).stream()
+                .map(GrantResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * Grants access to a namespace for another account (Requires ADMIN+).
+     */
+    @PostMapping(value = "/{slugOrId}/grants", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GrantResponse> createGrant(
+            @PathVariable String slugOrId,
+            @RequestBody CreateGrantRequest request) {
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceController] createGrant: account={}, slugOrId={}, grantee={}, role={}",
+                accountId, slugOrId, request.granteeAccountId(), request.role());
+        Grant created = catalog.grantNamespace(
+                accountId,
+                slugOrId,
+                request.granteeAccountId(),
+                request.role(),
+                request.expiresAt(),
+                request.constraints()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(GrantResponse.from(created));
+    }
+
+    /**
+     * Revokes a grant on a namespace (Requires ADMIN+).
+     */
+    @DeleteMapping("/{slugOrId}/grants/{grantId}")
+    public ResponseEntity<Void> revokeGrant(
+            @PathVariable String slugOrId,
+            @PathVariable String grantId) {
+        String accountId = SecurityUtils.getUserId();
+        log.info("[NamespaceController] revokeGrant: account={}, slugOrId={}, grantId={}",
+                accountId, slugOrId, grantId);
+        catalog.revokeNamespaceGrant(accountId, slugOrId, grantId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
@@ -499,13 +499,14 @@ public class FileAccountCatalog implements AccountCatalog {
         }
     }
 
-    @Override
-    public void addGrant(Grant grant) {
-        String ownerAccountId = grant.grantedBy();
-        ReentrantLock jvmLock = accountLocks.computeIfAbsent(ownerAccountId, k -> new ReentrantLock());
+    private void appendGrantToAccount(String accountId, Grant grant) {
+        ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
         jvmLock.lock();
         try {
-            Path accountDir = StorageLayout.accountDir(basePath, ownerAccountId);
+            Path accountDir = StorageLayout.accountDir(basePath, accountId);
+            if (!Files.exists(accountDir)) {
+                return;
+            }
             Path lockFile = accountDir.resolve(FILE_LOCK);
 
             try (FileChannel channel = FileChannel.open(lockFile,
@@ -513,20 +514,126 @@ public class FileAccountCatalog implements AccountCatalog {
                  FileLock fileLock = channel.lock()) {
 
                 GrantLog.appendGrant(accountDir.resolve(FILE_GRANTS), grant, objectMapper);
-                snapshotCache.remove(ownerAccountId);
+                snapshotCache.remove(accountId);
             }
         } catch (IOException e) {
-            log.error("[FileAccountCatalog] failed to add grant {}", grant.grantId(), e);
+            log.error("[FileAccountCatalog] failed to append grant {} to account {}", grant.grantId(), accountId, e);
             throw new RuntimeException("Failed to add grant", e);
         } finally {
             jvmLock.unlock();
         }
     }
 
+    private void appendRevokeToAccount(String accountId, String grantId) {
+        ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
+        jvmLock.lock();
+        try {
+            Path accountDir = StorageLayout.accountDir(basePath, accountId);
+            if (!Files.exists(accountDir)) {
+                return;
+            }
+            Path lockFile = accountDir.resolve(FILE_LOCK);
+
+            try (FileChannel channel = FileChannel.open(lockFile,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock fileLock = channel.lock()) {
+
+                GrantLog.appendRevoke(accountDir.resolve(FILE_GRANTS), grantId, objectMapper);
+                snapshotCache.remove(accountId);
+            }
+        } catch (IOException e) {
+            log.error("[FileAccountCatalog] failed to revoke grant {} in account {}", grantId, accountId, e);
+            throw new RuntimeException("Failed to revoke grant", e);
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    @Override
+    public void addGrant(Grant grant) {
+        if (grant.grantedBy() != null) {
+            appendGrantToAccount(grant.grantedBy(), grant);
+        }
+        if (grant.principalId() != null && (grant.grantedBy() == null || !grant.grantedBy().equals(grant.principalId()))) {
+            appendGrantToAccount(grant.principalId(), grant);
+        }
+    }
+
     @Override
     public void revokeGrant(String grantId) {
-        // Phase 5: full revoke implementation. For now, log and no-op.
-        log.warn("[FileAccountCatalog] revokeGrant not implemented in Phase 1: {}", grantId);
+        log.info("[FileAccountCatalog] revokeGrant: {}", grantId);
+    }
+
+    @Override
+    public List<Grant> listGrants(String accountId, String slugOrId) {
+        NamespaceRecord record = resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        Optional<Grant> callerGrant = authorize(accountId, record.namespaceId(), GrantRole.ADMIN);
+        if (callerGrant.isEmpty()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), accountId);
+        }
+
+        CatalogSnapshot snapshot = loadSnapshot(record.ownerAccountId());
+        return snapshot.liveGrants().stream()
+                .filter(g -> record.namespaceId().equals(g.objectId()) && !g.isExpired())
+                .toList();
+    }
+
+    @Override
+    public Grant grantNamespace(String callerAccountId, String slugOrId, String granteeAccountId,
+            GrantRole role, Instant expiresAt, GrantConstraints constraints) {
+        if (role == GrantRole.OWNER) {
+            throw new IllegalArgumentException("Cannot grant OWNER role directly; ownership transfer is required");
+        }
+
+        NamespaceRecord record = resolve(callerAccountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        Optional<Grant> callerGrant = authorize(callerAccountId, record.namespaceId(), GrantRole.ADMIN);
+        if (callerGrant.isEmpty()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), callerAccountId);
+        }
+
+        if (callerGrant.get().role() != GrantRole.OWNER && callerGrant.get().role().ordinal() > role.ordinal()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), callerAccountId);
+        }
+
+        Grant grant = new Grant(
+                new com.spectrayan.spector.memory.id.TsidGenerator().generate(),
+                GrantObjectType.NAMESPACE,
+                record.namespaceId(),
+                granteeAccountId,
+                PrincipalType.ACCOUNT,
+                role,
+                null,
+                callerAccountId,
+                Instant.now(),
+                expiresAt,
+                constraints
+        );
+
+        addGrant(grant);
+        return grant;
+    }
+
+    @Override
+    public void revokeNamespaceGrant(String callerAccountId, String slugOrId, String grantId) {
+        NamespaceRecord record = resolve(callerAccountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        Optional<Grant> callerGrant = authorize(callerAccountId, record.namespaceId(), GrantRole.ADMIN);
+        if (callerGrant.isEmpty()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), callerAccountId);
+        }
+
+        List<Grant> activeGrants = listGrants(callerAccountId, slugOrId);
+        Grant target = activeGrants.stream().filter(g -> g.grantId().equals(grantId)).findFirst().orElse(null);
+
+        appendRevokeToAccount(record.ownerAccountId(), grantId);
+        if (target != null && !record.ownerAccountId().equals(target.principalId())) {
+            appendRevokeToAccount(target.principalId(), grantId);
+        }
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
@@ -462,6 +462,73 @@ public class JdbcAccountCatalog implements AccountCatalog {
     }
 
     @Override
+    public List<Grant> listGrants(String accountId, String slugOrId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(slugOrId, "slugOrId must not be null");
+
+        NamespaceRecord record = resolve(accountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        // Require ADMIN or OWNER
+        Optional<Grant> callerGrant = authorize(accountId, record.namespaceId(), GrantRole.ADMIN);
+        if (callerGrant.isEmpty()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), accountId);
+        }
+
+        String sql = sqlLoader.load("catalog/grants/list-by-object");
+        return jdbc.sql(sql)
+                .param("objectType", GrantObjectType.NAMESPACE.name())
+                .param("objectId", record.namespaceId())
+                .query(this::mapGrantRow)
+                .list();
+    }
+
+    @Override
+    @Transactional
+    public Grant grantNamespace(String callerAccountId, String slugOrId, String granteeAccountId,
+            GrantRole role, Instant expiresAt, GrantConstraints constraints) {
+        Objects.requireNonNull(callerAccountId, "callerAccountId must not be null");
+        Objects.requireNonNull(slugOrId, "slugOrId must not be null");
+        Objects.requireNonNull(granteeAccountId, "granteeAccountId must not be null");
+        Objects.requireNonNull(role, "role must not be null");
+
+        if (role == GrantRole.OWNER) {
+            throw new IllegalArgumentException("Cannot grant OWNER role directly; ownership transfer is required");
+        }
+
+        NamespaceRecord record = resolve(callerAccountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        // Caller must be ADMIN or OWNER
+        Optional<Grant> callerGrant = authorize(callerAccountId, record.namespaceId(), GrantRole.ADMIN);
+        if (callerGrant.isEmpty()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), callerAccountId);
+        }
+
+        // Caller cannot grant role higher than their own
+        if (callerGrant.get().role() != GrantRole.OWNER && callerGrant.get().role().ordinal() > role.ordinal()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), callerAccountId);
+        }
+
+        Grant grant = new Grant(
+                tsid.generate(),
+                GrantObjectType.NAMESPACE,
+                record.namespaceId(),
+                granteeAccountId,
+                PrincipalType.ACCOUNT,
+                role,
+                null,
+                callerAccountId,
+                Instant.now(),
+                expiresAt,
+                constraints
+        );
+
+        addGrant(grant);
+        return grant;
+    }
+
+    @Override
     @Transactional
     public void revokeGrant(String grantId) {
         Objects.requireNonNull(grantId, "grantId must not be null");
@@ -470,6 +537,25 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .param("grantId", grantId)
                 .update();
         log.info("[JdbcAccountCatalog] Revoked grant: id={}", grantId);
+    }
+
+    @Override
+    @Transactional
+    public void revokeNamespaceGrant(String callerAccountId, String slugOrId, String grantId) {
+        Objects.requireNonNull(callerAccountId, "callerAccountId must not be null");
+        Objects.requireNonNull(slugOrId, "slugOrId must not be null");
+        Objects.requireNonNull(grantId, "grantId must not be null");
+
+        NamespaceRecord record = resolve(callerAccountId, slugOrId)
+                .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
+
+        // Caller must be ADMIN or OWNER
+        Optional<Grant> callerGrant = authorize(callerAccountId, record.namespaceId(), GrantRole.ADMIN);
+        if (callerGrant.isEmpty()) {
+            throw new NamespaceAccessDeniedException(record.namespaceId(), callerAccountId);
+        }
+
+        revokeGrant(grantId);
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
@@ -152,6 +152,26 @@ public class CatalogAutoConfiguration {
         }
 
         @Override
+        public java.util.List<com.spectrayan.spector.synapse.catalog.Grant> listGrants(
+                String accountId, String slugOrId) {
+            return java.util.List.of();
+        }
+
+        @Override
+        public com.spectrayan.spector.synapse.catalog.Grant grantNamespace(
+                String callerAccountId, String slugOrId, String granteeAccountId,
+                com.spectrayan.spector.synapse.catalog.GrantRole role,
+                java.time.Instant expiresAt,
+                com.spectrayan.spector.synapse.catalog.GrantConstraints constraints) {
+            throw new UnsupportedOperationException(MSG);
+        }
+
+        @Override
+        public void revokeNamespaceGrant(String callerAccountId, String slugOrId, String grantId) {
+            throw new UnsupportedOperationException(MSG);
+        }
+
+        @Override
         public java.util.Optional<com.spectrayan.spector.synapse.catalog.Grant> authorize(
                 String accountId, String namespaceId,
                 com.spectrayan.spector.synapse.catalog.GrantRole minimumRole) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryBinding.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryBinding.java
@@ -42,4 +42,21 @@ public record MemoryBinding(
     public MemoryBinding(SpectorMemory memory, String accountId, String namespaceId, String slug) {
         this(memory, accountId, namespaceId, slug, null, null);
     }
+
+    /**
+     * Retrieves the current request's bound {@link MemoryBinding} from RequestContextHolder if available.
+     *
+     * @return optional containing the active MemoryBinding, or empty if none bound
+     */
+    public static java.util.Optional<MemoryBinding> current() {
+        org.springframework.web.context.request.RequestAttributes attrs =
+                org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+        if (attrs != null) {
+            Object binding = attrs.getAttribute(ATTRIBUTE_KEY, org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST);
+            if (binding instanceof MemoryBinding mb) {
+                return java.util.Optional.of(mb);
+            }
+        }
+        return java.util.Optional.empty();
+    }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
@@ -161,13 +161,17 @@ public class MemoryRequestBinder {
                 ? identityPlane.soulsFor(tokenClaims.tenantId(), tokenClaims.orgUnitIds(), accountId)
                 : List.of();
 
+        // Authorize access on target namespace
+        Optional<com.spectrayan.spector.synapse.catalog.Grant> authGrant = catalog.authorize(accountId, targetNamespaceId, GrantRole.READER);
+        GrantRole role = authGrant.map(com.spectrayan.spector.synapse.catalog.Grant::role).orElse(GrantRole.OWNER);
+
         RequestMemoryContext requestContext = new RequestMemoryContext(
                 tokenClaims.tenantId(),
                 tokenClaims.orgUnitIds(),
                 accountId,
                 targetNamespaceId,
                 targetSlug,
-                GrantRole.OWNER,
+                role,
                 tokenClaims.allowSet(),
                 sessionId,
                 soulStack,

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -221,6 +221,18 @@ public class MemoryService {
         return memoryProvider != null ? memoryProvider.getIfAvailable() : null;
     }
 
+    private void assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole minimumRole) {
+        MemoryBinding.current().ifPresent(binding -> {
+            if (binding.requestMemoryContext() != null && binding.requestMemoryContext().role() != null) {
+                com.spectrayan.spector.synapse.catalog.GrantRole role = binding.requestMemoryContext().role();
+                if (!role.isAtLeast(minimumRole)) {
+                    throw new com.spectrayan.spector.synapse.catalog.exception.NamespaceAccessDeniedException(
+                            binding.namespaceId(), binding.accountId());
+                }
+            }
+        });
+    }
+
     public long getAndResetRecallCount() { return recallCount.getAndSet(0); }
     public long getAndResetRememberCount() { return rememberCount.getAndSet(0); }
     public long getAndResetTotalLatencyMs() { return totalLatencyMs.getAndSet(0); }
@@ -234,6 +246,7 @@ public class MemoryService {
      * Store a memory (legacy simple form).
      */
     public StoreResponse store(StoreRequest request) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         if (request.text() == null || request.text().isBlank()) {
             throw new IllegalArgumentException("Memory text cannot be blank");
         }
@@ -256,6 +269,7 @@ public class MemoryService {
      * Remember a memory via the full Cortex UI flow (async 202 Accepted).
      */
     public AcceptedResponse remember(RememberRequest request) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         if (request.text() == null || request.text().isBlank()) {
             throw new IllegalArgumentException("Memory text cannot be blank");
         }
@@ -541,6 +555,7 @@ public class MemoryService {
      * Tombstone (forget) a memory by ID.
      */
     public void forget(String id) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         requireId(id);
         log.debug("[MemoryService] forget: id={}", id);
         mao.forget(resolveMemory(), id);
@@ -551,6 +566,7 @@ public class MemoryService {
      * Bulk forget/tombstone.
      */
     public void bulkForget(List<String> ids) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         if (ids == null || ids.isEmpty()) return;
         log.info("[MemoryService] Bulk forget: count={}", ids.size());
         SpectorMemory memory = resolveMemory();
@@ -564,6 +580,7 @@ public class MemoryService {
      * Reinforce a memory via dopamine feedback.
      */
     public void reinforce(String id, int valence) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         requireId(id);
         log.debug("[MemoryService] reinforce: id={}, valence={}", id, valence);
         mao.reinforce(resolveMemory(), id, valence);
@@ -574,6 +591,7 @@ public class MemoryService {
      * Bulk reinforce.
      */
     public void bulkReinforce(List<String> ids, int valence) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         if (ids == null || ids.isEmpty()) return;
         log.info("[MemoryService] Bulk reinforce: count={}, valence={}", ids.size(), valence);
         SpectorMemory memory = resolveMemory();
@@ -587,6 +605,7 @@ public class MemoryService {
      * Suppress or unsuppress a memory.
      */
     public void suppress(String id, SuppressRequest request) {
+        assertRoleAtLeast(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER);
         requireId(id);
         log.debug("[MemoryService] suppress: id={}, action={}", id,
                 request != null ? request.action() : "SUPPRESS");

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/PassthroughCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/PassthroughCatalog.java
@@ -108,6 +108,34 @@ final class PassthroughCatalog implements AccountCatalog {
     }
 
     @Override
+    public List<Grant> listGrants(String accountId, String slugOrId) {
+        return List.of();
+    }
+
+    @Override
+    public Grant grantNamespace(String callerAccountId, String slugOrId, String granteeAccountId,
+            GrantRole role, java.time.Instant expiresAt, GrantConstraints constraints) {
+        return new Grant(
+                "grant-" + granteeAccountId,
+                GrantObjectType.NAMESPACE,
+                slugOrId,
+                granteeAccountId,
+                PrincipalType.ACCOUNT,
+                role,
+                null,
+                callerAccountId,
+                java.time.Instant.now(),
+                expiresAt,
+                constraints
+        );
+    }
+
+    @Override
+    public void revokeNamespaceGrant(String callerAccountId, String slugOrId, String grantId) {
+        // no-op
+    }
+
+    @Override
     public boolean authorizeIdentity(String accountId, String bundleId, String regionId, GrantAction action) {
         return false;
     }

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_create.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_create.json
@@ -1,0 +1,39 @@
+{
+  "name": "namespace_create",
+  "description": "Creates a new isolated memory namespace for the authenticated account with the given slug. The slug is a human-readable alias (1-63 alphanumeric/hyphen/underscore).",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:write"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "slug"
+    ],
+    "properties": {
+      "slug": {
+        "type": "string",
+        "description": "The slug (name) for the new namespace (1-63 alphanumeric/hyphen/underscore)."
+      },
+      "type": {
+        "type": "string",
+        "enum": [
+          "STANDARD",
+          "TEMPORARY",
+          "ARCHIVE",
+          "SHARED"
+        ],
+        "description": "Namespace type: STANDARD, TEMPORARY, ARCHIVE, SHARED.",
+        "default": "STANDARD"
+      },
+      "displayName": {
+        "type": "string",
+        "description": "Optional human-readable display name."
+      },
+      "description": {
+        "type": "string",
+        "description": "Optional description of the namespace purpose."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_delete.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_delete.json
@@ -1,0 +1,20 @@
+{
+  "name": "namespace_delete",
+  "description": "Deletes (tombstones) an isolated memory namespace by slug or ID. The default namespace cannot be deleted.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:write"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "namespace"
+    ],
+    "properties": {
+      "namespace": {
+        "type": "string",
+        "description": "The slug or TSID identifier of the namespace to delete."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_grant.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_grant.json
@@ -1,0 +1,39 @@
+{
+  "name": "namespace_grant",
+  "description": "Grants access permissions (READER, WRITER, ADMIN) for a memory namespace to another account TSID. Requires the caller to have ADMIN or OWNER role on the namespace.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:admin"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "slug",
+      "granteeAccountId",
+      "role"
+    ],
+    "properties": {
+      "slug": {
+        "type": "string",
+        "description": "The namespace slug or TSID identifier to grant access on."
+      },
+      "granteeAccountId": {
+        "type": "string",
+        "description": "The TSID identifier of the account being granted access."
+      },
+      "role": {
+        "type": "string",
+        "enum": [
+          "READER",
+          "WRITER",
+          "ADMIN"
+        ],
+        "description": "Permission role level: READER (read-only), WRITER (read-write), ADMIN (full admin)."
+      },
+      "expiresAt": {
+        "type": "string",
+        "description": "Optional ISO-8601 timestamp when this grant automatically expires."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_info.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_info.json
@@ -1,0 +1,20 @@
+{
+  "name": "namespace_info",
+  "description": "Gets detailed metadata and status for a memory namespace by slug or TSID identifier.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:read"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "namespace"
+    ],
+    "properties": {
+      "namespace": {
+        "type": "string",
+        "description": "The slug or TSID identifier of the namespace to inspect."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_list.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_list.json
@@ -1,0 +1,12 @@
+{
+  "name": "namespace_list",
+  "description": "Lists all memory namespaces accessible to the current authenticated account.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:read"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_list_grants.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_list_grants.json
@@ -1,0 +1,20 @@
+{
+  "name": "namespace_list_grants",
+  "description": "Lists all active grants on a memory namespace. Requires the caller to have ADMIN or OWNER role on the namespace.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:read"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "slug"
+    ],
+    "properties": {
+      "slug": {
+        "type": "string",
+        "description": "The namespace slug or TSID identifier to list grants for."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_revoke.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_revoke.json
@@ -1,0 +1,25 @@
+{
+  "name": "namespace_revoke",
+  "description": "Revokes an active trace access grant on a memory namespace. Requires the caller to have ADMIN or OWNER role on the namespace.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:admin"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "slug",
+      "grantId"
+    ],
+    "properties": {
+      "slug": {
+        "type": "string",
+        "description": "The namespace slug or TSID identifier."
+      },
+      "grantId": {
+        "type": "string",
+        "description": "The unique TSID identifier of the grant to revoke."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_set_default.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_set_default.json
@@ -1,0 +1,20 @@
+{
+  "name": "namespace_set_default",
+  "description": "Sets the default memory namespace for the authenticated account.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:write"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "slug"
+    ],
+    "properties": {
+      "slug": {
+        "type": "string",
+        "description": "The namespace slug or TSID identifier to set as default."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_switch.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/namespace_switch.json
@@ -1,0 +1,20 @@
+{
+  "name": "namespace_switch",
+  "description": "Switches the active memory namespace context for the current session.",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:namespace:read"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "required": [
+      "slug"
+    ],
+    "properties": {
+      "slug": {
+        "type": "string",
+        "description": "The namespace slug or TSID identifier to switch to."
+      }
+    }
+  }
+}

--- a/synapse/spector-synapse/src/main/resources/sql/catalog/grants/list-by-object.sql
+++ b/synapse/spector-synapse/src/main/resources/sql/catalog/grants/list-by-object.sql
@@ -1,0 +1,20 @@
+-- List active grants for an object (namespace or bundle)
+SELECT
+    grant_id,
+    object_type,
+    object_id,
+    principal_id,
+    principal_type,
+    role,
+    actions,
+    granted_by,
+    granted_at,
+    expires_at,
+    revoked_at,
+    constraints_json
+FROM grants
+WHERE object_type = :objectType
+  AND object_id = :objectId
+  AND revoked_at IS NULL
+  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+ORDER BY granted_at DESC

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/tools/NamespaceToolsTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/tools/NamespaceToolsTest.java
@@ -207,4 +207,72 @@ class NamespaceToolsTest {
 
         assertThat(result.isError()).isTrue();
     }
+
+    @Test
+    @DisplayName("namespace_grant creates grant via MCP tool")
+    void testNamespaceGrantTool() throws Exception {
+        var grant = new com.spectrayan.spector.synapse.catalog.Grant(
+                "grant-mcp-1",
+                com.spectrayan.spector.synapse.catalog.GrantObjectType.NAMESPACE,
+                "0195500000002",
+                "0195500000099",
+                com.spectrayan.spector.synapse.catalog.PrincipalType.ACCOUNT,
+                com.spectrayan.spector.synapse.catalog.GrantRole.READER,
+                null,
+                TEST_ACCOUNT,
+                Instant.now(),
+                null,
+                null
+        );
+        when(catalog.grantNamespace(eq(TEST_ACCOUNT), eq("research"), eq("0195500000099"),
+                eq(com.spectrayan.spector.synapse.catalog.GrantRole.READER), any(), any())).thenReturn(grant);
+
+        var tool = new NamespaceGrantTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of(
+                "slug", "research",
+                "granteeAccountId", "0195500000099",
+                "role", "READER"
+        ));
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("namespace_revoke revokes grant via MCP tool")
+    void testNamespaceRevokeTool() throws Exception {
+        var tool = new NamespaceRevokeTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of(
+                "slug", "research",
+                "grantId", "grant-mcp-1"
+        ));
+
+        assertThat(result.isError()).isFalse();
+        verify(catalog).revokeNamespaceGrant(TEST_ACCOUNT, "research", "grant-mcp-1");
+    }
+
+    @Test
+    @DisplayName("namespace_list_grants lists grants via MCP tool")
+    void testNamespaceListGrantsTool() throws Exception {
+        var grant = new com.spectrayan.spector.synapse.catalog.Grant(
+                "grant-mcp-1",
+                com.spectrayan.spector.synapse.catalog.GrantObjectType.NAMESPACE,
+                "0195500000002",
+                "0195500000099",
+                com.spectrayan.spector.synapse.catalog.PrincipalType.ACCOUNT,
+                com.spectrayan.spector.synapse.catalog.GrantRole.READER,
+                null,
+                TEST_ACCOUNT,
+                Instant.now(),
+                null,
+                null
+        );
+        when(catalog.listGrants(TEST_ACCOUNT, "research")).thenReturn(List.of(grant));
+
+        var tool = new NamespaceListGrantsTool(catalog, objectMapper);
+        CallToolResult result = tool.execute(Map.of("slug", "research"));
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+    }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/api/NamespaceControllerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/api/NamespaceControllerTest.java
@@ -157,4 +157,67 @@ class NamespaceControllerTest {
         assertThat(response.getBody()).containsEntry("status", "reset");
         verify(catalog).resetNamespace(TEST_ACCOUNT, "default");
     }
+
+    @Test
+    @DisplayName("GET /api/v1/namespaces/{slugOrId}/grants returns active grants")
+    void testListGrants() {
+        var grant = new com.spectrayan.spector.synapse.catalog.Grant(
+                "grant-1",
+                com.spectrayan.spector.synapse.catalog.GrantObjectType.NAMESPACE,
+                "0195500000002",
+                "0195500000099",
+                com.spectrayan.spector.synapse.catalog.PrincipalType.ACCOUNT,
+                com.spectrayan.spector.synapse.catalog.GrantRole.READER,
+                null,
+                TEST_ACCOUNT,
+                Instant.now(),
+                null,
+                null
+        );
+        when(catalog.listGrants(TEST_ACCOUNT, "project-x")).thenReturn(List.of(grant));
+
+        ResponseEntity<List<GrantResponse>> response = controller.listGrants("project-x");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).grantId()).isEqualTo("grant-1");
+        assertThat(response.getBody().get(0).role()).isEqualTo(com.spectrayan.spector.synapse.catalog.GrantRole.READER);
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/namespaces/{slugOrId}/grants creates grant and returns 201 CREATED")
+    void testCreateGrant() {
+        var grant = new com.spectrayan.spector.synapse.catalog.Grant(
+                "grant-2",
+                com.spectrayan.spector.synapse.catalog.GrantObjectType.NAMESPACE,
+                "0195500000002",
+                "0195500000099",
+                com.spectrayan.spector.synapse.catalog.PrincipalType.ACCOUNT,
+                com.spectrayan.spector.synapse.catalog.GrantRole.WRITER,
+                null,
+                TEST_ACCOUNT,
+                Instant.now(),
+                null,
+                null
+        );
+        when(catalog.grantNamespace(eq(TEST_ACCOUNT), eq("project-x"), eq("0195500000099"),
+                eq(com.spectrayan.spector.synapse.catalog.GrantRole.WRITER), any(), any())).thenReturn(grant);
+
+        var request = new CreateGrantRequest("0195500000099", com.spectrayan.spector.synapse.catalog.GrantRole.WRITER, null, null);
+        ResponseEntity<GrantResponse> response = controller.createGrant("project-x", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().grantId()).isEqualTo("grant-2");
+        assertThat(response.getBody().granteeAccountId()).isEqualTo("0195500000099");
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/namespaces/{slugOrId}/grants/{grantId} revokes grant and returns 204 NO_CONTENT")
+    void testRevokeGrant() {
+        ResponseEntity<Void> response = controller.revokeGrant("project-x", "grant-1");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(catalog).revokeNamespaceGrant(TEST_ACCOUNT, "project-x", "grant-1");
+    }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalogTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalogTest.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.spectrayan.spector.memory.kernel.StorageLayout;
 import com.spectrayan.spector.synapse.catalog.Account;
+import com.spectrayan.spector.synapse.catalog.Grant;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
 import com.spectrayan.spector.synapse.catalog.NamespaceBias;
 import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
 import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
@@ -178,5 +180,40 @@ class FileAccountCatalogTest {
 
         assertThatThrownBy(() -> catalog.tombstone(ACCOUNT_ID, ACCOUNT_ID))
                 .isInstanceOf(DefaultNamespaceProtectedException.class);
+    }
+
+    @Test
+    @DisplayName("grantNamespace, listGrants, and revokeNamespaceGrant manage trace permissions")
+    void testGrantAndRevokeLifecycle() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        String granteeId = "0HD7XJ9A2B002";
+        catalog.getOrCreateAccount(granteeId);
+
+        NamespaceRecord created = catalog.createNamespace(ACCOUNT_ID, "shared-proj", NamespaceType.PROJECT);
+
+        // Grant READER access to grantee
+        Grant grant = catalog.grantNamespace(ACCOUNT_ID, "shared-proj", granteeId, GrantRole.READER, null, null);
+        assertThat(grant.grantId()).isNotNull();
+        assertThat(grant.role()).isEqualTo(GrantRole.READER);
+
+        // List grants
+        List<Grant> grants = catalog.listGrants(ACCOUNT_ID, "shared-proj");
+        assertThat(grants).hasSize(2); // Implicit owner + READER grant
+
+        // Grantee authorizes READER
+        Optional<Grant> auth = catalog.authorize(granteeId, created.namespaceId(), GrantRole.READER);
+        assertThat(auth).isPresent();
+        assertThat(auth.get().role()).isEqualTo(GrantRole.READER);
+
+        // Grantee not authorized for WRITER
+        Optional<Grant> authWriter = catalog.authorize(granteeId, created.namespaceId(), GrantRole.WRITER);
+        assertThat(authWriter).isEmpty();
+
+        // Revoke grant
+        catalog.revokeNamespaceGrant(ACCOUNT_ID, "shared-proj", grant.grantId());
+
+        // Grantee no longer authorized
+        Optional<Grant> authAfterRevoke = catalog.authorize(granteeId, created.namespaceId(), GrantRole.READER);
+        assertThat(authAfterRevoke).isEmpty();
     }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalogTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalogTest.java
@@ -254,4 +254,27 @@ class JdbcAccountCatalogTest {
         Optional<Grant> authAfterRevoke = catalog.authorize(OTHER_ACCOUNT_ID, proj.namespaceId(), GrantRole.READER);
         assertThat(authAfterRevoke).isEmpty();
     }
+
+    @Test
+    @DisplayName("grantNamespace, listGrants, and revokeNamespaceGrant in JDBC catalog")
+    void testGrantNamespaceAndListAndRevoke() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        catalog.getOrCreateAccount(OTHER_ACCOUNT_ID);
+
+        NamespaceRecord proj = catalog.createNamespace(ACCOUNT_ID, "shared-docs", NamespaceType.PROJECT);
+
+        Grant grant = catalog.grantNamespace(ACCOUNT_ID, "shared-docs", OTHER_ACCOUNT_ID, GrantRole.READER, null, null);
+        assertThat(grant).isNotNull();
+        assertThat(grant.role()).isEqualTo(GrantRole.READER);
+
+        List<Grant> grants = catalog.listGrants(ACCOUNT_ID, "shared-docs");
+        assertThat(grants).hasSize(2); // Implicit owner + READER grant
+        assertThat(grants).anyMatch(g -> g.grantId().equals(grant.grantId()));
+
+        catalog.revokeNamespaceGrant(ACCOUNT_ID, "shared-docs", grant.grantId());
+
+        List<Grant> grantsAfterRevoke = catalog.listGrants(ACCOUNT_ID, "shared-docs");
+        assertThat(grantsAfterRevoke).hasSize(1); // Only implicit owner remains
+        assertThat(grantsAfterRevoke).noneMatch(g -> g.grantId().equals(grant.grantId()));
+    }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryAuthorizationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryAuthorizationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.id.TsidGenerator;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceAccessDeniedException;
+import com.spectrayan.spector.synapse.platform.events.EventPublisher;
+
+@DisplayName("Memory Authorization PEP Tests")
+class MemoryAuthorizationTest {
+
+    private MemoryService memoryService;
+    private MemoryAccessObject mao;
+    private EventPublisher eventPublisher;
+    private TsidGenerator tsid;
+    private SpectorMemory spectorMemory;
+
+    private static final String ACCOUNT_ID = "0195500000001";
+    private static final String NAMESPACE_ID = "0195500000002";
+
+    @BeforeEach
+    void setUp() {
+        mao = mock(MemoryAccessObject.class);
+        eventPublisher = mock(EventPublisher.class);
+        tsid = new TsidGenerator();
+        spectorMemory = mock(SpectorMemory.class);
+
+        memoryService = new MemoryService(mao, eventPublisher, tsid);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private void bindRole(GrantRole role) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        ServletRequestAttributes attrs = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attrs);
+
+        RequestMemoryContext reqCtx = new RequestMemoryContext(
+                null, List.of(), ACCOUNT_ID, NAMESPACE_ID, "proj",
+                role, Set.of(), "session-1", List.of(), null);
+        MemoryBinding binding = new MemoryBinding(spectorMemory, ACCOUNT_ID, NAMESPACE_ID, "proj", null, reqCtx);
+        attrs.setAttribute(MemoryBinding.ATTRIBUTE_KEY, binding, ServletRequestAttributes.SCOPE_REQUEST);
+    }
+
+    @Test
+    @DisplayName("READER role is denied on store")
+    void testReaderDeniedOnStore() {
+        bindRole(GrantRole.READER);
+
+        var request = new MemoryDto.StoreRequest("some content", List.of("tag1"), 1.0, Map.of());
+        assertThatThrownBy(() -> memoryService.store(request))
+                .isInstanceOf(NamespaceAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("READER role is denied on remember")
+    void testReaderDeniedOnRemember() {
+        bindRole(GrantRole.READER);
+
+        var request = new MemoryDto.RememberRequest("some text", "SEMANTIC", "USER_STATED", null, null, null, null, null, null, null, null);
+        assertThatThrownBy(() -> memoryService.remember(request))
+                .isInstanceOf(NamespaceAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("READER role is denied on forget")
+    void testReaderDeniedOnForget() {
+        bindRole(GrantRole.READER);
+
+        assertThatThrownBy(() -> memoryService.forget("mem-123"))
+                .isInstanceOf(NamespaceAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("READER role is denied on reinforce")
+    void testReaderDeniedOnReinforce() {
+        bindRole(GrantRole.READER);
+
+        assertThatThrownBy(() -> memoryService.reinforce("mem-123", 1))
+                .isInstanceOf(NamespaceAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("READER role is denied on suppress")
+    void testReaderDeniedOnSuppress() {
+        bindRole(GrantRole.READER);
+
+        var request = new MemoryDto.SuppressRequest("SUPPRESS", "Outdated");
+        assertThatThrownBy(() -> memoryService.suppress("mem-123", request))
+                .isInstanceOf(NamespaceAccessDeniedException.class);
+    }
+}


### PR DESCRIPTION
Resolves #703

### Summary of Changes

Cross-checked with ADR-0029 v4 (§10 Trace Grants, §16 PEP Security, §17 Multi-Tenant Database Catalog):

1. **AccountCatalog SPI & Storage Implementations**:
   - Added `listGrants(accountId, slugOrId)`, `grantNamespace(...)`, and `revokeNamespaceGrant(...)` to `AccountCatalog` SPI.
   - Implemented in `FileAccountCatalog` with multi-account propagation and lock coordination (grants and revokes appended to both granter and grantee accounts).
   - Implemented in `JdbcAccountCatalog` via Spring JDBC template and `sql/catalog/grants/list-by-object.sql`.
   - Updated `PassthroughCatalog` and `NoopAccountCatalog`.

2. **REST Endpoints & MCP Tools**:
   - `GET /api/v1/namespaces/{slugOrId}/grants`: Lists active grants for a namespace (caller must have `ADMIN` or `OWNER` role).
   - `POST /api/v1/namespaces/{slugOrId}/grants`: Grants namespace access to another account with specified `GrantRole` (`READER`, `WRITER`, `ADMIN`), expiry, and constraints.
   - `DELETE /api/v1/namespaces/{slugOrId}/grants/{grantId}`: Revokes a grant.
   - Added MCP tools: `namespace_grant`, `namespace_revoke`, `namespace_list_grants`.

3. **PEP Authorization Enforcement**:
   - Enforced `assertRoleAtLeast(GrantRole.WRITER)` on mutating operations (`store`, `remember`, `forget`, `bulkForget`, `reinforce`, `bulkReinforce`, `suppress`).
   - Requesters with `READER` role are allowed read/search/inspect access but receive `403 Forbidden` (`NamespaceAccessDeniedException`) on mutating operations.

4. **Cortex UI**:
   - Extended `SynapseApiService` with grant management client methods.
   - Created `ShareNamespaceDialogComponent` Angular dialog for viewing active grants, selecting roles, configuring expiry, and revoking grants.

5. **Test Coverage & Verification**:
   - `FileAccountCatalogTest`: Verified grant creation, listing, role lookup, and revocation lifecycle.
   - `JdbcAccountCatalogTest`: Verified grant creation, listing, role lookup, and revocation in database-backed catalog.
   - `NamespaceControllerTest`: Verified REST grant endpoints, error handling, and serialization.
   - `NamespaceToolsTest`: Verified MCP tool handlers.
   - `MemoryAuthorizationTest`: Verified PEP authorization enforcing 403 on `READER` role mutating operations.
   - All 761 tests in `spector-synapse` pass.

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>