### PR TITLE
feat(synapse): implement ADR-0029 Phase 7 federated recall with budgets

### DIFF
--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/MemoryFederatedRecallTool.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/agent/tools/MemoryFederatedRecallTool.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.mcp.tools.McpToolHandler;
+import com.spectrayan.spector.synapse.memory.FederatedRecallRequest;
+import com.spectrayan.spector.synapse.memory.FederatedRecallResponse;
+import com.spectrayan.spector.synapse.memory.FederatedRecallService;
+import com.spectrayan.spector.synapse.security.SecurityUtils;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Declarative MCP tool handler for cross-rememberer federated recall (ADR-0029 §7).
+ */
+@Component
+public class MemoryFederatedRecallTool extends McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryFederatedRecallTool.class);
+
+    private final FederatedRecallService federatedRecallService;
+    private final ObjectMapper objectMapper;
+
+    public MemoryFederatedRecallTool(FederatedRecallService federatedRecallService, ObjectMapper objectMapper) {
+        super("memory_federated_recall");
+        this.federatedRecallService = federatedRecallService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments) throws Exception {
+        String accountId = SecurityUtils.getUserId();
+        String query = arguments.get("query") != null ? arguments.get("query").toString() : null;
+        if (query == null || query.isBlank()) {
+            query = arguments.get("queryText") != null ? arguments.get("queryText").toString() : null;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> namespaces = arguments.get("namespaces") instanceof List<?> list
+                ? list.stream().map(Object::toString).toList()
+                : null;
+
+        Integer topK = arguments.get("topK") instanceof Number n ? n.intValue() : null;
+        Integer perNamespaceTopK = arguments.get("perNamespaceTopK") instanceof Number n ? n.intValue() : null;
+        Integer timeoutMs = arguments.get("timeoutMs") instanceof Number n ? n.intValue() : null;
+        Integer maxColdOpens = arguments.get("maxColdOpens") instanceof Number n ? n.intValue() : null;
+
+        FederatedRecallRequest request = new FederatedRecallRequest(
+                query,
+                namespaces,
+                topK,
+                perNamespaceTopK,
+                timeoutMs,
+                maxColdOpens,
+                null,
+                null
+        );
+
+        log.debug("[MemoryFederatedRecallTool] executing for account={}, query='{}'", accountId, query);
+        FederatedRecallResponse response = federatedRecallService.federatedRecall(accountId, request);
+
+        String json = objectMapper.writeValueAsString(response);
+        return textResult(json);
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallHit.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallHit.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+
+/**
+ * A single recall hit returned from a federated recall operation (ADR-0029 §7).
+ *
+ * <p>Wraps the full, rich {@link CognitiveResult} telemetry alongside cross-rememberer
+ * provenance annotations (namespaceId, slug, role, local rank, and heuristic global rank).</p>
+ *
+ * @param namespaceId         globally unique namespace identifier (TSID)
+ * @param slug                account-scoped slug alias
+ * @param role                caller's access role on the namespace
+ * @param localRank           rank within the originating rememberer (1-indexed)
+ * @param heuristicGlobalRank heuristic merged rank across rememberers (1-indexed)
+ * @param result              full cognitive result with complete scoring telemetry and metadata
+ */
+public record FederatedRecallHit(
+        @JsonProperty("namespaceId") String namespaceId,
+        @JsonProperty("slug") String slug,
+        @JsonProperty("role") GrantRole role,
+        @JsonProperty("localRank") int localRank,
+        @JsonProperty("heuristicGlobalRank") int heuristicGlobalRank,
+        @JsonProperty("result") CognitiveResult result
+) {
+    /** Convenience accessor for memory ID. */
+    public String id() {
+        return result != null ? result.id() : null;
+    }
+
+    /** Convenience accessor for memory text. */
+    public String text() {
+        return result != null ? result.text() : null;
+    }
+
+    /** Convenience accessor for cognitive score. */
+    public float score() {
+        return result != null ? result.score() : 0.0f;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallRequest.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.ScoringMode;
+
+import java.util.List;
+
+/**
+ * Request for cross-rememberer federated recall (ADR-0029 §7).
+ *
+ * @param queryText        the query text to search for across rememberers
+ * @param namespaces       list of namespace slugs or IDs, or ["granted"] to query all accessible namespaces
+ * @param topK             overall maximum results to return across all namespaces (default 10)
+ * @param perNamespaceTopK maximum results to query per namespace (default 5)
+ * @param timeoutMs        maximum timeout budget in milliseconds (default 3000ms, max 10000ms)
+ * @param maxColdOpens     maximum number of cold (uncached) namespaces allowed to open (default 2)
+ * @param profile          optional cognitive profile preset
+ * @param scoringMode      optional scoring mode (COGNITIVE, SIMILARITY, ASSOCIATIVE)
+ */
+public record FederatedRecallRequest(
+        @JsonProperty("queryText") String queryText,
+        @JsonProperty("namespaces") List<String> namespaces,
+        @JsonProperty("topK") Integer topK,
+        @JsonProperty("perNamespaceTopK") Integer perNamespaceTopK,
+        @JsonProperty("timeoutMs") Integer timeoutMs,
+        @JsonProperty("maxColdOpens") Integer maxColdOpens,
+        @JsonProperty("profile") CognitiveProfile profile,
+        @JsonProperty("scoringMode") ScoringMode scoringMode
+) {
+    public FederatedRecallRequest {
+        if (topK == null || topK <= 0) topK = 10;
+        if (perNamespaceTopK == null || perNamespaceTopK <= 0) perNamespaceTopK = 5;
+        if (timeoutMs == null || timeoutMs <= 0) timeoutMs = 3000;
+        if (timeoutMs > 10000) timeoutMs = 10000;
+        if (maxColdOpens == null || maxColdOpens < 0) maxColdOpens = 2;
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallResponse.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Response returned from a federated recall operation (ADR-0029 §7).
+ *
+ * @param hits    ranked list of hits across queried rememberers
+ * @param summary execution statistics and diagnostic summary
+ */
+public record FederatedRecallResponse(
+        @JsonProperty("hits") List<FederatedRecallHit> hits,
+        @JsonProperty("summary") FederatedRecallSummary summary
+) {}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallService.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.spectrayan.spector.commons.concurrent.ConcurrentTasks;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.CognitiveProfile;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.ScoringMode;
+import com.spectrayan.spector.synapse.catalog.Account;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.Grant;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.exception.FederationDisabledException;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Executes cross-rememberer federated recall across isolated memory spaces (ADR-0029 §7).
+ *
+ * <p>Enforces account federation flags, query and cold-open budgets, parallel fan-out
+ * with virtual threads, and provenance-annotated heuristic merging.</p>
+ */
+@Service
+public class FederatedRecallService {
+
+    private static final Logger log = LoggerFactory.getLogger(FederatedRecallService.class);
+
+    private static final int MAX_FEDERATION_NAMESPACES = 10;
+    private static final int DEFAULT_MAX_NAMESPACES = 5;
+
+    private final AccountCatalog catalog;
+    private final MemoryRegistry userMemoryRegistry;
+    private final SynapseProperties synapseProps;
+
+    @Autowired
+    public FederatedRecallService(
+            AccountCatalog catalog,
+            MemoryRegistry userMemoryRegistry,
+            SynapseProperties synapseProps) {
+        this.catalog = catalog;
+        this.userMemoryRegistry = userMemoryRegistry;
+        this.synapseProps = synapseProps;
+    }
+
+    public FederatedRecallService(AccountCatalog catalog, MemoryRegistry userMemoryRegistry) {
+        this(catalog, userMemoryRegistry, null);
+    }
+
+    /**
+     * Executes federated recall across multiple namespaces on behalf of an authenticated principal.
+     *
+     * @param accountId the calling account ID (TSID)
+     * @param request   the federated recall request parameters
+     * @return the annotated federated hits and execution summary
+     * @throws FederationDisabledException if the account does not have federation enabled
+     * @throws SpectorValidationException if the query parameters are invalid
+     */
+    public FederatedRecallResponse federatedRecall(String accountId, FederatedRecallRequest request) {
+        if (request == null || request.queryText() == null || request.queryText().isBlank()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "queryText");
+        }
+
+        final long startTime = System.currentTimeMillis();
+        final boolean authEnabled = synapseProps == null || synapseProps.auth().enabled();
+
+        // 1. Quota & account federation flag check
+        if (authEnabled && accountId != null && !accountId.isBlank() && !"default".equals(accountId)) {
+            Account account = catalog.getOrCreateAccount(accountId);
+            if (account.flags() != null && !account.flags().federation()) {
+                log.warn("[FederatedRecall] Account '{}' attempted federated recall but federation flag is disabled", accountId);
+                throw new FederationDisabledException(accountId);
+            }
+        }
+
+        // 2. Target Namespace Resolution
+        final List<String> requested = request.namespaces();
+        final boolean queryAllGranted = requested == null || requested.isEmpty()
+                || (requested.size() == 1 && "granted".equalsIgnoreCase(requested.get(0).trim()));
+
+        final List<TargetNamespace> candidateTargets = new ArrayList<>();
+        final List<String> denied = new ArrayList<>();
+        final List<String> failed = new ArrayList<>();
+
+        if (queryAllGranted) {
+            if (authEnabled && accountId != null && !accountId.isBlank() && !"default".equals(accountId)) {
+                List<NamespaceRecord> accessible = catalog.listAccessible(accountId);
+                for (NamespaceRecord rec : accessible) {
+                    if (rec.status() == NamespaceStatus.TOMBSTONED) {
+                        continue;
+                    }
+                    GrantRole role = catalog.authorize(accountId, rec.namespaceId(), GrantRole.READER)
+                            .map(Grant::role)
+                            .orElse(accountId.equals(rec.ownerAccountId()) ? GrantRole.OWNER : GrantRole.READER);
+                    candidateTargets.add(new TargetNamespace(rec.namespaceId(), rec.slug(), role));
+                }
+            } else {
+                // Anonymous or auth-disabled: query default namespace
+                candidateTargets.add(new TargetNamespace("default", "default", GrantRole.OWNER));
+            }
+        } else {
+            for (String selector : requested) {
+                if (selector == null || selector.isBlank()) continue;
+                String trimmed = selector.trim();
+                try {
+                    Optional<NamespaceRecord> recOpt = catalog.resolve(accountId, trimmed);
+                    if (recOpt.isEmpty()) {
+                        log.debug("[FederatedRecall] Namespace '{}' not found for account '{}'", trimmed, accountId);
+                        denied.add(trimmed);
+                        continue;
+                    }
+                    NamespaceRecord rec = recOpt.get();
+                    if (rec.status() == NamespaceStatus.TOMBSTONED) {
+                        failed.add(trimmed);
+                        continue;
+                    }
+                    Optional<Grant> authOpt = catalog.authorize(accountId, rec.namespaceId(), GrantRole.READER);
+                    if (authOpt.isEmpty() && !accountId.equals(rec.ownerAccountId())) {
+                        denied.add(trimmed);
+                        continue;
+                    }
+                    GrantRole role = authOpt.map(Grant::role)
+                            .orElse(accountId.equals(rec.ownerAccountId()) ? GrantRole.OWNER : GrantRole.READER);
+                    candidateTargets.add(new TargetNamespace(rec.namespaceId(), rec.slug(), role));
+                } catch (Exception e) {
+                    log.warn("[FederatedRecall] Error resolving namespace '{}': {}", trimmed, e.getMessage());
+                    failed.add(trimmed);
+                }
+            }
+        }
+
+        // 3. Apply Namespace Caps & Cold-Open Budgets
+        final int targetBudget = Math.min(candidateTargets.size(), MAX_FEDERATION_NAMESPACES);
+        final int maxCold = request.maxColdOpens();
+        int coldOpened = 0;
+
+        final List<TargetNamespace> executableTargets = new ArrayList<>();
+        final List<String> skippedCold = new ArrayList<>();
+
+        for (int i = 0; i < targetBudget; i++) {
+            TargetNamespace target = candidateTargets.get(i);
+            boolean isHot = userMemoryRegistry.namespaceResolver() != null
+                    && userMemoryRegistry.namespaceResolver().isHot(target.namespaceId);
+            if (!isHot) {
+                if (coldOpened >= maxCold) {
+                    skippedCold.add(target.slug != null ? target.slug : target.namespaceId);
+                    continue;
+                }
+                coldOpened++;
+            }
+            executableTargets.add(target);
+        }
+
+        // Record any remaining targets exceeding max federation count as skipped
+        for (int i = targetBudget; i < candidateTargets.size(); i++) {
+            TargetNamespace target = candidateTargets.get(i);
+            skippedCold.add(target.slug != null ? target.slug : target.namespaceId);
+        }
+
+        // 4. Parallel Fan-Out Execution via ConcurrentTasks (Structured Concurrency & Virtual Threads)
+        final List<String> opened = new ArrayList<>();
+        final List<FederatedRecallHit> allHits = new ArrayList<>();
+        final RecallOptions recallOptions = RecallOptions.builder()
+                .topK(request.perNamespaceTopK())
+                .profile(request.profile() != null ? request.profile() : CognitiveProfile.BALANCED)
+                .scoringMode(request.scoringMode() != null ? request.scoringMode() : ScoringMode.COGNITIVE)
+                .build();
+
+        if (!executableTargets.isEmpty()) {
+            final Map<String, TargetNamespace> targetMap = new LinkedHashMap<>();
+            final List<ConcurrentTasks.LabeledTask<List<CognitiveResult>>> tasks = new ArrayList<>();
+
+            for (TargetNamespace target : executableTargets) {
+                String label = target.slug != null ? target.slug : target.namespaceId;
+                targetMap.put(label, target);
+                tasks.add(new ConcurrentTasks.LabeledTask<>(label, () -> {
+                    SpectorMemory memory = userMemoryRegistry.namespaceResolver() != null
+                            ? userMemoryRegistry.namespaceResolver().resolve(accountId, target.namespaceId)
+                            : userMemoryRegistry.resolveFor(target.namespaceId);
+                    return memory.recall(request.queryText(), recallOptions);
+                }));
+            }
+
+            try {
+                java.time.Duration timeout = java.time.Duration.ofMillis(request.timeoutMs());
+                ConcurrentTasks.PartialResult<List<CognitiveResult>> partial = ConcurrentTasks.forkJoinPartial(tasks, timeout);
+
+                for (ConcurrentTasks.PartialResult.Entry<List<CognitiveResult>> entry : partial.successes()) {
+                    TargetNamespace target = targetMap.get(entry.label());
+                    opened.add(entry.label());
+                    List<CognitiveResult> results = entry.result();
+                    if (results != null) {
+                        for (int rank = 0; rank < results.size(); rank++) {
+                            CognitiveResult cr = results.get(rank);
+                            allHits.add(new FederatedRecallHit(
+                                    target.namespaceId,
+                                    target.slug,
+                                    target.role,
+                                    rank + 1,
+                                    0, // Will be set after merge
+                                    cr
+                            ));
+                        }
+                    }
+                }
+
+                for (String timedOutLabel : partial.timedOut()) {
+                    log.warn("[FederatedRecall] Namespace '{}' query timed out", timedOutLabel);
+                    failed.add(timedOutLabel);
+                }
+
+                for (ConcurrentTasks.PartialResult.Failure failure : partial.failures()) {
+                    log.warn("[FederatedRecall] Namespace '{}' query failed: {}", failure.label(), failure.cause().getMessage());
+                    failed.add(failure.label());
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                log.warn("[FederatedRecall] Federated recall interrupted: {}", ie.getMessage());
+                for (TargetNamespace target : executableTargets) {
+                    failed.add(target.slug != null ? target.slug : target.namespaceId);
+                }
+            }
+        }
+
+        // 5. Heuristic Merging & Ranking
+        allHits.sort(Comparator.comparing(FederatedRecallHit::score).reversed()
+                .thenComparing(FederatedRecallHit::id));
+
+        final List<FederatedRecallHit> mergedHits = new ArrayList<>();
+        final int globalLimit = Math.min(allHits.size(), request.topK());
+        for (int rank = 0; rank < globalLimit; rank++) {
+            FederatedRecallHit original = allHits.get(rank);
+            mergedHits.add(new FederatedRecallHit(
+                    original.namespaceId(),
+                    original.slug(),
+                    original.role(),
+                    original.localRank(),
+                    rank + 1,
+                    original.result()
+            ));
+        }
+
+        final long durationMs = System.currentTimeMillis() - startTime;
+        final FederatedRecallSummary summary = new FederatedRecallSummary(
+                candidateTargets.size(),
+                opened,
+                skippedCold,
+                denied,
+                failed,
+                durationMs
+        );
+
+        return new FederatedRecallResponse(mergedHits, summary);
+    }
+
+    private record TargetNamespace(String namespaceId, String slug, GrantRole role) {}
+    private record NamespaceExecutionResult(TargetNamespace target, List<CognitiveResult> results, Throwable error) {}
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallSummary.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallSummary.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Diagnostic execution summary for a federated recall operation (ADR-0029 §7).
+ *
+ * @param queriedCount         number of namespaces evaluated
+ * @param openedNamespaces     list of namespace IDs or slugs successfully opened and queried
+ * @param skippedColdNamespaces list of cold namespace IDs or slugs skipped due to maxColdOpens budget
+ * @param deniedNamespaces     list of namespace IDs or slugs where the caller lacks access
+ * @param failedNamespaces     list of namespace IDs or slugs that failed during execution
+ * @param executionDurationMs  total elapsed duration of the federated query in milliseconds
+ */
+public record FederatedRecallSummary(
+        @JsonProperty("queriedCount") int queriedCount,
+        @JsonProperty("openedNamespaces") List<String> openedNamespaces,
+        @JsonProperty("skippedColdNamespaces") List<String> skippedColdNamespaces,
+        @JsonProperty("deniedNamespaces") List<String> deniedNamespaces,
+        @JsonProperty("failedNamespaces") List<String> failedNamespaces,
+        @JsonProperty("executionDurationMs") long executionDurationMs
+) {}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
@@ -88,9 +88,18 @@ public class MemoryController {
     private static final Logger log = LoggerFactory.getLogger(MemoryController.class);
 
     private final MemoryService memoryService;
+    private final FederatedRecallService federatedRecallService;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public MemoryController(
+            MemoryService memoryService,
+            @org.springframework.beans.factory.annotation.Autowired(required = false) FederatedRecallService federatedRecallService) {
+        this.memoryService = memoryService;
+        this.federatedRecallService = federatedRecallService;
+    }
 
     public MemoryController(MemoryService memoryService) {
-        this.memoryService = memoryService;
+        this(memoryService, null);
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -178,6 +187,20 @@ public class MemoryController {
     @PostMapping("/recall")
     public ResponseEntity<List<RecallResult>> recall(@RequestBody RecallRequest request) {
         return ResponseEntity.ok(memoryService.recall(request));
+    }
+
+    /**
+     * Cross-rememberer federated recall (ADR-0029 §7).
+     *
+     * <p>{@code POST /api/v1/memory/federated-recall}</p>
+     */
+    @PostMapping("/federated-recall")
+    public ResponseEntity<FederatedRecallResponse> federatedRecall(@RequestBody FederatedRecallRequest request) {
+        if (federatedRecallService == null) {
+            return ResponseEntity.status(org.springframework.http.HttpStatus.NOT_IMPLEMENTED).build();
+        }
+        String accountId = com.spectrayan.spector.synapse.security.SecurityUtils.getUserId();
+        return ResponseEntity.ok(federatedRecallService.federatedRecall(accountId, request));
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
@@ -70,8 +70,8 @@ public class MemoryRequestBinder {
         this.catalog = catalog;
         this.registry = registry;
         this.synapseProps = synapseProps;
-        this.sharedMemory = sharedMemoryProvider.getIfAvailable();
-        this.identityPlane = identityPlaneProvider.getIfAvailable();
+        this.sharedMemory = sharedMemoryProvider != null ? sharedMemoryProvider.getIfAvailable() : null;
+        this.identityPlane = identityPlaneProvider != null ? identityPlaneProvider.getIfAvailable() : null;
     }
 
     /**
@@ -94,6 +94,15 @@ public class MemoryRequestBinder {
      * @return the bound memory context
      */
     public MemoryBinding bind(Authentication auth, Optional<String> selector, String sessionId) {
+        if (selector != null && selector.isPresent() && !selector.get().isBlank()) {
+            String slugOrId = selector.get().trim();
+            if ("*".equals(slugOrId) || slugOrId.contains("*") || slugOrId.contains(",")) {
+                throw new com.spectrayan.spector.commons.error.SpectorValidationException(
+                        com.spectrayan.spector.commons.error.ErrorCode.ARGUMENT_INVALID,
+                        "Wildcard '*' or multi-namespace selection is not permitted on single-namespace memory operations. Use memory_federated_recall.");
+            }
+        }
+
         if (!synapseProps.auth().enabled() || auth == null || !auth.isAuthenticated()
                 || auth instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
             AutoCloseable lease = sharedMemory != null ? sharedMemory.acquireLease() : null;
@@ -123,9 +132,6 @@ public class MemoryRequestBinder {
 
         if (selector != null && selector.isPresent() && !selector.get().isBlank()) {
             String slugOrId = selector.get().trim();
-            if ("*".equals(slugOrId)) {
-                throw new IllegalArgumentException("Wildcard namespace '*' is not supported for memory operations");
-            }
             record = catalog.resolve(accountId, slugOrId)
                     .orElseThrow(() -> new NamespaceNotFoundException(slugOrId));
             if (record.status() == NamespaceStatus.TOMBSTONED) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
@@ -205,6 +205,17 @@ public class NamespaceResolver implements AutoCloseable {
     }
 
     /**
+     * Checks if a namespace instance is currently cached and hot.
+     *
+     * @param namespaceId the namespace identifier
+     * @return true if currently in the active instance cache
+     */
+    public boolean isHot(String namespaceId) {
+        if (namespaceId == null) return false;
+        return cache.containsKey(namespaceId);
+    }
+
+    /**
      * Gets or builds the SpectorMemory instance for the given namespaceId with hot cap
      * and lease-aware eviction checks.
      *

--- a/synapse/spector-synapse/src/main/resources/mcp/tools/memory_federated_recall.json
+++ b/synapse/spector-synapse/src/main/resources/mcp/tools/memory_federated_recall.json
@@ -1,0 +1,47 @@
+{
+  "name": "memory_federated_recall",
+  "description": "Executes cross-rememberer federated recall across multiple isolated namespaces within execution and budget boundaries (ADR-0029 §7).",
+  "category": "MEMORY",
+  "scopes": [
+    "spector:memory:read"
+  ],
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Natural language query to recall across memory spaces."
+      },
+      "namespaces": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of namespace slugs or IDs to query, or ['granted'] to query all accessible namespaces."
+      },
+      "topK": {
+        "type": "integer",
+        "description": "Total number of global merged memories to return across all namespaces (default: 10).",
+        "default": 10
+      },
+      "perNamespaceTopK": {
+        "type": "integer",
+        "description": "Maximum number of memories to retrieve per queried namespace (default: 5).",
+        "default": 5
+      },
+      "timeoutMs": {
+        "type": "integer",
+        "description": "Maximum query timeout budget in milliseconds (default: 3000).",
+        "default": 3000
+      },
+      "maxColdOpens": {
+        "type": "integer",
+        "description": "Maximum number of cold (uncached) namespaces allowed to open (default: 2).",
+        "default": 2
+      }
+    },
+    "required": [
+      "query"
+    ]
+  }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/tools/MemoryFederatedRecallToolTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/agent/tools/MemoryFederatedRecallToolTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.agent.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+import com.spectrayan.spector.synapse.memory.FederatedRecallHit;
+import com.spectrayan.spector.synapse.memory.FederatedRecallRequest;
+import com.spectrayan.spector.synapse.memory.FederatedRecallResponse;
+import com.spectrayan.spector.synapse.memory.FederatedRecallService;
+import com.spectrayan.spector.synapse.memory.FederatedRecallSummary;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemoryFederatedRecallTool — Unit Tests")
+class MemoryFederatedRecallToolTest {
+
+    @Mock
+    private FederatedRecallService federatedRecallService;
+
+    private ObjectMapper objectMapper;
+    private MemoryFederatedRecallTool tool;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        tool = new MemoryFederatedRecallTool(federatedRecallService, objectMapper);
+    }
+
+    @Test
+    @DisplayName("Executes federated recall tool with JSON serialization")
+    void testExecuteTool() throws Exception {
+        CognitiveResult cr = new CognitiveResult(
+                "mem-123",
+                "Cross-rememberer knowledge",
+                0.92f,
+                0.85f,
+                0.1f,
+                (short) 1,
+                (byte) 0,
+                MemoryType.SEMANTIC,
+                com.spectrayan.spector.memory.cortex.MemorySource.OBSERVED,
+                new String[]{"federation"},
+                1.0f,
+                1.0f
+        );
+        FederatedRecallHit hit = new FederatedRecallHit(
+                "01JXYZNS00001",
+                "default",
+                GrantRole.OWNER,
+                1,
+                1,
+                cr
+        );
+        FederatedRecallSummary summary = new FederatedRecallSummary(
+                1,
+                List.of("default"),
+                List.of(),
+                List.of(),
+                List.of(),
+                25L
+        );
+        FederatedRecallResponse response = new FederatedRecallResponse(List.of(hit), summary);
+
+        when(federatedRecallService.federatedRecall(anyString(), any(FederatedRecallRequest.class)))
+                .thenReturn(response);
+
+        Map<String, Object> arguments = Map.of(
+                "query", "cross-rememberer knowledge",
+                "namespaces", List.of("default"),
+                "topK", 5
+        );
+
+        McpSchema.CallToolResult result = tool.execute(arguments);
+
+        assertThat(result).isNotNull();
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+        McpSchema.TextContent textContent = (McpSchema.TextContent) result.content().get(0);
+        assertThat(textContent.text()).contains("mem-123", "01JXYZNS00001", "Cross-rememberer knowledge");
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/FederatedRecallServiceTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/FederatedRecallServiceTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.synapse.catalog.Account;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.AccountFlags;
+import com.spectrayan.spector.synapse.catalog.AccountProfile;
+import com.spectrayan.spector.synapse.catalog.AccountQuotas;
+import com.spectrayan.spector.synapse.catalog.Grant;
+import com.spectrayan.spector.synapse.catalog.GrantObjectType;
+import com.spectrayan.spector.synapse.catalog.GrantRole;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.catalog.PrincipalKind;
+import com.spectrayan.spector.synapse.catalog.PrincipalType;
+import com.spectrayan.spector.synapse.catalog.exception.FederationDisabledException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FederatedRecallService — Unit Tests")
+class FederatedRecallServiceTest {
+
+    @Mock
+    private AccountCatalog catalog;
+
+    @Mock
+    private MemoryRegistry memoryRegistry;
+
+    @Mock
+    private NamespaceResolver namespaceResolver;
+
+    private FederatedRecallService federatedService;
+
+    private static final String ACCOUNT_ID = "01JXYZTEST001";
+    private static final String NS_1 = "01JXYZNS00001";
+    private static final String NS_2 = "01JXYZNS00002";
+    private static final String NS_3 = "01JXYZNS00003";
+
+    @BeforeEach
+    void setUp() {
+        federatedService = new FederatedRecallService(catalog, memoryRegistry);
+    }
+
+    @Test
+    @DisplayName("Throws FederationDisabledException when account federation flag is disabled")
+    void testFederationDisabled() {
+        Account account = new Account(
+                ACCOUNT_ID,
+                PrincipalKind.HUMAN,
+                AccountProfile.HUMAN_SOLO,
+                "Test User",
+                new AccountQuotas(4, 2, 10_000_000L, 10_000L),
+                new AccountFlags(true, false, false), // federation = false
+                ACCOUNT_ID,
+                Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        FederatedRecallRequest request = new FederatedRecallRequest(
+                "query text",
+                List.of("default"),
+                10,
+                5,
+                3000,
+                2,
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> federatedService.federatedRecall(ACCOUNT_ID, request))
+                .isInstanceOf(FederationDisabledException.class)
+                .hasMessageContaining(ACCOUNT_ID);
+    }
+
+    @Test
+    @DisplayName("Throws SpectorValidationException on empty query")
+    void testEmptyQueryValidation() {
+        FederatedRecallRequest request = new FederatedRecallRequest(
+                "",
+                List.of("default"),
+                10,
+                5,
+                3000,
+                2,
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> federatedService.federatedRecall(ACCOUNT_ID, request))
+                .isInstanceOf(SpectorValidationException.class);
+    }
+
+    @Test
+    @DisplayName("Successful fan-out across multiple namespaces with provenance annotation and heuristic merge")
+    void testSuccessfulFederatedRecall() {
+        Account account = new Account(
+                ACCOUNT_ID,
+                PrincipalKind.SERVICE,
+                AccountProfile.SERVICE,
+                "Service Account",
+                new AccountQuotas(64, 8, 100_000_000L, 100_000L),
+                new AccountFlags(true, true, true), // federation = true
+                NS_1,
+                Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        NamespaceRecord rec1 = new NamespaceRecord(NS_1, "default", ACCOUNT_ID, NamespaceType.DEFAULT, NamespaceStatus.ACTIVE, "Default", "", null, Instant.now(), null, false);
+        NamespaceRecord rec2 = new NamespaceRecord(NS_2, "project-alpha", ACCOUNT_ID, NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "Alpha", "", null, Instant.now(), null, false);
+
+        when(catalog.resolve(ACCOUNT_ID, "default")).thenReturn(Optional.of(rec1));
+        when(catalog.resolve(ACCOUNT_ID, "project-alpha")).thenReturn(Optional.of(rec2));
+        when(catalog.authorize(ACCOUNT_ID, NS_1, GrantRole.READER)).thenReturn(Optional.of(new Grant("g1", GrantObjectType.NAMESPACE, NS_1, ACCOUNT_ID, PrincipalType.ACCOUNT, GrantRole.OWNER, null, ACCOUNT_ID, Instant.now(), null, null)));
+        when(catalog.authorize(ACCOUNT_ID, NS_2, GrantRole.READER)).thenReturn(Optional.of(new Grant("g2", GrantObjectType.NAMESPACE, NS_2, ACCOUNT_ID, PrincipalType.ACCOUNT, GrantRole.WRITER, null, ACCOUNT_ID, Instant.now(), null, null)));
+
+        when(memoryRegistry.namespaceResolver()).thenReturn(namespaceResolver);
+        when(namespaceResolver.isHot(NS_1)).thenReturn(true);
+        when(namespaceResolver.isHot(NS_2)).thenReturn(true);
+
+        SpectorMemory mem1 = mock(SpectorMemory.class);
+        SpectorMemory mem2 = mock(SpectorMemory.class);
+        when(namespaceResolver.resolve(ACCOUNT_ID, NS_1)).thenReturn(mem1);
+        when(namespaceResolver.resolve(ACCOUNT_ID, NS_2)).thenReturn(mem2);
+
+        CognitiveResult r1 = new CognitiveResult("mem-1", "Database timeout error", 0.95f, 0.8f, 0.1f, (short) 1, (byte) 0, MemoryType.EPISODIC, MemorySource.OBSERVED, new String[]{"db"}, 1.0f, 1.0f);
+        CognitiveResult r2 = new CognitiveResult("mem-2", "Java concurrency best practices", 0.85f, 0.7f, 0.2f, (short) 2, (byte) 0, MemoryType.SEMANTIC, MemorySource.OBSERVED, new String[]{"java"}, 1.0f, 1.0f);
+        when(mem1.recall(eq("concurrency database"), any(RecallOptions.class))).thenReturn(List.of(r1));
+        when(mem2.recall(eq("concurrency database"), any(RecallOptions.class))).thenReturn(List.of(r2));
+
+        FederatedRecallRequest request = new FederatedRecallRequest(
+                "concurrency database",
+                List.of("default", "project-alpha"),
+                5,
+                5,
+                3000,
+                2,
+                null,
+                null
+        );
+
+        FederatedRecallResponse response = federatedService.federatedRecall(ACCOUNT_ID, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.hits()).hasSize(2);
+
+        FederatedRecallHit hit1 = response.hits().get(0);
+        assertThat(hit1.id()).isEqualTo("mem-1");
+        assertThat(hit1.namespaceId()).isEqualTo(NS_1);
+        assertThat(hit1.slug()).isEqualTo("default");
+        assertThat(hit1.role()).isEqualTo(GrantRole.OWNER);
+        assertThat(hit1.localRank()).isEqualTo(1);
+        assertThat(hit1.heuristicGlobalRank()).isEqualTo(1);
+
+        FederatedRecallHit hit2 = response.hits().get(1);
+        assertThat(hit2.id()).isEqualTo("mem-2");
+        assertThat(hit2.namespaceId()).isEqualTo(NS_2);
+        assertThat(hit2.slug()).isEqualTo("project-alpha");
+        assertThat(hit2.role()).isEqualTo(GrantRole.WRITER);
+        assertThat(hit2.localRank()).isEqualTo(1);
+        assertThat(hit2.heuristicGlobalRank()).isEqualTo(2);
+
+        assertThat(response.summary().openedNamespaces()).containsExactlyInAnyOrder("default", "project-alpha");
+        assertThat(response.summary().skippedColdNamespaces()).isEmpty();
+        assertThat(response.summary().deniedNamespaces()).isEmpty();
+        assertThat(response.summary().failedNamespaces()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Respects maxColdOpens budget and marks excess cold namespaces as skippedCold")
+    void testColdOpenBudgetEnforcement() {
+        Account account = new Account(
+                ACCOUNT_ID,
+                PrincipalKind.SERVICE,
+                AccountProfile.SERVICE,
+                "Service Account",
+                new AccountQuotas(64, 8, 100_000_000L, 100_000L),
+                new AccountFlags(true, true, true),
+                NS_1,
+                Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        NamespaceRecord rec1 = new NamespaceRecord(NS_1, "ns-1", ACCOUNT_ID, NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "NS1", "", null, Instant.now(), null, false);
+        NamespaceRecord rec2 = new NamespaceRecord(NS_2, "ns-2", ACCOUNT_ID, NamespaceType.PROJECT, NamespaceStatus.ACTIVE, "NS2", "", null, Instant.now(), null, false);
+
+        when(catalog.resolve(ACCOUNT_ID, "ns-1")).thenReturn(Optional.of(rec1));
+        when(catalog.resolve(ACCOUNT_ID, "ns-2")).thenReturn(Optional.of(rec2));
+        when(catalog.authorize(ACCOUNT_ID, NS_1, GrantRole.READER)).thenReturn(Optional.of(new Grant("g1", GrantObjectType.NAMESPACE, NS_1, ACCOUNT_ID, PrincipalType.ACCOUNT, GrantRole.OWNER, null, ACCOUNT_ID, Instant.now(), null, null)));
+        when(catalog.authorize(ACCOUNT_ID, NS_2, GrantRole.READER)).thenReturn(Optional.of(new Grant("g2", GrantObjectType.NAMESPACE, NS_2, ACCOUNT_ID, PrincipalType.ACCOUNT, GrantRole.OWNER, null, ACCOUNT_ID, Instant.now(), null, null)));
+
+        when(memoryRegistry.namespaceResolver()).thenReturn(namespaceResolver);
+        when(namespaceResolver.isHot(NS_1)).thenReturn(false); // cold
+        when(namespaceResolver.isHot(NS_2)).thenReturn(false); // cold
+
+        SpectorMemory mem1 = mock(SpectorMemory.class);
+        when(namespaceResolver.resolve(ACCOUNT_ID, NS_1)).thenReturn(mem1);
+        when(mem1.recall(eq("test"), any(RecallOptions.class))).thenReturn(List.of());
+
+        // maxColdOpens = 1 -> ns-1 opened, ns-2 skipped
+        FederatedRecallRequest request = new FederatedRecallRequest(
+                "test",
+                List.of("ns-1", "ns-2"),
+                10,
+                5,
+                3000,
+                1, // maxColdOpens = 1
+                null,
+                null
+        );
+
+        FederatedRecallResponse response = federatedService.federatedRecall(ACCOUNT_ID, request);
+
+        assertThat(response.summary().openedNamespaces()).containsExactly("ns-1");
+        assertThat(response.summary().skippedColdNamespaces()).containsExactly("ns-2");
+    }
+
+    @Test
+    @DisplayName("Querying 'granted' expands to all accessible namespaces")
+    void testQueryAllGrantedExpansion() {
+        Account account = new Account(
+                ACCOUNT_ID,
+                PrincipalKind.SERVICE,
+                AccountProfile.SERVICE,
+                "Service Account",
+                new AccountQuotas(64, 8, 100_000_000L, 100_000L),
+                new AccountFlags(true, true, true),
+                NS_1,
+                Instant.now()
+        );
+        when(catalog.getOrCreateAccount(ACCOUNT_ID)).thenReturn(account);
+
+        NamespaceRecord rec1 = new NamespaceRecord(NS_1, "default", ACCOUNT_ID, NamespaceType.DEFAULT, NamespaceStatus.ACTIVE, "Default", "", null, Instant.now(), null, false);
+        NamespaceRecord rec2 = new NamespaceRecord(NS_2, "team-kb", ACCOUNT_ID, NamespaceType.SHARED, NamespaceStatus.ACTIVE, "KB", "", null, Instant.now(), null, false);
+
+        when(catalog.listAccessible(ACCOUNT_ID)).thenReturn(List.of(rec1, rec2));
+        when(catalog.authorize(ACCOUNT_ID, NS_1, GrantRole.READER)).thenReturn(Optional.of(new Grant("g1", GrantObjectType.NAMESPACE, NS_1, ACCOUNT_ID, PrincipalType.ACCOUNT, GrantRole.OWNER, null, ACCOUNT_ID, Instant.now(), null, null)));
+        when(catalog.authorize(ACCOUNT_ID, NS_2, GrantRole.READER)).thenReturn(Optional.of(new Grant("g2", GrantObjectType.NAMESPACE, NS_2, ACCOUNT_ID, PrincipalType.ACCOUNT, GrantRole.READER, null, ACCOUNT_ID, Instant.now(), null, null)));
+
+        when(memoryRegistry.namespaceResolver()).thenReturn(namespaceResolver);
+        when(namespaceResolver.isHot(NS_1)).thenReturn(true);
+        when(namespaceResolver.isHot(NS_2)).thenReturn(true);
+        SpectorMemory mem1 = mock(SpectorMemory.class);
+        SpectorMemory mem2 = mock(SpectorMemory.class);
+        when(namespaceResolver.resolve(ACCOUNT_ID, NS_1)).thenReturn(mem1);
+        when(namespaceResolver.resolve(ACCOUNT_ID, NS_2)).thenReturn(mem2);
+
+        when(mem1.recall(eq("test query"), any(RecallOptions.class))).thenReturn(List.of());
+        when(mem2.recall(eq("test query"), any(RecallOptions.class))).thenReturn(List.of());
+
+        FederatedRecallRequest request = new FederatedRecallRequest(
+                "test query",
+                List.of("granted"),
+                10,
+                5,
+                3000,
+                2,
+                null,
+                null
+        );
+
+        FederatedRecallResponse response = federatedService.federatedRecall(ACCOUNT_ID, request);
+
+        assertThat(response.summary().openedNamespaces()).containsExactlyInAnyOrder("default", "team-kb");
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryControllerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryControllerTest.java
@@ -53,6 +53,7 @@ class MemoryControllerTest {
     @Autowired WebApplicationContext wac;
     @Autowired ObjectMapper mapper;
     @MockitoBean MemoryService memoryService;
+    @MockitoBean FederatedRecallService federatedRecallService;
 
     MockMvc mvc;
 
@@ -366,6 +367,55 @@ class MemoryControllerTest {
                 .andExpect(jsonPath("$.avgValence", is(4.5)));
 
         verify(memoryService).getScoringStats();
+    }
+
+    @Test
+    @DisplayName("POST /memory/federated-recall — returns 200 with federated hits and summary")
+    void federatedRecall_returnsHits() throws Exception {
+        var cr = new com.spectrayan.spector.memory.model.CognitiveResult(
+                "mem-123",
+                "Cross-rememberer knowledge",
+                0.92f,
+                0.85f,
+                0.1f,
+                (short) 1,
+                (byte) 0,
+                com.spectrayan.spector.memory.model.MemoryType.SEMANTIC,
+                com.spectrayan.spector.memory.cortex.MemorySource.OBSERVED,
+                new String[]{"federation"},
+                1.0f,
+                1.0f
+        );
+        var hit = new FederatedRecallHit(
+                "01JXYZNS00001",
+                "default",
+                com.spectrayan.spector.synapse.catalog.GrantRole.OWNER,
+                1,
+                1,
+                cr
+        );
+        var summary = new FederatedRecallSummary(
+                1,
+                List.of("default"),
+                List.of(),
+                List.of(),
+                List.of(),
+                25L
+        );
+        var response = new FederatedRecallResponse(List.of(hit), summary);
+
+        when(federatedRecallService.federatedRecall(Mockito.anyString(), Mockito.any(FederatedRecallRequest.class)))
+                .thenReturn(response);
+
+        var request = new FederatedRecallRequest("cross-rememberer knowledge", List.of("default"), 5, 5, 3000, 2, null, null);
+
+        mvc.perform(post("/api/v1/memory/federated-recall")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hits[0].result.id", is("mem-123")))
+                .andExpect(jsonPath("$.hits[0].namespaceId", is("01JXYZNS00001")))
+                .andExpect(jsonPath("$.summary.openedNamespaces[0]", is("default")));
     }
 }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryWildcardRejectionTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryWildcardRejectionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemoryWildcardRejection — Unit Tests")
+class MemoryWildcardRejectionTest {
+
+    @Mock
+    private AccountCatalog catalog;
+
+    @Mock
+    private MemoryRegistry memoryRegistry;
+
+    private MemoryRequestBinder binder;
+
+    @BeforeEach
+    void setUp() {
+        SynapseProperties props = new SynapseProperties();
+        props.auth().setEnabled(true);
+        binder = new MemoryRequestBinder(catalog, memoryRegistry, props, null, null);
+    }
+
+    @Test
+    @DisplayName("Rejects wildcard '*' on single-namespace binding")
+    void testRejectsWildcard() {
+        Authentication auth = new TestingAuthenticationToken("01JXYZTEST001", "password");
+
+        assertThatThrownBy(() -> binder.bind(auth, Optional.of("*")))
+                .isInstanceOf(SpectorValidationException.class)
+                .hasMessageContaining("Wildcard '*' or multi-namespace selection is not permitted");
+    }
+
+    @Test
+    @DisplayName("Rejects comma-separated multi-namespace selectors on single-namespace binding")
+    void testRejectsCommaSeparatedSelectors() {
+        Authentication auth = new TestingAuthenticationToken("01JXYZTEST001", "password");
+
+        assertThatThrownBy(() -> binder.bind(auth, Optional.of("default,project-alpha")))
+                .isInstanceOf(SpectorValidationException.class)
+                .hasMessageContaining("Wildcard '*' or multi-namespace selection is not permitted");
+    }
+}


### PR DESCRIPTION
## Summary

Delivers **ADR-0029 v4 Phase 7: Cross-Rememberer Operations & Federated Recall (`memory_federated_recall`) with Budgets**.

### Highlights
1. **Quota & Flag Enforcement**:
   - Gated behind `account.flags().federation()`. Unpermitted requests return `403 Forbidden` (`FederationDisabledException`).
   - Rejects wildcard `'*'` and multi-namespace comma selectors on single-namespace `memory_recall` with `SpectorValidationException`.
2. **Execution Budgets & Resiliency**:
   - Enforces `maxNamespaces` (default 5, capped at 10) and `maxColdOpens` (default 2, cold rememberers beyond cap marked `skippedCold`).
   - Supports keyword `'granted'` expanding to all accessible active namespaces.
   - Partial failure isolation reporting per-namespace diagnostic execution status (`opened`, `skippedCold`, `denied`, `failed`).
3. **Structured Concurrency Fan-Out**:
   - Leverages Spector's centralized `ConcurrentTasks.forkJoinPartial` using structured concurrency (`StructuredTaskScope` / virtual threads) with deadline cancellation (`timeoutMs`).
4. **Telemetry & Heuristic Merging**:
   - `FederatedRecallHit` wraps full, rich `CognitiveResult` telemetry alongside cross-rememberer provenance annotations (`namespaceId`, `slug`, `role`, `localRank`, and `heuristicGlobalRank`).
5. **REST API & Declarative MCP Spec**:
   - Exposes `POST /api/v1/memory/federated-recall`.
   - Adds declarative MCP spec `memory_federated_recall.json` and tool handler `MemoryFederatedRecallTool`.
6. **Testing**:
   - Added `FederatedRecallServiceTest`, `MemoryWildcardRejectionTest`, `MemoryFederatedRecallToolTest`, and controller test in `MemoryControllerTest`.
   - Full 24-module reactor build passing cleanly.

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>