### PR TITLE
feat(identity): implement ADR-0029 MCP binder integration, region PEP, and request-scoped identity

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RememberPathway.java
@@ -214,11 +214,22 @@ public final class RememberPathway implements IngestionTarget, AutoCloseable {
             final String[] tags,
             final MemorySource source,
             final IngestionContext context) {
+        final SalienceProfile effectiveSalience = (context != null && context.salienceProfile() != null)
+                ? context.salienceProfile()
+                : this.salienceProfile;
+        final short effectiveSoulVersion = (context != null && context.soulVersion() != null)
+                ? context.soulVersion()
+                : this.currentSoulVersion;
+        final java.util.List<com.spectrayan.spector.memory.model.SoulContext> effectiveSoulStack =
+                (context != null && context.soulContexts() != null && !context.soulContexts().isEmpty())
+                ? context.soulContexts()
+                : this.soulContexts;
+
         final RememberSignal signal = RememberSignal.forCognitiveWithContext(
                 id, text, vector, type, tags, source, context,
-                salienceProfile, currentSoulVersion
+                effectiveSalience, effectiveSoulVersion
         );
-        signal.soulContexts(this.soulContexts);
+        signal.soulContexts(effectiveSoulStack);
         pathway.conduct(signal);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/IngestionContext.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/IngestionContext.java
@@ -66,6 +66,9 @@ import java.util.Map;
  *                            When null, the ingestion pipeline uses wall-clock time. Essential for benchmark
  *                            data and historical memory import where the original event time must be preserved
  *                            for correct temporal decay, circadian scoring, and temporal chain ordering.
+ * @param soulContexts        request-scoped soul hierarchy for multi-soul ICNU importance evaluation
+ * @param salienceProfile     request-scoped effective salience profile
+ * @param soulVersion         request-scoped soul version
  */
 public record IngestionContext(
         IngestionHints hints,
@@ -73,29 +76,40 @@ public record IngestionContext(
         List<HebbianEdgeHint> hebbianEdges,
         List<TemporalLinkHint> temporalLinks,
         Long overrideTimestampMs,
-        Map<String, String> metadata
+        Map<String, String> metadata,
+        List<SoulContext> soulContexts,
+        SalienceProfile salienceProfile,
+        Short soulVersion
 ) {
 
-    /** Canonical constructor — enforces unmodifiable metadata. */
+    /** Canonical constructor — enforces unmodifiable metadata and defensive copies. */
     public IngestionContext {
         metadata = metadata != null ? Collections.unmodifiableMap(new HashMap<>(metadata)) : Map.of();
+        soulContexts = soulContexts != null ? List.copyOf(soulContexts) : List.of();
+    }
+
+    /** Constructor with metadata — no request-scoped identity. */
+    public IngestionContext(IngestionHints hints, List<ExtractedEntity> entities,
+                            List<HebbianEdgeHint> hebbianEdges, List<TemporalLinkHint> temporalLinks,
+                            Long overrideTimestampMs, Map<String, String> metadata) {
+        this(hints, entities, hebbianEdges, temporalLinks, overrideTimestampMs, metadata, List.of(), null, null);
     }
 
     /** Backward-compatible constructor — no timestamp override, no metadata. */
     public IngestionContext(IngestionHints hints, List<ExtractedEntity> entities,
                             List<HebbianEdgeHint> hebbianEdges, List<TemporalLinkHint> temporalLinks) {
-        this(hints, entities, hebbianEdges, temporalLinks, null, null);
+        this(hints, entities, hebbianEdges, temporalLinks, null, null, List.of(), null, null);
     }
 
     /** Backward-compatible constructor — timestamp override, no metadata. */
     public IngestionContext(IngestionHints hints, List<ExtractedEntity> entities,
                             List<HebbianEdgeHint> hebbianEdges, List<TemporalLinkHint> temporalLinks,
                             Long overrideTimestampMs) {
-        this(hints, entities, hebbianEdges, temporalLinks, overrideTimestampMs, null);
+        this(hints, entities, hebbianEdges, temporalLinks, overrideTimestampMs, null, List.of(), null, null);
     }
 
     /** Empty context — triggers all automatic pipelines with novelty-only importance. */
-    public static final IngestionContext EMPTY = new IngestionContext(null, null, null, null, null, null);
+    public static final IngestionContext EMPTY = new IngestionContext(null, null, null, null, null, null, List.of(), null, null);
 
     /** Returns true if pre-extracted entities are provided. */
     public boolean hasEntities() { return entities != null && !entities.isEmpty(); }
@@ -299,9 +313,28 @@ public record IngestionContext(
             return this;
         }
 
+        private java.util.List<SoulContext> soulContexts;
+        private SalienceProfile salienceProfile;
+        private Short soulVersion;
+
+        public Builder soulContexts(List<SoulContext> soulContexts) {
+            this.soulContexts = soulContexts;
+            return this;
+        }
+
+        public Builder salienceProfile(SalienceProfile salienceProfile) {
+            this.salienceProfile = salienceProfile;
+            return this;
+        }
+
+        public Builder soulVersion(Short soulVersion) {
+            this.soulVersion = soulVersion;
+            return this;
+        }
+
         public IngestionContext build() {
             return new IngestionContext(hints, entities, hebbianEdges, temporalLinks,
-                    overrideTimestampMs, metadata);
+                    overrideTimestampMs, metadata, soulContexts, salienceProfile, soulVersion);
         }
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/RememberPathwayDirectTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/RememberPathwayDirectTest.java
@@ -81,6 +81,55 @@ class RememberPathwayDirectTest {
         assertThat(profile).isNotNull();
     }
 
+    @Test
+    @DisplayName("Concurrent scoped identity ingestion isolates soul stacks and importance scoring")
+    void testConcurrentScopedIdentityIngestionIsolation() throws Exception {
+        com.spectrayan.spector.memory.model.UserSoul soulA = new com.spectrayan.spector.memory.model.UserSoul(
+                "user-a", "Alice", "Astrophysicist",
+                com.spectrayan.spector.memory.model.PersonaContext.builder().about("Astrophysicist").occupation("Astrophysics").build(),
+                null);
+
+        com.spectrayan.spector.memory.model.UserSoul soulB = new com.spectrayan.spector.memory.model.UserSoul(
+                "user-b", "Bob", "Chef",
+                com.spectrayan.spector.memory.model.PersonaContext.builder().about("Chef").occupation("Culinary").build(),
+                null);
+
+        com.spectrayan.spector.memory.model.IngestionContext ctxA = com.spectrayan.spector.memory.model.IngestionContext.builder()
+                .soulContexts(List.of(soulA))
+                .soulVersion(soulA.soulVersion())
+                .build();
+
+        com.spectrayan.spector.memory.model.IngestionContext ctxB = com.spectrayan.spector.memory.model.IngestionContext.builder()
+                .soulContexts(List.of(soulB))
+                .soulVersion(soulB.soulVersion())
+                .build();
+
+        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(2);
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+
+        var futureA = executor.submit(() -> {
+            latch.await();
+            memory.remember("mem-a", "James Webb telescope discovered high-redshift galaxy",
+                    MemoryType.SEMANTIC, MemorySource.USER_STATED, ctxA, "astronomy");
+            return true;
+        });
+
+        var futureB = executor.submit(() -> {
+            latch.await();
+            memory.remember("mem-b", "French sourdough fermentation technique and recipe",
+                    MemoryType.SEMANTIC, MemorySource.USER_STATED, ctxB, "culinary");
+            return true;
+        });
+
+        latch.countDown();
+        futureA.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        futureB.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertThat(memory.inspect("mem-a")).isNotNull();
+        assertThat(memory.inspect("mem-b")).isNotNull();
+    }
+
     private static class MockEmbeddingProvider implements EmbeddingProvider {
         private final int dims;
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/RememberPathwayDirectTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/RememberPathwayDirectTest.java
@@ -94,14 +94,28 @@ class RememberPathwayDirectTest {
                 com.spectrayan.spector.memory.model.PersonaContext.builder().about("Chef").occupation("Culinary").build(),
                 null);
 
+        SalienceProfile salienceA = SalienceProfile.builder()
+                .interest("astronomy", com.spectrayan.spector.memory.model.InterestLevel.HIGH)
+                .alpha(0.8f)
+                .beta(0.2f)
+                .build();
+
+        SalienceProfile salienceB = SalienceProfile.builder()
+                .interest("culinary", com.spectrayan.spector.memory.model.InterestLevel.HIGH)
+                .alpha(0.3f)
+                .beta(0.7f)
+                .build();
+
         com.spectrayan.spector.memory.model.IngestionContext ctxA = com.spectrayan.spector.memory.model.IngestionContext.builder()
                 .soulContexts(List.of(soulA))
                 .soulVersion(soulA.soulVersion())
+                .salienceProfile(salienceA)
                 .build();
 
         com.spectrayan.spector.memory.model.IngestionContext ctxB = com.spectrayan.spector.memory.model.IngestionContext.builder()
                 .soulContexts(List.of(soulB))
                 .soulVersion(soulB.soulVersion())
+                .salienceProfile(salienceB)
                 .build();
 
         java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(2);
@@ -126,8 +140,26 @@ class RememberPathwayDirectTest {
         futureB.get(5, java.util.concurrent.TimeUnit.SECONDS);
         executor.shutdown();
 
-        assertThat(memory.inspect("mem-a")).isNotNull();
-        assertThat(memory.inspect("mem-b")).isNotNull();
+        com.spectrayan.spector.memory.model.CognitiveRecord recA = memory.inspect("mem-a");
+        com.spectrayan.spector.memory.model.CognitiveRecord recB = memory.inspect("mem-b");
+
+        assertThat(recA).as("mem-a record").isNotNull();
+        assertThat(recB).as("mem-b record").isNotNull();
+
+        assertThat(recA.tags()).containsExactly("astronomy");
+        assertThat(recB.tags()).containsExactly("culinary");
+        assertThat(recA.text()).contains("telescope");
+        assertThat(recB.text()).contains("sourdough");
+
+        // Scoped recall verifies salience interest routing per soul profile
+        var resultsA = memory.recall("telescope galaxy", RecallOptions.builder().topK(5).salienceProfile(salienceA).build());
+        var resultsB = memory.recall("sourdough recipe", RecallOptions.builder().topK(5).salienceProfile(salienceB).build());
+
+        assertThat(resultsA).isNotEmpty();
+        assertThat(resultsA.get(0).id()).isEqualTo("mem-a");
+
+        assertThat(resultsB).isNotEmpty();
+        assertThat(resultsB.get(0).id()).isEqualTo("mem-b");
     }
 
     private static class MockEmbeddingProvider implements EmbeddingProvider {

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -409,6 +409,13 @@ public class MeteredSpectorMemory implements SpectorMemory {
     }
 
     @Override
+    public void applyIdentity(com.spectrayan.spector.memory.model.SoulContext primarySoul,
+                              java.util.List<com.spectrayan.spector.memory.model.SoulContext> soulStack,
+                              com.spectrayan.spector.memory.model.SalienceProfile salience) {
+        delegate.applyIdentity(primarySoul, soulStack, salience);
+    }
+
+    @Override
     public com.spectrayan.spector.memory.model.SalienceProfile salienceProfile() {
         return delegate.salienceProfile();
     }

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
@@ -360,6 +360,13 @@ public class ObservedSpectorMemory extends ObservableComponent implements Specto
     }
 
     @Override
+    public void applyIdentity(com.spectrayan.spector.memory.model.SoulContext primarySoul,
+                              List<com.spectrayan.spector.memory.model.SoulContext> soulStack,
+                              SalienceProfile salience) {
+        delegate.applyIdentity(primarySoul, soulStack, salience);
+    }
+
+    @Override
     public SalienceProfile salienceProfile() {
         return delegate.salienceProfile();
     }

--- a/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
+++ b/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
@@ -34,6 +34,8 @@ import com.spectrayan.spector.memory.sync.MemoryWal;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -144,6 +146,21 @@ class MeteredSpectorMemoryTest {
 
         metered.admin();
         metered.close();
+    }
+
+    @Test
+    void testApplyIdentityDelegation() {
+        SpectorMemory delegate = mock(SpectorMemory.class);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        MeteredSpectorMemory memory = new MeteredSpectorMemory(delegate, registry);
+
+        com.spectrayan.spector.memory.model.SoulContext soul = new com.spectrayan.spector.memory.model.UserSoul("user-1", "primary", "desc", null, null);
+        List<com.spectrayan.spector.memory.model.SoulContext> soulStack = List.of(soul);
+        var salience = com.spectrayan.spector.memory.model.SalienceProfile.NEUTRAL;
+
+        memory.applyIdentity(soul, soulStack, salience);
+
+        verify(delegate).applyIdentity(soul, soulStack, salience);
     }
 
     static class DummySpectorMemory implements SpectorMemory {

--- a/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
+++ b/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/MeteredSpectorMemoryTest.java
@@ -139,6 +139,9 @@ class MeteredSpectorMemoryTest {
         metered.assertFact("s", "p", "o", 0, 100, 1.0f, false);
         metered.factHistory("s", "p");
 
+        com.spectrayan.spector.memory.model.SoulContext soul = new com.spectrayan.spector.memory.model.UserSoul("user-1", "primary", "desc", null, null);
+        metered.applyIdentity(soul, List.of(soul), SalienceProfile.NEUTRAL);
+
         metered.admin();
         metered.close();
     }

--- a/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/ObservedSpectorMemoryTest.java
+++ b/memory/spector-metrics/src/test/java/com/spectrayan/spector/metrics/ObservedSpectorMemoryTest.java
@@ -171,4 +171,16 @@ class ObservedSpectorMemoryTest {
                 .hasLowCardinalityKeyValue("spector.namespace", "ns-42")
                 .hasHighCardinalityKeyValue("custom_key", "custom_val");
     }
+
+    @Test
+    @DisplayName("applyIdentity() delegates to wrapped memory instance")
+    void testApplyIdentityDelegation() {
+        com.spectrayan.spector.memory.model.SoulContext soul = new com.spectrayan.spector.memory.model.UserSoul("user-1", "primary", "desc", null, null);
+        List<com.spectrayan.spector.memory.model.SoulContext> soulStack = List.of(soul);
+        var salience = com.spectrayan.spector.memory.model.SalienceProfile.NEUTRAL;
+
+        memory.applyIdentity(soul, soulStack, salience);
+
+        verify(delegate).applyIdentity(soul, soulStack, salience);
+    }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
@@ -27,7 +27,15 @@ public interface AccountCatalog {
 
     Account getOrCreateAccount(String accountId);
 
+    default Account getOrCreateAccount(String accountId, AccountProfile profile, PrincipalKind kind) {
+        return getOrCreateAccount(accountId);
+    }
+
     Account getAccount(String accountId);
+
+    default void addOrgMember(String accountId, String orgUnitId) {}
+
+    default void removeOrgMember(String accountId, String orgUnitId) {}
 
     default NamespaceRecord createNamespace(String accountId, String slug, NamespaceType type) {
         return createNamespace(accountId, slug, type, null, null, null);

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
@@ -33,19 +33,9 @@ import java.util.concurrent.locks.ReentrantLock;
  * File-backed implementation of {@link AccountCatalog} using per-account JSON files
  * (ADR-0029 §4.2, §19).
  *
- * <p>Catalog layout per account:</p>
- * <pre>
- * accounts/{shard}/{accountId}/
- * ├── account.json     # Account record
- * ├── slugs.json       # Map&lt;slug, namespaceId&gt;
- * ├── grants.jsonl     # Append-only grant log
- * └── LOCK             # File lock token
- * </pre>
- *
- * <p>Concurrency: one {@link ReentrantLock} per accountId (JVM) plus an exclusive
- * {@link FileLock} on the per-account {@code LOCK} file (OS). Reads are lock-free
- * on a cached snapshot invalidated by mtime.</p>
+ * @deprecated Legacy standalone mode only. In enterprise deployments, use {@link com.spectrayan.spector.synapse.catalog.jdbc.JdbcAccountCatalog}.
  */
+@Deprecated(since = "0.1.0-alpha")
 public class FileAccountCatalog implements AccountCatalog {
 
     private static final Logger log = LoggerFactory.getLogger(FileAccountCatalog.class);
@@ -106,41 +96,50 @@ public class FileAccountCatalog implements AccountCatalog {
             }
 
             Path grantsFile = accountDir.resolve(FILE_GRANTS);
-            List<Grant> grants = GrantLog.parseGrants(grantsFile, objectMapper);
+            List<Grant> grants = new ArrayList<>();
+            if (Files.exists(grantsFile)) {
+                grants = GrantLog.parseGrants(grantsFile, objectMapper);
+            }
 
-            CatalogSnapshot snapshot = new CatalogSnapshot(account, slugs, namespaces, grants, mtime);
+            CatalogSnapshot snapshot = new CatalogSnapshot(
+                    account,
+                    Collections.unmodifiableMap(slugs),
+                    Collections.unmodifiableMap(namespaces),
+                    Collections.unmodifiableList(grants),
+                    mtime
+            );
             snapshotCache.put(accountId, snapshot);
             return snapshot;
         } catch (IOException e) {
             log.error("[FileAccountCatalog] failed to load snapshot for account {}", accountId, e);
-            throw new RuntimeException("Failed to load catalog snapshot", e);
+            throw new RuntimeException("Failed to read account catalog snapshot", e);
         }
     }
 
     // ══════════════════════════════════════════════════════════════
-    // AccountCatalog SPI implementation
+    // Write operations (JVM + file lock guarded)
     // ══════════════════════════════════════════════════════════════
 
     @Override
     public Account getOrCreateAccount(String accountId) {
-        Path accountDir = StorageLayout.accountDir(basePath, accountId);
-        Path accountFile = accountDir.resolve(FILE_ACCOUNT);
+        return getOrCreateAccount(accountId, AccountProfile.HUMAN_SOLO, PrincipalKind.HUMAN);
+    }
 
-        // Fast path: account already exists
-        if (Files.exists(accountFile)) {
-            try {
-                return objectMapper.readValue(accountFile.toFile(), Account.class);
-            } catch (IOException e) {
-                log.error("[FileAccountCatalog] failed to read account file: {}", accountFile, e);
-                throw new RuntimeException(e);
-            }
+    @Override
+    public Account getOrCreateAccount(String accountId, AccountProfile profile, PrincipalKind kind) {
+        if (accountId == null || accountId.isBlank()) {
+            throw new IllegalArgumentException("accountId must not be null or blank");
         }
 
-        // Cold path: create account under lock
+        AccountProfile effProfile = profile != null ? profile : AccountProfile.HUMAN_SOLO;
+        PrincipalKind effKind = kind != null ? kind : PrincipalKind.HUMAN;
+
         ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
         jvmLock.lock();
         try {
-            // Double-check after acquiring lock
+            Path accountDir = StorageLayout.accountDir(basePath, accountId);
+            Path accountFile = accountDir.resolve(FILE_ACCOUNT);
+
             if (Files.exists(accountFile)) {
                 return objectMapper.readValue(accountFile.toFile(), Account.class);
             }
@@ -155,14 +154,14 @@ public class FileAccountCatalog implements AccountCatalog {
                     StandardOpenOption.CREATE, StandardOpenOption.WRITE);
                  FileLock fileLock = channel.lock()) {
 
-                // Create account with HUMAN_SOLO profile defaults
+                // Create account with requested profile defaults
                 Account account = new Account(
                         accountId,
-                        PrincipalKind.HUMAN,
-                        AccountProfile.HUMAN_SOLO,
+                        effKind,
+                        effProfile,
                         null,  // displayName
-                        AccountQuotas.forProfile(AccountProfile.HUMAN_SOLO),
-                        AccountFlags.forProfile(AccountProfile.HUMAN_SOLO),
+                        AccountQuotas.forProfile(effProfile),
+                        AccountFlags.forProfile(effProfile),
                         accountId,  // defaultNamespaceId == accountId (invariant §12)
                         Instant.now()
                 );

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
@@ -76,6 +76,12 @@ public class JdbcAccountCatalog implements AccountCatalog {
     @Override
     @Transactional
     public Account getOrCreateAccount(String accountId) {
+        return getOrCreateAccount(accountId, AccountProfile.HUMAN_SOLO, PrincipalKind.HUMAN);
+    }
+
+    @Override
+    @Transactional
+    public Account getOrCreateAccount(String accountId, AccountProfile profile, PrincipalKind kind) {
         Objects.requireNonNull(accountId, "accountId must not be null");
 
         Optional<Account> existing = findAccountById(accountId);
@@ -84,6 +90,9 @@ public class JdbcAccountCatalog implements AccountCatalog {
             ensureDefaultNamespaceExists(account);
             return account;
         }
+
+        AccountProfile effProfile = profile != null ? profile : AccountProfile.HUMAN_SOLO;
+        PrincipalKind effKind = kind != null ? kind : PrincipalKind.HUMAN;
 
         log.info("[JdbcAccountCatalog] Auto-provisioning account for ID: {}", accountId);
         Instant now = Instant.now();
@@ -95,7 +104,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
                     profile, kind, flags, default_namespace_id, created_at, updated_at
                 ) VALUES (
                     :userId, :username, '', :displayName, 'ROLE_USER', '',
-                    'HUMAN_SOLO', 'HUMAN', '{}', :defaultNamespaceId, :now, :now
+                    :profile, :kind, '{}', :defaultNamespaceId, :now, :now
                 )
                 """;
 
@@ -103,6 +112,8 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .param("userId", accountId)
                 .param("username", accountId)
                 .param("displayName", accountId)
+                .param("profile", effProfile.name())
+                .param("kind", effKind.name())
                 .param("defaultNamespaceId", accountId)
                 .param("now", Timestamp.from(now))
                 .update();
@@ -126,10 +137,10 @@ public class JdbcAccountCatalog implements AccountCatalog {
 
         Account newAccount = new Account(
                 accountId,
-                PrincipalKind.HUMAN,
-                AccountProfile.HUMAN_SOLO,
+                effKind,
+                effProfile,
                 accountId,
-                defaultQuotas(AccountProfile.HUMAN_SOLO, null, null),
+                defaultQuotas(effProfile, null, null),
                 new AccountFlags(true, true, true),
                 accountId,
                 now
@@ -490,6 +501,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .param("revokedAt", null)
                 .param("constraintsJson", serializeConstraints(grant.constraints()))
                 .update();
+        bumpMembershipVersion(grant.principalId());
         log.info("[JdbcAccountCatalog] Added grant: id={}, object={}:{}, principal={}",
                 grant.grantId(), grant.objectType(), grant.objectId(), grant.principalId());
     }
@@ -565,6 +577,17 @@ public class JdbcAccountCatalog implements AccountCatalog {
     @Transactional
     public void revokeGrant(String grantId) {
         Objects.requireNonNull(grantId, "grantId must not be null");
+        try {
+            String findSql = "SELECT principal_id FROM grants WHERE grant_id = :grantId";
+            String principalId = jdbc.sql(findSql)
+                    .param("grantId", grantId)
+                    .query(String.class)
+                    .optional().orElse(null);
+            if (principalId != null) {
+                bumpMembershipVersion(principalId);
+            }
+        } catch (Exception ignored) {
+        }
         String sql = sqlLoader.load("catalog/grants/revoke-grant");
         jdbc.sql(sql)
                 .param("grantId", grantId)
@@ -644,20 +667,50 @@ public class JdbcAccountCatalog implements AccountCatalog {
         Objects.requireNonNull(bundleId, "bundleId must not be null");
         Objects.requireNonNull(action, "action must not be null");
 
-        // Account owner has full access to own identity bundle
+        // 1. Account owner has full access to own identity bundle
         if (accountId.equals(bundleId)) {
             return true;
         }
 
+        // 2. Direct region grant (IDENTITY_REGION objectId=bundleId:regionId)
+        if (regionId != null && !regionId.isBlank()) {
+            String findGrantSql = sqlLoader.load("catalog/grants/find-active-grant");
+            List<Grant> regionGrants = jdbc.sql(findGrantSql)
+                    .param("objectType", GrantObjectType.IDENTITY_REGION.name())
+                    .param("objectId", bundleId + ":" + regionId)
+                    .param("principalId", accountId)
+                    .query(this::mapGrantRow)
+                    .list();
+
+            if (regionGrants.stream().anyMatch(g -> g.actions() != null
+                    && (g.actions().contains(action) || g.actions().contains(GrantAction.ADMIN)))) {
+                return true;
+            }
+        }
+
+        // 3. Bundle-level grant (IDENTITY_BUNDLE objectId=bundleId with optional region constraints)
         String findGrantSql = sqlLoader.load("catalog/grants/find-active-grant");
-        List<Grant> grants = jdbc.sql(findGrantSql)
+        List<Grant> bundleGrants = jdbc.sql(findGrantSql)
                 .param("objectType", GrantObjectType.IDENTITY_BUNDLE.name())
                 .param("objectId", bundleId)
                 .param("principalId", accountId)
                 .query(this::mapGrantRow)
                 .list();
 
-        return grants.stream().anyMatch(g -> g.actions() != null && g.actions().contains(action));
+        for (Grant grant : bundleGrants) {
+            if (grant.actions() == null || (!grant.actions().contains(action) && !grant.actions().contains(GrantAction.ADMIN))) {
+                continue;
+            }
+            if (regionId != null && !regionId.isBlank() && grant.constraints() != null) {
+                Set<String> allowedRegions = grant.constraints().regionIds();
+                if (allowedRegions != null && !allowedRegions.isEmpty() && !allowedRegions.contains(regionId)) {
+                    continue;
+                }
+            }
+            return true;
+        }
+
+        return false;
     }
 
     @Override
@@ -670,6 +723,67 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .param("accountId", accountId)
                 .query((rs, rowNum) -> rs.getString("org_unit_id"))
                 .list();
+    }
+
+    @Override
+    @Transactional
+    public void addOrgMember(String accountId, String orgUnitId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(orgUnitId, "orgUnitId must not be null");
+
+        // Ensure user account exists
+        getOrCreateAccount(accountId);
+
+        // Ensure org_unit exists in org_units table
+        String checkOrgSql = "SELECT COUNT(*) FROM org_units WHERE org_unit_id = :orgUnitId";
+        Integer count = jdbc.sql(checkOrgSql)
+                .param("orgUnitId", orgUnitId)
+                .query(Integer.class)
+                .optional().orElse(0);
+        if (count == null || count == 0) {
+            jdbc.sql("INSERT INTO org_units (org_unit_id, tenant_id, name) VALUES (:orgUnitId, :tenantId, :name)")
+                    .param("orgUnitId", orgUnitId)
+                    .param("tenantId", "default")
+                    .param("name", orgUnitId)
+                    .update();
+        }
+
+        // Insert membership (ignore duplicate)
+        try {
+            jdbc.sql("INSERT INTO org_unit_members (org_unit_id, account_id) VALUES (:orgUnitId, :accountId)")
+                    .param("orgUnitId", orgUnitId)
+                    .param("accountId", accountId)
+                    .update();
+        } catch (Exception e) {
+            log.debug("[JdbcAccountCatalog] Org member insert duplicate or ignored: {}", e.getMessage());
+        }
+
+        bumpMembershipVersion(accountId);
+    }
+
+    @Override
+    @Transactional
+    public void removeOrgMember(String accountId, String orgUnitId) {
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(orgUnitId, "orgUnitId must not be null");
+
+        jdbc.sql("DELETE FROM org_unit_members WHERE org_unit_id = :orgUnitId AND account_id = :accountId")
+                .param("orgUnitId", orgUnitId)
+                .param("accountId", accountId)
+                .update();
+
+        bumpMembershipVersion(accountId);
+    }
+
+    private void bumpMembershipVersion(String accountId) {
+        if (accountId == null) return;
+        try {
+            jdbc.sql("UPDATE users SET membership_version = membership_version + 1 WHERE user_id = :accountId")
+                    .param("accountId", accountId)
+                    .update();
+        } catch (Exception e) {
+            log.warn("[JdbcAccountCatalog] Failed to bump membership_version: {}", e.getMessage());
+        }
     }
 
     private boolean hasActiveGrant(String accountId, String namespaceId) {
@@ -718,7 +832,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
                     accountId,
                     PrincipalType.ACCOUNT,
                     GrantRole.OWNER,
-                    Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
+                    Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN, GrantAction.INJECT),
                     accountId,
                     Instant.now(),
                     null,

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
@@ -57,16 +57,27 @@ public class JdbcAccountCatalog implements AccountCatalog {
     private final SqlQueryLoader sqlLoader;
     private final ObjectMapper objectMapper;
     private final TsidGenerator tsid;
+    private final org.springframework.beans.factory.ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider;
 
-    public JdbcAccountCatalog(JdbcClient jdbc, SqlQueryLoader sqlLoader, ObjectMapper objectMapper, TsidGenerator tsid) {
+    public JdbcAccountCatalog(
+            JdbcClient jdbc,
+            SqlQueryLoader sqlLoader,
+            ObjectMapper objectMapper,
+            TsidGenerator tsid,
+            org.springframework.beans.factory.ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
         this.jdbc = Objects.requireNonNull(jdbc, "jdbc must not be null");
         this.sqlLoader = Objects.requireNonNull(sqlLoader, "sqlLoader must not be null");
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
         this.tsid = tsid != null ? tsid : new TsidGenerator();
+        this.cacheManagerProvider = cacheManagerProvider;
+    }
+
+    public JdbcAccountCatalog(JdbcClient jdbc, SqlQueryLoader sqlLoader, ObjectMapper objectMapper, TsidGenerator tsid) {
+        this(jdbc, sqlLoader, objectMapper, tsid, null);
     }
 
     public JdbcAccountCatalog(JdbcClient jdbc, SqlQueryLoader sqlLoader, ObjectMapper objectMapper) {
-        this(jdbc, sqlLoader, objectMapper, new TsidGenerator());
+        this(jdbc, sqlLoader, objectMapper, new TsidGenerator(), null);
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -586,7 +597,8 @@ public class JdbcAccountCatalog implements AccountCatalog {
             if (principalId != null) {
                 bumpMembershipVersion(principalId);
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            log.warn("[JdbcAccountCatalog] Error querying principal for grant bump: {}", e.getMessage());
         }
         String sql = sqlLoader.load("catalog/grants/revoke-grant");
         jdbc.sql(sql)
@@ -620,6 +632,16 @@ public class JdbcAccountCatalog implements AccountCatalog {
         Objects.requireNonNull(namespaceId, "namespaceId must not be null");
         Objects.requireNonNull(minimumRole, "minimumRole must not be null");
 
+        long version = getMembershipVersion(accountId);
+        String cacheKey = accountId + ":" + namespaceId + ":" + minimumRole.name() + ":v" + version;
+        var cache = getCache(com.spectrayan.spector.synapse.config.cache.SynapseCacheConstants.CACHE_PEP_NAMESPACE);
+        if (cache != null) {
+            Optional<Grant> cached = cache.get(cacheKey, Grant.class);
+            if (cached != null && cached.isPresent()) {
+                return cached;
+            }
+        }
+
         // 1. Check if owner in namespaces table
         String findNsSql = sqlLoader.load("catalog/namespaces/find-by-id");
         Optional<NamespaceRecord> ns = jdbc.sql(findNsSql)
@@ -628,19 +650,23 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .optional();
 
         if (ns.isPresent() && ns.get().ownerAccountId().equals(accountId)) {
-            return Optional.of(new Grant(
+            Grant ownerGrant = new Grant(
                     "implicit-owner-" + accountId + "-" + namespaceId,
                     GrantObjectType.NAMESPACE,
                     namespaceId,
                     accountId,
                     PrincipalType.ACCOUNT,
                     GrantRole.OWNER,
-                    Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
+                    Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN, GrantAction.INJECT),
                     accountId,
                     ns.get().createdAt(),
                     null,
                     null
-            ));
+            );
+            if (cache != null) {
+                cache.put(cacheKey, ownerGrant);
+            }
+            return Optional.of(ownerGrant);
         }
 
         // 2. Query active grants
@@ -654,6 +680,9 @@ public class JdbcAccountCatalog implements AccountCatalog {
 
         for (Grant grant : grants) {
             if (grant.role() != null && grant.role().ordinal() <= minimumRole.ordinal()) {
+                if (cache != null) {
+                    cache.put(cacheKey, grant);
+                }
                 return Optional.of(grant);
             }
         }
@@ -667,6 +696,24 @@ public class JdbcAccountCatalog implements AccountCatalog {
         Objects.requireNonNull(bundleId, "bundleId must not be null");
         Objects.requireNonNull(action, "action must not be null");
 
+        long version = getMembershipVersion(accountId);
+        String cacheKey = accountId + ":" + bundleId + ":" + (regionId != null ? regionId : "*") + ":" + action.name() + ":v" + version;
+        var cache = getCache(com.spectrayan.spector.synapse.config.cache.SynapseCacheConstants.CACHE_PEP_IDENTITY);
+        if (cache != null) {
+            Optional<Boolean> cached = cache.get(cacheKey, Boolean.class);
+            if (cached != null && cached.isPresent()) {
+                return cached.get();
+            }
+        }
+
+        boolean result = evaluateAuthorizeIdentity(accountId, bundleId, regionId, action);
+        if (cache != null) {
+            cache.put(cacheKey, result);
+        }
+        return result;
+    }
+
+    private boolean evaluateAuthorizeIdentity(String accountId, String bundleId, String regionId, GrantAction action) {
         // 1. Account owner has full access to own identity bundle
         if (accountId.equals(bundleId)) {
             return true;
@@ -682,8 +729,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
                     .query(this::mapGrantRow)
                     .list();
 
-            if (regionGrants.stream().anyMatch(g -> g.actions() != null
-                    && (g.actions().contains(action) || g.actions().contains(GrantAction.ADMIN)))) {
+            if (regionGrants.stream().anyMatch(g -> isActionPermitted(g, action))) {
                 return true;
             }
         }
@@ -698,7 +744,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .list();
 
         for (Grant grant : bundleGrants) {
-            if (grant.actions() == null || (!grant.actions().contains(action) && !grant.actions().contains(GrantAction.ADMIN))) {
+            if (!isActionPermitted(grant, action)) {
                 continue;
             }
             if (regionId != null && !regionId.isBlank() && grant.constraints() != null) {
@@ -711,6 +757,15 @@ public class JdbcAccountCatalog implements AccountCatalog {
         }
 
         return false;
+    }
+
+    private boolean isActionPermitted(Grant g, GrantAction action) {
+        if (g == null || g.actions() == null) return false;
+        if (action == GrantAction.INJECT) {
+            // ADMIN does NOT imply INJECT. INJECT must be explicitly granted.
+            return g.actions().contains(GrantAction.INJECT);
+        }
+        return g.actions().contains(action) || g.actions().contains(GrantAction.ADMIN);
     }
 
     @Override
@@ -741,11 +796,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
                 .query(Integer.class)
                 .optional().orElse(0);
         if (count == null || count == 0) {
-            jdbc.sql("INSERT INTO org_units (org_unit_id, tenant_id, name) VALUES (:orgUnitId, :tenantId, :name)")
-                    .param("orgUnitId", orgUnitId)
-                    .param("tenantId", "default")
-                    .param("name", orgUnitId)
-                    .update();
+            throw new IllegalArgumentException("OrgUnit '" + orgUnitId + "' does not exist in catalog");
         }
 
         // Insert membership (ignore duplicate)
@@ -759,6 +810,25 @@ public class JdbcAccountCatalog implements AccountCatalog {
         }
 
         bumpMembershipVersion(accountId);
+    }
+
+    private com.spectrayan.spector.commons.cache.SpectorCache getCache(String name) {
+        if (cacheManagerProvider == null) return null;
+        var cm = cacheManagerProvider.getIfAvailable();
+        return cm != null ? cm.getCache(name) : null;
+    }
+
+    private long getMembershipVersion(String accountId) {
+        if (accountId == null) return 0L;
+        try {
+            Long v = jdbc.sql("SELECT membership_version FROM users WHERE user_id = :userId")
+                    .param("userId", accountId)
+                    .query(Long.class)
+                    .optional().orElse(0L);
+            return v != null ? v : 0L;
+        } catch (Exception e) {
+            return 0L;
+        }
     }
 
     @Override

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
@@ -29,6 +29,8 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * JDBC-backed implementation of {@link AccountCatalog} for enterprise and production
@@ -50,14 +52,18 @@ public class JdbcAccountCatalog implements AccountCatalog {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcAccountCatalog.class);
 
-    private static final Pattern SLUG_PATTERN =
-            Pattern.compile("^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$");
+    private static final Pattern SLUG_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$");
 
     private final JdbcClient jdbc;
     private final SqlQueryLoader sqlLoader;
     private final ObjectMapper objectMapper;
     private final TsidGenerator tsid;
     private final org.springframework.beans.factory.ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider;
+
+    private final Cache<String, Long> membershipVersionCache = Caffeine.newBuilder()
+            .maximumSize(4096)
+            .expireAfterWrite(java.time.Duration.ofSeconds(5))
+            .build();
 
     public JdbcAccountCatalog(
             JdbcClient jdbc,
@@ -820,15 +826,17 @@ public class JdbcAccountCatalog implements AccountCatalog {
 
     private long getMembershipVersion(String accountId) {
         if (accountId == null) return 0L;
-        try {
-            Long v = jdbc.sql("SELECT membership_version FROM users WHERE user_id = :userId")
-                    .param("userId", accountId)
-                    .query(Long.class)
-                    .optional().orElse(0L);
-            return v != null ? v : 0L;
-        } catch (Exception e) {
-            return 0L;
-        }
+        return membershipVersionCache.get(accountId, id -> {
+            try {
+                Long v = jdbc.sql("SELECT membership_version FROM users WHERE user_id = :userId")
+                        .param("userId", id)
+                        .query(Long.class)
+                        .optional().orElse(0L);
+                return v != null ? v : 0L;
+            } catch (Exception e) {
+                return 0L;
+            }
+        });
     }
 
     @Override
@@ -847,6 +855,7 @@ public class JdbcAccountCatalog implements AccountCatalog {
 
     private void bumpMembershipVersion(String accountId) {
         if (accountId == null) return;
+        membershipVersionCache.invalidate(accountId);
         try {
             jdbc.sql("UPDATE users SET membership_version = membership_version + 1 WHERE user_id = :accountId")
                     .param("accountId", accountId)

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/CatalogAutoConfiguration.java
@@ -48,9 +48,10 @@ public class CatalogAutoConfiguration {
     public AccountCatalog jdbcAccountCatalog(
             org.springframework.jdbc.core.simple.JdbcClient jdbc,
             com.spectrayan.spector.synapse.config.sql.SqlQueryLoader sqlLoader,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            org.springframework.beans.factory.ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
         log.info("[CatalogAutoConfiguration] creating JdbcAccountCatalog");
-        return new com.spectrayan.spector.synapse.catalog.jdbc.JdbcAccountCatalog(jdbc, sqlLoader, objectMapper);
+        return new com.spectrayan.spector.synapse.catalog.jdbc.JdbcAccountCatalog(jdbc, sqlLoader, objectMapper, null, cacheManagerProvider);
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/McpServerConfig.java
@@ -98,10 +98,11 @@ public class McpServerConfig {
     public McpStatelessSyncServer mcpStatelessServer(HttpServletStatelessServerTransport transport,
                                                       ToolRegistry toolRegistry,
                                                       MemoryRegistry userMemoryRegistry,
+                                                      ObjectProvider<com.spectrayan.spector.synapse.memory.MemoryRequestBinder> binderProvider,
                                                       SynapseProperties synapseProperties) {
         boolean authEnabled = synapseProperties.auth().enabled();
         List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecs =
-                buildStatelessToolSpecs(toolRegistry, userMemoryRegistry, authEnabled);
+                buildStatelessToolSpecs(toolRegistry, binderProvider, userMemoryRegistry, authEnabled);
 
         return McpServer.sync(transport)
                 .serverInfo(SERVER_NAME, SERVER_VERSION)
@@ -112,6 +113,13 @@ public class McpServerConfig {
                         .build())
                 .tools(toolSpecs)
                 .build();
+    }
+
+    public McpStatelessSyncServer mcpStatelessServer(HttpServletStatelessServerTransport transport,
+                                                      ToolRegistry toolRegistry,
+                                                      MemoryRegistry userMemoryRegistry,
+                                                      SynapseProperties synapseProperties) {
+        return mcpStatelessServer(transport, toolRegistry, userMemoryRegistry, null, synapseProperties);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -142,10 +150,11 @@ public class McpServerConfig {
     public McpSyncServer mcpSseServer(HttpServletSseServerTransportProvider transportProvider,
                                       ToolRegistry toolRegistry,
                                       MemoryRegistry userMemoryRegistry,
+                                      ObjectProvider<com.spectrayan.spector.synapse.memory.MemoryRequestBinder> binderProvider,
                                       SynapseProperties synapseProperties) {
         boolean authEnabled = synapseProperties.auth().enabled();
         List<McpServerFeatures.SyncToolSpecification> toolSpecs =
-                buildSyncToolSpecs(toolRegistry, userMemoryRegistry, authEnabled);
+                buildSyncToolSpecs(toolRegistry, binderProvider, userMemoryRegistry, authEnabled);
 
         return McpServer.sync(transportProvider)
                 .serverInfo(SERVER_NAME, SERVER_VERSION)
@@ -156,6 +165,13 @@ public class McpServerConfig {
                         .build())
                 .tools(toolSpecs)
                 .build();
+    }
+
+    public McpSyncServer mcpSseServer(HttpServletSseServerTransportProvider transportProvider,
+                                      ToolRegistry toolRegistry,
+                                      MemoryRegistry userMemoryRegistry,
+                                      SynapseProperties synapseProperties) {
+        return mcpSseServer(transportProvider, toolRegistry, userMemoryRegistry, null, synapseProperties);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -185,10 +201,11 @@ public class McpServerConfig {
     public McpSyncServer mcpStreamableServer(HttpServletStreamableServerTransportProvider transportProvider,
                                              ToolRegistry toolRegistry,
                                              MemoryRegistry userMemoryRegistry,
+                                             ObjectProvider<com.spectrayan.spector.synapse.memory.MemoryRequestBinder> binderProvider,
                                              SynapseProperties synapseProperties) {
         boolean authEnabled = synapseProperties.auth().enabled();
         List<McpServerFeatures.SyncToolSpecification> toolSpecs =
-                buildSyncToolSpecs(toolRegistry, userMemoryRegistry, authEnabled);
+                buildSyncToolSpecs(toolRegistry, binderProvider, userMemoryRegistry, authEnabled);
 
         return McpServer.sync(transportProvider)
                 .serverInfo(SERVER_NAME, SERVER_VERSION)
@@ -201,12 +218,22 @@ public class McpServerConfig {
                 .build();
     }
 
+    public McpSyncServer mcpStreamableServer(HttpServletStreamableServerTransportProvider transportProvider,
+                                             ToolRegistry toolRegistry,
+                                             MemoryRegistry userMemoryRegistry,
+                                             SynapseProperties synapseProperties) {
+        return mcpStreamableServer(transportProvider, toolRegistry, userMemoryRegistry, null, synapseProperties);
+    }
+
     // ─────────────────────────────────────────────────────────────
     // TOOL SPECIFICATION BUILDERS & MEMORY BINDING
     // ─────────────────────────────────────────────────────────────
 
     private static List<McpStatelessServerFeatures.SyncToolSpecification> buildStatelessToolSpecs(
-            ToolRegistry toolRegistry, MemoryRegistry userMemoryRegistry, boolean authEnabled) {
+            ToolRegistry toolRegistry,
+            ObjectProvider<com.spectrayan.spector.synapse.memory.MemoryRequestBinder> binderProvider,
+            MemoryRegistry userMemoryRegistry,
+            boolean authEnabled) {
         return toolRegistry.all().values().stream()
                 .map(mcpTool -> {
                     var tool = McpSchema.Tool.builder(mcpTool.name())
@@ -217,8 +244,10 @@ public class McpServerConfig {
                     return new McpStatelessServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
                         Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
                         String namespace = args.get("namespace") != null ? String.valueOf(args.get("namespace")) : null;
-                        Optional<McpRequestMemory.DenyReason> deny =
-                                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
+                        var binder = binderProvider != null ? binderProvider.getIfAvailable() : null;
+                        Optional<McpRequestMemory.DenyReason> deny = binder != null
+                                ? McpRequestMemory.bindForCurrentRequest(binder, authEnabled, namespace, null)
+                                : McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
                         if (deny.isPresent()) {
                             return toolError(McpRequestMemory.message(deny.get()));
                         }
@@ -235,7 +264,10 @@ public class McpServerConfig {
     }
 
     private static List<McpServerFeatures.SyncToolSpecification> buildSyncToolSpecs(
-            ToolRegistry toolRegistry, MemoryRegistry userMemoryRegistry, boolean authEnabled) {
+            ToolRegistry toolRegistry,
+            ObjectProvider<com.spectrayan.spector.synapse.memory.MemoryRequestBinder> binderProvider,
+            MemoryRegistry userMemoryRegistry,
+            boolean authEnabled) {
         return toolRegistry.all().values().stream()
                 .map(mcpTool -> {
                     var tool = McpSchema.Tool.builder(mcpTool.name())
@@ -246,8 +278,10 @@ public class McpServerConfig {
                     return new McpServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
                         Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
                         String namespace = args.get("namespace") != null ? String.valueOf(args.get("namespace")) : null;
-                        Optional<McpRequestMemory.DenyReason> deny =
-                                McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
+                        var binder = binderProvider != null ? binderProvider.getIfAvailable() : null;
+                        Optional<McpRequestMemory.DenyReason> deny = binder != null
+                                ? McpRequestMemory.bindForCurrentRequest(binder, authEnabled, namespace, null)
+                                : McpRequestMemory.bindForCurrentRequest(userMemoryRegistry, authEnabled, namespace, null);
                         if (deny.isPresent()) {
                             return toolError(McpRequestMemory.message(deny.get()));
                         }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/cache/SynapseCacheConstants.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/cache/SynapseCacheConstants.java
@@ -114,6 +114,48 @@ public final class SynapseCacheConstants {
     public static final long MAX_SIZE_MEMORY_SCORING_STATS = 100;
 
     /**
+     * Cache for catalog accounts (profiles, quotas, default namespace).
+     */
+    public static final String CACHE_CATALOG_ACCOUNTS = "catalog.accounts";
+    public static final Duration TTL_CATALOG_ACCOUNTS = Duration.ofMinutes(10);
+    public static final long MAX_SIZE_CATALOG_ACCOUNTS = 5_000;
+
+    /**
+     * Cache for catalog namespace records by (accountId, slugOrId).
+     */
+    public static final String CACHE_CATALOG_NAMESPACES = "catalog.namespaces";
+    public static final Duration TTL_CATALOG_NAMESPACES = Duration.ofMinutes(10);
+    public static final long MAX_SIZE_CATALOG_NAMESPACES = 10_000;
+
+    /**
+     * Cache for catalog active grants.
+     */
+    public static final String CACHE_CATALOG_GRANTS = "catalog.grants";
+    public static final Duration TTL_CATALOG_GRANTS = Duration.ofSeconds(30);
+    public static final long MAX_SIZE_CATALOG_GRANTS = 10_000;
+
+    /**
+     * Cache for org unit memberships by account ID.
+     */
+    public static final String CACHE_CATALOG_ORG_MEMBERSHIP = "catalog.org-membership";
+    public static final Duration TTL_CATALOG_ORG_MEMBERSHIP = Duration.ofMinutes(5);
+    public static final long MAX_SIZE_CATALOG_ORG_MEMBERSHIP = 5_000;
+
+    /**
+     * Cache for PEP namespace authorization decisions.
+     */
+    public static final String CACHE_PEP_NAMESPACE = "pep.namespace";
+    public static final Duration TTL_PEP_NAMESPACE = Duration.ofSeconds(15);
+    public static final long MAX_SIZE_PEP_NAMESPACE = 10_000;
+
+    /**
+     * Cache for PEP identity region authorization decisions.
+     */
+    public static final String CACHE_PEP_IDENTITY = "pep.identity";
+    public static final Duration TTL_PEP_IDENTITY = Duration.ofSeconds(15);
+    public static final long MAX_SIZE_PEP_IDENTITY = 10_000;
+
+    /**
      * All managed cache names in Synapse.
      */
     public static final String[] ALL_CACHES = {
@@ -129,6 +171,12 @@ public final class SynapseCacheConstants {
             CACHE_MEMORY_GRAPH_OVERVIEW,
             CACHE_MEMORY_TOPOLOGY_STATS,
             CACHE_MEMORY_STATS,
-            CACHE_MEMORY_SCORING_STATS
+            CACHE_MEMORY_SCORING_STATS,
+            CACHE_CATALOG_ACCOUNTS,
+            CACHE_CATALOG_NAMESPACES,
+            CACHE_CATALOG_GRANTS,
+            CACHE_CATALOG_ORG_MEMBERSHIP,
+            CACHE_PEP_NAMESPACE,
+            CACHE_PEP_IDENTITY
     };
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/cache/SynapseCacheProperties.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/cache/SynapseCacheProperties.java
@@ -55,6 +55,12 @@ public class SynapseCacheProperties {
         specs.put(SynapseCacheConstants.CACHE_MEMORY_TOPOLOGY_STATS, new CacheSpec(Duration.ofSeconds(5), 10));
         specs.put(SynapseCacheConstants.CACHE_MEMORY_STATS, new CacheSpec(Duration.ofSeconds(5), 100));
         specs.put(SynapseCacheConstants.CACHE_MEMORY_SCORING_STATS, new CacheSpec(Duration.ofSeconds(5), 100));
+        specs.put(SynapseCacheConstants.CACHE_CATALOG_ACCOUNTS, new CacheSpec(SynapseCacheConstants.TTL_CATALOG_ACCOUNTS, SynapseCacheConstants.MAX_SIZE_CATALOG_ACCOUNTS));
+        specs.put(SynapseCacheConstants.CACHE_CATALOG_NAMESPACES, new CacheSpec(SynapseCacheConstants.TTL_CATALOG_NAMESPACES, SynapseCacheConstants.MAX_SIZE_CATALOG_NAMESPACES));
+        specs.put(SynapseCacheConstants.CACHE_CATALOG_GRANTS, new CacheSpec(SynapseCacheConstants.TTL_CATALOG_GRANTS, SynapseCacheConstants.MAX_SIZE_CATALOG_GRANTS));
+        specs.put(SynapseCacheConstants.CACHE_CATALOG_ORG_MEMBERSHIP, new CacheSpec(SynapseCacheConstants.TTL_CATALOG_ORG_MEMBERSHIP, SynapseCacheConstants.MAX_SIZE_CATALOG_ORG_MEMBERSHIP));
+        specs.put(SynapseCacheConstants.CACHE_PEP_NAMESPACE, new CacheSpec(SynapseCacheConstants.TTL_PEP_NAMESPACE, SynapseCacheConstants.MAX_SIZE_PEP_NAMESPACE));
+        specs.put(SynapseCacheConstants.CACHE_PEP_IDENTITY, new CacheSpec(SynapseCacheConstants.TTL_PEP_IDENTITY, SynapseCacheConstants.MAX_SIZE_PEP_IDENTITY));
     }
 
     public boolean isEnabled() {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
@@ -97,16 +97,6 @@ public class IdentityCache implements AutoCloseable {
         return pinned != null ? pinned.acquire() : null;
     }
 
-    public IdentityBundle getOrOpenAccount(String accountId) {
-        IdentityHandle handle = openAccount(accountId);
-        return handle != null ? handle.bundle() : null;
-    }
-
-    public IdentityBundle getOrOpenTenant(String tenantId) {
-        IdentityHandle handle = openTenant(tenantId);
-        return handle != null ? handle.bundle() : null;
-    }
-
     public void invalidateAccount(String accountId) {
         accountBundles.invalidate(accountId);
     }
@@ -179,10 +169,6 @@ public class IdentityCache implements AutoCloseable {
 
         public IdentityHandle(PinnedBundle pinned) {
             this.pinned = pinned;
-        }
-
-        public static IdentityHandle of(IdentityBundle bundle) {
-            return bundle != null ? new IdentityHandle(new PinnedBundle(bundle)) : null;
         }
 
         public IdentityBundle bundle() {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.synapse.identity;
 
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -30,9 +31,10 @@ import com.spectrayan.spector.synapse.config.SynapseProperties;
 /**
  * Process pin table for open {@link IdentityBundle} instances (ADR-0029 §23.7, §25).
  *
- * <p>Pins up to 256 accounts and 32 tenants using a Caffeine-backed LRU with a removal listener
- * that safely closes bundles on eviction. Identity bundles map only 1 FD each and
- * <strong>do not</strong> count against the data-plane {@code maxHotNamespaces} quota.</p>
+ * <p>Pins up to 256 accounts and 32 tenants using a Caffeine-backed LRU with reference-counted
+ * pin handles so active readers/writers never encounter an unmapped memory segment on eviction.
+ * Identity bundles map only 1 FD each and <strong>do not</strong> count against the data-plane
+ * {@code maxHotNamespaces} quota.</p>
  */
 @Component
 public class IdentityCache implements AutoCloseable {
@@ -43,8 +45,8 @@ public class IdentityCache implements AutoCloseable {
     public static final int MAX_HOT_TENANTS = 32;
 
     private final Path dataDir;
-    private final Cache<String, IdentityBundle> accountBundles;
-    private final Cache<String, IdentityBundle> tenantBundles;
+    private final Cache<String, PinnedBundle> accountBundles;
+    private final Cache<String, PinnedBundle> tenantBundles;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     @Autowired
@@ -56,47 +58,53 @@ public class IdentityCache implements AutoCloseable {
         this.dataDir = dataDir;
         this.accountBundles = Caffeine.newBuilder()
                 .maximumSize(MAX_HOT_ACCOUNTS)
-                .removalListener((String key, IdentityBundle bundle, RemovalCause cause) -> {
-                    if (bundle != null) {
-                        try {
-                            bundle.close();
-                        } catch (Exception e) {
-                            log.warn("[IdentityCache] Error closing account bundle on eviction (id withheld): {}", e.getMessage());
-                        }
+                .removalListener((String key, PinnedBundle pinned, RemovalCause cause) -> {
+                    if (pinned != null) {
+                        pinned.markEvicted();
                     }
                 })
                 .build();
 
         this.tenantBundles = Caffeine.newBuilder()
                 .maximumSize(MAX_HOT_TENANTS)
-                .removalListener((String key, IdentityBundle bundle, RemovalCause cause) -> {
-                    if (bundle != null) {
-                        try {
-                            bundle.close();
-                        } catch (Exception e) {
-                            log.warn("[IdentityCache] Error closing tenant bundle on eviction (id withheld): {}", e.getMessage());
-                        }
+                .removalListener((String key, PinnedBundle pinned, RemovalCause cause) -> {
+                    if (pinned != null) {
+                        pinned.markEvicted();
                     }
                 })
                 .build();
     }
 
-    public IdentityBundle getOrOpenAccount(String accountId) {
+    public IdentityHandle openAccount(String accountId) {
         ensureOpen();
-        return accountBundles.get(accountId, id -> {
+        PinnedBundle pinned = accountBundles.get(accountId, id -> {
             Path path = IdentityPaths.accountIdentityBundle(dataDir, id);
             log.debug("[IdentityCache] Opening account identity bundle at {}", path);
-            return IdentityBundle.open(path, true);
+            IdentityBundle bundle = IdentityBundle.open(path, true);
+            return new PinnedBundle(bundle);
         });
+        return pinned != null ? pinned.acquire() : null;
+    }
+
+    public IdentityHandle openTenant(String tenantId) {
+        ensureOpen();
+        PinnedBundle pinned = tenantBundles.get(tenantId, id -> {
+            Path path = IdentityPaths.tenantIdentityBundle(dataDir, id);
+            log.debug("[IdentityCache] Opening tenant identity bundle at {}", path);
+            IdentityBundle bundle = IdentityBundle.open(path, true);
+            return new PinnedBundle(bundle);
+        });
+        return pinned != null ? pinned.acquire() : null;
+    }
+
+    public IdentityBundle getOrOpenAccount(String accountId) {
+        IdentityHandle handle = openAccount(accountId);
+        return handle != null ? handle.bundle() : null;
     }
 
     public IdentityBundle getOrOpenTenant(String tenantId) {
-        ensureOpen();
-        return tenantBundles.get(tenantId, id -> {
-            Path path = IdentityPaths.tenantIdentityBundle(dataDir, id);
-            log.debug("[IdentityCache] Opening tenant identity bundle at {}", path);
-            return IdentityBundle.open(path, true);
-        });
+        IdentityHandle handle = openTenant(tenantId);
+        return handle != null ? handle.bundle() : null;
     }
 
     public void invalidateAccount(String accountId) {
@@ -124,4 +132,69 @@ public class IdentityCache implements AutoCloseable {
             tenantBundles.cleanUp();
         }
     }
+
+    public static final class PinnedBundle {
+        private final IdentityBundle bundle;
+        private final AtomicInteger pinCount = new AtomicInteger(0);
+        private final AtomicBoolean evicted = new AtomicBoolean(false);
+
+        public PinnedBundle(IdentityBundle bundle) {
+            this.bundle = bundle;
+        }
+
+        public IdentityBundle bundle() {
+            return bundle;
+        }
+
+        public IdentityHandle acquire() {
+            pinCount.incrementAndGet();
+            return new IdentityHandle(this);
+        }
+
+        void release() {
+            if (pinCount.decrementAndGet() == 0 && evicted.get()) {
+                closeBundle();
+            }
+        }
+
+        void markEvicted() {
+            evicted.set(true);
+            if (pinCount.get() == 0) {
+                closeBundle();
+            }
+        }
+
+        private void closeBundle() {
+            try {
+                bundle.close();
+            } catch (Exception e) {
+                log.warn("[IdentityCache] Error closing bundle on eviction: {}", e.getMessage());
+            }
+        }
+    }
+
+    public static final class IdentityHandle implements AutoCloseable {
+        private final PinnedBundle pinned;
+        private final AtomicBoolean closedHandle = new AtomicBoolean(false);
+
+        public IdentityHandle(PinnedBundle pinned) {
+            this.pinned = pinned;
+        }
+
+        public static IdentityHandle of(IdentityBundle bundle) {
+            return bundle != null ? new IdentityHandle(new PinnedBundle(bundle)) : null;
+        }
+
+        public IdentityBundle bundle() {
+            return pinned.bundle();
+        }
+
+        @Override
+        public void close() {
+            if (closedHandle.compareAndSet(false, true)) {
+                pinned.release();
+            }
+        }
+    }
 }
+

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityCache.java
@@ -13,21 +13,25 @@
 package com.spectrayan.spector.synapse.identity;
 
 import java.nio.file.Path;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.spectrayan.spector.memory.identity.IdentityBundle;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
 
 /**
- * Process cache for open {@link IdentityBundle} instances (ADR-0029 §23.7, §25).
+ * Process pin table for open {@link IdentityBundle} instances (ADR-0029 §23.7, §25).
  *
- * <p>Caches up to 256 accounts and 32 tenants. Identity bundles map only 1 FD each and
+ * <p>Pins up to 256 accounts and 32 tenants using a Caffeine-backed LRU with a removal listener
+ * that safely closes bundles on eviction. Identity bundles map only 1 FD each and
  * <strong>do not</strong> count against the data-plane {@code maxHotNamespaces} quota.</p>
  */
 @Component
@@ -39,31 +43,47 @@ public class IdentityCache implements AutoCloseable {
     public static final int MAX_HOT_TENANTS = 32;
 
     private final Path dataDir;
-    private final ConcurrentHashMap<String, IdentityBundle> accountBundles = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, IdentityBundle> tenantBundles = new ConcurrentHashMap<>();
+    private final Cache<String, IdentityBundle> accountBundles;
+    private final Cache<String, IdentityBundle> tenantBundles;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    @org.springframework.beans.factory.annotation.Autowired
+    @Autowired
     public IdentityCache(SynapseProperties properties) {
-        this.dataDir = properties.dataDir() != null ? Path.of(properties.dataDir()) : Path.of("./spector-data");
+        this(properties.dataDir() != null ? Path.of(properties.dataDir()) : Path.of("./spector-data"));
     }
 
     public IdentityCache(Path dataDir) {
         this.dataDir = dataDir;
-    }
+        this.accountBundles = Caffeine.newBuilder()
+                .maximumSize(MAX_HOT_ACCOUNTS)
+                .removalListener((String key, IdentityBundle bundle, RemovalCause cause) -> {
+                    if (bundle != null) {
+                        try {
+                            bundle.close();
+                        } catch (Exception e) {
+                            log.warn("[IdentityCache] Error closing account bundle on eviction (id withheld): {}", e.getMessage());
+                        }
+                    }
+                })
+                .build();
 
-    private final Object evictionLock = new Object();
-    private final java.util.concurrent.ConcurrentLinkedDeque<String> accountLru = new java.util.concurrent.ConcurrentLinkedDeque<>();
-    private final java.util.concurrent.ConcurrentLinkedDeque<String> tenantLru = new java.util.concurrent.ConcurrentLinkedDeque<>();
+        this.tenantBundles = Caffeine.newBuilder()
+                .maximumSize(MAX_HOT_TENANTS)
+                .removalListener((String key, IdentityBundle bundle, RemovalCause cause) -> {
+                    if (bundle != null) {
+                        try {
+                            bundle.close();
+                        } catch (Exception e) {
+                            log.warn("[IdentityCache] Error closing tenant bundle on eviction (id withheld): {}", e.getMessage());
+                        }
+                    }
+                })
+                .build();
+    }
 
     public IdentityBundle getOrOpenAccount(String accountId) {
         ensureOpen();
-        if (accountBundles.size() >= MAX_HOT_ACCOUNTS && !accountBundles.containsKey(accountId)) {
-            evictOldestAccount();
-        }
-        accountLru.remove(accountId);
-        accountLru.addLast(accountId);
-        return accountBundles.computeIfAbsent(accountId, id -> {
+        return accountBundles.get(accountId, id -> {
             Path path = IdentityPaths.accountIdentityBundle(dataDir, id);
             log.debug("[IdentityCache] Opening account identity bundle at {}", path);
             return IdentityBundle.open(path, true);
@@ -72,12 +92,7 @@ public class IdentityCache implements AutoCloseable {
 
     public IdentityBundle getOrOpenTenant(String tenantId) {
         ensureOpen();
-        if (tenantBundles.size() >= MAX_HOT_TENANTS && !tenantBundles.containsKey(tenantId)) {
-            evictOldestTenant();
-        }
-        tenantLru.remove(tenantId);
-        tenantLru.addLast(tenantId);
-        return tenantBundles.computeIfAbsent(tenantId, id -> {
+        return tenantBundles.get(tenantId, id -> {
             Path path = IdentityPaths.tenantIdentityBundle(dataDir, id);
             log.debug("[IdentityCache] Opening tenant identity bundle at {}", path);
             return IdentityBundle.open(path, true);
@@ -85,43 +100,11 @@ public class IdentityCache implements AutoCloseable {
     }
 
     public void invalidateAccount(String accountId) {
-        accountLru.remove(accountId);
-        IdentityBundle bundle = accountBundles.remove(accountId);
-        if (bundle != null) {
-            try {
-                bundle.close();
-            } catch (Exception e) {
-                log.warn("[IdentityCache] Failed to close invalidated bundle for account {}: {}", accountId, e.getMessage());
-            }
-        }
+        accountBundles.invalidate(accountId);
     }
 
-    private void evictOldestAccount() {
-        synchronized (evictionLock) {
-            while (accountBundles.size() >= MAX_HOT_ACCOUNTS) {
-                String oldest = accountLru.pollFirst();
-                if (oldest == null) break;
-                invalidateAccount(oldest);
-            }
-        }
-    }
-
-    private void evictOldestTenant() {
-        synchronized (evictionLock) {
-            while (tenantBundles.size() >= MAX_HOT_TENANTS) {
-                String oldest = tenantLru.pollFirst();
-                if (oldest == null) break;
-                tenantLru.remove(oldest);
-                IdentityBundle bundle = tenantBundles.remove(oldest);
-                if (bundle != null) {
-                    try {
-                        bundle.close();
-                    } catch (Exception e) {
-                        log.warn("[IdentityCache] Failed to close evicted tenant bundle {}: {}", oldest, e.getMessage());
-                    }
-                }
-            }
-        }
+    public void invalidateTenant(String tenantId) {
+        tenantBundles.invalidate(tenantId);
     }
 
     private void ensureOpen() {
@@ -135,18 +118,10 @@ public class IdentityCache implements AutoCloseable {
     public void close() {
         if (closed.compareAndSet(false, true)) {
             log.info("[IdentityCache] Closing all cached identity bundles");
-            accountBundles.forEach((id, bundle) -> {
-                try { bundle.close(); } catch (Exception e) {
-                    log.warn("[IdentityCache] Error closing account bundle for {}: {}", id, e.getMessage());
-                }
-            });
-            accountBundles.clear();
-            tenantBundles.forEach((id, bundle) -> {
-                try { bundle.close(); } catch (Exception e) {
-                    log.warn("[IdentityCache] Error closing tenant bundle for {}: {}", id, e.getMessage());
-                }
-            });
-            tenantBundles.clear();
+            accountBundles.invalidateAll();
+            accountBundles.cleanUp();
+            tenantBundles.invalidateAll();
+            tenantBundles.cleanUp();
         }
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
@@ -49,6 +49,20 @@ public class IdentityPlane {
         this.catalog = catalog;
     }
 
+    private IdentityCache.IdentityHandle openAccountHandle(String accountId) {
+        IdentityCache.IdentityHandle handle = identityCache.openAccount(accountId);
+        if (handle != null) return handle;
+        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
+        return bundle != null ? IdentityCache.IdentityHandle.of(bundle) : null;
+    }
+
+    private IdentityCache.IdentityHandle openTenantHandle(String tenantId) {
+        IdentityCache.IdentityHandle handle = identityCache.openTenant(tenantId);
+        if (handle != null) return handle;
+        IdentityBundle bundle = identityCache.getOrOpenTenant(tenantId);
+        return bundle != null ? IdentityCache.IdentityHandle.of(bundle) : null;
+    }
+
     /**
      * Reads the primary soul for the given account with PEP authorization check (ADR-0029 §24).
      *
@@ -64,8 +78,9 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity read denied on SOUL region");
             return Optional.empty();
         }
-        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
-        return bundle.readSoul();
+        try (var handle = openAccountHandle(accountId)) {
+            return handle != null ? handle.bundle().readSoul() : Optional.empty();
+        }
     }
 
     /**
@@ -82,8 +97,9 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity read denied on SALIENCE region");
             return Optional.empty();
         }
-        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
-        return bundle.readSalience();
+        try (var handle = openAccountHandle(accountId)) {
+            return handle != null ? handle.bundle().readSalience() : Optional.empty();
+        }
     }
 
     /**
@@ -99,17 +115,21 @@ public class IdentityPlane {
 
         if (tenantId != null && !tenantId.isBlank()) {
             if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.SOUL.name(), GrantAction.INJECT)) {
-                IdentityBundle tenantBundle = identityCache.getOrOpenTenant(tenantId);
-                tenantBundle.readSoul().ifPresent(stack::add);
+                try (var handle = openTenantHandle(tenantId)) {
+                    if (handle != null) {
+                        IdentityBundle tenantBundle = handle.bundle();
+                        tenantBundle.readSoul().ifPresent(stack::add);
 
-                // Process org unit souls from tenant ORG_DIR region (ADR-0029 §2.5.2)
-                if (orgUnitIds != null && !orgUnitIds.isEmpty()) {
-                    for (String orgUnitId : orgUnitIds) {
-                        if (orgUnitId == null || orgUnitId.isBlank()) {
-                            continue;
-                        }
-                        if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.ORG_DIR.name(), GrantAction.INJECT)) {
-                            tenantBundle.readOrgUnitSoul(orgUnitId).ifPresent(stack::add);
+                        // Process org unit souls from tenant ORG_DIR region (ADR-0029 §2.5.2)
+                        if (orgUnitIds != null && !orgUnitIds.isEmpty()) {
+                            for (String orgUnitId : orgUnitIds) {
+                                if (orgUnitId == null || orgUnitId.isBlank()) {
+                                    continue;
+                                }
+                                if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.ORG_DIR.name(), GrantAction.INJECT)) {
+                                    tenantBundle.readOrgUnitSoul(orgUnitId).ifPresent(stack::add);
+                                }
+                            }
                         }
                     }
                 }
@@ -139,9 +159,12 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity write denied on SOUL region");
             return;
         }
-        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
-        bundle.writeSoul(soul);
-        log.debug("[IdentityPlane] Updated primary soul");
+        try (var handle = openAccountHandle(accountId)) {
+            if (handle != null) {
+                handle.bundle().writeSoul(soul);
+                log.debug("[IdentityPlane] Updated primary soul");
+            }
+        }
     }
 
     /**
@@ -158,9 +181,12 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity write denied on SALIENCE region");
             return;
         }
-        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
-        bundle.writeSalience(salience);
-        log.debug("[IdentityPlane] Updated salience profile");
+        try (var handle = openAccountHandle(accountId)) {
+            if (handle != null) {
+                handle.bundle().writeSalience(salience);
+                log.debug("[IdentityPlane] Updated salience profile");
+            }
+        }
     }
 
     /**
@@ -177,9 +203,12 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity write denied on tenant SOUL region");
             return;
         }
-        IdentityBundle bundle = identityCache.getOrOpenTenant(tenantId);
-        bundle.writeSoul(soul);
-        log.debug("[IdentityPlane] Updated primary soul for tenant");
+        try (var handle = openTenantHandle(tenantId)) {
+            if (handle != null) {
+                handle.bundle().writeSoul(soul);
+                log.debug("[IdentityPlane] Updated primary soul for tenant");
+            }
+        }
     }
 
     /**
@@ -194,25 +223,36 @@ public class IdentityPlane {
         }
 
         try {
-            IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
-            if (!bundle.isEmpty(IdentityRegionId.SOUL)) {
-                return; // Already migrated or has soul
-            }
-
-            Optional<byte[]> insulaBytes = defaultMemory.admin().insularCortex().get();
-            if (insulaBytes.isEmpty()) {
+            // WRITE PEP check before executing migration write
+            if (!catalog.authorizeIdentity(accountId, accountId, IdentityRegionId.SOUL.name(), GrantAction.WRITE)) {
+                log.debug("[IdentityPlane] Skipping Region 24 migration: WRITE permission denied on SOUL region");
                 return;
             }
 
-            InsulaSelfModel model = mapper.readValue(insulaBytes.get(), InsulaSelfModel.class);
-            if (model != null) {
-                if (model.soul() != null) {
-                    bundle.writeSoul(model.soul());
-                    log.info("[IdentityPlane] Migrated Region 24 soul to identity.bundle for account {}", accountId);
+            try (var handle = openAccountHandle(accountId)) {
+                if (handle == null) {
+                    return;
                 }
-                if (model.salience() != null) {
-                    bundle.writeSalience(model.salience());
-                    log.info("[IdentityPlane] Migrated Region 24 salience to identity.bundle for account {}", accountId);
+                IdentityBundle bundle = handle.bundle();
+                if (!bundle.isEmpty(IdentityRegionId.SOUL)) {
+                    return; // Already migrated or has soul
+                }
+
+                Optional<byte[]> insulaBytes = defaultMemory.admin().insularCortex().get();
+                if (insulaBytes.isEmpty()) {
+                    return;
+                }
+
+                InsulaSelfModel model = mapper.readValue(insulaBytes.get(), InsulaSelfModel.class);
+                if (model != null) {
+                    if (model.soul() != null) {
+                        bundle.writeSoul(model.soul());
+                        log.info("[IdentityPlane] Migrated Region 24 soul to identity.bundle for account {}", accountId);
+                    }
+                    if (model.salience() != null && catalog.authorizeIdentity(accountId, accountId, IdentityRegionId.SALIENCE.name(), GrantAction.WRITE)) {
+                        bundle.writeSalience(model.salience());
+                        log.info("[IdentityPlane] Migrated Region 24 salience to identity.bundle for account {}", accountId);
+                    }
                 }
             }
         } catch (Exception e) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
@@ -98,7 +98,7 @@ public class IdentityPlane {
         List<SoulContext> stack = new ArrayList<>();
 
         if (tenantId != null && !tenantId.isBlank()) {
-            if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.SOUL.name(), GrantAction.READ)) {
+            if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.SOUL.name(), GrantAction.INJECT)) {
                 IdentityBundle tenantBundle = identityCache.getOrOpenTenant(tenantId);
                 tenantBundle.readSoul().ifPresent(stack::add);
 
@@ -108,11 +108,13 @@ public class IdentityPlane {
                         if (orgUnitId == null || orgUnitId.isBlank()) {
                             continue;
                         }
-                        tenantBundle.readOrgUnitSoul(orgUnitId).ifPresent(stack::add);
+                        if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.ORG_DIR.name(), GrantAction.INJECT)) {
+                            tenantBundle.readOrgUnitSoul(orgUnitId).ifPresent(stack::add);
+                        }
                     }
                 }
             } else {
-                log.warn("[IdentityPlane] Access denied on tenant SOUL region");
+                log.warn("[IdentityPlane] Access denied on tenant SOUL region for injection");
             }
         }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/identity/IdentityPlane.java
@@ -49,20 +49,6 @@ public class IdentityPlane {
         this.catalog = catalog;
     }
 
-    private IdentityCache.IdentityHandle openAccountHandle(String accountId) {
-        IdentityCache.IdentityHandle handle = identityCache.openAccount(accountId);
-        if (handle != null) return handle;
-        IdentityBundle bundle = identityCache.getOrOpenAccount(accountId);
-        return bundle != null ? IdentityCache.IdentityHandle.of(bundle) : null;
-    }
-
-    private IdentityCache.IdentityHandle openTenantHandle(String tenantId) {
-        IdentityCache.IdentityHandle handle = identityCache.openTenant(tenantId);
-        if (handle != null) return handle;
-        IdentityBundle bundle = identityCache.getOrOpenTenant(tenantId);
-        return bundle != null ? IdentityCache.IdentityHandle.of(bundle) : null;
-    }
-
     /**
      * Reads the primary soul for the given account with PEP authorization check (ADR-0029 §24).
      *
@@ -78,7 +64,7 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity read denied on SOUL region");
             return Optional.empty();
         }
-        try (var handle = openAccountHandle(accountId)) {
+        try (var handle = identityCache.openAccount(accountId)) {
             return handle != null ? handle.bundle().readSoul() : Optional.empty();
         }
     }
@@ -97,7 +83,7 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity read denied on SALIENCE region");
             return Optional.empty();
         }
-        try (var handle = openAccountHandle(accountId)) {
+        try (var handle = identityCache.openAccount(accountId)) {
             return handle != null ? handle.bundle().readSalience() : Optional.empty();
         }
     }
@@ -115,7 +101,7 @@ public class IdentityPlane {
 
         if (tenantId != null && !tenantId.isBlank()) {
             if (catalog.authorizeIdentity(accountId, tenantId, IdentityRegionId.SOUL.name(), GrantAction.INJECT)) {
-                try (var handle = openTenantHandle(tenantId)) {
+                try (var handle = identityCache.openTenant(tenantId)) {
                     if (handle != null) {
                         IdentityBundle tenantBundle = handle.bundle();
                         tenantBundle.readSoul().ifPresent(stack::add);
@@ -159,7 +145,7 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity write denied on SOUL region");
             return;
         }
-        try (var handle = openAccountHandle(accountId)) {
+        try (var handle = identityCache.openAccount(accountId)) {
             if (handle != null) {
                 handle.bundle().writeSoul(soul);
                 log.debug("[IdentityPlane] Updated primary soul");
@@ -181,7 +167,7 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity write denied on SALIENCE region");
             return;
         }
-        try (var handle = openAccountHandle(accountId)) {
+        try (var handle = identityCache.openAccount(accountId)) {
             if (handle != null) {
                 handle.bundle().writeSalience(salience);
                 log.debug("[IdentityPlane] Updated salience profile");
@@ -203,7 +189,7 @@ public class IdentityPlane {
             log.warn("[IdentityPlane] Identity write denied on tenant SOUL region");
             return;
         }
-        try (var handle = openTenantHandle(tenantId)) {
+        try (var handle = identityCache.openTenant(tenantId)) {
             if (handle != null) {
                 handle.bundle().writeSoul(soul);
                 log.debug("[IdentityPlane] Updated primary soul for tenant");
@@ -229,7 +215,7 @@ public class IdentityPlane {
                 return;
             }
 
-            try (var handle = openAccountHandle(accountId)) {
+            try (var handle = identityCache.openAccount(accountId)) {
                 if (handle == null) {
                     return;
                 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
@@ -16,47 +16,34 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceAccessDeniedException;
 import com.spectrayan.spector.synapse.catalog.exception.TokenNamespaceLockedException;
+import com.spectrayan.spector.synapse.memory.MemoryBinding;
 import com.spectrayan.spector.synapse.memory.MemoryRegistry;
+import com.spectrayan.spector.synapse.memory.MemoryRequestBinder;
 import com.spectrayan.spector.synapse.security.SecurityUtils;
 
 /**
  * Request-thread holder that routes an MCP tool invocation to the caller's per-user
- * {@link SpectorMemory} namespace.
+ * {@link MemoryBinding} and {@link SpectorMemory} namespace (ADR-0029 §16, §24).
  *
  * <p>MCP tools are executed synchronously on the servlet request thread
  * ({@code transport → SyncToolSpecification lambda → mcpTool.execute(args)}) and resolve
- * their {@link SpectorMemory} independently. This holder lets the invocation site bind the memory
- * resolved for the authenticated caller — via {@link MemoryRegistry#resolveForCurrentRequest()}
- * on that same thread — so a memory-aware tool operates exclusively on that user's namespace,
- * regardless of any client-supplied {@code namespace}/{@code workspace_id}/{@code agent_id} hints
- * (those never widen scope to another user; the effective root is always the caller's namespace).</p>
- *
- * <h3>Resolution and deny semantics</h3>
- * <ul>
- *   <li>When {@code spector.auth.enabled=false} or the principal is anonymous, the registry returns
- *       the single shared instance — byte-for-byte the legacy single-user behavior (also the stdio
- *       path, which never binds through this holder).</li>
- *   <li>When auth is enabled and no resolvable authenticated context is present, the call is
- *       denied with {@link DenyReason#AUTH_REQUIRED} and nothing is bound.</li>
- *   <li>When per-user memory resolution fails, the call is denied with
- *       {@link DenyReason#RESOLUTION_FAILED}, nothing is bound, and no memory is modified — the
- *       registry never falls back to the shared or another user's instance.</li>
- *   <li>When a token is locked to specific namespaces and an unauthorized namespace is requested,
- *       the call is denied with {@link DenyReason#TOKEN_LOCKED}.</li>
- * </ul>
- *
- * <p>The bound reference is confined to the current thread. Callers <strong>must</strong>
- * {@link #clear()} in a {@code finally} block after the tool completes so the thread-local never
- * leaks across pooled request threads.</p>
+ * their {@link MemoryBinding} via {@link MemoryRequestBinder}. This holder lets the invocation site
+ * bind the memory, lease, and identity context resolved for the authenticated caller on that same
+ * thread — so a memory-aware tool operates exclusively on that user's authorized namespace,
+ * with full soul stack, bias overlay, and org intersection.</p>
  */
 public final class McpRequestMemory {
 
     private static final Logger log = LoggerFactory.getLogger(McpRequestMemory.class);
 
-    private static final ThreadLocal<SpectorMemory> CURRENT = new ThreadLocal<>();
+    private static final ThreadLocal<MemoryBinding> CURRENT_BINDING = new ThreadLocal<>();
+    private static final ThreadLocal<MemoryRequestBinder> CURRENT_BINDER = new ThreadLocal<>();
 
     private McpRequestMemory() {
     }
@@ -65,6 +52,8 @@ public final class McpRequestMemory {
     public enum DenyReason {
         /** Auth is enabled but the request carries no resolvable authenticated security context. */
         AUTH_REQUIRED,
+        /** Caller does not have sufficient grant permissions to access the requested namespace. */
+        ACCESS_DENIED,
         /** Per-user memory resolution or lazy construction failed; the call fails closed. */
         RESOLUTION_FAILED,
         /** Wildcard '*' was supplied as a namespace selector (ADR-0029 Invariant 7). */
@@ -75,29 +64,17 @@ public final class McpRequestMemory {
 
     /**
      * Resolves the caller's memory on the current (request/servlet) thread and binds it for the
-     * duration of the invocation. Reads {@link SecurityContextHolder} via {@link SecurityUtils} and
-     * {@link MemoryRegistry}; never call this from an asynchronous task.
-     *
-     * @param registry    the per-user memory registry
-     * @param authEnabled whether {@code spector.auth.enabled} is {@code true}
-     * @return {@link Optional#empty()} when a memory instance was resolved and bound; otherwise the
-     *         {@link DenyReason} describing why the call must be denied (nothing is bound)
+     * duration of the invocation using {@link MemoryRequestBinder}.
      */
-    public static Optional<DenyReason> bindForCurrentRequest(MemoryRegistry registry, boolean authEnabled) {
-        return bindForCurrentRequest(registry, authEnabled, null, null);
+    public static Optional<DenyReason> bindForCurrentRequest(MemoryRequestBinder binder, boolean authEnabled) {
+        return bindForCurrentRequest(binder, authEnabled, null, null);
     }
 
     /**
-     * Resolves the caller's memory with an optional explicit namespace selector or connection ID.
-     *
-     * @param registry          the per-user memory registry
-     * @param authEnabled       whether {@code spector.auth.enabled} is {@code true}
-     * @param namespaceSelector optional explicit namespace slug or ID (from tool argument)
-     * @param connectionId      optional MCP connection or session identifier
-     * @return {@link Optional#empty()} when bound; otherwise {@link DenyReason}
+     * Resolves the caller's memory using {@link MemoryRequestBinder}.
      */
     public static Optional<DenyReason> bindForCurrentRequest(
-            MemoryRegistry registry,
+            MemoryRequestBinder binder,
             boolean authEnabled,
             String namespaceSelector,
             String connectionId) {
@@ -110,12 +87,72 @@ public final class McpRequestMemory {
         }
 
         try {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            String selector = (namespaceSelector != null && !namespaceSelector.isBlank())
+                    ? namespaceSelector.trim()
+                    : McpSessionContext.getSessionDefault(connectionId).orElse(null);
+
+            MemoryBinding binding;
+            if (binder != null) {
+                binding = binder.bind(auth, Optional.ofNullable(selector), connectionId);
+                CURRENT_BINDER.set(binder);
+            } else {
+                return Optional.of(DenyReason.RESOLUTION_FAILED);
+            }
+
+            CURRENT_BINDING.set(binding);
+            return Optional.empty();
+        } catch (NamespaceAccessDeniedException e) {
+            clear();
+            log.warn("[McpRequestMemory] access denied: {}", e.getMessage());
+            return Optional.of(DenyReason.ACCESS_DENIED);
+        } catch (TokenNamespaceLockedException e) {
+            clear();
+            log.warn("[McpRequestMemory] token namespace locked: {}", e.getMessage());
+            return Optional.of(DenyReason.TOKEN_LOCKED);
+        } catch (com.spectrayan.spector.commons.error.SpectorValidationException e) {
+            clear();
+            log.warn("[McpRequestMemory] validation error: {}", e.getMessage());
+            return Optional.of(DenyReason.WILDCARD_REJECTED);
+        } catch (RuntimeException e) {
+            clear();
+            log.warn("[McpRequestMemory] memory resolution failed; denying MCP call: {}", e.getMessage());
+            log.debug("[McpRequestMemory] resolution failure detail", e);
+            return Optional.of(DenyReason.RESOLUTION_FAILED);
+        }
+    }
+
+    /**
+     * Adapter method for callers that provide {@link MemoryRegistry}.
+     */
+    public static Optional<DenyReason> bindForCurrentRequest(MemoryRegistry registry, boolean authEnabled) {
+        return bindForCurrentRequest(registry, authEnabled, null, null);
+    }
+
+    /**
+     * Adapter method for callers that provide {@link MemoryRegistry}.
+     */
+    public static Optional<DenyReason> bindForCurrentRequest(
+            MemoryRegistry registry,
+            boolean authEnabled,
+            String namespaceSelector,
+            String connectionId) {
+        if (registry != null && registry.binder() != null) {
+            return bindForCurrentRequest(registry.binder(), authEnabled, namespaceSelector, connectionId);
+        }
+        if (authEnabled && !SecurityUtils.isAuthenticated()) {
+            return Optional.of(DenyReason.AUTH_REQUIRED);
+        }
+        if (namespaceSelector != null && "*".equals(namespaceSelector.trim())) {
+            return Optional.of(DenyReason.WILDCARD_REJECTED);
+        }
+        try {
             String userId = SecurityUtils.getUserId();
             String selector = (namespaceSelector != null && !namespaceSelector.isBlank())
                     ? namespaceSelector.trim()
                     : McpSessionContext.getSessionDefault(connectionId).orElse(null);
 
-            var catalog = registry.catalog();
+            var catalog = registry != null ? registry.catalog() : null;
             String targetNamespaceId = userId;
             if (selector != null && !selector.isBlank()) {
                 if (catalog != null && userId != null) {
@@ -127,12 +164,11 @@ public final class McpRequestMemory {
                 }
             }
 
-            // Fail-closed authorization on MCP path (ADR-0029 §24) — mirrors MemoryRequestBinder
             if (authEnabled && userId != null && catalog != null) {
                 var authGrant = catalog.authorize(userId, targetNamespaceId, com.spectrayan.spector.synapse.catalog.GrantRole.READER);
                 if (authGrant.isEmpty()) {
                     log.warn("[McpRequestMemory] Access denied: account={} has no grant on namespace={}", userId, targetNamespaceId);
-                    return Optional.of(DenyReason.RESOLUTION_FAILED);
+                    return Optional.of(DenyReason.ACCESS_DENIED);
                 }
             }
 
@@ -140,39 +176,58 @@ public final class McpRequestMemory {
                     ? registry.namespaceResolver().resolve(userId, targetNamespaceId)
                     : registry.resolveForCurrentRequest();
 
-            CURRENT.set(memory);
+            AutoCloseable lease = memory != null ? memory.acquireLease() : null;
+            MemoryBinding binding = new MemoryBinding(memory, userId, targetNamespaceId, selector != null ? selector : "default", lease, null);
+            CURRENT_BINDING.set(binding);
             return Optional.empty();
-        } catch (com.spectrayan.spector.synapse.catalog.exception.NamespaceAccessDeniedException e) {
+        } catch (NamespaceAccessDeniedException e) {
             clear();
             log.warn("[McpRequestMemory] access denied: {}", e.getMessage());
-            return Optional.of(DenyReason.RESOLUTION_FAILED);
+            return Optional.of(DenyReason.ACCESS_DENIED);
         } catch (TokenNamespaceLockedException e) {
             clear();
             log.warn("[McpRequestMemory] token namespace locked: {}", e.getMessage());
             return Optional.of(DenyReason.TOKEN_LOCKED);
         } catch (RuntimeException e) {
             clear();
-            // Never echo the resolved namespace/identifier; message stays generic.
             log.warn("[McpRequestMemory] memory resolution failed; denying MCP call: {}", e.getMessage());
-            log.debug("[McpRequestMemory] resolution failure detail (id withheld)", e);
             return Optional.of(DenyReason.RESOLUTION_FAILED);
         }
     }
 
     /**
-     * The memory bound for the current request thread, or {@code null} when none is bound (e.g. the
-     * stdio transport or any non-servlet caller). Memory-aware tools consult this first and fall
-     * back to their own shared provider when it is {@code null}.
+     * The memory bound for the current request thread, or {@code null} when none is bound.
      *
      * @return the request-scoped {@link SpectorMemory}, or {@code null}
      */
     public static SpectorMemory current() {
-        return CURRENT.get();
+        MemoryBinding binding = CURRENT_BINDING.get();
+        return binding != null ? binding.memory() : null;
     }
 
-    /** Removes any memory bound to the current thread. Must be invoked in a {@code finally} block. */
+    /**
+     * The full memory binding for the current request thread, or {@code null} when none is bound.
+     */
+    public static MemoryBinding currentBinding() {
+        return CURRENT_BINDING.get();
+    }
+
+    /** Removes any memory bound to the current thread and closes its lease. */
     public static void clear() {
-        CURRENT.remove();
+        MemoryBinding binding = CURRENT_BINDING.get();
+        MemoryRequestBinder binder = CURRENT_BINDER.get();
+        if (binding != null) {
+            if (binder != null) {
+                binder.unbind(binding);
+            } else if (binding.lease() != null) {
+                try {
+                    binding.lease().close();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        CURRENT_BINDING.remove();
+        CURRENT_BINDER.remove();
         McpSessionContext.clearFallback();
     }
 
@@ -186,6 +241,8 @@ public final class McpRequestMemory {
         return switch (reason) {
             case AUTH_REQUIRED ->
                     "Authentication is required to invoke MCP tools over /mcp.";
+            case ACCESS_DENIED ->
+                    "Access denied: caller does not have sufficient permissions to access the requested namespace.";
             case RESOLUTION_FAILED ->
                     "Memory resolution failed; the MCP call was denied and no memory was modified.";
             case WILDCARD_REJECTED ->

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/mcp/McpRequestMemory.java
@@ -140,8 +140,11 @@ public final class McpRequestMemory {
         if (registry != null && registry.binder() != null) {
             return bindForCurrentRequest(registry.binder(), authEnabled, namespaceSelector, connectionId);
         }
-        if (authEnabled && !SecurityUtils.isAuthenticated()) {
-            return Optional.of(DenyReason.AUTH_REQUIRED);
+        if (authEnabled) {
+            log.warn("[McpRequestMemory] Denying MCP call: MemoryRequestBinder unavailable under enabled auth");
+            return !SecurityUtils.isAuthenticated()
+                    ? Optional.of(DenyReason.AUTH_REQUIRED)
+                    : Optional.of(DenyReason.RESOLUTION_FAILED);
         }
         if (namespaceSelector != null && "*".equals(namespaceSelector.trim())) {
             return Optional.of(DenyReason.WILDCARD_REJECTED);
@@ -152,42 +155,14 @@ public final class McpRequestMemory {
                     ? namespaceSelector.trim()
                     : McpSessionContext.getSessionDefault(connectionId).orElse(null);
 
-            var catalog = registry != null ? registry.catalog() : null;
-            String targetNamespaceId = userId;
-            if (selector != null && !selector.isBlank()) {
-                if (catalog != null && userId != null) {
-                    targetNamespaceId = catalog.resolve(userId, selector)
-                            .map(com.spectrayan.spector.synapse.catalog.NamespaceRecord::namespaceId)
-                            .orElse(selector);
-                } else {
-                    targetNamespaceId = selector;
-                }
-            }
-
-            if (authEnabled && userId != null && catalog != null) {
-                var authGrant = catalog.authorize(userId, targetNamespaceId, com.spectrayan.spector.synapse.catalog.GrantRole.READER);
-                if (authGrant.isEmpty()) {
-                    log.warn("[McpRequestMemory] Access denied: account={} has no grant on namespace={}", userId, targetNamespaceId);
-                    return Optional.of(DenyReason.ACCESS_DENIED);
-                }
-            }
-
-            SpectorMemory memory = (selector != null && !selector.isBlank())
-                    ? registry.namespaceResolver().resolve(userId, targetNamespaceId)
-                    : registry.resolveForCurrentRequest();
+            SpectorMemory memory = (selector != null && !selector.isBlank()) && registry != null
+                    ? registry.namespaceResolver().resolve(userId, selector)
+                    : (registry != null ? registry.resolveForCurrentRequest() : null);
 
             AutoCloseable lease = memory != null ? memory.acquireLease() : null;
-            MemoryBinding binding = new MemoryBinding(memory, userId, targetNamespaceId, selector != null ? selector : "default", lease, null);
+            MemoryBinding binding = new MemoryBinding(memory, userId, userId, selector != null ? selector : "default", lease, null);
             CURRENT_BINDING.set(binding);
             return Optional.empty();
-        } catch (NamespaceAccessDeniedException e) {
-            clear();
-            log.warn("[McpRequestMemory] access denied: {}", e.getMessage());
-            return Optional.of(DenyReason.ACCESS_DENIED);
-        } catch (TokenNamespaceLockedException e) {
-            clear();
-            log.warn("[McpRequestMemory] token namespace locked: {}", e.getMessage());
-            return Optional.of(DenyReason.TOKEN_LOCKED);
         } catch (RuntimeException e) {
             clear();
             log.warn("[McpRequestMemory] memory resolution failed; denying MCP call: {}", e.getMessage());

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/FederatedRecallService.java
@@ -189,11 +189,22 @@ public class FederatedRecallService {
         // 4. Parallel Fan-Out Execution via ConcurrentTasks (Structured Concurrency & Virtual Threads)
         final List<String> opened = new ArrayList<>();
         final List<FederatedRecallHit> allHits = new ArrayList<>();
-        final RecallOptions recallOptions = RecallOptions.builder()
+        RequestMemoryContext reqCtx = MemoryBinding.current()
+                .map(MemoryBinding::requestMemoryContext)
+                .orElse(null);
+        final RecallOptions.Builder optBuilder = RecallOptions.builder()
                 .topK(request.perNamespaceTopK())
                 .profile(request.profile() != null ? request.profile() : CognitiveProfile.BALANCED)
-                .scoringMode(request.scoringMode() != null ? request.scoringMode() : ScoringMode.COGNITIVE)
-                .build();
+                .scoringMode(request.scoringMode() != null ? request.scoringMode() : ScoringMode.COGNITIVE);
+        if (reqCtx != null) {
+            if (reqCtx.effectiveSalience() != null) {
+                optBuilder.salienceProfile(reqCtx.effectiveSalience());
+            }
+            if (reqCtx.primarySoul() != null && reqCtx.primarySoul().id() != null) {
+                optBuilder.personaId(reqCtx.primarySoul().id());
+            }
+        }
+        final RecallOptions recallOptions = optBuilder.build();
 
         if (!executableTargets.isEmpty()) {
             final Map<String, TargetNamespace> targetMap = new LinkedHashMap<>();

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
@@ -244,10 +244,14 @@ public class MemoryAccessObject {
     }
 
     /**
-     * Call cognitive recall synchronously.
+     * Call cognitive recall synchronously with request-scoped identity and salience overlay (ADR-0029 §2.5).
      */
     public List<CognitiveResult> recall(SpectorMemory memory, String query) {
         if (!isAvailable(memory)) return List.of();
+        RequestMemoryContext reqCtx = resolveCurrentRequestContext();
+        if (reqCtx != null && (reqCtx.effectiveSalience() != null || reqCtx.primarySoul() != null)) {
+            return recall(memory, query, RecallOptions.DEFAULT);
+        }
         try {
             return memory.recall(query);
         } catch (Exception e) {
@@ -257,7 +261,7 @@ public class MemoryAccessObject {
     }
 
     /**
-     * Call cognitive recall with explicit {@link RecallOptions}.
+     * Call cognitive recall with explicit {@link RecallOptions} and request-scoped identity/salience overlay (ADR-0029 §2.5).
      *
      * <p>Enables tag-filtered recall via
      * {@link RecallOptions.Builder#synapticFilter(String...)}, scoring mode
@@ -267,7 +271,18 @@ public class MemoryAccessObject {
     public List<CognitiveResult> recall(SpectorMemory memory, String query, RecallOptions options) {
         if (!isAvailable(memory)) return List.of();
         try {
-            return memory.recall(query, options);
+            RequestMemoryContext reqCtx = resolveCurrentRequestContext();
+            if (reqCtx != null) {
+                RecallOptions.Builder builder = (options != null ? options : RecallOptions.DEFAULT).toBuilder();
+                if (reqCtx.effectiveSalience() != null) {
+                    builder.salienceProfile(reqCtx.effectiveSalience());
+                }
+                if (reqCtx.primarySoul() != null && reqCtx.primarySoul().id() != null && (options == null || options.personaId() == null)) {
+                    builder.personaId(reqCtx.primarySoul().id());
+                }
+                options = builder.build();
+            }
+            return options != null ? memory.recall(query, options) : memory.recall(query);
         } catch (Exception e) {
             log.error("[MemoryAccessObject] Recall with options failed: {}", e.getMessage(), e);
             return List.of();

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
@@ -89,23 +89,37 @@ public class MemoryAccessObject {
     }
 
     /**
-     * Store/remember a memory synchronously with optional timestamp override.
+     * Store/remember a memory synchronously with optional timestamp override and request context.
      */
-    public String remember(SpectorMemory memory, String id, String text, MemoryType type, MemorySource source, IngestionHints hints, String[] tags, Long timestampMs) {
+    public String remember(SpectorMemory memory, String id, String text, MemoryType type, MemorySource source,
+                           IngestionHints hints, String[] tags, Long timestampMs, RequestMemoryContext requestContext) {
         if (!isAvailable(memory)) {
             log.warn("[MemoryAccessObject] Stub mode: remember ignored (id={})", id);
             return id;
         }
         try {
+            RequestMemoryContext reqCtx = requestContext != null ? requestContext : resolveCurrentRequestContext();
+            com.spectrayan.spector.memory.model.IngestionContext.Builder ctxBuilder =
+                    com.spectrayan.spector.memory.model.IngestionContext.builder()
+                            .hints(hints);
             if (timestampMs != null && timestampMs > 0) {
-                com.spectrayan.spector.memory.model.IngestionContext ctx = com.spectrayan.spector.memory.model.IngestionContext.builder()
-                        .hints(hints)
-                        .overrideTimestampMs(timestampMs)
-                        .build();
-                memory.remember(id, text, type, source, ctx, tags);
-            } else {
-                memory.remember(id, text, type, source, (IngestionHints) hints, tags);
+                ctxBuilder.overrideTimestampMs(timestampMs);
             }
+
+            if (reqCtx != null) {
+                if (reqCtx.soulStack() != null && !reqCtx.soulStack().isEmpty()) {
+                    ctxBuilder.soulContexts(reqCtx.soulStack());
+                }
+                if (reqCtx.effectiveSalience() != null) {
+                    ctxBuilder.salienceProfile(reqCtx.effectiveSalience());
+                }
+                if (reqCtx.primarySoul() != null) {
+                    ctxBuilder.soulVersion(reqCtx.primarySoul().soulVersion());
+                }
+            }
+
+            com.spectrayan.spector.memory.model.IngestionContext ctx = ctxBuilder.build();
+            memory.remember(id, text, type, source, ctx, tags);
             log.debug("[MemoryAccessObject] Remembered memory: id={}", id);
             return id;
         } catch (Exception e) {
@@ -115,10 +129,27 @@ public class MemoryAccessObject {
     }
 
     /**
+     * Store/remember a memory synchronously with optional timestamp override.
+     */
+    public String remember(SpectorMemory memory, String id, String text, MemoryType type, MemorySource source,
+                           IngestionHints hints, String[] tags, Long timestampMs) {
+        return remember(memory, id, text, type, source, hints, tags, timestampMs, null);
+    }
+
+    /**
      * Backward-compatible overload without timestamp override.
      */
-    public String remember(SpectorMemory memory, String id, String text, MemoryType type, MemorySource source, IngestionHints hints, String[] tags) {
-        return remember(memory, id, text, type, source, hints, tags, null);
+    public String remember(SpectorMemory memory, String id, String text, MemoryType type, MemorySource source,
+                           IngestionHints hints, String[] tags) {
+        return remember(memory, id, text, type, source, hints, tags, null, null);
+    }
+
+    private RequestMemoryContext resolveCurrentRequestContext() {
+        return MemoryBinding.current()
+                .map(MemoryBinding::requestMemoryContext)
+                .or(() -> java.util.Optional.ofNullable(com.spectrayan.spector.synapse.mcp.McpRequestMemory.currentBinding())
+                        .map(MemoryBinding::requestMemoryContext))
+                .orElse(null);
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRegistry.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRegistry.java
@@ -63,6 +63,16 @@ public final class MemoryRegistry implements AutoCloseable {
     private final ObjectProvider<SpectorMemory> sharedProvider;
     private final SynapseProperties synapseProps;
     private final NamespaceResolver resolver;
+    private ObjectProvider<MemoryRequestBinder> binderProvider;
+
+    @Autowired(required = false)
+    void setBinderProvider(ObjectProvider<MemoryRequestBinder> binderProvider) {
+        this.binderProvider = binderProvider;
+    }
+
+    public MemoryRequestBinder binder() {
+        return binderProvider != null ? binderProvider.getIfAvailable() : null;
+    }
 
     /**
      * Test/non-Spring constructor that bypasses the catalog plane. When auth is enabled,

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
@@ -30,9 +30,11 @@ import com.spectrayan.spector.memory.SpectorMemory;
 import com.spectrayan.spector.memory.model.SoulContext;
 import com.spectrayan.spector.synapse.catalog.Account;
 import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.AccountProfile;
 import com.spectrayan.spector.synapse.catalog.GrantRole;
 import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
 import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
+import com.spectrayan.spector.synapse.catalog.PrincipalKind;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceNotFoundException;
 import com.spectrayan.spector.synapse.catalog.exception.NamespaceTombstonedException;
 import com.spectrayan.spector.synapse.catalog.exception.TokenNamespaceLockedException;
@@ -101,7 +103,10 @@ public class MemoryRequestBinder {
         }
 
         TokenClaims tokenClaims = extractTokenClaims(auth);
-        Account account = catalog.getOrCreateAccount(accountId);
+        Account account = catalog.getOrCreateAccount(accountId, tokenClaims.profile(), tokenClaims.kind());
+        if (account == null) {
+            account = catalog.getOrCreateAccount(accountId);
+        }
 
         String targetSlug;
         String targetNamespaceId;
@@ -174,9 +179,6 @@ public class MemoryRequestBinder {
                     && record.bias() != com.spectrayan.spector.synapse.catalog.NamespaceBias.EMPTY) {
                 salience = NamespaceBiasApplier.apply(salience, record.bias());
             }
-            if (memory != null) {
-                memory.applyIdentity(primarySoul, soulStack, salience);
-            }
 
             RequestMemoryContext requestContext = new RequestMemoryContext(
                     tokenClaims.tenantId(),
@@ -188,7 +190,8 @@ public class MemoryRequestBinder {
                     tokenClaims.allowSet(),
                     sessionId,
                     soulStack,
-                    primarySoul
+                    primarySoul,
+                    salience
             );
             return new MemoryBinding(memory, accountId, targetNamespaceId, targetSlug, lease, requestContext);
         } catch (RuntimeException e) {
@@ -239,7 +242,7 @@ public class MemoryRequestBinder {
             jwt = credJwt;
         }
         if (jwt == null) {
-            return new TokenClaims(null, List.of(), Set.of(), null, null);
+            return new TokenClaims(null, List.of(), Set.of(), null, null, AccountProfile.HUMAN_SOLO, PrincipalKind.HUMAN);
         }
         String tenantId = jwt.getClaimAsString("tid");
         List<String> orgUnitIds = jwt.getClaimAsStringList("org");
@@ -255,7 +258,28 @@ public class MemoryRequestBinder {
         if (nsIds != null) {
             combinedAllowSet.addAll(nsIds);
         }
-        return new TokenClaims(tenantId, orgUnitIds, Collections.unmodifiableSet(combinedAllowSet), nsSlugs, nsIds);
+
+        String profileStr = jwt.getClaimAsString("profile");
+        if (profileStr == null) {
+            profileStr = jwt.getClaimAsString("acct_type");
+        }
+        AccountProfile profile = AccountProfile.HUMAN_SOLO;
+        if (profileStr != null) {
+            try {
+                profile = AccountProfile.valueOf(profileStr.toUpperCase());
+            } catch (IllegalArgumentException ignored) {}
+        }
+
+        String kindStr = jwt.getClaimAsString("kind");
+        PrincipalKind kind = PrincipalKind.HUMAN;
+        if (kindStr != null) {
+            try {
+                kind = PrincipalKind.valueOf(kindStr.toUpperCase());
+            } catch (IllegalArgumentException ignored) {}
+        }
+
+        return new TokenClaims(tenantId, orgUnitIds, Collections.unmodifiableSet(combinedAllowSet),
+                nsSlugs, nsIds, profile, kind);
     }
 
     private record TokenClaims(
@@ -263,6 +287,8 @@ public class MemoryRequestBinder {
             List<String> orgUnitIds,
             Set<String> allowSet,
             List<String> nsSlugs,
-            List<String> nsIds
+            List<String> nsIds,
+            AccountProfile profile,
+            PrincipalKind kind
     ) {}
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -425,12 +425,24 @@ public class MemoryService {
 
         // Build RecallOptions from DTO when tag/mode fields are present
         List<CognitiveResult> results;
-        boolean hasOptions = (request.tags() != null && !request.tags().isEmpty())
+        RequestMemoryContext reqCtx = MemoryBinding.current()
+                .map(MemoryBinding::requestMemoryContext)
+                .orElse(null);
+        boolean hasCustomOptions = (request.tags() != null && !request.tags().isEmpty())
                 || request.scoringMode() != null
-                || request.recallMode() != null;
+                || request.recallMode() != null
+                || (reqCtx != null && (reqCtx.effectiveSalience() != null || reqCtx.primarySoul() != null));
 
-        if (hasOptions) {
-            var optionsBuilder = RecallOptions.builder().topK(request.topK());
+        if (hasCustomOptions) {
+            var optionsBuilder = RecallOptions.builder().topK(request.topK() > 0 ? request.topK() : 10);
+            if (reqCtx != null) {
+                if (reqCtx.effectiveSalience() != null) {
+                    optionsBuilder.salienceProfile(reqCtx.effectiveSalience());
+                }
+                if (reqCtx.primarySoul() != null && reqCtx.primarySoul().id() != null) {
+                    optionsBuilder.personaId(reqCtx.primarySoul().id());
+                }
+            }
             if (request.tags() != null && !request.tags().isEmpty()) {
                 optionsBuilder.synapticFilter(request.tags().toArray(String[]::new));
             }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -306,6 +306,12 @@ public class MemoryService {
         final IngestionHints finalHints = hints;
         final String finalId = effectiveId;
 
+        final RequestMemoryContext capturedContext = MemoryBinding.current()
+                .map(MemoryBinding::requestMemoryContext)
+                .or(() -> java.util.Optional.ofNullable(com.spectrayan.spector.synapse.mcp.McpRequestMemory.currentBinding())
+                        .map(MemoryBinding::requestMemoryContext))
+                .orElse(null);
+
         CompletableFuture.runAsync(() -> {
             try {
                 eventPublisher.broadcast("ingestion.progress", Map.of(
@@ -316,7 +322,7 @@ public class MemoryService {
                         "timestamp", Instant.now().toEpochMilli()
                 ));
                  long t0 = System.currentTimeMillis();
-                 mao.remember(memory, finalId, request.text(), tier, source, finalHints, tags, request.timestampMs());
+                 mao.remember(memory, finalId, request.text(), tier, source, finalHints, tags, request.timestampMs(), capturedContext);
                  long elapsed = System.currentTimeMillis() - t0;
                  rememberCount.incrementAndGet();
                  totalLatencyMs.addAndGet(elapsed);
@@ -744,6 +750,11 @@ public class MemoryService {
 
             MemoryType tier = MemoryTypeParser.safeMemoryType(tierName, MemoryType.SEMANTIC);
             MemorySource source = MemoryTypeParser.safeMemorySource(sourceName, MemorySource.OBSERVED);
+            final RequestMemoryContext capturedContext = MemoryBinding.current()
+                    .map(MemoryBinding::requestMemoryContext)
+                    .or(() -> java.util.Optional.ofNullable(com.spectrayan.spector.synapse.mcp.McpRequestMemory.currentBinding())
+                            .map(MemoryBinding::requestMemoryContext))
+                    .orElse(null);
 
             CompletableFuture.runAsync(() -> {
                 try {
@@ -754,7 +765,7 @@ public class MemoryService {
                             "progress", 50.0,
                             "timestamp", Instant.now().toEpochMilli()
                     ));
-                    mao.remember(memory, documentId, content, tier, source, null, new String[]{originalName});
+                    mao.remember(memory, documentId, content, tier, source, null, new String[]{originalName}, null, capturedContext);
                     log.info("[MemoryService] Async ingestion completed: file={}, id={}", originalName, documentId);
                     eventPublisher.broadcast("ingestion.completed", Map.of(
                             "taskId", taskId,

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceBiasApplier.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceBiasApplier.java
@@ -30,7 +30,9 @@ public final class NamespaceBiasApplier {
         if (bias == null || bias == NamespaceBias.EMPTY) {
             return base;
         }
-        if (bias.domainFocus() == null || bias.domainFocus().isEmpty()) {
+        boolean hasDomainFocus = bias.domainFocus() != null && !bias.domainFocus().isEmpty();
+        boolean hasTagWeights = bias.tagWeights() != null && !bias.tagWeights().isEmpty();
+        if (!hasDomainFocus && !hasTagWeights) {
             return base;
         }
         SalienceProfile src = base != null ? base : SalienceProfile.NEUTRAL;
@@ -52,9 +54,28 @@ public final class NamespaceBiasApplier {
         for (InterestDomain domain : src.disinterests()) {
             builder.disinterest(domain);
         }
-        for (String domain : bias.domainFocus()) {
-            if (domain != null && !domain.isBlank()) {
-                builder.interest(domain.trim(), InterestLevel.MEDIUM);
+        if (hasDomainFocus) {
+            for (String domain : bias.domainFocus()) {
+                if (domain != null && !domain.isBlank()) {
+                    builder.interest(domain.trim(), InterestLevel.MEDIUM);
+                }
+            }
+        }
+        if (hasTagWeights) {
+            for (java.util.Map.Entry<String, Float> entry : bias.tagWeights().entrySet()) {
+                String tag = entry.getKey();
+                Float weight = entry.getValue();
+                if (tag != null && !tag.isBlank() && weight != null) {
+                    if (weight <= 0.0f) {
+                        builder.disinterest(tag.trim(), InterestLevel.HIGH);
+                    } else if (weight >= 1.5f) {
+                        builder.interest(tag.trim(), InterestLevel.HIGH);
+                    } else if (weight >= 1.0f) {
+                        builder.interest(tag.trim(), InterestLevel.MEDIUM);
+                    } else {
+                        builder.interest(tag.trim(), InterestLevel.LOW);
+                    }
+                }
             }
         }
         return builder.build();

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/RequestMemoryContext.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/RequestMemoryContext.java
@@ -15,22 +15,24 @@ package com.spectrayan.spector.synapse.memory;
 import java.util.List;
 import java.util.Set;
 
+import com.spectrayan.spector.memory.model.SalienceProfile;
 import com.spectrayan.spector.memory.model.SoulContext;
 import com.spectrayan.spector.synapse.catalog.GrantRole;
 
 /**
  * Encapsulates the resolved security and memory context for an active request or session (ADR-0029 §6.1).
  *
- * @param tenantId     the tenant identifier (nullable on OSS)
- * @param orgUnitIds   the effective organizational unit identifiers
- * @param accountId    the authenticated account TSID
- * @param namespaceId  the resolved memory namespace TSID
- * @param slug         the requested or resolved namespace slug
- * @param role         the principal's authorization role on this namespace
- * @param allowSet     allowed namespace slugs / IDs from JWT claims (empty = unrestricted)
- * @param sessionId    optional session or connection ID
- * @param soulStack    the resolved hierarchical soul stack
- * @param primarySoul  the primary soul context
+ * @param tenantId          the tenant identifier (nullable on OSS)
+ * @param orgUnitIds        the effective organizational unit identifiers
+ * @param accountId         the authenticated account TSID
+ * @param namespaceId       the resolved memory namespace TSID
+ * @param slug              the requested or resolved namespace slug
+ * @param role              the principal's authorization role on this namespace
+ * @param allowSet          allowed namespace slugs / IDs from JWT claims (empty = unrestricted)
+ * @param sessionId         optional session or connection ID
+ * @param soulStack         the resolved hierarchical soul stack
+ * @param primarySoul       the primary soul context
+ * @param effectiveSalience the resolved effective salience profile for this request
  */
 public record RequestMemoryContext(
         String tenantId,
@@ -42,11 +44,28 @@ public record RequestMemoryContext(
         Set<String> allowSet,
         String sessionId,
         List<SoulContext> soulStack,
-        SoulContext primarySoul
+        SoulContext primarySoul,
+        SalienceProfile effectiveSalience
 ) {
     public RequestMemoryContext {
         orgUnitIds = orgUnitIds != null ? List.copyOf(orgUnitIds) : List.of();
         allowSet = allowSet != null ? Set.copyOf(allowSet) : Set.of();
         soulStack = soulStack != null ? List.copyOf(soulStack) : List.of();
     }
+
+    public RequestMemoryContext(
+            String tenantId,
+            List<String> orgUnitIds,
+            String accountId,
+            String namespaceId,
+            String slug,
+            GrantRole role,
+            Set<String> allowSet,
+            String sessionId,
+            List<SoulContext> soulStack,
+            SoulContext primarySoul
+    ) {
+        this(tenantId, orgUnitIds, accountId, namespaceId, slug, role, allowSet, sessionId, soulStack, primarySoul, null);
+    }
 }
+

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalogTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalogTest.java
@@ -277,4 +277,104 @@ class JdbcAccountCatalogTest {
         assertThat(grantsAfterRevoke).hasSize(1); // Only implicit owner remains
         assertThat(grantsAfterRevoke).noneMatch(g -> g.grantId().equals(grant.grantId()));
     }
+
+    @Test
+    @DisplayName("authorizeIdentity enforces region PEP, constraints, and ADMIN !=> INJECT")
+    void testAuthorizeIdentityRules() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+        catalog.getOrCreateAccount(OTHER_ACCOUNT_ID);
+
+        // 1. Owner always authorized on own bundle
+        assertThat(catalog.authorizeIdentity(ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.READ)).isTrue();
+        assertThat(catalog.authorizeIdentity(ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.WRITE)).isTrue();
+        assertThat(catalog.authorizeIdentity(ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.INJECT)).isTrue();
+
+        // 2. Cross-account unauthorized before grant
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.READ)).isFalse();
+
+        // 3. Grant direct region grant for SOUL READ
+        catalog.addGrant(new Grant(
+                "0195500000004",
+                GrantObjectType.IDENTITY_REGION,
+                ACCOUNT_ID + ":SOUL",
+                OTHER_ACCOUNT_ID,
+                PrincipalType.ACCOUNT,
+                GrantRole.READER,
+                Set.of(GrantAction.READ),
+                ACCOUNT_ID,
+                Instant.now(),
+                null,
+                null
+        ));
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.READ)).isTrue();
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.WRITE)).isFalse();
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.INJECT)).isFalse();
+
+        // 4. Grant ADMIN on bundle with region constraints: only SALIENCE
+        catalog.addGrant(new Grant(
+                "0195500000005",
+                GrantObjectType.IDENTITY_BUNDLE,
+                ACCOUNT_ID,
+                OTHER_ACCOUNT_ID,
+                PrincipalType.ACCOUNT,
+                GrantRole.ADMIN,
+                Set.of(GrantAction.READ, GrantAction.WRITE, GrantAction.ADMIN),
+                ACCOUNT_ID,
+                Instant.now(),
+                null,
+                new GrantConstraints(null, null, null, Set.of("SALIENCE"))
+        ));
+
+        // SALIENCE allows READ, WRITE, ADMIN
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SALIENCE", GrantAction.READ)).isTrue();
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SALIENCE", GrantAction.WRITE)).isTrue();
+        // ADMIN does NOT imply INJECT
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SALIENCE", GrantAction.INJECT)).isFalse();
+        // POLICY is not in region constraints
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "POLICY", GrantAction.READ)).isFalse();
+
+        // 5. Grant explicit INJECT on bundle
+        catalog.addGrant(new Grant(
+                "0195500000006",
+                GrantObjectType.IDENTITY_BUNDLE,
+                ACCOUNT_ID,
+                OTHER_ACCOUNT_ID,
+                PrincipalType.ACCOUNT,
+                GrantRole.READER,
+                Set.of(GrantAction.INJECT),
+                ACCOUNT_ID,
+                Instant.now(),
+                null,
+                null
+        ));
+        assertThat(catalog.authorizeIdentity(OTHER_ACCOUNT_ID, ACCOUNT_ID, "SOUL", GrantAction.INJECT)).isTrue();
+    }
+
+    @Test
+    @DisplayName("addOrgMember validates org unit existence and throws when missing")
+    void testAddOrgMemberValidation() {
+        catalog.getOrCreateAccount(ACCOUNT_ID);
+
+        // Non-existent org unit should throw IllegalArgumentException
+        assertThatThrownBy(() -> catalog.addOrgMember(ACCOUNT_ID, "non-existent-org"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in catalog");
+
+        // Insert legitimate org unit into DB
+        jdbc.sql("INSERT INTO org_units (org_unit_id, tenant_id, name) VALUES (:id, :tid, :name)")
+                .param("id", "engineering")
+                .param("tid", "tenant-1")
+                .param("name", "Engineering")
+                .update();
+
+        // Now addOrgMember succeeds
+        catalog.addOrgMember(ACCOUNT_ID, "engineering");
+        List<String> orgs = catalog.orgUnitIdsForAccount(ACCOUNT_ID);
+        assertThat(orgs).contains("engineering");
+
+        // Remove org member
+        catalog.removeOrgMember(ACCOUNT_ID, "engineering");
+        assertThat(catalog.orgUnitIdsForAccount(ACCOUNT_ID)).doesNotContain("engineering");
+    }
 }
+

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/IdentityPlaneTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/IdentityPlaneTest.java
@@ -100,7 +100,7 @@ class IdentityPlaneTest {
     void assembleSoulStack() {
         TenantSoul tenantSoul = new TenantSoul("ten-hospital", "Acme Health", "HIPAA Compliant",
                 List.of("medical"), List.of("HIPAA"), null, (short) 1, Instant.now(), Instant.now());
-        identityCache.getOrOpenTenant("ten-hospital").writeSoul(tenantSoul);
+        identityPlane.updateTenantSoul("ten-hospital", tenantSoul);
 
         UserSoul userSoul = new UserSoul("acc-doc", "Dr. Bob", "Cardiologist", null, null, (short) 1, Instant.now(), Instant.now());
         identityPlane.updateAccountSoul("acc-doc", userSoul);

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/RegionPepAuthorizationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/RegionPepAuthorizationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.identity.IdentityBundle;
+import com.spectrayan.spector.memory.identity.IdentityRegionId;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.memory.model.SoulContext;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.GrantAction;
+
+@DisplayName("Region PEP and IdentityPlane Authorization Specifications")
+class RegionPepAuthorizationTest {
+
+    @Test
+    @DisplayName("soulsFor requires INJECT on tenant SOUL and ORG_DIR regions")
+    void testSoulsForRequiresInject() {
+        IdentityCache cache = mock(IdentityCache.class);
+        ObjectMapper mapper = new ObjectMapper();
+        AccountCatalog catalog = mock(AccountCatalog.class);
+
+        IdentityPlane plane = new IdentityPlane(cache, mapper, catalog);
+
+        SoulContext tenantSoul = new com.spectrayan.spector.memory.model.TenantSoul(
+                "tenant-1", "tenant-root", "desc", List.of(), List.of(), null, (short) 0, null, null);
+        SoulContext orgSoul = new com.spectrayan.spector.memory.model.OrgUnitSoul(
+                "org-eng", "engineering", "desc", List.of(), null, (short) 0, null, null);
+        SoulContext userSoul = new com.spectrayan.spector.memory.model.UserSoul(
+                "user-1", "user-solo", "desc", null, null);
+
+        IdentityBundle tenantBundle = mock(IdentityBundle.class);
+        when(tenantBundle.readSoul()).thenReturn(Optional.of(tenantSoul));
+        when(tenantBundle.readOrgUnitSoul("org-eng")).thenReturn(Optional.of(orgSoul));
+        when(cache.getOrOpenTenant("tenant-1")).thenReturn(tenantBundle);
+
+        IdentityBundle userBundle = mock(IdentityBundle.class);
+        when(userBundle.readSoul()).thenReturn(Optional.of(userSoul));
+        when(cache.getOrOpenAccount("user-1")).thenReturn(userBundle);
+
+        // Permitted on SOUL and ORG_DIR with INJECT
+        when(catalog.authorizeIdentity("user-1", "tenant-1", IdentityRegionId.SOUL.name(), GrantAction.INJECT))
+                .thenReturn(true);
+        when(catalog.authorizeIdentity("user-1", "tenant-1", IdentityRegionId.ORG_DIR.name(), GrantAction.INJECT))
+                .thenReturn(true);
+        when(catalog.authorizeIdentity("user-1", "user-1", IdentityRegionId.SOUL.name(), GrantAction.READ))
+                .thenReturn(true);
+
+        List<SoulContext> souls = plane.soulsFor("tenant-1", List.of("org-eng"), "user-1");
+
+        assertThat(souls).containsExactly(tenantSoul, orgSoul, userSoul);
+        verify(catalog).authorizeIdentity("user-1", "tenant-1", IdentityRegionId.SOUL.name(), GrantAction.INJECT);
+        verify(catalog).authorizeIdentity("user-1", "tenant-1", IdentityRegionId.ORG_DIR.name(), GrantAction.INJECT);
+    }
+
+    @Test
+    @DisplayName("soulsFor excludes tenant souls when INJECT grant is denied")
+    void testSoulsForDeniedInject() {
+        IdentityCache cache = mock(IdentityCache.class);
+        ObjectMapper mapper = new ObjectMapper();
+        AccountCatalog catalog = mock(AccountCatalog.class);
+
+        IdentityPlane plane = new IdentityPlane(cache, mapper, catalog);
+
+        SoulContext userSoul = new com.spectrayan.spector.memory.model.UserSoul(
+                "user-1", "user-solo", "desc", null, null);
+        IdentityBundle userBundle = mock(IdentityBundle.class);
+        when(userBundle.readSoul()).thenReturn(Optional.of(userSoul));
+        when(cache.getOrOpenAccount("user-1")).thenReturn(userBundle);
+
+        // Deny INJECT on tenant SOUL
+        when(catalog.authorizeIdentity("user-1", "tenant-1", IdentityRegionId.SOUL.name(), GrantAction.INJECT))
+                .thenReturn(false);
+        when(catalog.authorizeIdentity("user-1", "user-1", IdentityRegionId.SOUL.name(), GrantAction.READ))
+                .thenReturn(true);
+
+        List<SoulContext> souls = plane.soulsFor("tenant-1", List.of("org-eng"), "user-1");
+
+        assertThat(souls).containsExactly(userSoul);
+    }
+
+    @Test
+    @DisplayName("primarySoulFor and salienceFor require READ permission")
+    void testReadRequiresReadAction() {
+        IdentityCache cache = mock(IdentityCache.class);
+        ObjectMapper mapper = new ObjectMapper();
+        AccountCatalog catalog = mock(AccountCatalog.class);
+
+        IdentityPlane plane = new IdentityPlane(cache, mapper, catalog);
+
+        SoulContext userSoul = new com.spectrayan.spector.memory.model.UserSoul(
+                "user-1", "user-solo", "desc", null, null);
+        IdentityBundle userBundle = mock(IdentityBundle.class);
+        when(userBundle.readSoul()).thenReturn(Optional.of(userSoul));
+        when(userBundle.readSalience()).thenReturn(Optional.of(SalienceProfile.NEUTRAL));
+        when(cache.getOrOpenAccount("user-1")).thenReturn(userBundle);
+
+        when(catalog.authorizeIdentity("user-1", "user-1", IdentityRegionId.SOUL.name(), GrantAction.READ))
+                .thenReturn(true);
+        when(catalog.authorizeIdentity("user-1", "user-1", IdentityRegionId.SALIENCE.name(), GrantAction.READ))
+                .thenReturn(true);
+
+        assertThat(plane.primarySoulFor("user-1")).contains(userSoul);
+        assertThat(plane.salienceFor("user-1")).contains(SalienceProfile.NEUTRAL);
+
+        verify(catalog).authorizeIdentity("user-1", "user-1", IdentityRegionId.SOUL.name(), GrantAction.READ);
+        verify(catalog).authorizeIdentity("user-1", "user-1", IdentityRegionId.SALIENCE.name(), GrantAction.READ);
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/RegionPepAuthorizationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/identity/RegionPepAuthorizationTest.java
@@ -56,11 +56,11 @@ class RegionPepAuthorizationTest {
         IdentityBundle tenantBundle = mock(IdentityBundle.class);
         when(tenantBundle.readSoul()).thenReturn(Optional.of(tenantSoul));
         when(tenantBundle.readOrgUnitSoul("org-eng")).thenReturn(Optional.of(orgSoul));
-        when(cache.getOrOpenTenant("tenant-1")).thenReturn(tenantBundle);
+        when(cache.openTenant("tenant-1")).thenAnswer(inv -> mockHandle(tenantBundle));
 
         IdentityBundle userBundle = mock(IdentityBundle.class);
         when(userBundle.readSoul()).thenReturn(Optional.of(userSoul));
-        when(cache.getOrOpenAccount("user-1")).thenReturn(userBundle);
+        when(cache.openAccount("user-1")).thenAnswer(inv -> mockHandle(userBundle));
 
         // Permitted on SOUL and ORG_DIR with INJECT
         when(catalog.authorizeIdentity("user-1", "tenant-1", IdentityRegionId.SOUL.name(), GrantAction.INJECT))
@@ -90,7 +90,7 @@ class RegionPepAuthorizationTest {
                 "user-1", "user-solo", "desc", null, null);
         IdentityBundle userBundle = mock(IdentityBundle.class);
         when(userBundle.readSoul()).thenReturn(Optional.of(userSoul));
-        when(cache.getOrOpenAccount("user-1")).thenReturn(userBundle);
+        when(cache.openAccount("user-1")).thenAnswer(inv -> mockHandle(userBundle));
 
         // Deny INJECT on tenant SOUL
         when(catalog.authorizeIdentity("user-1", "tenant-1", IdentityRegionId.SOUL.name(), GrantAction.INJECT))
@@ -117,7 +117,7 @@ class RegionPepAuthorizationTest {
         IdentityBundle userBundle = mock(IdentityBundle.class);
         when(userBundle.readSoul()).thenReturn(Optional.of(userSoul));
         when(userBundle.readSalience()).thenReturn(Optional.of(SalienceProfile.NEUTRAL));
-        when(cache.getOrOpenAccount("user-1")).thenReturn(userBundle);
+        when(cache.openAccount("user-1")).thenAnswer(inv -> mockHandle(userBundle));
 
         when(catalog.authorizeIdentity("user-1", "user-1", IdentityRegionId.SOUL.name(), GrantAction.READ))
                 .thenReturn(true);
@@ -129,5 +129,9 @@ class RegionPepAuthorizationTest {
 
         verify(catalog).authorizeIdentity("user-1", "user-1", IdentityRegionId.SOUL.name(), GrantAction.READ);
         verify(catalog).authorizeIdentity("user-1", "user-1", IdentityRegionId.SALIENCE.name(), GrantAction.READ);
+    }
+
+    private static IdentityCache.IdentityHandle mockHandle(IdentityBundle bundle) {
+        return new IdentityCache.IdentityHandle(new IdentityCache.PinnedBundle(bundle));
     }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpRequestMemoryBinderTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpRequestMemoryBinderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.synapse.catalog.exception.NamespaceAccessDeniedException;
+import com.spectrayan.spector.synapse.catalog.exception.TokenNamespaceLockedException;
+import com.spectrayan.spector.synapse.memory.MemoryBinding;
+import com.spectrayan.spector.synapse.memory.MemoryRequestBinder;
+import com.spectrayan.spector.synapse.memory.RequestMemoryContext;
+
+@DisplayName("McpRequestMemory MemoryRequestBinder Integration")
+class McpRequestMemoryBinderTest {
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        McpRequestMemory.clear();
+    }
+
+    @Test
+    @DisplayName("bindForCurrentRequest binds MemoryBinding and closes lease on clear")
+    void testBindAndClearWithLease() throws Exception {
+        MemoryRequestBinder binder = mock(MemoryRequestBinder.class);
+        SpectorMemory memory = mock(SpectorMemory.class);
+        AutoCloseable lease = mock(AutoCloseable.class);
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("user-1", "pass", AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        RequestMemoryContext context = new RequestMemoryContext("tenant-1", java.util.List.of(), "user-1", "user-1", "default",
+                com.spectrayan.spector.synapse.catalog.GrantRole.OWNER, java.util.Set.of(), "conn-1", java.util.List.of(), null);
+        MemoryBinding binding = new MemoryBinding(memory, "user-1", "user-1", "default", lease, context);
+
+        when(binder.bind(eq(auth), eq(Optional.of("default")), eq("conn-1"))).thenReturn(binding);
+
+        Optional<McpRequestMemory.DenyReason> deny = McpRequestMemory.bindForCurrentRequest(binder, true, "default", "conn-1");
+        assertThat(deny).isEmpty();
+        assertThat(McpRequestMemory.current()).isSameAs(memory);
+        assertThat(McpRequestMemory.currentBinding()).isSameAs(binding);
+
+        McpRequestMemory.clear();
+        verify(binder).unbind(binding);
+        assertThat(McpRequestMemory.current()).isNull();
+        assertThat(McpRequestMemory.currentBinding()).isNull();
+    }
+
+    @Test
+    @DisplayName("bindForCurrentRequest returns AUTH_REQUIRED when unauthenticated and auth enabled")
+    void testAuthRequired() {
+        MemoryRequestBinder binder = mock(MemoryRequestBinder.class);
+        Optional<McpRequestMemory.DenyReason> deny = McpRequestMemory.bindForCurrentRequest(binder, true, "default", "conn-1");
+        assertThat(deny).contains(McpRequestMemory.DenyReason.AUTH_REQUIRED);
+        assertThat(McpRequestMemory.current()).isNull();
+    }
+
+    @Test
+    @DisplayName("bindForCurrentRequest returns WILDCARD_REJECTED when namespace selector is *")
+    void testWildcardRejected() {
+        MemoryRequestBinder binder = mock(MemoryRequestBinder.class);
+        Authentication auth = new UsernamePasswordAuthenticationToken("user-1", "pass", AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Optional<McpRequestMemory.DenyReason> deny = McpRequestMemory.bindForCurrentRequest(binder, true, "*", "conn-1");
+        assertThat(deny).contains(McpRequestMemory.DenyReason.WILDCARD_REJECTED);
+        assertThat(McpRequestMemory.current()).isNull();
+    }
+
+    @Test
+    @DisplayName("bindForCurrentRequest returns ACCESS_DENIED on NamespaceAccessDeniedException")
+    void testAccessDenied() {
+        MemoryRequestBinder binder = mock(MemoryRequestBinder.class);
+        Authentication auth = new UsernamePasswordAuthenticationToken("user-1", "pass", AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        when(binder.bind(any(), any(), any())).thenThrow(new NamespaceAccessDeniedException("ns-secret", "user-1"));
+
+        Optional<McpRequestMemory.DenyReason> deny = McpRequestMemory.bindForCurrentRequest(binder, true, "ns-secret", "conn-1");
+        assertThat(deny).contains(McpRequestMemory.DenyReason.ACCESS_DENIED);
+        assertThat(McpRequestMemory.current()).isNull();
+    }
+
+    @Test
+    @DisplayName("bindForCurrentRequest returns TOKEN_LOCKED on TokenNamespaceLockedException")
+    void testTokenLocked() {
+        MemoryRequestBinder binder = mock(MemoryRequestBinder.class);
+        Authentication auth = new UsernamePasswordAuthenticationToken("user-1", "pass", AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        when(binder.bind(any(), any(), any())).thenThrow(new TokenNamespaceLockedException("ns-allowed", "ns-locked"));
+
+        Optional<McpRequestMemory.DenyReason> deny = McpRequestMemory.bindForCurrentRequest(binder, true, "ns-locked", "conn-1");
+        assertThat(deny).contains(McpRequestMemory.DenyReason.TOKEN_LOCKED);
+        assertThat(McpRequestMemory.current()).isNull();
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpRequestMemoryBinderTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpRequestMemoryBinderTest.java
@@ -120,4 +120,20 @@ class McpRequestMemoryBinderTest {
         assertThat(deny).contains(McpRequestMemory.DenyReason.TOKEN_LOCKED);
         assertThat(McpRequestMemory.current()).isNull();
     }
+
+    @Test
+    @DisplayName("bindForCurrentRequest fails closed with RESOLUTION_FAILED if registry binder is null under enabled auth")
+    void testFailClosedWhenBinderNullAndAuthEnabled() {
+        com.spectrayan.spector.synapse.memory.MemoryRegistry registry =
+                mock(com.spectrayan.spector.synapse.memory.MemoryRegistry.class);
+        when(registry.binder()).thenReturn(null);
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("user-1", "pass", AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Optional<McpRequestMemory.DenyReason> deny =
+                McpRequestMemory.bindForCurrentRequest(registry, true, "ns-1", "conn-1");
+        assertThat(deny).contains(McpRequestMemory.DenyReason.RESOLUTION_FAILED);
+        assertThat(McpRequestMemory.current()).isNull();
+    }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpToolIsolationIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/mcp/McpToolIsolationIntegrationTest.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.synapse.mcp;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.ObjectProvider;
@@ -45,6 +47,7 @@ import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.spring.autoconfigure.SpectorConfigProperties;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
 import com.spectrayan.spector.synapse.memory.MemoryRegistry;
+import com.spectrayan.spector.synapse.memory.NamespaceResolver;
 
 /**
  * Integration test for <strong>MCP tool isolation</strong> (Requirement 11).
@@ -281,14 +284,63 @@ class McpToolIsolationIntegrationTest {
         ObjectProvider<ObjectMapper> objectMapperProvider = mockProvider();
         when(objectMapperProvider.getIfAvailable()).thenReturn(new ObjectMapper());
 
-        return new MemoryRegistry(
+        SynapseProperties props = synapseProps(authEnabled);
+        MemoryRegistry registry = new MemoryRegistry(
                 sharedProvider,
-                synapseProps(authEnabled),
+                props,
                 embedderProvider,
                 textGenProvider,
                 salienceProvider,
                 objectMapperProvider,
                 512);
+
+        try {
+            Field resolverField = MemoryRegistry.class.getDeclaredField("resolver");
+            resolverField.setAccessible(true);
+            NamespaceResolver resolver = (NamespaceResolver) resolverField.get(registry);
+
+            com.spectrayan.spector.synapse.catalog.AccountCatalog catalog = mock(com.spectrayan.spector.synapse.catalog.AccountCatalog.class);
+            when(catalog.getOrCreateAccount(any())).thenAnswer(inv -> {
+                String id = inv.getArgument(0);
+                return new com.spectrayan.spector.synapse.catalog.Account(id,
+                        com.spectrayan.spector.synapse.catalog.PrincipalKind.HUMAN,
+                        com.spectrayan.spector.synapse.catalog.AccountProfile.HUMAN_SOLO, id,
+                        com.spectrayan.spector.synapse.catalog.AccountQuotas.forProfile(com.spectrayan.spector.synapse.catalog.AccountProfile.HUMAN_SOLO),
+                        com.spectrayan.spector.synapse.catalog.AccountFlags.forProfile(com.spectrayan.spector.synapse.catalog.AccountProfile.HUMAN_SOLO),
+                        id, java.time.Instant.now());
+            });
+            when(catalog.authorize(any(), any(), any())).thenAnswer(inv -> {
+                String id = inv.getArgument(0);
+                String ns = inv.getArgument(1);
+                return Optional.of(new com.spectrayan.spector.synapse.catalog.Grant("g-" + id,
+                        com.spectrayan.spector.synapse.catalog.GrantObjectType.NAMESPACE, ns, id,
+                        com.spectrayan.spector.synapse.catalog.PrincipalType.ACCOUNT,
+                        com.spectrayan.spector.synapse.catalog.GrantRole.OWNER,
+                        java.util.Set.of(), id, java.time.Instant.now(), null, null));
+            });
+            when(catalog.resolve(any(), any())).thenAnswer(inv -> {
+                String id = inv.getArgument(0);
+                String slug = inv.getArgument(1);
+                return Optional.of(new com.spectrayan.spector.synapse.catalog.NamespaceRecord(id, slug, id,
+                        com.spectrayan.spector.synapse.catalog.NamespaceType.DEFAULT,
+                        com.spectrayan.spector.synapse.catalog.NamespaceStatus.ACTIVE, slug, "", null,
+                        java.time.Instant.now(), java.time.Instant.now()));
+            });
+
+            com.spectrayan.spector.synapse.memory.MemoryRequestBinder binder =
+                    new com.spectrayan.spector.synapse.memory.MemoryRequestBinder(
+                            catalog, registry, props, sharedProvider, null);
+            ObjectProvider<com.spectrayan.spector.synapse.memory.MemoryRequestBinder> binderProvider = mockProvider();
+            when(binderProvider.getIfAvailable()).thenReturn(binder);
+
+            Method setBinder = MemoryRegistry.class.getDeclaredMethod("setBinderProvider", ObjectProvider.class);
+            setBinder.setAccessible(true);
+            setBinder.invoke(registry, binderProvider);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return registry;
     }
 
     private SynapseProperties synapseProps(boolean authEnabled) {

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/ConcurrentRequestThreadCaptureIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/ConcurrentRequestThreadCaptureIntegrationTest.java
@@ -106,7 +106,7 @@ class ConcurrentRequestThreadCaptureIntegrationTest {
         MemoryAccessObject mao = mock(MemoryAccessObject.class);
         when(mao.isAvailable(any())).thenReturn(true);
         // Async write completes immediately; capture happens on the request thread before dispatch.
-        when(mao.remember(any(), any(), any(), any(), any(), any(), any(), any()))
+        when(mao.remember(any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenAnswer(inv -> inv.getArgument(1));
 
         MemoryRegistry registry = buildRegistry(true);
@@ -138,13 +138,13 @@ class ConcurrentRequestThreadCaptureIntegrationTest {
 
         // Each user's write is routed to that user's own instance (Req 10.4) — waiting for the async task.
         verify(mao, timeout(5_000)).remember(same(memA), eq(idA), eq("user A content"),
-                any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), any());
         verify(mao, timeout(5_000)).remember(same(memB), eq(idB), eq("user B content"),
-                any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), any());
 
         // No write ever crosses into another user's instance (Req 10.4).
-        verify(mao, never()).remember(same(memB), eq(idA), any(), any(), any(), any(), any(), any());
-        verify(mao, never()).remember(same(memA), eq(idB), any(), any(), any(), any(), any(), any());
+        verify(mao, never()).remember(same(memB), eq(idA), any(), any(), any(), any(), any(), any(), any());
+        verify(mao, never()).remember(same(memA), eq(idB), any(), any(), any(), any(), any(), any(), any());
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -162,7 +162,7 @@ class ConcurrentRequestThreadCaptureIntegrationTest {
         CountDownLatch entered = new CountDownLatch(1);
         MemoryAccessObject mao = mock(MemoryAccessObject.class);
         when(mao.isAvailable(any())).thenReturn(true);
-        when(mao.remember(any(), any(), any(), any(), any(), any(), any(), any())).thenAnswer(inv -> {
+        when(mao.remember(any(), any(), any(), any(), any(), any(), any(), any(), any())).thenAnswer(inv -> {
             entered.countDown();
             proceed.await(5, TimeUnit.SECONDS);
             return inv.getArgument(1);
@@ -183,7 +183,7 @@ class ConcurrentRequestThreadCaptureIntegrationTest {
         proceed.countDown();
 
         verify(mao, timeout(5_000)).remember(same(memA), eq("MEM0000000AAA"),
-                eq("captured on request thread"), any(), any(), any(), any(), any());
+                eq("captured on request thread"), any(), any(), any(), any(), any(), any());
     }
 
     // ══════════════════════════════════════════════════════════════

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryAccessObjectTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryAccessObjectTest.java
@@ -73,16 +73,44 @@ class MemoryAccessObjectTest {
 
     @Test
     @DisplayName("remember — live mode calls memory.remember and returns id")
-    @SuppressWarnings("unchecked")
     void remember_liveMode_callsRemember() {
         doNothing().when(mockMemory)
                 .remember(eq("mem-xyz"), eq("knowledge about HNSW index"),
-                        eq(MemoryType.SEMANTIC), eq(MemorySource.USER_STATED), nullable(IngestionHints.class), any(String[].class));
+                        eq(MemoryType.SEMANTIC), eq(MemorySource.USER_STATED), any(com.spectrayan.spector.memory.model.IngestionContext.class), any(String[].class));
 
         var result = mao.remember(mockMemory, "mem-xyz", "knowledge about HNSW index",
                 MemoryType.SEMANTIC, MemorySource.USER_STATED, null, new String[]{"index", "hnsw"});
 
         assertThat(result).isEqualTo("mem-xyz");
+    }
+
+    @Test
+    @DisplayName("remember — passes soulStack, salienceProfile, and soulVersion from RequestMemoryContext")
+    void remember_withRequestContext_passesIngestionContext() {
+        org.mockito.ArgumentCaptor<com.spectrayan.spector.memory.model.IngestionContext> captor =
+                org.mockito.ArgumentCaptor.forClass(com.spectrayan.spector.memory.model.IngestionContext.class);
+
+        com.spectrayan.spector.memory.model.SoulContext soul =
+                new com.spectrayan.spector.memory.model.UserSoul("user-1", "Developer", "Test soul", null, null);
+        var salience = com.spectrayan.spector.memory.model.SalienceProfile.NEUTRAL;
+
+        RequestMemoryContext reqCtx = new RequestMemoryContext(
+                "tenant-1", List.of("eng"), "user-1", "user-1", "default",
+                com.spectrayan.spector.synapse.catalog.GrantRole.OWNER, java.util.Set.of(),
+                "session-1", List.of(soul), soul, salience
+        );
+
+        mao.remember(mockMemory, "mem-scoped", "Scoped content",
+                MemoryType.SEMANTIC, MemorySource.USER_STATED, null, new String[]{"tag1"}, null, reqCtx);
+
+        verify(mockMemory).remember(eq("mem-scoped"), eq("Scoped content"),
+                eq(MemoryType.SEMANTIC), eq(MemorySource.USER_STATED), captor.capture(), any(String[].class));
+
+        com.spectrayan.spector.memory.model.IngestionContext passedCtx = captor.getValue();
+        assertThat(passedCtx).isNotNull();
+        assertThat(passedCtx.soulContexts()).contains(soul);
+        assertThat(passedCtx.salienceProfile()).isEqualTo(salience);
+        assertThat(passedCtx.soulVersion()).isEqualTo(soul.soulVersion());
     }
 
     @Test

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/NamespaceBiasTagWeightsTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/NamespaceBiasTagWeightsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.spectrayan.spector.memory.model.InterestDomain;
+import com.spectrayan.spector.memory.model.InterestLevel;
+import com.spectrayan.spector.memory.model.SalienceProfile;
+import com.spectrayan.spector.synapse.catalog.NamespaceBias;
+
+@DisplayName("NamespaceBias tagWeights and domainFocus Salience Overlay Specifications")
+class NamespaceBiasTagWeightsTest {
+
+    @Test
+    @DisplayName("Empty or null bias returns base profile unchanged")
+    void testEmptyBiasReturnsBase() {
+        SalienceProfile base = SalienceProfile.NEUTRAL;
+        assertThat(NamespaceBiasApplier.apply(base, null)).isSameAs(base);
+        assertThat(NamespaceBiasApplier.apply(base, NamespaceBias.EMPTY)).isSameAs(base);
+        assertThat(NamespaceBiasApplier.apply(base, new NamespaceBias(List.of(), Map.of()))).isSameAs(base);
+    }
+
+    @Test
+    @DisplayName("domainFocus adds interest domains at MEDIUM level")
+    void testDomainFocusOverlay() {
+        NamespaceBias bias = new NamespaceBias(List.of("quantum-computing", "neuroscience"), Map.of());
+        SalienceProfile result = NamespaceBiasApplier.apply(SalienceProfile.NEUTRAL, bias);
+
+        assertThat(result.interests())
+                .contains(
+                        new InterestDomain("quantum-computing", InterestLevel.MEDIUM),
+                        new InterestDomain("neuroscience", InterestLevel.MEDIUM)
+                );
+    }
+
+    @Test
+    @DisplayName("tagWeights maps weights to appropriate interest and disinterest levels")
+    void testTagWeightsOverlay() {
+        NamespaceBias bias = new NamespaceBias(
+                List.of(),
+                Map.of(
+                        "critical-tag", 2.0f,
+                        "standard-tag", 1.0f,
+                        "low-tag", 0.5f,
+                        "ignored-tag", -1.0f
+                )
+        );
+
+        SalienceProfile result = NamespaceBiasApplier.apply(SalienceProfile.NEUTRAL, bias);
+
+        assertThat(result.interests())
+                .contains(
+                        new InterestDomain("critical-tag", InterestLevel.HIGH),
+                        new InterestDomain("standard-tag", InterestLevel.MEDIUM),
+                        new InterestDomain("low-tag", InterestLevel.LOW)
+                );
+
+        assertThat(result.disinterests())
+                .contains(
+                        new InterestDomain("ignored-tag", InterestLevel.HIGH)
+                );
+    }
+}


### PR DESCRIPTION
## Summary

Addresses all ADR-0029 review findings across the MCP path, wrapper dispatch, request-scoped identity, refcounted identity handles, and Policy Enforcement Point (PEP) caching.

### Key Changes

1. **Request-Scoped Identity Ingestion (Must-Fix 1)**
   - Dropped mutating `memory.applyIdentity(...)` from `MemoryRequestBinder.bind()`.
   - Carries `effectiveSalience`, `soulStack`, and `soulVersion` via `RequestMemoryContext` into `IngestionContext` and propagates across virtual threads in `MemoryService` and `MemoryAccessObject`.
   - Added concurrent scoped identity ingestion isolation test asserting soul contexts do not cross-contaminate.

2. **MCP Binder Fail-Closed Hardening (Must-Fix 2)**
   - In `McpRequestMemory`, fails closed with `RESOLUTION_FAILED` (or `AUTH_REQUIRED`) when auth is enabled and registry binder is unavailable.
   - Documented synchronous servlet-thread adapter model.

3. **SpectorCache PEP Integration with Membership Version (Must-Fix 3)**
   - Wired `CACHE_PEP_NAMESPACE` and `CACHE_PEP_IDENTITY` in `JdbcAccountCatalog` with versioned cache keys (`...:v{membership_version}`).
   - Adding/revoking grants or altering org memberships automatically bumps `users.membership_version`, invalidating cached decisions without requiring distributed cache purges.

4. **Refcounted Identity Bundle Handles (Must-Fix 4)**
   - Implemented `PinnedBundle` and `IdentityHandle` in `IdentityCache` with reference counting (`pinCount` and `evicted` flag) so evicted bundles only close when active readers finish.
   - Wrapped all `IdentityPlane` operations in try-with-resources holding `IdentityHandle`.

5. **PEP Authorization & Admin Decoupling (Should-Fix 1 & 2)**
   - Disallowed `GrantAction.ADMIN` from implying `GrantAction.INJECT` in `authorizeIdentity` (explicit `INJECT` action required for `SOUL` / `ORG_DIR`).
   - Validated org unit existence in `addOrgMember` (throws `IllegalArgumentException` on missing unit).

6. **Catalog Profile Provisioning & Deprecation (Should-Fix 3 & 4)**
   - Extracted `profile` and `kind` token claims in binder and passed them to `catalog.getOrCreateAccount(accountId, profile, kind)`.
   - Deprecated `FileAccountCatalog` with `@Deprecated(since = "0.1.0-alpha")` and implemented 3-arg `getOrCreateAccount`.

7. **Region 24 Migration WRITE PEP & Revocation Logging (Should-Fix 5 & 6)**
   - Enforced WRITE PEP check on `SOUL` and `SALIENCE` regions before migrating in `IdentityPlane.checkAndMigrateRegion24`.
   - Fixed `revokeGrant` to log warnings on membership version bump failure without swallowing exceptions.

8. **Observability Wrappers & Test Coverage (Should-Fix 7 & 8)**
   - Added `MeteredSpectorMemoryTest` delegation assertions alongside `ObservedSpectorMemoryTest`.
   - Added unit tests in `JdbcAccountCatalogTest` for region PEP, constraints, `ADMIN !=> INJECT`, org unit validation, and PEP cache invalidation.

---

## Test Plan

- Unit tests added/updated:
  - `RememberPathwayDirectTest.testConcurrentScopedIdentityIngestionIsolation`: verifies concurrent ingestions with different souls on the same namespace do not cross-contaminate.
  - `JdbcAccountCatalogTest.testAuthorizeIdentityRules` & `testAddOrgMemberValidation`: tests region PEP matching, `ADMIN !=> INJECT`, org membership validation, and PEP caching.
  - `MemoryAccessObjectTest.remember_withRequestContext_passesIngestionContext`: verifies request-scoped context mapping to `IngestionContext`.
  - `McpRequestMemoryBinderTest.testFailClosedWhenBinderNullAndAuthEnabled`: verifies fail-closed resolution when binder is missing under enabled auth.
  - `MeteredSpectorMemoryTest.testApplyIdentityDelegation` & `ObservedSpectorMemoryTest`: verifies wrapper delegation.
  - `ConcurrentRequestThreadCaptureIntegrationTest` & `McpToolIsolationIntegrationTest`: verified request-thread capture and 9-arg `remember` calls.
- Full test suites passing: 795 tests in `spector-synapse`, all tests in `spector-memory` and `spector-metrics` passing with 0 failures, 0 errors.
- License headers verified across all files in checked modules (`mvn license:check` OK).

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>