### PR TITLE
feat(memory): Spacetime Vector Search & Synaptic Relay Architecture (ADR-0030 v1) (#719)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -391,8 +391,8 @@ public final class RecallPathway {
 
                     final float importance = 0.5f;
                     final byte valence = 0;
-                    final float ageDays = (float) ((nowMs - layout.readTimestamp(seg, offset))
-                            / (double) (24 * 60 * 60 * 1000));
+                    final long ts = layout.readTimestamp(seg, offset);
+                    final float ageDays = (float) ((nowMs - ts) / (double) (24 * 60 * 60 * 1000));
 
                     final java.util.Map<String, String> rMeta = snapshot.index().metadata(memId);
                     final SourceModality rModality = rMeta != null
@@ -403,7 +403,7 @@ public final class RecallPathway {
                             Math.max(0, ageDays),
                             (short) 0, valence, MemoryType.SEMANTIC, source,
                             memTags, 1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
-                            rModality, rMeta));
+                            rModality, rMeta, (byte) 0, ts));
 
                 } catch (final RuntimeException e) {
                     log.debug("REPLAY: skipping memory '{}': {}", memId, e.getMessage());
@@ -478,11 +478,7 @@ public final class RecallPathway {
                         contextTagList, r.synapticTags());
                 if (predictive > 0) {
                     final float boosted = r.score() * (1.0f + predictive * 0.5f);
-                    associativeResults.set(i, new CognitiveResult(
-                            r.id(), r.text(), boosted, r.importance(), r.ageDays(),
-                            r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
-                            r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
-                            r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+                    associativeResults.set(i, r.withScore(boosted));
                 }
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -675,7 +675,8 @@ public final class RecallPathway {
                 id != null ? id : "unknown-" + sr.index(),
                 resultText, sr.score(), header.importance(), ageDays,
                 recallCount, header.valence(), type, source, tags,
-                rawDecay, ltpDecay, mode, breakdown, null, modality, metadata);
+                rawDecay, ltpDecay, mode, breakdown, null, modality, metadata,
+                (byte) 0, header.timestampMs());
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -24,6 +24,7 @@ import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoreBreakdown;
 import com.spectrayan.spector.memory.model.ScoringMode;
+import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.synapse.DecayStrategy;
 import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Fused HNSW + Cognitive Scoring recall strategy for Semantic Memory (ADR-0009, #445).
@@ -147,10 +149,12 @@ public final class SemanticRecallStrategy {
                 if (SynapticHeaderConstants.isContradicted(cFlags)) continue;
             }
 
-            // Phase 1b: Temporal gating (absolute timestamp bounds)
+            // Phase 1b: Temporal gating & Future causal horizon gate
             long timestamp = header.timestampMs();
-            if (minTimestamp != null && timestamp < minTimestamp) continue;
-            if (maxTimestamp != null && timestamp > maxTimestamp) continue;
+            if (com.spectrayan.spector.memory.synapse.scan.RecordGates.isTemporalGated(
+                    timestamp, minTimestamp, maxTimestamp, nowMs, options.allowFuture())) {
+                continue;
+            }
 
             // Phase 2: Synaptic tag gating
             long recordTags = header.synapticTags();
@@ -219,7 +223,8 @@ public final class SemanticRecallStrategy {
                     id, text, finalScore, importance, ageDays,
                     agentRecallCount, valence, MemoryType.SEMANTIC, source,
                     tags, rawDecay, decay,
-                    CognitiveResult.RetrievalMode.STANDARD, breakdown));
+                    CognitiveResult.RetrievalMode.STANDARD, breakdown, null,
+                    SourceModality.TEXT, Map.of(), (byte) 0, timestamp));
         }
 
         // Sort by fused score descending

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -189,13 +189,20 @@ public final class SemanticRecallStrategy {
                 decay = 1.0f;
                 rawDecay = 1.0f;
             } else {
-                int rawBucket = DecayStrategy.ageToBucket(timestamp, nowMs);
-                int adjusted = DecayStrategy.adjustForReconsolidation(rawBucket, agentRecallCount);
-                decay = DecayStrategy.decay(adjusted);
-                rawDecay = DecayStrategy.decay(rawBucket);
+                final byte arousal = layout.headerLayout().version() >= 2 ? header.arousal() : (byte) 0;
+                final float storage = layout.headerLayout().version() >= 2
+                        ? layout.headerLayout().readStorageStrength(headerSlab, headerOffset)
+                        : 1.0f;
+                final float cognitiveMass = com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion
+                        .computeCognitiveMass(importance, arousal, storage);
 
-                float baseScore = alpha * similarity + beta * importance * decay;
-                float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
+                decay = com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion
+                        .computeMassDilatedDecay(timestamp, nowMs, cognitiveMass, arousal, agentRecallCount, false);
+                rawDecay = com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion
+                        .computeMassDilatedDecay(timestamp, nowMs, cognitiveMass, (byte) 0, 0, false);
+
+                final float baseScore = alpha * similarity + beta * (importance / 10.0f) * decay;
+                final float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
                 finalScore = baseScore * (1.0f + tagOverlap * tagRelevanceBoost);
             }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -27,6 +27,8 @@ import com.spectrayan.spector.memory.model.ScoringMode;
 import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.synapse.DecayStrategy;
 import com.spectrayan.spector.memory.synapse.SynapticTagEncoder;
+import com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion;
+import com.spectrayan.spector.memory.synapse.scan.RecordGates;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,7 +153,7 @@ public final class SemanticRecallStrategy {
 
             // Phase 1b: Temporal gating & Future causal horizon gate
             long timestamp = header.timestampMs();
-            if (com.spectrayan.spector.memory.synapse.scan.RecordGates.isTemporalGated(
+            if (RecordGates.isTemporalGated(
                     timestamp, minTimestamp, maxTimestamp, nowMs, options.allowFuture())) {
                 continue;
             }
@@ -193,13 +195,10 @@ public final class SemanticRecallStrategy {
                 final float storage = layout.headerLayout().version() >= 2
                         ? layout.headerLayout().readStorageStrength(headerSlab, headerOffset)
                         : 1.0f;
-                final float cognitiveMass = com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion
-                        .computeCognitiveMass(importance, arousal, storage);
+                final float cognitiveMass = CognitiveScoreFusion.computeCognitiveMass(importance, arousal, storage);
 
-                decay = com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion
-                        .computeMassDilatedDecay(timestamp, nowMs, cognitiveMass, arousal, agentRecallCount, false);
-                rawDecay = com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion
-                        .computeMassDilatedDecay(timestamp, nowMs, cognitiveMass, (byte) 0, 0, false);
+                decay = CognitiveScoreFusion.computeMassDilatedDecay(timestamp, nowMs, cognitiveMass, arousal, agentRecallCount, false);
+                rawDecay = CognitiveScoreFusion.computeMassDilatedDecay(timestamp, nowMs, cognitiveMass, (byte) 0, 0, false);
 
                 final float baseScore = alpha * similarity + beta * (importance / 10.0f) * decay;
                 final float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
@@ -175,6 +175,24 @@ public record CognitiveResult(
     }
 
     /**
+     * Returns a copy of this result with updated score.
+     */
+    public CognitiveResult withScore(float newScore) {
+        return new CognitiveResult(id, text, newScore, importance, ageDays, agentRecallCount,
+                valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
+                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags);
+    }
+
+    /**
+     * Returns a copy of this result with updated score and breakdown.
+     */
+    public CognitiveResult withScoreAndBreakdown(float newScore, ScoreBreakdown newBreakdown) {
+        return new CognitiveResult(id, text, newScore, importance, ageDays, agentRecallCount,
+                valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
+                retrievalMode, newBreakdown, trace, sourceModality, metadata, consolidationFlags);
+    }
+
+    /**
      * Returns a copy of this result with updated text content.
      */
     public CognitiveResult withText(String newText) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * Immutable result record returned by {@link com.spectrayan.spector.memory.SpectorMemory#recall}.
  *
  * <p>Contains the memory text, cognitive scoring metadata, provenance information,
- * and biological state (recall count, valence, decay factor). Designed to give
+ * and biological state (recall count, valence, decay factor, timestampMs). Designed to give
  * the LLM maximum contextual grounding for reasoning about memory reliability.</p>
  *
  * @param id              unique memory identifier
@@ -28,7 +28,7 @@ import java.util.Map;
  * @param score           final fused cognitive score (similarity × decay × importance)
  * @param importance      base importance weight (auto-set by Prediction Error engine)
  * @param ageDays         age of the memory in days
- * @param agentRecallCount     number of times this memory has been recalled (LTP/reconsolidation)
+ * @param agentRecallCount number of times this memory has been recalled (LTP/reconsolidation)
  * @param valence         emotional valence (-128 to +127)
  * @param memoryType      cognitive memory tier (Working, Episodic, Semantic, Procedural)
  * @param source          provenance source (Observed, UserStated, Reflected, etc.)
@@ -40,6 +40,8 @@ import java.util.Map;
  * @param trace           per-step pipeline scoring trace (nullable — only populated when enableTrace=true)
  * @param sourceModality  what the memory originally was before ingestion (TEXT, IMAGE, AUDIO, VIDEO)
  * @param metadata        multimodal metadata (source_uri, etc.) — empty map for text-only memories
+ * @param consolidationFlags consolidation provenance flags
+ * @param timestampMs     epoch millisecond timestamp when the memory was formed (ADR-0030 v1)
  */
 public record CognitiveResult(
         String id,
@@ -59,13 +61,33 @@ public record CognitiveResult(
         RecallTrace trace,
         SourceModality sourceModality,
         Map<String, String> metadata,
-        byte consolidationFlags
+        byte consolidationFlags,
+        long timestampMs
 ) {
 
-    /** Compact constructor — defaults null modality/metadata. */
+    /** Compact constructor — defaults null modality/metadata and derives timestampMs if omitted. */
     public CognitiveResult {
         if (sourceModality == null) sourceModality = SourceModality.TEXT;
         if (metadata == null) metadata = Map.of();
+        if (timestampMs == 0L && ageDays > 0.0f) {
+            timestampMs = System.currentTimeMillis() - (long) (ageDays * 86_400_000.0);
+        }
+    }
+
+    /**
+     * Backward-compatible 18-argument constructor.
+     */
+    public CognitiveResult(String id, String text, float score, float importance,
+                           float ageDays, int agentRecallCount, byte valence,
+                           MemoryType memoryType, MemorySource source,
+                           String[] synapticTags, float decayFactor,
+                           float ltpAdjustedDecay, RetrievalMode retrievalMode,
+                           ScoreBreakdown breakdown, RecallTrace trace,
+                           SourceModality sourceModality, Map<String, String> metadata,
+                           byte consolidationFlags) {
+        this(id, text, score, importance, ageDays, agentRecallCount, valence,
+                memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
+                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags, 0L);
     }
 
     /**
@@ -80,20 +102,11 @@ public record CognitiveResult(
                            SourceModality sourceModality, Map<String, String> metadata) {
         this(id, text, score, importance, ageDays, agentRecallCount, valence,
                 memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, trace, sourceModality, metadata, (byte) 0);
+                retrievalMode, breakdown, trace, sourceModality, metadata, (byte) 0, 0L);
     }
 
     /**
      * How a memory was retrieved — enables the LLM to reason about result provenance.
-     *
-     * <h3>Neurodivergent Cognitive Profiles</h3>
-     * <ul>
-     *   <li>{@code STANDARD} — normal similarity-based retrieval</li>
-     *   <li>{@code LATERAL} — cross-domain retrieval via orthogonal tag matching
-     *       (divergent thinking / ADHD profile)</li>
-     *   <li>{@code HYPERFOCUS} — zero-decay retrieval for focus-matched memories
-     *       (monotropism / autistic profile)</li>
-     * </ul>
      */
     public enum RetrievalMode {
         /** Standard similarity-based retrieval. */
@@ -114,7 +127,7 @@ public record CognitiveResult(
                             float ltpAdjustedDecay) {
         this(id, text, score, importance, ageDays, agentRecallCount, valence,
                 memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                RetrievalMode.STANDARD, null, null, null, null, (byte) 0);
+                RetrievalMode.STANDARD, null, null, null, null, (byte) 0, 0L);
     }
 
     /**
@@ -127,7 +140,7 @@ public record CognitiveResult(
                             float ltpAdjustedDecay, RetrievalMode retrievalMode) {
         this(id, text, score, importance, ageDays, agentRecallCount, valence,
                 memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, null, null, null, null, (byte) 0);
+                retrievalMode, null, null, null, null, (byte) 0, 0L);
     }
 
     /**
@@ -141,7 +154,7 @@ public record CognitiveResult(
                             ScoreBreakdown breakdown) {
         this(id, text, score, importance, ageDays, agentRecallCount, valence,
                 memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, null, null, null, (byte) 0);
+                retrievalMode, breakdown, null, null, null, (byte) 0, 0L);
     }
 
     /**
@@ -171,7 +184,7 @@ public record CognitiveResult(
     public CognitiveResult withTrace(RecallTrace trace) {
         return new CognitiveResult(id, text, score, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags);
+                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags, timestampMs);
     }
 
     /**
@@ -180,7 +193,7 @@ public record CognitiveResult(
     public CognitiveResult withScore(float newScore) {
         return new CognitiveResult(id, text, newScore, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags);
+                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags, timestampMs);
     }
 
     /**
@@ -189,7 +202,7 @@ public record CognitiveResult(
     public CognitiveResult withScoreAndTrace(float newScore, RecallTrace newTrace) {
         return new CognitiveResult(id, text, newScore, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, newTrace, sourceModality, metadata, consolidationFlags);
+                retrievalMode, breakdown, newTrace, sourceModality, metadata, consolidationFlags, timestampMs);
     }
 
     /**
@@ -198,7 +211,16 @@ public record CognitiveResult(
     public CognitiveResult withScoreAndBreakdown(float newScore, ScoreBreakdown newBreakdown) {
         return new CognitiveResult(id, text, newScore, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, newBreakdown, trace, sourceModality, metadata, consolidationFlags);
+                retrievalMode, newBreakdown, trace, sourceModality, metadata, consolidationFlags, timestampMs);
+    }
+
+    /**
+     * Returns a copy of this result with updated timestampMs.
+     */
+    public CognitiveResult withTimestampMs(long timestampMs) {
+        return new CognitiveResult(id, text, score, importance, ageDays, agentRecallCount,
+                valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
+                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags, timestampMs);
     }
 
     /**
@@ -207,7 +229,7 @@ public record CognitiveResult(
     public CognitiveResult withText(String newText) {
         return new CognitiveResult(id, newText, score, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags);
+                retrievalMode, breakdown, trace, sourceModality, metadata, consolidationFlags, timestampMs);
     }
 
     /**
@@ -216,7 +238,7 @@ public record CognitiveResult(
     public CognitiveResult withModality(SourceModality modality, Map<String, String> metadata) {
         return new CognitiveResult(id, text, score, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, trace, modality, metadata, consolidationFlags);
+                retrievalMode, breakdown, trace, modality, metadata, consolidationFlags, timestampMs);
     }
 
     /**
@@ -225,7 +247,7 @@ public record CognitiveResult(
     public CognitiveResult withConsolidationFlags(byte flags) {
         return new CognitiveResult(id, text, score, importance, ageDays, agentRecallCount,
                 valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
-                retrievalMode, breakdown, trace, sourceModality, metadata, flags);
+                retrievalMode, breakdown, trace, sourceModality, metadata, flags, timestampMs);
     }
 
     /**
@@ -270,4 +292,3 @@ public record CognitiveResult(
         return retrievalMode == RetrievalMode.HYPERFOCUS;
     }
 }
-

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
@@ -184,6 +184,15 @@ public record CognitiveResult(
     }
 
     /**
+     * Returns a copy of this result with updated score and trace.
+     */
+    public CognitiveResult withScoreAndTrace(float newScore, RecallTrace newTrace) {
+        return new CognitiveResult(id, text, newScore, importance, ageDays, agentRecallCount,
+                valence, memoryType, source, synapticTags, decayFactor, ltpAdjustedDecay,
+                retrievalMode, breakdown, newTrace, sourceModality, metadata, consolidationFlags);
+    }
+
+    /**
      * Returns a copy of this result with updated score and breakdown.
      */
     public CognitiveResult withScoreAndBreakdown(float newScore, ScoreBreakdown newBreakdown) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -143,7 +143,11 @@ public record RecallOptions(
         boolean enableAssociativePrior,
         float associativePriorDelta,
         float associativePriorStdpWeight,
-        float associativePriorHubWeight
+        float associativePriorHubWeight,
+        //  Spacetime Vector Search (ADR-0030 v1)
+        boolean allowFuture,
+        boolean enableSpacetime,
+        float spacetimeHarmonicWeight
 ) {
 
     /** Default options: top 10, no filters, balanced scoring. */
@@ -430,6 +434,29 @@ public record RecallOptions(
         /** Sets hub degree weight for associative prior (default 0.3). */
         public Builder associativePriorHubWeight(float weight) {
             this.associativePriorHubWeight = weight;
+            return this;
+        }
+
+        // ─── Spacetime Vector Search (ADR-0030 v1) ───
+        private boolean allowFuture = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_ALLOW_FUTURE;
+        private boolean enableSpacetime = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_SPACETIME_ENABLED;
+        private float spacetimeHarmonicWeight = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_SPACETIME_HARMONIC_WEIGHT;
+
+        /** Enables or disables recalling future memories (past query timestamp). */
+        public Builder allowFuture(boolean allow) {
+            this.allowFuture = allow;
+            return this;
+        }
+
+        /** Enables or disables shortlist spacetime harmonic re-ranking. */
+        public Builder enableSpacetime(boolean enable) {
+            this.enableSpacetime = enable;
+            return this;
+        }
+
+        /** Sets harmonic weight rho for spacetime re-ranking (default 0.15). */
+        public Builder spacetimeHarmonicWeight(float weight) {
+            this.spacetimeHarmonicWeight = weight;
             return this;
         }
 
@@ -1033,7 +1060,10 @@ public record RecallOptions(
                     enableAssociativePrior,
                     associativePriorDelta,
                     associativePriorStdpWeight,
-                    associativePriorHubWeight);
+                    associativePriorHubWeight,
+                    allowFuture,
+                    enableSpacetime,
+                    spacetimeHarmonicWeight);
             return options;
         }
     }
@@ -1130,36 +1160,69 @@ public record RecallOptions(
         return warnings;
     }
 
+    // ==============================================================
+    // Factory presets for common recall archetypes
+    // ==============================================================
+
     /**
-     * Parses a profile name string (case-insensitive) into a {@link CognitiveProfile}.
-     *
-     * <p>Intended for MCP/REST integrations where profile arrives as a string.
-     * Returns {@code null} if the name is null, empty, or doesn't match any profile.</p>
-     *
-     * @param profileName profile name (e.g., "DEBUGGING", "debugging", "Debugging")
-     * @return the matching profile, or {@code null} if not found
+     * Preset for strict factual verification.
+     */
+    public static RecallOptions factual(int topK) {
+        return builder()
+                .topK(topK)
+                .profile(CognitiveProfile.SYSTEMATIZER)
+                .strictnessCoefficient(5.0f)
+                .build();
+    }
+
+    /**
+     * Preset for broad exploration / brainstorming.
+     */
+    public static RecallOptions exploratory(int topK) {
+        return builder()
+                .topK(topK)
+                .profile(CognitiveProfile.DIVERGENT)
+                .lateralMode(true)
+                .build();
+    }
+
+    /**
+     * Preset for emotional debugging / incident investigation.
+     */
+    public static RecallOptions postMortem(int topK, String... tags) {
+        return builder()
+                .topK(topK)
+                .synapticFilter(tags)
+                .maxValence((byte) -1)
+                .build();
+    }
+
+    /**
+     * Preset for associative recall without text or LLM calls.
+     */
+    public static RecallOptions associative(int topK, float minImportance) {
+        return builder()
+                .topK(topK)
+                .minImportance(minImportance)
+                .build();
+    }
+
+    /**
+     * Parses a string profile name into a {@link CognitiveProfile}.
      */
     public static CognitiveProfile parseProfile(String profileName) {
-        if (profileName == null || profileName.isBlank()) return null;
-        if ("AUTO".equalsIgnoreCase(profileName.strip())) return null;
+        if (profileName == null || profileName.isBlank()) {
+            return null;
+        }
         try {
             return CognitiveProfile.valueOf(profileName.strip().toUpperCase());
         } catch (IllegalArgumentException e) {
-            VALIDATION_LOG.warn("Unknown CognitiveProfile: '" + profileName
-                    + "'. Available: " + java.util.Arrays.toString(CognitiveProfile.values()));
             return null;
         }
     }
 
     /**
      * Checks if the given profile name represents the AUTO detection mode.
-     *
-     * <p>Use in combination with {@link #parseProfile} and {@link Builder#autoProfile}:
-     * if this returns {@code true}, set {@code autoProfile(true)} on the builder
-     * instead of applying a specific profile.</p>
-     *
-     * @param profileName profile name string (may be null)
-     * @return true if the name is "AUTO" (case-insensitive)
      */
     public static boolean isAutoProfile(String profileName) {
         return profileName != null && "AUTO".equalsIgnoreCase(profileName.strip());
@@ -1223,7 +1286,9 @@ public record RecallOptions(
         b.associativePriorDelta = this.associativePriorDelta;
         b.associativePriorStdpWeight = this.associativePriorStdpWeight;
         b.associativePriorHubWeight = this.associativePriorHubWeight;
+        b.allowFuture = this.allowFuture;
+        b.enableSpacetime = this.enableSpacetime;
+        b.spacetimeHarmonicWeight = this.spacetimeHarmonicWeight;
         return b;
     }
 }
-

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/RecallOptions.java
@@ -1160,69 +1160,36 @@ public record RecallOptions(
         return warnings;
     }
 
-    // ==============================================================
-    // Factory presets for common recall archetypes
-    // ==============================================================
-
     /**
-     * Preset for strict factual verification.
-     */
-    public static RecallOptions factual(int topK) {
-        return builder()
-                .topK(topK)
-                .profile(CognitiveProfile.SYSTEMATIZER)
-                .strictnessCoefficient(5.0f)
-                .build();
-    }
-
-    /**
-     * Preset for broad exploration / brainstorming.
-     */
-    public static RecallOptions exploratory(int topK) {
-        return builder()
-                .topK(topK)
-                .profile(CognitiveProfile.DIVERGENT)
-                .lateralMode(true)
-                .build();
-    }
-
-    /**
-     * Preset for emotional debugging / incident investigation.
-     */
-    public static RecallOptions postMortem(int topK, String... tags) {
-        return builder()
-                .topK(topK)
-                .synapticFilter(tags)
-                .maxValence((byte) -1)
-                .build();
-    }
-
-    /**
-     * Preset for associative recall without text or LLM calls.
-     */
-    public static RecallOptions associative(int topK, float minImportance) {
-        return builder()
-                .topK(topK)
-                .minImportance(minImportance)
-                .build();
-    }
-
-    /**
-     * Parses a string profile name into a {@link CognitiveProfile}.
+     * Parses a profile name string (case-insensitive) into a {@link CognitiveProfile}.
+     *
+     * <p>Intended for MCP/REST integrations where profile arrives as a string.
+     * Returns {@code null} if the name is null, empty, or doesn't match any profile.</p>
+     *
+     * @param profileName profile name (e.g., "DEBUGGING", "debugging", "Debugging")
+     * @return the matching profile, or {@code null} if not found
      */
     public static CognitiveProfile parseProfile(String profileName) {
-        if (profileName == null || profileName.isBlank()) {
-            return null;
-        }
+        if (profileName == null || profileName.isBlank()) return null;
+        if ("AUTO".equalsIgnoreCase(profileName.strip())) return null;
         try {
             return CognitiveProfile.valueOf(profileName.strip().toUpperCase());
         } catch (IllegalArgumentException e) {
+            VALIDATION_LOG.warn("Unknown CognitiveProfile: '" + profileName
+                    + "'. Available: " + java.util.Arrays.toString(CognitiveProfile.values()));
             return null;
         }
     }
 
     /**
      * Checks if the given profile name represents the AUTO detection mode.
+     *
+     * <p>Use in combination with {@link #parseProfile} and {@link Builder#autoProfile}:
+     * if this returns {@code true}, set {@code autoProfile(true)} on the builder
+     * instead of applying a specific profile.</p>
+     *
+     * @param profileName profile name string (may be null)
+     * @return true if the name is "AUTO" (case-insensitive)
      */
     public static boolean isAutoProfile(String profileName) {
         return profileName != null && "AUTO".equalsIgnoreCase(profileName.strip());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/RelayNames.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/RelayNames.java
@@ -24,6 +24,7 @@ public final class RelayNames {
     public static final String PROSPECTIVE           = "prospective";
     public static final String GOVERNED_RELEASE_GATE = "governed_release_gate";
     public static final String VECTOR_SEARCH         = "vector_search";
+    public static final String SPACETIME_SCORING     = "spacetime_scoring";
     public static final String SCORING               = "scoring";
     public static final String GRAPH_EXPANSION       = "graph_expansion";
     public static final String EVIDENCE_FUSION       = "evidence_fusion";

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -783,13 +783,7 @@ public final class RecallPipeline {
                             CognitiveResult r = toRerank.get(i);
                             Float newScore = rerankScores.get(r.id());
                             if (newScore != null) {
-                                allResults.set(i, new CognitiveResult(
-                                        r.id(), r.text(), newScore, r.importance(),
-                                        r.ageDays(), r.agentRecallCount(), r.valence(),
-                                        r.memoryType(), r.source(), r.synapticTags(),
-                                        r.decayFactor(), r.ltpAdjustedDecay(),
-                                        r.retrievalMode(), r.breakdown(), r.trace(),
-                                        r.sourceModality(), r.metadata()));
+                                allResults.set(i, r.withScore(newScore));
                             }
                         }
 
@@ -1421,17 +1415,11 @@ public final class RecallPipeline {
             List<String> contextTagList = new ArrayList<>(contextTags.keySet());
             for (int i = 0; i < associativeResults.size(); i++) {
                 CognitiveResult r = associativeResults.get(i);
-                if (r.synapticTags() == null || r.synapticTags().length == 0) continue;
-
                 float predictive = coActivationTracker.getPredictiveStrength(
                         contextTagList, r.synapticTags());
                 if (predictive > 0) {
-                    float boosted = r.score() * (1.0f + predictive * 0.5f);
-                    associativeResults.set(i, new CognitiveResult(
-                            r.id(), r.text(), boosted, r.importance(), r.ageDays(),
-                            r.agentRecallCount(), r.valence(), r.memoryType(), r.source(),
-                            r.synapticTags(), r.decayFactor(), r.ltpAdjustedDecay(),
-                            r.retrievalMode(), r.breakdown(), r.trace(), r.sourceModality(), r.metadata()));
+                    final float boosted = r.score() * (1.0f + predictive * 0.5f);
+                    associativeResults.set(i, r.withScore(boosted));
                 }
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
@@ -102,13 +102,7 @@ public class RecallCandidateGatherer {
 
             if (existing != null) {
                 float tierBoost = (existing.memoryType() == MemoryType.SEMANTIC || existing.memoryType() == MemoryType.PROCEDURAL) ? 2.0f : 1.0f;
-                vectorResults.add(new CognitiveResult(
-                        existing.id(), existing.text(), rrfScore * tierBoost, existing.importance(),
-                        existing.ageDays(), existing.agentRecallCount(), existing.valence(),
-                        existing.memoryType(), existing.source(), existing.synapticTags(),
-                        existing.decayFactor(), existing.ltpAdjustedDecay(),
-                        existing.retrievalMode(), existing.breakdown(), existing.trace(),
-                        existing.sourceModality(), existing.metadata()));
+                vectorResults.add(existing.withScore(rrfScore * tierBoost));
             } else if (index != null) {
                 MemoryIndex.MemoryLocation loc = index.locate(id);
                 if (loc == null) continue;
@@ -120,6 +114,7 @@ public class RecallCandidateGatherer {
                 byte valence = 0;
                 float ageDays = 0f;
                 short recallCount = 0;
+                long ts = 0L;
 
                 if (partitionRegistry != null) {
                     CognitiveMemoryRouter router = partitionRegistry.routerFor(loc.colocatedPartition());
@@ -134,7 +129,7 @@ public class RecallCandidateGatherer {
                             importance = header.importance();
                             valence = header.valence();
                             recallCount = (short) header.agentRecallCount();
-                            long ts = header.timestampMs();
+                            ts = header.timestampMs();
                             if (options.minTimestamp() != null && ts < options.minTimestamp()) continue;
                             if (options.maxTimestamp() != null && ts > options.maxTimestamp()) continue;
                             if (ts > 0) {
@@ -172,7 +167,7 @@ public class RecallCandidateGatherer {
                         id, text, rrfScore * tierBoost, importance, ageDays,
                         recallCount, valence, type, source,
                         tags, 1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
-                        bm25Modality, bm25Meta));
+                        bm25Modality, bm25Meta, (byte) 0, ts));
             }
         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CognitiveRerankRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CognitiveRerankRelay.java
@@ -71,13 +71,7 @@ public final class CognitiveRerankRelay implements SynapticRelay<RecallSignal> {
                             final CognitiveResult r = toRerank.get(i);
                             final Float newScore = rerankScores.get(r.id());
                             if (newScore != null) {
-                                allResults.set(i, new CognitiveResult(
-                                        r.id(), r.text(), newScore, r.importance(),
-                                        r.ageDays(), r.agentRecallCount(), r.valence(),
-                                        r.memoryType(), r.source(), r.synapticTags(),
-                                        r.decayFactor(), r.ltpAdjustedDecay(),
-                                        r.retrievalMode(), r.breakdown(), r.trace(),
-                                        r.sourceModality(), r.metadata()));
+                                allResults.set(i, r.withScore(newScore));
                             }
                         }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CorticalTierScanRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CorticalTierScanRelay.java
@@ -80,7 +80,7 @@ public final class CorticalTierScanRelay implements SynapticRelay<RecallSignal> 
     public boolean transmit(final RecallSignal signal) {
         final float[] queryVector = signal.queryVector();
         final RecallOptions options = signal.options();
-        final long nowMs = signal.timestampMs();
+        final long nowMs = signal.queryTimeMs() > 0 ? signal.queryTimeMs() : signal.timestampMs();
         final MemoryType[] targetTypes = options.memoryTypes();
         final List<CognitiveResult> allResults = signal.candidates();
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/LateralInhibitionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/LateralInhibitionRelay.java
@@ -208,14 +208,7 @@ public final class LateralInhibitionRelay implements SynapticRelay<RecallSignal>
                 competitors
         );
 
-        candidates.set(idx, new CognitiveResult(
-                r.id(), r.text(), newScore, r.importance(),
-                r.ageDays(), r.agentRecallCount(), r.valence(),
-                r.memoryType(), r.source(), r.synapticTags(),
-                r.decayFactor(), r.ltpAdjustedDecay(),
-                r.retrievalMode(), newBd, r.trace(),
-                r.sourceModality(), r.metadata(), r.consolidationFlags()
-        ));
+        candidates.set(idx, r.withScoreAndBreakdown(newScore, newBd));
     }
 
     private static float cosineSimilarity(float[] a, float[] b) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/QueryTransductionRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/QueryTransductionRelay.java
@@ -15,11 +15,12 @@ package com.spectrayan.spector.memory.recall.relay;
 import com.spectrayan.spector.commons.pathway.SynapticRelay;
 import com.spectrayan.spector.memory.pathway.RelayNames;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.core.spacetime.Time2VecProjector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Transduces a raw text query into a vector representation.
+ * Transduces a raw text query into a vector representation and computes reference spacetime coordinates.
  */
 public final class QueryTransductionRelay implements SynapticRelay<RecallSignal> {
 
@@ -33,11 +34,18 @@ public final class QueryTransductionRelay implements SynapticRelay<RecallSignal>
 
     @Override
     public boolean transmit(final RecallSignal signal) {
-        if (signal.queryVector() == null) {
+        if (signal.queryVector() == null && signal.rawQuery() != null) {
             final var result = embeddingProvider.embed(signal.rawQuery());
             signal.setQueryVector(result.vector());
             log.debug("Embedded query vector for text: {}", signal.rawQuery());
         }
+
+        final long queryTime = (signal.options().replayTimestamp() != null)
+                ? signal.options().replayTimestamp().toEpochMilli()
+                : signal.timestampMs();
+        signal.setQueryTimeMs(queryTime);
+        signal.setQueryTau(Time2VecProjector.project(queryTime));
+
         return true;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallGates.java
@@ -123,4 +123,11 @@ public final class RecallGates {
     public static final Specification<RecallSignal> EPISTEMIC_LEARNING_ENABLED =
         Specification.of("epistemic learning not enabled in AISME options",
             s -> s.options().enableAisme() && (s.options().aismeConfig().enableFreeEnergy() || s.options().aismeConfig().enableHomeostasis()));
+
+    /**
+     * Gate evaluating whether Spacetime harmonic re-ranking is enabled (ADR-0030 v1).
+     */
+    public static final Specification<RecallSignal> SPACETIME_ENABLED =
+        Specification.of("spacetime vector search not enabled in recall options",
+            s -> s.options().enableSpacetime() && s.queryTau() != null);
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
@@ -175,6 +175,45 @@ public final class RecallPathwayFactory {
             final SynapticRelay<RecallSignal> constructiveMemoryPersistenceRelay,
             final SynapticRelay<RecallSignal> epistemicLearningRelay,
             final ConsolidationRelay<RecallSignal> consolidationRelay) {
+        return create(interceptor, transductionRelay, prospectiveRelay, governedReleaseGateRelay,
+                homeostaticBiasRelay, vectorSearchRelay, freeEnergyGuidedRelay, null, scoringRelay,
+                graphExpansionRelay, hopfieldAssociativeRelay, evidenceFusionRelay, lateralInhibitionRelay,
+                bm25SearchRelay, rrfRescoreRelay, manifoldRerankRelay, constructiveSimulationRelay,
+                consciousnessContinuityRelay, sortAndTruncateRelay, cognitiveRerankRelay,
+                mmrDiversityRelay, temperatureSoftmaxRelay, consciousAccessRelay,
+                constructiveMemoryPersistenceRelay, epistemicLearningRelay, consolidationRelay);
+    }
+
+    /**
+     * Creates the full cognitive recall pathway with custom spacetime scoring relay injection.
+     */
+    public static CognitivePathway<RecallSignal> create(
+            final Function<SynapticRelay<RecallSignal>, SynapticRelay<RecallSignal>> interceptor,
+            final SynapticRelay<RecallSignal> transductionRelay,
+            final SynapticRelay<RecallSignal> prospectiveRelay,
+            final SynapticRelay<RecallSignal> governedReleaseGateRelay,
+            final SynapticRelay<RecallSignal> homeostaticBiasRelay,
+            final SynapticRelay<RecallSignal> vectorSearchRelay,
+            final SynapticRelay<RecallSignal> freeEnergyGuidedRelay,
+            final SynapticRelay<RecallSignal> spacetimeScoringRelay,
+            final SynapticRelay<RecallSignal> scoringRelay,
+            final SynapticRelay<RecallSignal> graphExpansionRelay,
+            final SynapticRelay<RecallSignal> hopfieldAssociativeRelay,
+            final SynapticRelay<RecallSignal> evidenceFusionRelay,
+            final SynapticRelay<RecallSignal> lateralInhibitionRelay,
+            final SynapticRelay<RecallSignal> bm25SearchRelay,
+            final RrfRescoreRelay rrfRescoreRelay,
+            final SynapticRelay<RecallSignal> manifoldRerankRelay,
+            final SynapticRelay<RecallSignal> constructiveSimulationRelay,
+            final SynapticRelay<RecallSignal> consciousnessContinuityRelay,
+            final SortAndTruncateRelay sortAndTruncateRelay,
+            final CognitiveRerankRelay cognitiveRerankRelay,
+            final MmrDiversityRelay mmrDiversityRelay,
+            final TemperatureSoftmaxRelay temperatureSoftmaxRelay,
+            final SynapticRelay<RecallSignal> consciousAccessRelay,
+            final SynapticRelay<RecallSignal> constructiveMemoryPersistenceRelay,
+            final SynapticRelay<RecallSignal> epistemicLearningRelay,
+            final ConsolidationRelay<RecallSignal> consolidationRelay) {
 
         final var builder = CognitivePathway.<RecallSignal>pathway("recall");
         if (interceptor != null) {
@@ -194,7 +233,8 @@ public final class RecallPathwayFactory {
             builder.gated(RelayNames.FREE_ENERGY_GUIDED, RecallGates.FREE_ENERGY_ENABLED, freeEnergyGuidedRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
         }
 
-        builder.gated(RelayNames.SPACETIME_SCORING, RecallGates.SPACETIME_ENABLED, new SpacetimeScoringRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
+        final var effectiveSpacetimeRelay = spacetimeScoringRelay != null ? spacetimeScoringRelay : new SpacetimeScoringRelay();
+        builder.gated(RelayNames.SPACETIME_SCORING, RecallGates.SPACETIME_ENABLED, effectiveSpacetimeRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
                .relay(RelayNames.SCORING, scoringRelay)
                .relay(RelayNames.GRAPH_EXPANSION, graphExpansionRelay);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallPathwayFactory.java
@@ -194,7 +194,8 @@ public final class RecallPathwayFactory {
             builder.gated(RelayNames.FREE_ENERGY_GUIDED, RecallGates.FREE_ENERGY_ENABLED, freeEnergyGuidedRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
         }
 
-        builder.relay(RelayNames.SCORING, scoringRelay)
+        builder.gated(RelayNames.SPACETIME_SCORING, RecallGates.SPACETIME_ENABLED, new SpacetimeScoringRelay(), ErrorPolicy.DEGRADE_GRACEFULLY)
+               .relay(RelayNames.SCORING, scoringRelay)
                .relay(RelayNames.GRAPH_EXPANSION, graphExpansionRelay);
 
         if (hopfieldAssociativeRelay != null) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/RecallSignal.java
@@ -39,6 +39,8 @@ public final class RecallSignal implements DivergentCapable<RecallSignal>, Trace
 
     // Mutable working state
     private float[] queryVector;
+    private float[] queryTau;
+    private long queryTimeMs;
     private final List<CognitiveResult> candidates = new ArrayList<>();
     private boolean textSearchExecuted = false;
     private boolean rrfFused = false;
@@ -83,6 +85,8 @@ public final class RecallSignal implements DivergentCapable<RecallSignal>, Trace
     @Override
     public RecallSignal fork() {
         final RecallSignal fork = new RecallSignal(rawQuery, queryVector, options, timestampMs);
+        fork.queryTau = this.queryTau;
+        fork.queryTimeMs = this.queryTimeMs;
         fork.candidates.addAll(this.candidates);
         fork.textSearchExecuted = this.textSearchExecuted;
         fork.rrfFused = this.rrfFused;
@@ -184,6 +188,42 @@ public final class RecallSignal implements DivergentCapable<RecallSignal>, Trace
      */
     public void setQueryVector(final float[] queryVector) {
         this.queryVector = queryVector;
+    }
+
+    /**
+     * Returns the 8-dimensional harmonic basis vector for the query timestamp.
+     *
+     * @return 8-element harmonic vector, or null if not computed
+     */
+    public float[] queryTau() {
+        return queryTau;
+    }
+
+    /**
+     * Sets the 8-dimensional harmonic basis vector for the query.
+     *
+     * @param queryTau harmonic basis vector
+     */
+    public void setQueryTau(final float[] queryTau) {
+        this.queryTau = queryTau;
+    }
+
+    /**
+     * Returns the effective reference query timestamp in epoch milliseconds.
+     *
+     * @return query timestamp in epoch ms
+     */
+    public long queryTimeMs() {
+        return queryTimeMs;
+    }
+
+    /**
+     * Sets the effective reference query timestamp in epoch milliseconds.
+     *
+     * @param queryTimeMs reference query timestamp in epoch ms
+     */
+    public void setQueryTimeMs(final long queryTimeMs) {
+        this.queryTimeMs = queryTimeMs;
     }
 
     /**

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SpacetimeScoringRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SpacetimeScoringRelay.java
@@ -66,7 +66,23 @@ public final class SpacetimeScoringRelay implements SynapticRelay<RecallSignal> 
             final float harmonicDelta = rho * harmonicAlignment;
             final float newScore = Math.max(0.0f, candidate.score() + harmonicDelta);
 
-            updated.add(candidate.withScore(newScore));
+            if (candidate.trace() != null) {
+                final java.util.List<com.spectrayan.spector.memory.model.RecallTrace.TraceStep> steps =
+                        new ArrayList<>(candidate.trace().steps());
+                steps.add(new com.spectrayan.spector.memory.model.RecallTrace.TraceStep(
+                        RelayNames.SPACETIME_SCORING,
+                        candidate.score(),
+                        newScore,
+                        candidates.size(),
+                        candidates.size(),
+                        String.format("harmonicAlignment=%.4f, rho=%.2f, delta=%+.4f", harmonicAlignment, rho, harmonicDelta)));
+                final com.spectrayan.spector.memory.model.RecallTrace updatedTrace =
+                        new com.spectrayan.spector.memory.model.RecallTrace(
+                                candidate.id(), java.util.Collections.unmodifiableList(steps));
+                updated.add(candidate.withScoreAndTrace(newScore, updatedTrace));
+            } else {
+                updated.add(candidate.withScore(newScore));
+            }
         }
 
         // Re-sort candidates by adjusted score descending

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SpacetimeScoringRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SpacetimeScoringRelay.java
@@ -58,13 +58,15 @@ public final class SpacetimeScoringRelay implements SynapticRelay<RecallSignal> 
         final List<CognitiveResult> updated = new ArrayList<>(candidates.size());
 
         for (final CognitiveResult candidate : candidates) {
-            // Reconstruct candidate timestamp from age in days
-            final long candidateTimeMs = queryTimeMs - (long) (candidate.ageDays() * MS_PER_DAY);
+            // Direct candidate timestamp lookup (fallback to ageDays reconstruction only if timestampMs is unset)
+            final long candidateTimeMs = candidate.timestampMs() > 0
+                    ? candidate.timestampMs()
+                    : queryTimeMs - (long) (candidate.ageDays() * MS_PER_DAY);
             final float[] candidateTau = Time2VecProjector.project(candidateTimeMs);
             final float harmonicAlignment = Time2VecProjector.dot(queryTau, candidateTau);
 
             final float harmonicDelta = rho * harmonicAlignment;
-            final float newScore = Math.max(0.0f, candidate.score() + harmonicDelta);
+            final float newScore = candidate.score() + harmonicDelta;
 
             if (candidate.trace() != null) {
                 final java.util.List<com.spectrayan.spector.memory.model.RecallTrace.TraceStep> steps =

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SpacetimeScoringRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/SpacetimeScoringRelay.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.recall.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.core.spacetime.Time2VecProjector;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Applies shortlist harmonic Spacetime re-ranking (ADR-0030 v1) to recall candidates.
+ *
+ * <p>Computes the 8-dimensional harmonic inner product {@code ⟨τ(t_q), τ(t_i)⟩} between the query's
+ * temporal position and each candidate memory's timestamp, adjusting the final score by {@code ρ * dot}.
+ * Operates strictly on the candidate shortlist (K ≤ 200) to keep latency under 35 µs.</p>
+ */
+public final class SpacetimeScoringRelay implements SynapticRelay<RecallSignal> {
+
+    private static final Logger log = LoggerFactory.getLogger(SpacetimeScoringRelay.class);
+    private static final double MS_PER_DAY = 86_400_000.0;
+
+    @Override
+    public boolean transmit(final RecallSignal signal) {
+        if (!signal.options().enableSpacetime()) {
+            return true;
+        }
+
+        final float[] queryTau = signal.queryTau();
+        if (queryTau == null) {
+            log.debug("Spacetime re-ranking skipped: queryTau is null");
+            return true;
+        }
+
+        final List<CognitiveResult> candidates = signal.candidates();
+        if (candidates.isEmpty()) {
+            return true;
+        }
+
+        final float rho = signal.options().spacetimeHarmonicWeight();
+        final long queryTimeMs = signal.queryTimeMs() > 0 ? signal.queryTimeMs() : signal.timestampMs();
+
+        final List<CognitiveResult> updated = new ArrayList<>(candidates.size());
+
+        for (final CognitiveResult candidate : candidates) {
+            // Reconstruct candidate timestamp from age in days
+            final long candidateTimeMs = queryTimeMs - (long) (candidate.ageDays() * MS_PER_DAY);
+            final float[] candidateTau = Time2VecProjector.project(candidateTimeMs);
+            final float harmonicAlignment = Time2VecProjector.dot(queryTau, candidateTau);
+
+            final float harmonicDelta = rho * harmonicAlignment;
+            final float newScore = Math.max(0.0f, candidate.score() + harmonicDelta);
+
+            updated.add(candidate.withScore(newScore));
+        }
+
+        // Re-sort candidates by adjusted score descending
+        updated.sort(Comparator.comparingDouble(CognitiveResult::score).reversed());
+        signal.setCandidates(updated);
+
+        log.debug("Spacetime harmonic re-ranking applied to {} candidates (rho={})", updated.size(), rho);
+        return true;
+    }
+
+    @Override
+    public String relayName() {
+        return RelayNames.SPACETIME_SCORING;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
@@ -12,18 +12,17 @@
  */
 package com.spectrayan.spector.memory.synapse;
 
-import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
-import com.spectrayan.spector.memory.kernel.layout.HeaderLayout;
-import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
-
 import com.spectrayan.spector.core.similarity.SimilarityFunction;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ScoreFusionMode;
 import com.spectrayan.spector.memory.model.ScoringMode;
-import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion;
+import com.spectrayan.spector.memory.synapse.scan.FlatMinHeap;
+import com.spectrayan.spector.memory.synapse.scan.RecordGates;
 
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -31,71 +30,27 @@ import java.util.PriorityQueue;
 import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.*;
 
 /**
- * Fused SIMD cognitive scoring loop — the heart of Spector Memory's
- * performance.
+ * Fused SIMD cognitive scoring loop — the heart of Spector Memory's performance.
  *
- * <h3>6-Phase Pipeline</h3>
- * 
+ * <h3>6-Phase Modular Scan (ADR-0030 v1)</h3>
  * <pre>
- *   Phase 1: Tombstone check          (~1 cycle)   — skip deleted records
- *   Phase 2: Synaptic tag gating      (~1 cycle)   — Bloom filter pre-screen
- *   Phase 3: Valence filter           (~2 cycles)  — skip outside valence range
- *   Phase 4: Temporal/importance pre-screen         — skip stale, low-importance
- *   Phase 5: Vector distance          (~200 cycles) — calibrated INT8 L2 distance
- *   Phase 6: Fused cognitive score    (~7 cycles)   — MULTIPLICATIVE / ADDITIVE (α·sim + (1-α)·tag) + prior
+ *   Phase 1 &amp; 1c: Tombstone &amp; contradiction check (~1 cycle)  — {@link RecordGates#isDeletedOrContradicted}
+ *   Phase 1b:    Temporal &amp; future causal gate   (~1 cycle)  — {@link RecordGates#isTemporalGated}
+ *   Phase 2:     Synaptic tag &amp; hyperfocus gate  (~1 cycle)  — {@link RecordGates#isTagGated}
+ *   Phase 3:     Valence range filter            (~2 cycles) — {@link RecordGates#isValenceGated}
+ *   Phase 4:     Age decay with high-mass exempt (~2 cycles) — {@link RecordGates#isStaleAndWeak}
+ *   Phase 5:     Zero-copy SIMD L2 distance      (~200 cyc)  — {@link SimilarityFunction#computeQuantizedFromSegment}
+ *   Phase 6:     Fused neuromodulatory score     (~7 cycles) — {@link CognitiveScoreFusion#computeFusedScore}
  * </pre>
- *
- * <h3>Biological Analog: Sensory Gating + Fused Retrieval</h3>
- * <p>
- * The brain doesn't consider every memory for every retrieval. It gates early —
- * suppressing irrelevant memories before the expensive associative search
- * begins.
- * This scorer replicates that: phases 1–4 eliminate 99% of records before the
- * expensive vector distance computation in phase 5.
- * </p>
- *
- * <h3>Distance Computation</h3>
- * <p>
- * Phase 5 delegates to {@link SimilarityFunction#computeQuantizedFromSegment},
- * the same zero-copy off-heap SIMD kernel used by
- * {@code spector-index}. When calibration parameters
- * ({@code mins[]}/{@code scales[]})
- * are provided (from
- * {@link com.spectrayan.spector.core.quantization.ScalarQuantizer}),
- * the distance computation uses proper per-dimension affine dequantization.
- * In uncalibrated mode, identity transform ({@code min=0, scale=1/255}) is
- * used.
- * </p>
- *
- * <h3>Performance</h3>
- * <p>
- * With 1M episodic memories and 1% tag match rate:
- * Phases 1-4 eliminate 990K records in ~1ms → Phase 5 computes distance on ~10K
- * → Total ~2ms (vs ~200ms without gating).
- * </p>
  */
 public final class CognitiveScorer {
 
     private CognitiveScorer() {
+        // utility class
     }
 
     /**
      * Represents a scored record for the priority queue.
-     *
-     * <p>
-     * Carries the full {@link CognitiveHeader} to avoid a second off-heap read
-     * during result assembly (P8 performance optimization).
-     * </p>
-     *
-     * <p>
-     * <b>TODO (JDK 28+ / Project Valhalla):</b> Convert to {@code value record}
-     * once
-     * JEP 401 (Value Classes) and JEP 402 (Specialized Generics) are available.
-     * As a value class, ScoredRecord would be scalarized by the JIT in the scorer
-     * loop — zero heap allocation for the ~10K candidates that don't enter the
-     * PriorityQueue. Combined with specialized generics, the PriorityQueue backing
-     * array would store flattened values instead of boxed pointers.
-     * </p>
      *
      * @param lateral true if this record came from the lateral retrieval heap
      */
@@ -103,391 +58,194 @@ public final class CognitiveScorer {
             implements Comparable<ScoredRecord> {
 
         /** Standard (non-lateral) constructor for backward compatibility. */
-        public ScoredRecord(long offset, float score, int index, CognitiveHeader header) {
+        public ScoredRecord(final long offset, final float score, final int index, final CognitiveHeader header) {
             this(offset, score, index, header, false);
         }
 
         @Override
-        public int compareTo(ScoredRecord other) {
+        public int compareTo(final ScoredRecord other) {
             return Float.compare(this.score, other.score); // min-heap for top-K
         }
     }
 
-    // ── Precomputed Storage Boost LUT ─────────────────────────────────────
-    // Replaces Math.pow(storageStrength, 0.3) in the hot loop (~150 cycles → ~3
-    // cycles).
-    // Maps S ∈ [1.0, 5.0] to S^0.3 via 64-entry linear interpolation.
-    // Max error: < 0.2% within the [1.0, 5.0] range.
-    private static final int STORAGE_BOOST_LUT_SIZE = 64;
-    private static final float STORAGE_BOOST_LUT_MIN = 1.0f;
-    private static final float STORAGE_BOOST_LUT_MAX = 5.0f;
-    private static final float STORAGE_BOOST_LUT_RANGE = STORAGE_BOOST_LUT_MAX - STORAGE_BOOST_LUT_MIN;
-    private static final float[] STORAGE_BOOST_LUT = new float[STORAGE_BOOST_LUT_SIZE];
-    static {
-        for (int i = 0; i < STORAGE_BOOST_LUT_SIZE; i++) {
-            float s = STORAGE_BOOST_LUT_MIN + (i / (float) (STORAGE_BOOST_LUT_SIZE - 1)) * STORAGE_BOOST_LUT_RANGE;
-            STORAGE_BOOST_LUT[i] = (float) Math.pow(s, 0.3);
-        }
-    }
-
-    /**
-     * Fast approximation of {@code S^exponent} using precomputed LUT.
-     * Falls back to {@link Math#pow} for exponents other than 0.3 or
-     * storage strengths outside [1.0, 5.0].
-     */
-    private static float fastStorageBoost(float storageStrength, float exponent) {
-        // Fast path: use LUT for default exponent and in-range values
-        if (exponent == 0.3f && storageStrength >= STORAGE_BOOST_LUT_MIN
-                && storageStrength <= STORAGE_BOOST_LUT_MAX) {
-            float normalized = (storageStrength - STORAGE_BOOST_LUT_MIN)
-                    * ((STORAGE_BOOST_LUT_SIZE - 1) / STORAGE_BOOST_LUT_RANGE);
-            int idx = (int) normalized;
-            if (idx >= STORAGE_BOOST_LUT_SIZE - 1)
-                return STORAGE_BOOST_LUT[STORAGE_BOOST_LUT_SIZE - 1];
-            // Linear interpolation between adjacent entries
-            float frac = normalized - idx;
-            return STORAGE_BOOST_LUT[idx] + frac * (STORAGE_BOOST_LUT[idx + 1] - STORAGE_BOOST_LUT[idx]);
-        }
-        // Slow path: arbitrary exponent or out-of-range
-        return (float) Math.pow(storageStrength, exponent);
-    }
-
     /**
      * Scans a memory segment and returns the top-K scored records.
-     * Uses uncalibrated identity quantization (for backward compatibility and
-     * tests).
-     *
-     * @param segment     off-heap segment containing cognitive records
-     * @param recordCount number of records in the segment
-     * @param layout      cognitive record layout
-     * @param queryVector the query vector (float32)
-     * @param options     recall options (topK, filters, weights)
-     * @param nowMs       current time in epoch millis
-     * @return top-K scored records sorted by descending score
      */
-    public static List<ScoredRecord> score(MemorySegment segment, int recordCount,
-            CognitiveRecordLayout layout,
-            float[] queryVector, RecallOptions options,
-            long nowMs) {
+    public static List<ScoredRecord> score(
+            final MemorySegment segment, final int recordCount, final CognitiveRecordLayout layout,
+            final float[] queryVector, final RecallOptions options, final long nowMs) {
         return score(segment, recordCount, layout, queryVector, options, nowMs, 0L, null, null);
     }
 
     /**
-     * Scans a memory segment and returns the top-K scored records.
-     * Uses uncalibrated identity quantization with a base offset.
-     *
-     * @param segment     off-heap segment containing cognitive records
-     * @param recordCount number of records in the segment
-     * @param layout      cognitive record layout
-     * @param queryVector the query vector (float32)
-     * @param options     recall options (topK, filters, weights)
-     * @param nowMs       current time in epoch millis
-     * @param baseOffset  byte offset where records begin (e.g., metadata header
-     *                    size for mmap partitions)
-     * @return top-K scored records sorted by descending score
+     * Scans a memory segment and returns the top-K scored records with base offset.
      */
-    public static List<ScoredRecord> score(MemorySegment segment, int recordCount,
-            CognitiveRecordLayout layout,
-            float[] queryVector, RecallOptions options,
-            long nowMs, long baseOffset) {
+    public static List<ScoredRecord> score(
+            final MemorySegment segment, final int recordCount, final CognitiveRecordLayout layout,
+            final float[] queryVector, final RecallOptions options, final long nowMs, final long baseOffset) {
         return score(segment, recordCount, layout, queryVector, options, nowMs, baseOffset, null, null);
     }
 
     /**
-     * Scans a memory segment and returns the top-K scored records using calibrated
-     * {@link SimilarityFunction#computeQuantizedFromSegment} for distance
-     * computation.
-     *
-     * <p>
-     * When {@code mins} and {@code scales} are provided (from
-     * {@link com.spectrayan.spector.core.quantization.ScalarQuantizer}), the
-     * distance
-     * uses proper per-dimension affine dequantization:
-     * {@code value = unsigned_byte * scale[i] + min[i]}.
-     * When null, falls back to identity transform for backward compatibility.
-     * </p>
-     *
-     * @param segment     off-heap segment containing cognitive records
-     * @param recordCount number of records in the segment
-     * @param layout      cognitive record layout
-     * @param queryVector the query vector (float32)
-     * @param options     recall options (topK, filters, weights)
-     * @param nowMs       current time in epoch millis
-     * @param baseOffset  byte offset where records begin (e.g., metadata header
-     *                    size for mmap partitions)
-     * @param mins        per-dimension minimum values from ScalarQuantizer
-     *                    calibration (null = identity)
-     * @param scales      per-dimension scale values from ScalarQuantizer
-     *                    calibration (null = identity)
-     * @return top-K scored records sorted by descending score
+     * Scans a memory segment using calibrated scalar quantization parameters.
      */
-    public static List<ScoredRecord> score(MemorySegment segment, int recordCount,
-            CognitiveRecordLayout layout,
-            float[] queryVector, RecallOptions options,
-            long nowMs, long baseOffset,
-            float[] mins, float[] scales) {
+    public static List<ScoredRecord> score(
+            final MemorySegment segment, final int recordCount, final CognitiveRecordLayout layout,
+            final float[] queryVector, final RecallOptions options, final long nowMs, final long baseOffset,
+            final float[] mins, final float[] scales) {
         return score(segment, recordCount, layout, queryVector, options, nowMs, baseOffset, mins, scales, null, null);
     }
 
     /**
-     * Scans a memory segment and returns the top-K scored records using calibrated
-     * distance computation and early O(1) graph associative prior (MR-06).
+     * Full scan entrypoint with calibrated distance and early associative prior (MR-06).
      */
-    public static List<ScoredRecord> score(MemorySegment segment, int recordCount,
-            CognitiveRecordLayout layout,
-            float[] queryVector, RecallOptions options,
-            long nowMs, long baseOffset,
-            float[] mins, float[] scales,
-            AssociativePriorProvider priorProvider,
-            QueryAssociativeContext priorContext) {
-        int topK = options.topK();
-        long queryTagMask = options.synapticTagMask();
-        float minImportance = options.minImportance();
-        byte minValence = options.minValence();
-        byte maxValence = options.maxValence();
-        float alpha = options.alpha();
-        float beta = options.beta();
-        float tagRelevanceBoost = options.tagRelevanceBoost();
-        float strictness = options.strictnessCoefficient();
-        Long minTimestamp = options.minTimestamp();
-        Long maxTimestamp = options.maxTimestamp();
-        boolean pureSimilarity = options.scoringMode() == ScoringMode.SIMILARITY;
-        ScoreFusionMode fusionMode = options.scoreFusionMode() != null
+    public static List<ScoredRecord> score(
+            final MemorySegment segment, final int recordCount, final CognitiveRecordLayout layout,
+            final float[] queryVector, final RecallOptions options, final long nowMs, final long baseOffset,
+            final float[] mins, final float[] scales,
+            final AssociativePriorProvider priorProvider,
+            final QueryAssociativeContext priorContext) {
+
+        final int topK = options.topK();
+        final long queryTagMask = options.synapticTagMask();
+        final float minImportance = options.minImportance();
+        final byte minValence = options.minValence();
+        final byte maxValence = options.maxValence();
+        final float alpha = options.alpha();
+        final float beta = options.beta();
+        final float tagRelevanceBoost = options.tagRelevanceBoost();
+        final float strictness = options.strictnessCoefficient();
+        final Long minTimestamp = options.minTimestamp();
+        final Long maxTimestamp = options.maxTimestamp();
+        final boolean allowFuture = options.allowFuture();
+        final boolean pureSimilarity = options.scoringMode() == ScoringMode.SIMILARITY;
+        final ScoreFusionMode fusionMode = options.scoreFusionMode() != null
                 ? options.scoreFusionMode()
                 : ScoreFusionMode.MULTIPLICATIVE;
-        boolean enableAssociativePrior = options.enableAssociativePrior() && priorProvider != null && priorContext != null;
-        float associativePriorDelta = options.associativePriorDelta();
+        final boolean enableAssociativePrior = options.enableAssociativePrior() && priorProvider != null && priorContext != null;
+        final float associativePriorDelta = options.associativePriorDelta();
 
-        // ── Valence Alignment (State-Dependent Recall) ──
-        boolean valenceAlign = options.enableValenceAlignment();
-        byte queryValence = options.queryValence();
+        final boolean valenceAlign = options.enableValenceAlignment();
+        final byte queryValence = options.queryValence();
 
-        // ── Neurodivergent: Hyperfocus parameters ──
-        long hyperfocusMask = options.hyperfocusMask();
-        float hyperfocusBoost = options.hyperfocusBoost();
+        final long hyperfocusMask = options.hyperfocusMask();
+        final float hyperfocusBoost = options.hyperfocusBoost();
 
-        // ── Neurodivergent: Lateral retrieval parameters ──
-        boolean lateralMode = options.lateralMode();
-        float lateralDistanceThreshold = options.lateralDistanceThreshold();
-        int lateralMaxResults = options.lateralMaxResults();
-        float lateralMinTagOverlap = options.lateralMinTagOverlap();
+        final boolean lateralMode = options.lateralMode();
+        final float lateralDistanceThreshold = options.lateralDistanceThreshold();
+        final int lateralMaxResults = options.lateralMaxResults();
+        final float lateralMinTagOverlap = options.lateralMinTagOverlap();
 
-        // Resolve calibration: use identity transform if not calibrated
-        int dims = queryVector.length;
-        float[] effectiveMins = mins != null ? mins : IdentityCalibration.mins(dims);
-        float[] effectiveScales = scales != null ? scales : IdentityCalibration.scales(dims);
+        final int dims = queryVector.length;
+        final float[] effectiveMins = mins != null ? mins : IdentityCalibration.mins(dims);
+        final float[] effectiveScales = scales != null ? scales : IdentityCalibration.scales(dims);
 
-        int stride = layout.stride();
-        boolean hasArousal = layout.headerLayout().headerBytes() > HEADER_BYTES; // V2+ has arousal
-        boolean hasStorageStrength = hasArousal; // V2+ has both arousal and storage_strength
+        final int stride = layout.stride();
+        final boolean hasArousal = layout.headerLayout().headerBytes() > HEADER_BYTES;
+        final boolean hasStorageStrength = hasArousal;
 
-        FlatMinHeap heap = new FlatMinHeap(topK);
-
-        // Lateral heap: separate collection for cross-domain candidates (lateral mode
-        // only).
-        // Lateral mode is rare and its candidate count is small, so PriorityQueue is
-        // acceptable.
-        PriorityQueue<ScoredRecord> lateralHeap = lateralMode
+        final FlatMinHeap heap = new FlatMinHeap(topK);
+        final PriorityQueue<ScoredRecord> lateralHeap = lateralMode
                 ? new PriorityQueue<>(lateralMaxResults + 1)
                 : null;
 
         for (int i = 0; i < recordCount; i++) {
-            long offset = baseOffset + (long) i * stride;
+            final long offset = baseOffset + (long) i * stride;
             if (offset + stride > segment.byteSize()) {
                 break;
             }
 
-            // ── Phase 1: Tombstone check (~1 cycle) ──
-            byte flags = segment.get(LAYOUT_FLAGS, offset + OFFSET_FLAGS);
-            if (isTombstoned(flags))
+            // Phase 1 & 1c: Tombstone and Contradiction checks
+            final byte flags = segment.get(LAYOUT_FLAGS, offset + OFFSET_FLAGS);
+            final byte cFlags = segment.get(LAYOUT_CONSOLIDATION_FLAGS, offset + OFFSET_CONSOLIDATION_FLAGS);
+            if (RecordGates.isDeletedOrContradicted(flags, cFlags, options.includeContradictions())) {
                 continue;
-
-            // ── Phase 1c: Contradiction Gating ──
-            if (!options.includeContradictions()) {
-                byte cFlags = segment.get(LAYOUT_CONSOLIDATION_FLAGS, offset + OFFSET_CONSOLIDATION_FLAGS);
-                if (isContradicted(cFlags))
-                    continue;
             }
 
-            // ── Phase 1b: Temporal gating (absolute timestamp bounds) ──
-            long timestamp = segment.get(LAYOUT_TIMESTAMP, offset + OFFSET_TIMESTAMP);
-            if (minTimestamp != null && timestamp < minTimestamp)
+            // Phase 1b: Temporal gating & Future causal horizon gate
+            final long timestamp = segment.get(LAYOUT_TIMESTAMP, offset + OFFSET_TIMESTAMP);
+            if (RecordGates.isTemporalGated(timestamp, minTimestamp, maxTimestamp, nowMs, allowFuture)) {
                 continue;
-            if (maxTimestamp != null && timestamp > maxTimestamp)
-                continue;
+            }
 
-            // ── Phase 2: Synaptic tag gating (~1 cycle) ──
-            // Neurodivergent: Hyperfocus uses STRICT equality (all mask bits must match).
-            // Standard mode uses containment (any overlap passes).
+            // Phase 2: Synaptic tag gating
             long recordTags = 0;
-            if (hyperfocusMask != 0) {
-                // Hyperfocus: strict equality gate — reject anything that doesn't
-                // match ALL focus tags. This creates a "tunnel" that blocks off-topic noise.
+            if (hyperfocusMask != 0 || queryTagMask != 0) {
                 recordTags = segment.get(LAYOUT_SYNAPTIC_TAGS, offset + OFFSET_SYNAPTIC_TAGS);
-                if ((recordTags & hyperfocusMask) != hyperfocusMask)
+                if (RecordGates.isTagGated(recordTags, queryTagMask, hyperfocusMask)) {
                     continue;
-            } else if (queryTagMask != 0) {
-                // Standard: broadened containment — skip only on zero overlap
-                recordTags = segment.get(LAYOUT_SYNAPTIC_TAGS, offset + OFFSET_SYNAPTIC_TAGS);
-                if ((recordTags & queryTagMask) == 0)
-                    continue;
+                }
             }
 
-            // ── Phase 3: Valence filter (~2 cycles) ──
-            byte valence = segment.get(LAYOUT_VALENCE, offset + OFFSET_VALENCE);
-            if (valence < minValence || valence > maxValence)
+            // Phase 3: Valence filter
+            final byte valence = segment.get(LAYOUT_VALENCE, offset + OFFSET_VALENCE);
+            if (RecordGates.isValenceGated(valence, minValence, maxValence)) {
                 continue;
+            }
 
-            // ── Phase 4: Temporal/importance pre-screen with reconsolidation ──
-            float importance = segment.get(LAYOUT_IMPORTANCE, offset + OFFSET_IMPORTANCE);
-            if (importance < minImportance)
+            // Phase 4: Temporal / importance pre-screen with reconsolidation & high-mass exemption
+            final float importance = segment.get(LAYOUT_IMPORTANCE, offset + OFFSET_IMPORTANCE);
+            if (importance < minImportance) {
                 continue;
+            }
 
-            int agentRecallCount = segment.get(LAYOUT_AGENT_RECALL_COUNT, offset + OFFSET_AGENT_RECALL_COUNT);
-            int rawBucket = DecayStrategy.ageToBucket(timestamp, nowMs);
+            final int agentRecallCount = segment.get(LAYOUT_AGENT_RECALL_COUNT, offset + OFFSET_AGENT_RECALL_COUNT);
+            final int rawBucket = DecayStrategy.ageToBucket(timestamp, nowMs);
             int adjustedBucket = DecayStrategy.adjustForReconsolidation(rawBucket, agentRecallCount);
 
-            // Phase 2B: Apply gentler auto-recall adjustment from spector-internal passive LTP (V3 only)
-            if (hasStorageStrength) { // V2+ (V3 in practice — V2 returns 0 for spectorRecallCount)
-                int spectorRecallCount = segment.get(LAYOUT_SPECTOR_RECALL_COUNT, offset + OFFSET_SPECTOR_RECALL_COUNT);
+            if (hasStorageStrength) {
+                final int spectorRecallCount = segment.get(LAYOUT_SPECTOR_RECALL_COUNT, offset + OFFSET_SPECTOR_RECALL_COUNT);
                 adjustedBucket = DecayStrategy.adjustForAutoRecall(adjustedBucket, spectorRecallCount);
             }
 
-            // Neurodivergent: Hyperfocus — clamp decay to 1.0 (zero time effect)
-            // for memories that match the focus mask.
-            boolean focusMatch = hyperfocusMask != 0
-                    && (recordTags & hyperfocusMask) == hyperfocusMask;
-            if (focusMatch) {
-                adjustedBucket = 0; // time ceases to exist for this topic
-            }
-
-            // Zeigarnik Effect: unresolved memories resist time-decay.
-            // They act like a biological "itch" — always fresh until explicitly resolved.
-            if (!isResolved(flags) && !isPinned(flags)) {
+            final boolean focusMatch = hyperfocusMask != 0 && (recordTags & hyperfocusMask) == hyperfocusMask;
+            if (focusMatch || (!isResolved(flags) && !isPinned(flags))) {
                 adjustedBucket = 0;
             }
 
-            // Arousal-modulated decay: emotionally intense memories resist forgetting.
-            // On V2+ layouts, read the arousal byte; on V1, arousal=0 (no effect).
-            byte arousal = hasArousal
-                    ? segment.get(LAYOUT_AROUSAL, offset + OFFSET_AROUSAL)
-                    : (byte) 0;
+            final byte arousal = hasArousal ? segment.get(LAYOUT_AROUSAL, offset + OFFSET_AROUSAL) : (byte) 0;
+            final float storageStrength = hasStorageStrength
+                    ? layout.headerLayout().readStorageStrength(segment, offset)
+                    : 1.0f;
+            final float cognitiveMass = CognitiveScoreFusion.computeCognitiveMass(importance, arousal, storageStrength);
 
-            // Skip if too old AND low importance (pinned/unresolved memories are exempt)
-            if (adjustedBucket >= DecayStrategy.MAX_BUCKET
-                    && importance < 1.0f
-                    && !isPinned(flags)
-                    && isResolved(flags)) {
+            if (RecordGates.isStaleAndWeak(adjustedBucket, importance, flags, cognitiveMass)) {
                 continue;
             }
 
-            // ── Phase 5: Calibrated INT8 L2 distance via SimilarityFunction ──
-            float l2dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
+            // Phase 5: Calibrated SIMD L2 distance
+            final float l2dist = SimilarityFunction.EUCLIDEAN.computeQuantizedFromSegment(
                     queryVector, segment, layout.vectorOffset(offset),
                     effectiveMins, effectiveScales, layout.quantizedVecBytes());
 
-            // ── Phase 6: Fused cognitive score with weighted tag relevance (~7 cycles) ──
-            float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
+            // Phase 6: Fused score composition
+            final float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
 
-            // Neurodivergent: Lateral retrieval — collect tag-matched but
-            // semantically distant candidates into a separate heap.
-            if (lateralMode && l2dist > lateralDistanceThreshold
-                    && tagOverlap >= lateralMinTagOverlap) {
+            if (lateralMode && l2dist > lateralDistanceThreshold && tagOverlap >= lateralMinTagOverlap) {
                 scoreLateral(lateralHeap, lateralMaxResults, segment, offset,
                         l2dist, tagOverlap, importance, adjustedBucket, arousal,
                         timestamp, recordTags, valence, flags, agentRecallCount, i);
                 continue;
             }
 
-            // Standard scoring path — with configurable strictness coefficient.
-            // strictness=1.0 → standard curve: 1/(1+L2)
-            // strictness=10.0 → Heaviside cliff: near-matches stay high, vague matches
-            // plummet
-            float similarity = 1.0f / (1.0f + l2dist * strictness);
-            float finalScore;
+            final float finalScore = CognitiveScoreFusion.computeFusedScore(
+                    l2dist, strictness, pureSimilarity, adjustedBucket, arousal, storageStrength,
+                    hasStorageStrength, options.twoFactorConfig().enabled(), options.twoFactorConfig().sExponent(),
+                    importance, beta, alpha, tagOverlap, fusionMode, valenceAlign, queryValence,
+                    valence, tagRelevanceBoost, focusMatch, hyperfocusBoost, flags,
+                    enableAssociativePrior, priorProvider, offset, recordTags, priorContext, associativePriorDelta);
 
-            if (pureSimilarity) {
-                finalScore = similarity;
-            } else {
-                float decay = DecayStrategy.decay(adjustedBucket) * DecayStrategy.arousalModifier(arousal);
-                decay = Math.min(1.0f, decay);
-
-                // Two-Factor Memory: S(t)^sExponent modulates importance
-                float storageBoost = 1.0f;
-                if (hasStorageStrength) {
-                    float storageStrength = layout.headerLayout()
-                            .readStorageStrength(segment, offset);
-                    TwoFactorConfig tfc = options.twoFactorConfig();
-                    if (tfc.enabled() && storageStrength > 1.0f) {
-                        storageBoost = fastStorageBoost(storageStrength, tfc.sExponent());
-                    }
-                }
-
-                // Importance normalized to [0,1] so boost ranges from 1.0x to 1.0+beta
-                float importanceNorm = importance / 10.0f;
-                float impDecayFactor = 1.0f + beta * importanceNorm * decay * storageBoost;
-
-                float baseScore;
-                if (fusionMode == ScoreFusionMode.ADDITIVE) {
-                    // Additive convex combination: S_base = alpha * similarity + (1 - alpha) * tagOverlap
-                    float baseSimilarity = alpha * similarity + (1.0f - alpha) * tagOverlap;
-                    baseScore = baseSimilarity * impDecayFactor;
-                } else {
-                    // Multiplicative fusion (default): similarity is primary signal
-                    baseScore = similarity * impDecayFactor;
-                }
-
-                // Valence alignment: state-dependent recall (mood-congruent memory)
-                if (valenceAlign) {
-                    float valenceMultiplier = 1.0f - (Math.abs(queryValence - valence) / 255.0f);
-                    baseScore *= valenceMultiplier;
-                }
-
-                // Weighted tag relevance / final score composition
-                if (fusionMode == ScoreFusionMode.ADDITIVE) {
-                    finalScore = baseScore;
-                } else {
-                    finalScore = baseScore * (1.0f + tagOverlap * tagRelevanceBoost);
-                }
-
-                // Neurodivergent: Hyperfocus — post-score boost for focus-matched memories
-                if (focusMatch && hyperfocusBoost != 1.0f) {
-                    finalScore *= hyperfocusBoost;
-                }
-
-                // Two-Tier Recall: SEMANTIC and PROCEDURAL memories represent consolidated knowledge and receive priority over raw EPISODIC logs
-                int mType = memoryTypeOrdinal(flags);
-                if (mType == 1 || mType == 2) { // 1 = SEMANTIC, 2 = PROCEDURAL
-                    finalScore *= 2.0f;
-                }
-
-                // MR-06: Early associative graph prior (Phase 6 fusion)
-                if (enableAssociativePrior) {
-                    float ag = priorProvider.priorFor(offset, recordTags, priorContext);
-                    if (fusionMode == ScoreFusionMode.ADDITIVE) {
-                        finalScore += associativePriorDelta * ag;
-                    } else {
-                        finalScore *= (1.0f + associativePriorDelta * ag);
-                    }
-                }
-            }
-
-            // ── Insert into flat min-heap (ZERO object allocation) ──
-            // Only read remaining header fields (exactNorm, centroidId) if this record
-            // will actually enter the heap.
+            // Top-K insertion
             if (heap.shouldInsert(finalScore)) {
-                long synapticTags = queryTagMask != 0 || hyperfocusMask != 0
-                        ? recordTags
-                        : 0;
-                float exactNorm = segment.get(LAYOUT_EXACT_NORM, offset + OFFSET_EXACT_NORM);
-                short centroidId = segment.get(LAYOUT_CENTROID_ID, offset + OFFSET_CENTROID_ID);
+                final long synapticTags = queryTagMask != 0 || hyperfocusMask != 0 ? recordTags : 0;
+                final float exactNorm = segment.get(LAYOUT_EXACT_NORM, offset + OFFSET_EXACT_NORM);
+                final short centroidId = segment.get(LAYOUT_CENTROID_ID, offset + OFFSET_CENTROID_ID);
                 heap.insert(finalScore, offset, i, timestamp, synapticTags,
                         exactNorm, importance, agentRecallCount, centroidId, valence, flags);
             }
         }
 
-        // ── Post-scan: Build ScoredRecord objects ONLY for the surviving topK ──
-        List<ScoredRecord> results = heap.drain();
+        final List<ScoredRecord> results = heap.drain();
         if (lateralHeap != null && !lateralHeap.isEmpty()) {
             results.addAll(lateralHeap);
         }
@@ -495,33 +253,25 @@ public final class CognitiveScorer {
         return results;
     }
 
-    /**
-     * Scores a lateral (cross-domain) candidate and inserts into the lateral heap.
-     *
-     * <p>Lateral retrieval uses a parabolic RBF that peaks at orthogonality
-     * (L2²≈2.0 for normalized vectors), finding memories that share context tags
-     * but are semantically distant — enabling creative association.</p>
-     */
-    private static void scoreLateral(PriorityQueue<ScoredRecord> lateralHeap,
-            int lateralMaxResults, MemorySegment segment, long offset,
-            float l2dist, float tagOverlap, float importance,
-            int adjustedBucket, byte arousal,
-            long timestamp, long recordTags, byte valence, byte flags,
-            int agentRecallCount, int recordIndex) {
-        // Parabolic RBF: peaks at orthogonality (L2²=2.0 for normalized vectors).
-        // Formula: 1.0 - 0.25 * (L2² - 2.0)²
-        float l2sq = l2dist * l2dist;
-        float diff = l2sq - 2.0f;
-        float lateralSimilarity = Math.max(0f, 1.0f - 0.25f * diff * diff);
+    private static void scoreLateral(
+            final PriorityQueue<ScoredRecord> lateralHeap, final int lateralMaxResults,
+            final MemorySegment segment, final long offset,
+            final float l2dist, final float tagOverlap, final float importance,
+            final int adjustedBucket, final byte arousal,
+            final long timestamp, final long recordTags, final byte valence, final byte flags,
+            final int agentRecallCount, final int recordIndex) {
+
+        final float l2sq = l2dist * l2dist;
+        final float diff = l2sq - 2.0f;
+        final float lateralSimilarity = Math.max(0.0f, 1.0f - 0.25f * diff * diff);
         float decay = DecayStrategy.decay(adjustedBucket) * DecayStrategy.arousalModifier(arousal);
         decay = Math.min(1.0f, decay);
-        // Multiplicative fusion for lateral path — normalized importance
-        float importanceNorm = importance / 10.0f;
-        float lateralScore = lateralSimilarity * tagOverlap * (1.0f + importanceNorm * decay);
+        final float importanceNorm = importance / 10.0f;
+        final float lateralScore = lateralSimilarity * tagOverlap * (1.0f + importanceNorm * decay);
 
-        float exactNorm = segment.get(LAYOUT_EXACT_NORM, offset + OFFSET_EXACT_NORM);
-        short centroidId = segment.get(LAYOUT_CENTROID_ID, offset + OFFSET_CENTROID_ID);
-        CognitiveHeader header = new CognitiveHeader(
+        final float exactNorm = segment.get(LAYOUT_EXACT_NORM, offset + OFFSET_EXACT_NORM);
+        final short centroidId = segment.get(LAYOUT_CENTROID_ID, offset + OFFSET_CENTROID_ID);
+        final CognitiveHeader header = new CognitiveHeader(
                 timestamp, recordTags, exactNorm, importance,
                 agentRecallCount, centroidId, valence, flags);
 
@@ -530,160 +280,6 @@ public final class CognitiveScorer {
         } else if (lateralScore > lateralHeap.peek().score()) {
             lateralHeap.poll();
             lateralHeap.offer(new ScoredRecord(offset, lateralScore, recordIndex, header, true));
-        }
-    }
-
-    // ══════════════════════════════════════════════════════════════
-    // FlatMinHeap — zero-allocation top-K tracker using parallel arrays
-    // ══════════════════════════════════════════════════════════════
-
-    /**
-     * A fixed-capacity min-heap backed by parallel primitive arrays.
-     *
-     * <p>Replaces {@code PriorityQueue<ScoredRecord>} to eliminate per-candidate
-     * {@link CognitiveHeader} and {@link ScoredRecord} allocations in the scoring
-     * inner loop. Header fields are stored as flat arrays; {@code CognitiveHeader}
-     * objects are only created when {@link #drain()} is called after the scan.</p>
-     *
-     * <p>All methods are designed for JIT inlining — no virtual dispatch,
-     * no boxing, no allocation on the fast path.</p>
-     *
-     * <p><b>TODO (JDK 28+ / Project Valhalla):</b> When value classes (JEP 401)
-     * and specialized generics (JEP 402) are available, replace this class with
-     * a standard {@code PriorityQueue<ScoredRecord>} where ScoredRecord is a
-     * value record. The JIT will scalarize value records and PriorityQueue will
-     * store flattened values, achieving the same zero-alloc behavior with proper
-     * class representation.</p>
-     */
-    private static final class FlatMinHeap {
-
-        private final int capacity;
-        private int size;
-
-        // Core fields
-        private final float[] scores;
-        private final long[] offsets;
-        private final int[] indices;
-
-        // Header fields (stored flat, assembled into CognitiveHeader on drain)
-        private final long[] timestamps;
-        private final long[] synapticTags;
-        private final float[] exactNorms;
-        private final float[] importances;
-        private final int[] agentRecallCounts;
-        private final short[] centroidIds;
-        private final byte[] valences;
-        private final byte[] flags;
-
-        FlatMinHeap(int capacity) {
-            this.capacity = capacity;
-            this.size = 0;
-            int len = capacity + 1; // +1 for sift workspace
-            this.scores = new float[len];
-            this.offsets = new long[len];
-            this.indices = new int[len];
-            this.timestamps = new long[len];
-            this.synapticTags = new long[len];
-            this.exactNorms = new float[len];
-            this.importances = new float[len];
-            this.agentRecallCounts = new int[len];
-            this.centroidIds = new short[len];
-            this.valences = new byte[len];
-            this.flags = new byte[len];
-        }
-
-        /** Returns true if the given score should be inserted (heap not full, or beats min). */
-        boolean shouldInsert(float score) {
-            return size < capacity || score > scores[0];
-        }
-
-        /**
-         * Inserts or replaces the minimum entry. Caller must check
-         * {@link #shouldInsert(float)} first.
-         */
-        void insert(float score, long offset, int index,
-                long timestamp, long tags, float exactNorm, float importance,
-                int agentRecallCount, short centroidId, byte valence, byte flag) {
-            if (size < capacity) {
-                int idx = size;
-                set(idx, score, offset, index, timestamp, tags, exactNorm,
-                        importance, agentRecallCount, centroidId, valence, flag);
-                size++;
-                siftUp(idx);
-            } else {
-                // Replace root (minimum)
-                set(0, score, offset, index, timestamp, tags, exactNorm,
-                        importance, agentRecallCount, centroidId, valence, flag);
-                siftDown(0);
-            }
-        }
-
-        /** Drains the heap into a list of ScoredRecords (creates CognitiveHeader objects). */
-        List<ScoredRecord> drain() {
-            List<ScoredRecord> results = new ArrayList<>(size);
-            for (int h = 0; h < size; h++) {
-                CognitiveHeader header = new CognitiveHeader(
-                        timestamps[h], synapticTags[h], exactNorms[h], importances[h],
-                        agentRecallCounts[h], centroidIds[h], valences[h], flags[h]);
-                results.add(new ScoredRecord(offsets[h], scores[h], indices[h], header));
-            }
-            return results;
-        }
-
-        private void set(int idx, float score, long offset, int index,
-                long timestamp, long tags, float exactNorm, float importance,
-                int agentRecallCount, short centroidId, byte valence, byte flag) {
-            scores[idx] = score;
-            offsets[idx] = offset;
-            indices[idx] = index;
-            timestamps[idx] = timestamp;
-            synapticTags[idx] = tags;
-            exactNorms[idx] = exactNorm;
-            importances[idx] = importance;
-            agentRecallCounts[idx] = agentRecallCount;
-            centroidIds[idx] = centroidId;
-            valences[idx] = valence;
-            flags[idx] = flag;
-        }
-
-        private void siftUp(int idx) {
-            while (idx > 0) {
-                int parent = (idx - 1) >>> 1;
-                if (scores[idx] >= scores[parent])
-                    break;
-                swap(idx, parent);
-                idx = parent;
-            }
-        }
-
-        private void siftDown(int idx) {
-            while (true) {
-                int left = 2 * idx + 1;
-                int right = left + 1;
-                int smallest = idx;
-                if (left < size && scores[left] < scores[smallest])
-                    smallest = left;
-                if (right < size && scores[right] < scores[smallest])
-                    smallest = right;
-                if (smallest == idx)
-                    break;
-                swap(idx, smallest);
-                idx = smallest;
-            }
-        }
-
-        private void swap(int a, int b) {
-            float ts = scores[a]; scores[a] = scores[b]; scores[b] = ts;
-            long to = offsets[a]; offsets[a] = offsets[b]; offsets[b] = to;
-            int ti = indices[a]; indices[a] = indices[b]; indices[b] = ti;
-            long tt = timestamps[a]; timestamps[a] = timestamps[b]; timestamps[b] = tt;
-            long tg = synapticTags[a]; synapticTags[a] = synapticTags[b]; synapticTags[b] = tg;
-            float tn = exactNorms[a]; exactNorms[a] = exactNorms[b]; exactNorms[b] = tn;
-            float tp = importances[a]; importances[a] = importances[b]; importances[b] = tp;
-            int tr = agentRecallCounts[a]; agentRecallCounts[a] = agentRecallCounts[b]; agentRecallCounts[b] = tr;
-            short tc = centroidIds[a]; centroidIds[a] = centroidIds[b]; centroidIds[b] = tc;
-            byte tv = valences[a]; valences[a] = valences[b]; valences[b] = tv;
-            byte tf = flags[a]; flags[a] = flags[b]; flags[b] = tf;
         }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
@@ -40,7 +40,7 @@ import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstant
  *   Phase 3:     Valence range filter            (~2 cycles) — {@link RecordGates#isValenceGated}
  *   Phase 4:     Age decay with high-mass exempt (~2 cycles) — {@link RecordGates#isStaleAndWeak}
  *   Phase 5:     Zero-copy SIMD L2 distance      (~200 cyc)  — {@link SimilarityFunction#computeQuantizedFromSegment}
- *   Phase 6:     Fused neuromodulatory score     (~7 cycles) — {@link CognitiveScoreFusion#computeFusedScore}
+ *   Phase 6:     Fused mass-dilated score        (~7 cycles) — {@link CognitiveScoreFusion#computeFusedScore}
  * </pre>
  */
 public final class CognitiveScorer {
@@ -125,6 +125,9 @@ public final class CognitiveScorer {
         final boolean enableAssociativePrior = options.enableAssociativePrior() && priorProvider != null && priorContext != null;
         final float associativePriorDelta = options.associativePriorDelta();
 
+        final boolean twoFactorEnabled = options.twoFactorConfig() != null && options.twoFactorConfig().enabled();
+        final float sExponent = options.twoFactorConfig() != null ? options.twoFactorConfig().sExponent() : 0.3f;
+
         final boolean valenceAlign = options.enableValenceAlignment();
         final byte queryValence = options.queryValence();
 
@@ -141,7 +144,7 @@ public final class CognitiveScorer {
         final float[] effectiveScales = scales != null ? scales : IdentityCalibration.scales(dims);
 
         final int stride = layout.stride();
-        final boolean hasArousal = layout.headerLayout().headerBytes() > HEADER_BYTES;
+        final boolean hasArousal = layout.headerLayout().version() >= 2;
         final boolean hasStorageStrength = hasArousal;
 
         final FlatMinHeap heap = new FlatMinHeap(topK);
@@ -155,11 +158,18 @@ public final class CognitiveScorer {
                 break;
             }
 
-            // Phase 1 & 1c: Tombstone and Contradiction checks
+            // Phase 1: Tombstone check (~1 cycle)
             final byte flags = segment.get(LAYOUT_FLAGS, offset + OFFSET_FLAGS);
-            final byte cFlags = segment.get(LAYOUT_CONSOLIDATION_FLAGS, offset + OFFSET_CONSOLIDATION_FLAGS);
-            if (RecordGates.isDeletedOrContradicted(flags, cFlags, options.includeContradictions())) {
+            if (isTombstoned(flags)) {
                 continue;
+            }
+
+            // Phase 1c: Contradiction check (short-circuit: only read cFlags when filtering contradictions)
+            if (!options.includeContradictions()) {
+                final byte cFlags = segment.get(LAYOUT_CONSOLIDATION_FLAGS, offset + OFFSET_CONSOLIDATION_FLAGS);
+                if (isContradicted(cFlags)) {
+                    continue;
+                }
             }
 
             // Phase 1b: Temporal gating & Future causal horizon gate
@@ -199,9 +209,7 @@ public final class CognitiveScorer {
             }
 
             final boolean focusMatch = hyperfocusMask != 0 && (recordTags & hyperfocusMask) == hyperfocusMask;
-            if (focusMatch || (!isResolved(flags) && !isPinned(flags))) {
-                adjustedBucket = 0;
-            }
+            final boolean zeroTimeDecay = focusMatch || (!isResolved(flags) && !isPinned(flags));
 
             final byte arousal = hasArousal ? segment.get(LAYOUT_AROUSAL, offset + OFFSET_AROUSAL) : (byte) 0;
             final float storageStrength = hasStorageStrength
@@ -218,7 +226,7 @@ public final class CognitiveScorer {
                     queryVector, segment, layout.vectorOffset(offset),
                     effectiveMins, effectiveScales, layout.quantizedVecBytes());
 
-            // Phase 6: Fused score composition
+            // Phase 6: Fused score composition with mass-dilated continuous log recency
             final float tagOverlap = SynapticTagEncoder.overlapRatio(recordTags, queryTagMask);
 
             if (lateralMode && l2dist > lateralDistanceThreshold && tagOverlap >= lateralMinTagOverlap) {
@@ -229,11 +237,12 @@ public final class CognitiveScorer {
             }
 
             final float finalScore = CognitiveScoreFusion.computeFusedScore(
-                    l2dist, strictness, pureSimilarity, adjustedBucket, arousal, storageStrength,
-                    hasStorageStrength, options.twoFactorConfig().enabled(), options.twoFactorConfig().sExponent(),
-                    importance, beta, alpha, tagOverlap, fusionMode, valenceAlign, queryValence,
-                    valence, tagRelevanceBoost, focusMatch, hyperfocusBoost, flags,
-                    enableAssociativePrior, priorProvider, offset, recordTags, priorContext, associativePriorDelta);
+                    l2dist, strictness, pureSimilarity, timestamp, nowMs, cognitiveMass,
+                    arousal, storageStrength, hasStorageStrength, twoFactorEnabled, sExponent,
+                    agentRecallCount, importance, beta, alpha, tagOverlap, fusionMode,
+                    valenceAlign, queryValence, valence, tagRelevanceBoost, focusMatch,
+                    zeroTimeDecay, hyperfocusBoost, flags, enableAssociativePrior,
+                    priorProvider, offset, recordTags, priorContext, associativePriorDelta);
 
             // Top-K insertion
             if (heap.shouldInsert(finalScore)) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/CognitiveScoreFusion.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/CognitiveScoreFusion.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.synapse.scan;
+
+import com.spectrayan.spector.memory.model.ScoreFusionMode;
+import com.spectrayan.spector.memory.synapse.AssociativePriorProvider;
+import com.spectrayan.spector.memory.synapse.DecayStrategy;
+import com.spectrayan.spector.memory.synapse.QueryAssociativeContext;
+
+import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.memoryTypeOrdinal;
+
+/**
+ * Fused SIMD cognitive score composition, mass calculation, and neuromodulatory weighting (Phase 6).
+ */
+public final class CognitiveScoreFusion {
+
+    private CognitiveScoreFusion() {
+        // utility class
+    }
+
+    /**
+     * Computes the dynamic Cognitive Mass M_i from L1 cache fields.
+     *
+     * @param importance      raw importance score [0.0..10.0]
+     * @param arousal         unsigned 8-bit arousal [0..255]
+     * @param storageStrength consolidated storage strength [1.0..5.0]
+     * @return dynamic cognitive mass
+     */
+    public static float computeCognitiveMass(
+            final float importance, final byte arousal, final float storageStrength) {
+        final float importanceNorm = importance / 10.0f;
+        final float arousalNorm = 1.0f + ((arousal & 0xFF) / 128.0f);
+        final float storageBoost = StorageBoostLut.fastStorageBoost(storageStrength, 0.3f);
+        return importanceNorm * arousalNorm * storageBoost;
+    }
+
+    /**
+     * Computes the final fused cognitive score for a candidate memory.
+     */
+    public static float computeFusedScore(
+            final float l2dist, final float strictness, final boolean pureSimilarity,
+            final int adjustedBucket, final byte arousal, final float storageStrength,
+            final boolean hasStorageStrength, final boolean twoFactorEnabled, final float sExponent,
+            final float importance, final float beta, final float alpha, final float tagOverlap,
+            final ScoreFusionMode fusionMode, final boolean valenceAlign, final byte queryValence,
+            final byte valence, final float tagRelevanceBoost, final boolean focusMatch,
+            final float hyperfocusBoost, final byte flags, final boolean enableAssociativePrior,
+            final AssociativePriorProvider priorProvider, final long offset, final long recordTags,
+            final QueryAssociativeContext priorContext, final float associativePriorDelta) {
+
+        final float similarity = 1.0f / (1.0f + l2dist * strictness);
+        if (pureSimilarity) {
+            return similarity;
+        }
+
+        float decay = DecayStrategy.decay(adjustedBucket) * DecayStrategy.arousalModifier(arousal);
+        decay = Math.min(1.0f, decay);
+
+        float storageBoost = 1.0f;
+        if (hasStorageStrength && twoFactorEnabled && storageStrength > 1.0f) {
+            storageBoost = StorageBoostLut.fastStorageBoost(storageStrength, sExponent);
+        }
+
+        final float importanceNorm = importance / 10.0f;
+        final float impDecayFactor = 1.0f + beta * importanceNorm * decay * storageBoost;
+
+        float baseScore;
+        if (fusionMode == ScoreFusionMode.ADDITIVE) {
+            final float baseSimilarity = alpha * similarity + (1.0f - alpha) * tagOverlap;
+            baseScore = baseSimilarity * impDecayFactor;
+        } else {
+            baseScore = similarity * impDecayFactor;
+        }
+
+        if (valenceAlign) {
+            final float valenceMultiplier = 1.0f - (Math.abs(queryValence - valence) / 255.0f);
+            baseScore *= valenceMultiplier;
+        }
+
+        float finalScore;
+        if (fusionMode == ScoreFusionMode.ADDITIVE) {
+            finalScore = baseScore;
+        } else {
+            finalScore = baseScore * (1.0f + tagOverlap * tagRelevanceBoost);
+        }
+
+        if (focusMatch && hyperfocusBoost != 1.0f) {
+            finalScore *= hyperfocusBoost;
+        }
+
+        final int mType = memoryTypeOrdinal(flags);
+        if (mType == 1 || mType == 2) { // 1 = SEMANTIC, 2 = PROCEDURAL
+            finalScore *= 2.0f;
+        }
+
+        if (enableAssociativePrior && priorProvider != null) {
+            final float ag = priorProvider.priorFor(offset, recordTags, priorContext);
+            if (fusionMode == ScoreFusionMode.ADDITIVE) {
+                finalScore += associativePriorDelta * ag;
+            } else {
+                finalScore *= (1.0f + associativePriorDelta * ag);
+            }
+        }
+
+        return finalScore;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/CognitiveScoreFusion.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/CognitiveScoreFusion.java
@@ -20,9 +20,11 @@ import com.spectrayan.spector.memory.synapse.QueryAssociativeContext;
 import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.memoryTypeOrdinal;
 
 /**
- * Fused SIMD cognitive score composition, mass calculation, and neuromodulatory weighting (Phase 6).
+ * Fused SIMD cognitive score composition, dynamic mass calculation, and mass-dilated log recency (Phase 6).
  */
 public final class CognitiveScoreFusion {
+
+    private static final double MS_PER_DAY = 86_400_000.0;
 
     private CognitiveScoreFusion() {
         // utility class
@@ -30,6 +32,8 @@ public final class CognitiveScoreFusion {
 
     /**
      * Computes the dynamic Cognitive Mass M_i from L1 cache fields.
+     *
+     * <p>M_i = (I_i / 10) * (1 + (A_i mod 256) / 128) * S_i^0.3</p>
      *
      * @param importance      raw importance score [0.0..10.0]
      * @param arousal         unsigned 8-bit arousal [0..255]
@@ -45,26 +49,60 @@ public final class CognitiveScoreFusion {
     }
 
     /**
-     * Computes the final fused cognitive score for a candidate memory.
+     * Computes the continuous mass-dilated recency decay factor.
+     *
+     * <p>Formula: R(Δt, M_i) = 1 / (1 + ln(1 + Δt_days) / (1 + M_i)) * arousalModifier</p>
+     *
+     * @param timestampMs       creation timestamp in epoch millis
+     * @param nowMs             reference query clock in epoch millis
+     * @param cognitiveMass     dynamic cognitive mass M_i
+     * @param arousal           arousal intensity byte
+     * @param agentRecallCount  number of prior agent recalls for reconsolidation
+     * @param zeroTimeDecay     true if time decay is suspended (focus match, unpinned/unresolved)
+     * @return decay multiplier in (0.0..1.0]
+     */
+    public static float computeMassDilatedDecay(
+            final long timestampMs, final long nowMs, final float cognitiveMass,
+            final byte arousal, final int agentRecallCount, final boolean zeroTimeDecay) {
+
+        if (zeroTimeDecay) {
+            return 1.0f * DecayStrategy.arousalModifier(arousal);
+        }
+
+        final double elapsedDays = Math.max(0.0, (nowMs - timestampMs) / MS_PER_DAY);
+        final float logTerm = (float) Math.log1p(elapsedDays);
+        final float massDenominator = 1.0f + Math.max(0.0f, cognitiveMass);
+
+        final float dilatedDecay = 1.0f / (1.0f + (logTerm / massDenominator));
+        final float reconsolidationBoost = 1.0f + 0.05f * Math.min(agentRecallCount, 10);
+        final float finalDecay = dilatedDecay * DecayStrategy.arousalModifier(arousal) * reconsolidationBoost;
+
+        return Math.min(1.0f, Math.max(0.0f, finalDecay));
+    }
+
+    /**
+     * Computes the final fused cognitive score for a candidate memory (Phase 6).
      */
     public static float computeFusedScore(
             final float l2dist, final float strictness, final boolean pureSimilarity,
-            final int adjustedBucket, final byte arousal, final float storageStrength,
-            final boolean hasStorageStrength, final boolean twoFactorEnabled, final float sExponent,
+            final long timestampMs, final long nowMs, final float cognitiveMass,
+            final byte arousal, final float storageStrength, final boolean hasStorageStrength,
+            final boolean twoFactorEnabled, final float sExponent, final int agentRecallCount,
             final float importance, final float beta, final float alpha, final float tagOverlap,
             final ScoreFusionMode fusionMode, final boolean valenceAlign, final byte queryValence,
             final byte valence, final float tagRelevanceBoost, final boolean focusMatch,
-            final float hyperfocusBoost, final byte flags, final boolean enableAssociativePrior,
-            final AssociativePriorProvider priorProvider, final long offset, final long recordTags,
-            final QueryAssociativeContext priorContext, final float associativePriorDelta) {
+            final boolean zeroTimeDecay, final float hyperfocusBoost, final byte flags,
+            final boolean enableAssociativePrior, final AssociativePriorProvider priorProvider,
+            final long offset, final long recordTags, final QueryAssociativeContext priorContext,
+            final float associativePriorDelta) {
 
         final float similarity = 1.0f / (1.0f + l2dist * strictness);
         if (pureSimilarity) {
             return similarity;
         }
 
-        float decay = DecayStrategy.decay(adjustedBucket) * DecayStrategy.arousalModifier(arousal);
-        decay = Math.min(1.0f, decay);
+        final float decay = computeMassDilatedDecay(
+                timestampMs, nowMs, cognitiveMass, arousal, agentRecallCount, zeroTimeDecay);
 
         float storageBoost = 1.0f;
         if (hasStorageStrength && twoFactorEnabled && storageStrength > 1.0f) {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/FlatMinHeap.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/FlatMinHeap.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.synapse.scan;
+
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A fixed-capacity min-heap backed by parallel primitive arrays for zero-allocation top-K scoring.
+ *
+ * <p>Header fields are stored in flat primitive arrays during the scan loop. {@link CognitiveHeader}
+ * and {@link ScoredRecord} objects are created ONLY when {@link #drain()} is called on the surviving top-K.</p>
+ */
+public final class FlatMinHeap {
+
+    private final int capacity;
+    private int size;
+
+    // Core fields
+    private final float[] scores;
+    private final long[] offsets;
+    private final int[] indices;
+
+    // Header fields (stored flat, assembled into CognitiveHeader on drain)
+    private final long[] timestamps;
+    private final long[] synapticTags;
+    private final float[] exactNorms;
+    private final float[] importances;
+    private final int[] agentRecallCounts;
+    private final short[] centroidIds;
+    private final byte[] valences;
+    private final byte[] flags;
+
+    /**
+     * Creates a new flat min-heap with the given capacity.
+     *
+     * @param capacity top-K capacity
+     */
+    public FlatMinHeap(final int capacity) {
+        this.capacity = capacity;
+        this.size = 0;
+        final int len = capacity + 1; // +1 for sift workspace
+        this.scores = new float[len];
+        this.offsets = new long[len];
+        this.indices = new int[len];
+        this.timestamps = new long[len];
+        this.synapticTags = new long[len];
+        this.exactNorms = new float[len];
+        this.importances = new float[len];
+        this.agentRecallCounts = new int[len];
+        this.centroidIds = new short[len];
+        this.valences = new byte[len];
+        this.flags = new byte[len];
+    }
+
+    /**
+     * Returns true if the given score should be inserted (heap not full, or beats minimum).
+     *
+     * @param score score to check
+     * @return true if score qualifies for heap insertion
+     */
+    public boolean shouldInsert(final float score) {
+        return size < capacity || score > scores[0];
+    }
+
+    /**
+     * Inserts or replaces the minimum entry. Caller must check {@link #shouldInsert(float)} first.
+     */
+    public void insert(
+            final float score, final long offset, final int index,
+            final long timestamp, final long tags, final float exactNorm, final float importance,
+            final int agentRecallCount, final short centroidId, final byte valence, final byte flag) {
+        if (size < capacity) {
+            final int idx = size;
+            set(idx, score, offset, index, timestamp, tags, exactNorm,
+                    importance, agentRecallCount, centroidId, valence, flag);
+            size++;
+            siftUp(idx);
+        } else {
+            // Replace root (minimum)
+            set(0, score, offset, index, timestamp, tags, exactNorm,
+                    importance, agentRecallCount, centroidId, valence, flag);
+            siftDown(0);
+        }
+    }
+
+    /**
+     * Drains the heap into a list of {@link ScoredRecord} objects.
+     *
+     * @return drained list of scored records
+     */
+    public List<ScoredRecord> drain() {
+        final List<ScoredRecord> results = new ArrayList<>(size);
+        for (int h = 0; h < size; h++) {
+            final CognitiveHeader header = new CognitiveHeader(
+                    timestamps[h], synapticTags[h], exactNorms[h], importances[h],
+                    agentRecallCounts[h], centroidIds[h], valences[h], flags[h]);
+            results.add(new ScoredRecord(offsets[h], scores[h], indices[h], header));
+        }
+        return results;
+    }
+
+    private void set(
+            final int idx, final float score, final long offset, final int index,
+            final long timestamp, final long tags, final float exactNorm, final float importance,
+            final int agentRecallCount, final short centroidId, final byte valence, final byte flag) {
+        scores[idx] = score;
+        offsets[idx] = offset;
+        indices[idx] = index;
+        timestamps[idx] = timestamp;
+        synapticTags[idx] = tags;
+        exactNorms[idx] = exactNorm;
+        importances[idx] = importance;
+        agentRecallCounts[idx] = agentRecallCount;
+        centroidIds[idx] = centroidId;
+        valences[idx] = valence;
+        flags[idx] = flag;
+    }
+
+    private void siftUp(int idx) {
+        while (idx > 0) {
+            final int parent = (idx - 1) >>> 1;
+            if (scores[idx] >= scores[parent]) {
+                break;
+            }
+            swap(idx, parent);
+            idx = parent;
+        }
+    }
+
+    private void siftDown(int idx) {
+        while (true) {
+            final int left = 2 * idx + 1;
+            final int right = left + 1;
+            int smallest = idx;
+            if (left < size && scores[left] < scores[smallest]) {
+                smallest = left;
+            }
+            if (right < size && scores[right] < scores[smallest]) {
+                smallest = right;
+            }
+            if (smallest == idx) {
+                break;
+            }
+            swap(idx, smallest);
+            idx = smallest;
+        }
+    }
+
+    private void swap(final int a, final int b) {
+        final float ts = scores[a]; scores[a] = scores[b]; scores[b] = ts;
+        final long to = offsets[a]; offsets[a] = offsets[b]; offsets[b] = to;
+        final int ti = indices[a]; indices[a] = indices[b]; indices[b] = ti;
+        final long tt = timestamps[a]; timestamps[a] = timestamps[b]; timestamps[b] = tt;
+        final long tg = synapticTags[a]; synapticTags[a] = synapticTags[b]; synapticTags[b] = tg;
+        final float tn = exactNorms[a]; exactNorms[a] = exactNorms[b]; exactNorms[b] = tn;
+        final float tp = importances[a]; importances[a] = importances[b]; importances[b] = tp;
+        final int tr = agentRecallCounts[a]; agentRecallCounts[a] = agentRecallCounts[b]; agentRecallCounts[b] = tr;
+        final short tc = centroidIds[a]; centroidIds[a] = centroidIds[b]; centroidIds[b] = tc;
+        final byte tv = valences[a]; valences[a] = valences[b]; valences[b] = tv;
+        final byte tf = flags[a]; flags[a] = flags[b]; flags[b] = tf;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/RecordGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/RecordGates.java
@@ -112,7 +112,7 @@ public final class RecordGates {
             final int adjustedBucket, final float importance, final byte flags, final float cognitiveMass) {
         return adjustedBucket >= DecayStrategy.MAX_BUCKET
                 && importance < 1.0f
-                && cognitiveMass < 3.0f
+                && cognitiveMass < 0.30f
                 && !isPinned(flags)
                 && isResolved(flags);
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/RecordGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/RecordGates.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.synapse.scan;
+
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.synapse.DecayStrategy;
+
+import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.isPinned;
+import static com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.isResolved;
+
+/**
+ * High-speed candidate screening and gating predicates for off-heap segment scan (Phases 1-4).
+ *
+ * <p>All methods are static final and designed for aggressive JIT inlining without allocations.</p>
+ */
+public final class RecordGates {
+
+    private RecordGates() {
+        // utility class
+    }
+
+    /**
+     * Phase 1 & 1c: Evaluates tombstone and contradiction flags.
+     *
+     * @param flags                synaptic header flags byte
+     * @param consolidationFlags   consolidation flags byte
+     * @param includeContradictions whether contradicted records should be admitted
+     * @return true if the record is rejected
+     */
+    public static boolean isDeletedOrContradicted(
+            final byte flags, final byte consolidationFlags, final boolean includeContradictions) {
+        if (SynapticHeaderConstants.isTombstoned(flags)) {
+            return true;
+        }
+        return !includeContradictions && SynapticHeaderConstants.isContradicted(consolidationFlags);
+    }
+
+    /**
+     * Phase 1b: Evaluates temporal bounds and the 1-cycle future causal horizon gate.
+     *
+     * @param timestampMs  memory record timestamp in epoch milliseconds
+     * @param minTimestamp optional minimum timestamp filter
+     * @param maxTimestamp optional maximum timestamp filter
+     * @param queryTimeMs  query reference timestamp in epoch milliseconds
+     * @param allowFuture  true to allow future/predictive memory recall (DMN mode)
+     * @return true if the record is rejected
+     */
+    public static boolean isTemporalGated(
+            final long timestampMs, final Long minTimestamp, final Long maxTimestamp,
+            final long queryTimeMs, final boolean allowFuture) {
+        if (minTimestamp != null && timestampMs < minTimestamp) {
+            return true;
+        }
+        if (maxTimestamp != null && timestampMs > maxTimestamp) {
+            return true;
+        }
+        return !allowFuture && queryTimeMs > 0 && timestampMs > queryTimeMs;
+    }
+
+    /**
+     * Phase 2: Evaluates synaptic tag masks for standard containment or hyperfocus tunnels.
+     *
+     * @param recordTags     memory record 64-bit synaptic tag mask
+     * @param queryTagMask   query tag mask
+     * @param hyperfocusMask hyperfocus strict tag mask (0 if inactive)
+     * @return true if the record is rejected
+     */
+    public static boolean isTagGated(
+            final long recordTags, final long queryTagMask, final long hyperfocusMask) {
+        if (hyperfocusMask != 0) {
+            return (recordTags & hyperfocusMask) != hyperfocusMask;
+        }
+        if (queryTagMask != 0) {
+            return (recordTags & queryTagMask) == 0;
+        }
+        return false;
+    }
+
+    /**
+     * Phase 3: Evaluates emotional valence bounds.
+     *
+     * @param valence    memory record signed 8-bit valence [-128, 127]
+     * @param minValence minimum allowable valence
+     * @param maxValence maximum allowable valence
+     * @return true if the record is rejected
+     */
+    public static boolean isValenceGated(
+            final byte valence, final byte minValence, final byte maxValence) {
+        return valence < minValence || valence > maxValence;
+    }
+
+    /**
+     * Phase 4: Evaluates temporal age decay against the maximum age threshold with high-mass and Zeigarnik exemptions.
+     *
+     * @param adjustedBucket adjusted decay age bucket [0..11]
+     * @param importance     raw importance score [0.0..10.0]
+     * @param flags          synaptic header flags byte
+     * @param cognitiveMass  computed cognitive mass M_i
+     * @return true if the record is stale and low-importance, and should be skipped
+     */
+    public static boolean isStaleAndWeak(
+            final int adjustedBucket, final float importance, final byte flags, final float cognitiveMass) {
+        return adjustedBucket >= DecayStrategy.MAX_BUCKET
+                && importance < 1.0f
+                && cognitiveMass < 3.0f
+                && !isPinned(flags)
+                && isResolved(flags);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/RecordGates.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/RecordGates.java
@@ -99,6 +99,9 @@ public final class RecordGates {
         return valence < minValence || valence > maxValence;
     }
 
+    /** Minimum cognitive mass required to exempt low-importance memories (I < 1.0) from stale pruning. */
+    public static final float FLASHBULB_MASS_FLOOR = com.spectrayan.spector.config.SpectorPropertyConstants.DEFAULT_RECALL_FLASHBULB_MASS_FLOOR;
+
     /**
      * Phase 4: Evaluates temporal age decay against the maximum age threshold with high-mass and Zeigarnik exemptions.
      *
@@ -112,7 +115,7 @@ public final class RecordGates {
             final int adjustedBucket, final float importance, final byte flags, final float cognitiveMass) {
         return adjustedBucket >= DecayStrategy.MAX_BUCKET
                 && importance < 1.0f
-                && cognitiveMass < 0.30f
+                && cognitiveMass < FLASHBULB_MASS_FLOOR
                 && !isPinned(flags)
                 && isResolved(flags);
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/StorageBoostLut.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/StorageBoostLut.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.synapse.scan;
+
+/**
+ * Precomputed lookup table for {@code storageStrength^0.3} in the hot scoring scan.
+ *
+ * <p>Replaces {@code Math.pow(storageStrength, 0.3)} in the hot loop (~150 cycles → ~3 cycles).
+ * Maps S ∈ [1.0, 5.0] to S^0.3 via 64-entry linear interpolation with < 0.2% error.</p>
+ */
+public final class StorageBoostLut {
+
+    private static final int STORAGE_BOOST_LUT_SIZE = 64;
+    private static final float STORAGE_BOOST_LUT_MIN = 1.0f;
+    private static final float STORAGE_BOOST_LUT_MAX = 5.0f;
+    private static final float STORAGE_BOOST_LUT_RANGE = STORAGE_BOOST_LUT_MAX - STORAGE_BOOST_LUT_MIN;
+    private static final float[] STORAGE_BOOST_LUT = new float[STORAGE_BOOST_LUT_SIZE];
+
+    static {
+        for (int i = 0; i < STORAGE_BOOST_LUT_SIZE; i++) {
+            float s = STORAGE_BOOST_LUT_MIN + (i / (float) (STORAGE_BOOST_LUT_SIZE - 1)) * STORAGE_BOOST_LUT_RANGE;
+            STORAGE_BOOST_LUT[i] = (float) Math.pow(s, 0.3);
+        }
+    }
+
+    private StorageBoostLut() {
+        // utility class
+    }
+
+    /**
+     * Fast approximation of {@code S^exponent} using precomputed LUT.
+     * Falls back to {@link Math#pow} for exponents other than 0.3 or storage strengths outside [1.0, 5.0].
+     *
+     * @param storageStrength consolidated storage strength in [1.0, 5.0]
+     * @param exponent        power exponent (default 0.3)
+     * @return storage boost multiplier
+     */
+    public static float fastStorageBoost(final float storageStrength, final float exponent) {
+        if (exponent == 0.3f && storageStrength >= STORAGE_BOOST_LUT_MIN && storageStrength <= STORAGE_BOOST_LUT_MAX) {
+            final float normalized = (storageStrength - STORAGE_BOOST_LUT_MIN)
+                    * ((STORAGE_BOOST_LUT_SIZE - 1) / STORAGE_BOOST_LUT_RANGE);
+            final int idx = (int) normalized;
+            if (idx >= STORAGE_BOOST_LUT_SIZE - 1) {
+                return STORAGE_BOOST_LUT[STORAGE_BOOST_LUT_SIZE - 1];
+            }
+            final float frac = normalized - idx;
+            return STORAGE_BOOST_LUT[idx] + frac * (STORAGE_BOOST_LUT[idx + 1] - STORAGE_BOOST_LUT[idx]);
+        }
+        return (float) Math.pow(storageStrength, exponent);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/package-info.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+
+/**
+ * Off-heap segment scan helpers, gates, and scoring fusion kernels.
+ */
+package com.spectrayan.spector.memory.synapse.scan;

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
@@ -20,15 +20,18 @@ import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.SourceModality;
 import com.spectrayan.spector.memory.pathway.RelayNames;
 import com.spectrayan.spector.memory.recall.relay.RecallSignal;
 import com.spectrayan.spector.memory.recall.relay.SpacetimeScoringRelay;
 import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
+import com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -109,30 +112,72 @@ class SpacetimeScoringFixtureTest {
     class CognitiveMassRetentionTests {
 
         @Test
-        @DisplayName("Fixture A: High-mass flashbulb memory (5y old) is protected from stale pruning")
-        void highMassFlashbulbMemoryRetained() {
+        @DisplayName("Fixture A: High-mass memory with I < 1.0 is exempted from stale pruning via M >= 3.0")
+        void highMassExemptsLowImportanceStaleMemory() {
             final SemanticRecordMemory store = new SemanticRecordMemory(DIMS, 10);
             final CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
             final long now = System.currentTimeMillis();
 
-            // Record 0: 5-year-old memory with high importance (9.0) and high storage strength
-            final byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.EPISODIC.ordinal());
-            final CognitiveHeader flashbulb = new CognitiveHeader(
-                    now - FIVE_YEARS_MS, 0L, 1.0f, 9.0f, 5, (short) 0, (byte) 50, flags, (byte) 100, 4.0f);
-            store.append(flashbulb, new byte[layout.quantizedVecBytes()]);
+            // Record 0: 5-year-old memory with low base importance (0.8 < 1.0) but high arousal (220) and storage strength (4.5)
+            // M = (0.8 / 10) * (1 + 220/128) * (4.5^0.3) = 0.08 * 2.71875 * 1.57 = ~0.34
+            // Let's compute M >= 3.0: with I=8.0, A=220, S=4.5 -> M = 0.8 * 2.71875 * 1.57 = 3.41 >= 3.0
+            // For I < 1.0: with I=0.8, flags=RESOLVED, adjustedBucket=MAX_BUCKET(11), let's verify computeCognitiveMass directly:
+            final float highMass = CognitiveScoreFusion.computeCognitiveMass(8.0f, (byte) 220, 4.5f);
+            assertThat(highMass).isGreaterThanOrEqualTo(3.0f);
+
+            final float lowMass = CognitiveScoreFusion.computeCognitiveMass(0.5f, (byte) 0, 1.0f);
+            assertThat(lowMass).isLessThan(3.0f);
+
+            // Record 0: High-mass memory (I=8.0, A=220, S=4.5) -> Survives Phase 4 & Phase 6
+            final byte flagsResolved = SynapticHeaderConstants.withMemoryType(
+                    SynapticHeaderConstants.FLAG_RESOLVED, MemoryType.EPISODIC.ordinal());
+            final CognitiveHeader highMassHeader = new CognitiveHeader(
+                    now - FIVE_YEARS_MS, 0L, 1.0f, 8.0f, 0, (short) 0, (byte) 50, flagsResolved, (byte) 220, 4.5f);
+            store.append(highMassHeader, new byte[layout.quantizedVecBytes()]);
+
+            // Record 1: Stale & weak control memory (5 years old, I=0.5, A=0, S=1.0, RESOLVED) -> Must be pruned
+            final CognitiveHeader lowMassHeader = new CognitiveHeader(
+                    now - FIVE_YEARS_MS, 0L, 1.0f, 0.5f, 0, (short) 0, (byte) 0, flagsResolved, (byte) 0, 1.0f);
+            store.append(lowMassHeader, new byte[layout.quantizedVecBytes()]);
 
             final float[] queryVec = new float[DIMS];
             final RecallOptions opts = RecallOptions.builder()
                     .topK(5)
+                    .minImportance(0.1f)
                     .build();
 
             final List<ScoredRecord> results = CognitiveScorer.score(
-                    store.segment(), 1, layout, queryVec, opts, now, 0L, null, null);
+                    store.segment(), 2, layout, queryVec, opts, now, 0L, null, null);
 
+            // Only the high-mass memory survives Phase 4 screening
             assertThat(results).hasSize(1);
+            assertThat(results.get(0).header().timestampMs()).isEqualTo(highMassHeader.timestampMs());
             assertThat(results.get(0).score()).isGreaterThan(0.0f);
 
             store.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Phase 6: Continuous Mass-Dilated Log Recency")
+    class Phase6ContinuousMassDilationTests {
+
+        @Test
+        @DisplayName("Higher cognitive mass significantly dilates time decay over identical elapsed intervals")
+        void massDilatesTimeDecay() {
+            final long now = 1774900000000L;
+            final long monthAgo = now - (30L * ONE_DAY_MS);
+
+            // High mass: M = 4.0
+            final float decayHighMass = CognitiveScoreFusion.computeMassDilatedDecay(
+                    monthAgo, now, 4.0f, (byte) 50, 0, false);
+
+            // Low mass: M = 0.2
+            final float decayLowMass = CognitiveScoreFusion.computeMassDilatedDecay(
+                    monthAgo, now, 0.2f, (byte) 0, 0, false);
+
+            // High-mass memory experiences far less temporal degradation
+            assertThat(decayHighMass).isGreaterThan(decayLowMass * 1.5f);
         }
     }
 
@@ -156,16 +201,20 @@ class SpacetimeScoringFixtureTest {
             signal.setQueryTau(queryTau);
 
             // Candidate 1: Exactly 7 days ago (100% weekly + circadian harmonic phase match)
-            final float ageDays1 = 7.0f;
+            final long timeC1 = queryTimeMs - (7L * ONE_DAY_MS);
             final CognitiveResult c1 = new CognitiveResult(
-                    "c1", "7 days ago memory", 0.70f, 5.0f, ageDays1, 0, (byte) 0,
-                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f);
+                    "c1", "7 days ago memory", 0.70f, 5.0f, 7.0f, 0, (byte) 0,
+                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f,
+                    CognitiveResult.RetrievalMode.STANDARD, null, null,
+                    SourceModality.TEXT, Map.of(), (byte) 0, timeC1);
 
             // Candidate 2: 3.5 days ago (half-week anti-phase)
-            final float ageDays2 = 3.5f;
+            final long timeC2 = queryTimeMs - (long) (3.5 * ONE_DAY_MS);
             final CognitiveResult c2 = new CognitiveResult(
-                    "c2", "3.5 days ago memory", 0.70f, 5.0f, ageDays2, 0, (byte) 0,
-                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f);
+                    "c2", "3.5 days ago memory", 0.70f, 5.0f, 3.5f, 0, (byte) 0,
+                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f,
+                    CognitiveResult.RetrievalMode.STANDARD, null, null,
+                    SourceModality.TEXT, Map.of(), (byte) 0, timeC2);
 
             signal.setCandidates(List.of(c1, c2));
 
@@ -176,7 +225,6 @@ class SpacetimeScoringFixtureTest {
             final List<CognitiveResult> updated = signal.candidates();
             assertThat(updated).hasSize(2);
 
-            // c1 should have received a higher harmonic alignment boost than c2
             final CognitiveResult updatedC1 = updated.stream().filter(c -> c.id().equals("c1")).findFirst().orElseThrow();
             final CognitiveResult updatedC2 = updated.stream().filter(c -> c.id().equals("c2")).findFirst().orElseThrow();
 
@@ -207,7 +255,7 @@ class SpacetimeScoringFixtureTest {
                     "c1", "traced memory", 0.50f, 5.0f, 1.0f, 0, (byte) 0,
                     MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f,
                     CognitiveResult.RetrievalMode.STANDARD, null, initialTrace,
-                    com.spectrayan.spector.memory.model.SourceModality.TEXT, java.util.Map.of());
+                    SourceModality.TEXT, Map.of(), (byte) 0, queryTimeMs - ONE_DAY_MS);
 
             signal.setCandidates(List.of(c1));
 

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
@@ -20,6 +20,7 @@ import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.pathway.RelayNames;
 import com.spectrayan.spector.memory.recall.relay.RecallSignal;
 import com.spectrayan.spector.memory.recall.relay.SpacetimeScoringRelay;
 import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
@@ -180,6 +181,44 @@ class SpacetimeScoringFixtureTest {
             final CognitiveResult updatedC2 = updated.stream().filter(c -> c.id().equals("c2")).findFirst().orElseThrow();
 
             assertThat(updatedC1.score()).isGreaterThan(updatedC2.score());
+        }
+
+        @Test
+        @DisplayName("SpacetimeScoringRelay generates RecallTrace step when trace is present on candidate")
+        void harmonicTracingGeneratesPipelineTraceStep() {
+            final long queryTimeMs = 1774900000000L;
+            final float[] queryTau = Time2VecProjector.project(queryTimeMs);
+
+            final RecallOptions opts = RecallOptions.builder()
+                    .enableSpacetime(true)
+                    .spacetimeHarmonicWeight(0.15f)
+                    .build();
+
+            final RecallSignal signal = RecallSignal.forVectorQuery(new float[DIMS], opts);
+            signal.setQueryTimeMs(queryTimeMs);
+            signal.setQueryTau(queryTau);
+
+            final com.spectrayan.spector.memory.model.RecallTrace initialTrace =
+                    new com.spectrayan.spector.memory.model.RecallTrace("c1", List.of(
+                            new com.spectrayan.spector.memory.model.RecallTrace.TraceStep(
+                                    "INITIAL", 0.5f, 0.5f, 1, 1, "seed")));
+
+            final CognitiveResult c1 = new CognitiveResult(
+                    "c1", "traced memory", 0.50f, 5.0f, 1.0f, 0, (byte) 0,
+                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f,
+                    CognitiveResult.RetrievalMode.STANDARD, null, initialTrace,
+                    com.spectrayan.spector.memory.model.SourceModality.TEXT, java.util.Map.of());
+
+            signal.setCandidates(List.of(c1));
+
+            final SpacetimeScoringRelay relay = new SpacetimeScoringRelay();
+            final boolean success = relay.transmit(signal);
+
+            assertThat(success).isTrue();
+            final CognitiveResult result = signal.candidates().get(0);
+            assertThat(result.trace()).isNotNull();
+            assertThat(result.trace().steps()).hasSize(2);
+            assertThat(result.trace().steps().get(1).phaseName()).isEqualTo(RelayNames.SPACETIME_SCORING);
         }
     }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.synapse;
+
+import com.spectrayan.spector.core.spacetime.Time2VecProjector;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.recall.relay.RecallSignal;
+import com.spectrayan.spector.memory.recall.relay.SpacetimeScoringRelay;
+import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Spacetime Retrieval & Synaptic Relay Fixtures (ADR-0030 v1)")
+class SpacetimeScoringFixtureTest {
+
+    private static final int DIMS = 8;
+    private static final long ONE_DAY_MS = 86_400_000L;
+    private static final long FIVE_YEARS_MS = 5L * 365 * ONE_DAY_MS;
+
+    @Nested
+    @DisplayName("Phase 1b: Causal Horizon Gating (Fixture E)")
+    class CausalHorizonTests {
+
+        @Test
+        @DisplayName("Fixture E: Future memory (t_i > t_q) is hard-dropped when allowFuture=false")
+        void futureMemoryDroppedByDefault() {
+            final SemanticRecordMemory store = new SemanticRecordMemory(DIMS, 10);
+            final CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
+            final long now = System.currentTimeMillis();
+
+            // Record 0: Normal past memory
+            final CognitiveHeader pastHeader = new CognitiveHeader(
+                    now - 60_000L, 0L, 1.0f, 5.0f, 0, (short) 0, (byte) 0, (byte) 0);
+            store.append(pastHeader, new byte[layout.quantizedVecBytes()]);
+
+            // Record 1: Future memory (tomorrow)
+            final CognitiveHeader futureHeader = new CognitiveHeader(
+                    now + ONE_DAY_MS, 0L, 1.0f, 9.0f, 0, (short) 0, (byte) 0, (byte) 0);
+            store.append(futureHeader, new byte[layout.quantizedVecBytes()]);
+
+            final float[] queryVec = new float[DIMS];
+            final RecallOptions optsDefault = RecallOptions.builder()
+                    .topK(10)
+                    .allowFuture(false)
+                    .build();
+
+            final List<ScoredRecord> results = CognitiveScorer.score(
+                    store.segment(), 2, layout, queryVec, optsDefault, now, 0L, null, null);
+
+            // Future memory MUST be rejected before entering heap
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).header().timestampMs()).isEqualTo(pastHeader.timestampMs());
+
+            store.close();
+        }
+
+        @Test
+        @DisplayName("Fixture E: Future memory (t_i > t_q) is admitted when allowFuture=true (DMN mode)")
+        void futureMemoryAdmittedInDmnMode() {
+            final SemanticRecordMemory store = new SemanticRecordMemory(DIMS, 10);
+            final CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
+            final long now = System.currentTimeMillis();
+
+            // Record 0: Future memory (tomorrow)
+            final CognitiveHeader futureHeader = new CognitiveHeader(
+                    now + ONE_DAY_MS, 0L, 1.0f, 8.0f, 0, (short) 0, (byte) 0, (byte) 0);
+            store.append(futureHeader, new byte[layout.quantizedVecBytes()]);
+
+            final float[] queryVec = new float[DIMS];
+            final RecallOptions optsDmn = RecallOptions.builder()
+                    .topK(10)
+                    .allowFuture(true)
+                    .build();
+
+            final List<ScoredRecord> results = CognitiveScorer.score(
+                    store.segment(), 1, layout, queryVec, optsDmn, now, 0L, null, null);
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).header().timestampMs()).isEqualTo(futureHeader.timestampMs());
+
+            store.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Phase 4 & 6: Flashbulb Cognitive Mass Retention (Fixture A)")
+    class CognitiveMassRetentionTests {
+
+        @Test
+        @DisplayName("Fixture A: High-mass flashbulb memory (5y old) is protected from stale pruning")
+        void highMassFlashbulbMemoryRetained() {
+            final SemanticRecordMemory store = new SemanticRecordMemory(DIMS, 10);
+            final CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
+            final long now = System.currentTimeMillis();
+
+            // Record 0: 5-year-old memory with high importance (9.0) and high storage strength
+            final byte flags = SynapticHeaderConstants.withMemoryType((byte) 0, MemoryType.EPISODIC.ordinal());
+            final CognitiveHeader flashbulb = new CognitiveHeader(
+                    now - FIVE_YEARS_MS, 0L, 1.0f, 9.0f, 5, (short) 0, (byte) 50, flags, (byte) 100, 4.0f);
+            store.append(flashbulb, new byte[layout.quantizedVecBytes()]);
+
+            final float[] queryVec = new float[DIMS];
+            final RecallOptions opts = RecallOptions.builder()
+                    .topK(5)
+                    .build();
+
+            final List<ScoredRecord> results = CognitiveScorer.score(
+                    store.segment(), 1, layout, queryVec, opts, now, 0L, null, null);
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).score()).isGreaterThan(0.0f);
+
+            store.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("SpacetimeScoringRelay: Shortlist Harmonic Re-ranking")
+    class ShortlistHarmonicRelayTests {
+
+        @Test
+        @DisplayName("Candidates aligned with circadian/weekly query harmonics receive positive boost")
+        void harmonicAlignmentBoostsScore() {
+            final long queryTimeMs = 1774900000000L; // Reference query clock
+            final float[] queryTau = Time2VecProjector.project(queryTimeMs);
+
+            final RecallOptions opts = RecallOptions.builder()
+                    .enableSpacetime(true)
+                    .spacetimeHarmonicWeight(0.20f)
+                    .build();
+
+            final RecallSignal signal = RecallSignal.forVectorQuery(new float[DIMS], opts);
+            signal.setQueryTimeMs(queryTimeMs);
+            signal.setQueryTau(queryTau);
+
+            // Candidate 1: Exactly 7 days ago (100% weekly + circadian harmonic phase match)
+            final float ageDays1 = 7.0f;
+            final CognitiveResult c1 = new CognitiveResult(
+                    "c1", "7 days ago memory", 0.70f, 5.0f, ageDays1, 0, (byte) 0,
+                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f);
+
+            // Candidate 2: 3.5 days ago (half-week anti-phase)
+            final float ageDays2 = 3.5f;
+            final CognitiveResult c2 = new CognitiveResult(
+                    "c2", "3.5 days ago memory", 0.70f, 5.0f, ageDays2, 0, (byte) 0,
+                    MemoryType.EPISODIC, null, new String[0], 0.5f, 0.5f);
+
+            signal.setCandidates(List.of(c1, c2));
+
+            final SpacetimeScoringRelay relay = new SpacetimeScoringRelay();
+            final boolean success = relay.transmit(signal);
+
+            assertThat(success).isTrue();
+            final List<CognitiveResult> updated = signal.candidates();
+            assertThat(updated).hasSize(2);
+
+            // c1 should have received a higher harmonic alignment boost than c2
+            final CognitiveResult updatedC1 = updated.stream().filter(c -> c.id().equals("c1")).findFirst().orElseThrow();
+            final CognitiveResult updatedC2 = updated.stream().filter(c -> c.id().equals("c2")).findFirst().orElseThrow();
+
+            assertThat(updatedC1.score()).isGreaterThan(updatedC2.score());
+        }
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
@@ -26,6 +26,7 @@ import com.spectrayan.spector.memory.recall.relay.RecallSignal;
 import com.spectrayan.spector.memory.recall.relay.SpacetimeScoringRelay;
 import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
 import com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion;
+import com.spectrayan.spector.memory.synapse.scan.RecordGates;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -119,14 +120,14 @@ class SpacetimeScoringFixtureTest {
             final long now = System.currentTimeMillis();
 
             // Record 0: 5-year-old memory with low base importance (0.8 < 1.0) but high arousal (240) and storage strength (4.0)
-            // M = (0.8 / 10) * (1 + 240/128) * (4.0^0.3) = 0.08 * 2.875 * 1.516 = 0.349 >= 0.30
+            // M = (0.8 / 10) * (1 + 240/128) * (4.0^0.3) = 0.08 * 2.875 * 1.516 = 0.349 >= FLASHBULB_MASS_FLOOR (0.30)
             final float highMass = CognitiveScoreFusion.computeCognitiveMass(0.8f, (byte) 240, 4.0f);
-            assertThat(highMass).isGreaterThanOrEqualTo(0.30f);
+            assertThat(highMass).isGreaterThanOrEqualTo(RecordGates.FLASHBULB_MASS_FLOOR);
 
             final float lowMass = CognitiveScoreFusion.computeCognitiveMass(0.5f, (byte) 0, 1.0f);
-            assertThat(lowMass).isLessThan(0.30f);
+            assertThat(lowMass).isLessThan(RecordGates.FLASHBULB_MASS_FLOOR);
 
-            // Record 0: High-mass memory (I=0.8 < 1.0, A=240, S=4.0) -> Survives Phase 4 via M >= 0.30 exemption
+            // Record 0: High-mass memory (I=0.8 < 1.0, A=240, S=4.0) -> Survives Phase 4 via M >= FLASHBULB_MASS_FLOOR exemption
             final byte flagsResolved = SynapticHeaderConstants.withMemoryType(
                     SynapticHeaderConstants.FLAG_RESOLVED, MemoryType.EPISODIC.ordinal());
             final CognitiveHeader highMassHeader = new CognitiveHeader(

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/synapse/SpacetimeScoringFixtureTest.java
@@ -112,30 +112,28 @@ class SpacetimeScoringFixtureTest {
     class CognitiveMassRetentionTests {
 
         @Test
-        @DisplayName("Fixture A: High-mass memory with I < 1.0 is exempted from stale pruning via M >= 3.0")
+        @DisplayName("Fixture A: High-mass memory with I < 1.0 is exempted from stale pruning via M >= 0.30")
         void highMassExemptsLowImportanceStaleMemory() {
             final SemanticRecordMemory store = new SemanticRecordMemory(DIMS, 10);
             final CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
             final long now = System.currentTimeMillis();
 
-            // Record 0: 5-year-old memory with low base importance (0.8 < 1.0) but high arousal (220) and storage strength (4.5)
-            // M = (0.8 / 10) * (1 + 220/128) * (4.5^0.3) = 0.08 * 2.71875 * 1.57 = ~0.34
-            // Let's compute M >= 3.0: with I=8.0, A=220, S=4.5 -> M = 0.8 * 2.71875 * 1.57 = 3.41 >= 3.0
-            // For I < 1.0: with I=0.8, flags=RESOLVED, adjustedBucket=MAX_BUCKET(11), let's verify computeCognitiveMass directly:
-            final float highMass = CognitiveScoreFusion.computeCognitiveMass(8.0f, (byte) 220, 4.5f);
-            assertThat(highMass).isGreaterThanOrEqualTo(3.0f);
+            // Record 0: 5-year-old memory with low base importance (0.8 < 1.0) but high arousal (240) and storage strength (4.0)
+            // M = (0.8 / 10) * (1 + 240/128) * (4.0^0.3) = 0.08 * 2.875 * 1.516 = 0.349 >= 0.30
+            final float highMass = CognitiveScoreFusion.computeCognitiveMass(0.8f, (byte) 240, 4.0f);
+            assertThat(highMass).isGreaterThanOrEqualTo(0.30f);
 
             final float lowMass = CognitiveScoreFusion.computeCognitiveMass(0.5f, (byte) 0, 1.0f);
-            assertThat(lowMass).isLessThan(3.0f);
+            assertThat(lowMass).isLessThan(0.30f);
 
-            // Record 0: High-mass memory (I=8.0, A=220, S=4.5) -> Survives Phase 4 & Phase 6
+            // Record 0: High-mass memory (I=0.8 < 1.0, A=240, S=4.0) -> Survives Phase 4 via M >= 0.30 exemption
             final byte flagsResolved = SynapticHeaderConstants.withMemoryType(
                     SynapticHeaderConstants.FLAG_RESOLVED, MemoryType.EPISODIC.ordinal());
             final CognitiveHeader highMassHeader = new CognitiveHeader(
-                    now - FIVE_YEARS_MS, 0L, 1.0f, 8.0f, 0, (short) 0, (byte) 50, flagsResolved, (byte) 220, 4.5f);
+                    now - FIVE_YEARS_MS, 0L, 1.0f, 0.8f, 0, (short) 0, (byte) 50, flagsResolved, (byte) 240, 4.0f);
             store.append(highMassHeader, new byte[layout.quantizedVecBytes()]);
 
-            // Record 1: Stale & weak control memory (5 years old, I=0.5, A=0, S=1.0, RESOLVED) -> Must be pruned
+            // Record 1: Stale & weak control memory (5 years old, I=0.5 < 1.0, A=0, S=1.0, RESOLVED) -> Must be pruned
             final CognitiveHeader lowMassHeader = new CognitiveHeader(
                     now - FIVE_YEARS_MS, 0L, 1.0f, 0.5f, 0, (short) 0, (byte) 0, flagsResolved, (byte) 0, 1.0f);
             store.append(lowMassHeader, new byte[layout.quantizedVecBytes()]);
@@ -149,7 +147,7 @@ class SpacetimeScoringFixtureTest {
             final List<ScoredRecord> results = CognitiveScorer.score(
                     store.segment(), 2, layout, queryVec, opts, now, 0L, null, null);
 
-            // Only the high-mass memory survives Phase 4 screening
+            // Only the high-mass memory survives Phase 4 screening despite I < 1.0
             assertThat(results).hasSize(1);
             assertThat(results.get(0).header().timestampMs()).isEqualTo(highMassHeader.timestampMs());
             assertThat(results.get(0).score()).isGreaterThan(0.0f);

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -1283,7 +1283,7 @@ public final class SpectorPropertyConstants {
 
     // Spacetime Vector Search (ADR-0030 v1)
     public static final String RECALL_SPACETIME_ENABLED = "spector.recall.spacetime.enabled";
-    public static final boolean DEFAULT_RECALL_SPACETIME_ENABLED = true;
+    public static final boolean DEFAULT_RECALL_SPACETIME_ENABLED = false;
 
     public static final String RECALL_SPACETIME_HARMONIC_WEIGHT = "spector.recall.spacetime.harmonic-weight";
     public static final float DEFAULT_RECALL_SPACETIME_HARMONIC_WEIGHT = 0.15f;

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -1291,6 +1291,9 @@ public final class SpectorPropertyConstants {
     public static final String RECALL_ALLOW_FUTURE = "spector.recall.allow-future";
     public static final boolean DEFAULT_RECALL_ALLOW_FUTURE = false;
 
+    public static final String RECALL_FLASHBULB_MASS_FLOOR = "spector.recall.flashbulb.mass-floor";
+    public static final float DEFAULT_RECALL_FLASHBULB_MASS_FLOOR = 0.30f;
+
     // Server
     public static final String SERVER_PORT = "spector.server.port";
     public static final int DEFAULT_SERVER_PORT = 7070;

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -1281,6 +1281,16 @@ public final class SpectorPropertyConstants {
     public static final String PERSISTENCE_FILES_SHARD_DIR = "spector.persistence.files.shard-dir-name";
     public static final String DEFAULT_PERSISTENCE_FILES_SHARD_DIR = "index_shards";
 
+    // Spacetime Vector Search (ADR-0030 v1)
+    public static final String RECALL_SPACETIME_ENABLED = "spector.recall.spacetime.enabled";
+    public static final boolean DEFAULT_RECALL_SPACETIME_ENABLED = true;
+
+    public static final String RECALL_SPACETIME_HARMONIC_WEIGHT = "spector.recall.spacetime.harmonic-weight";
+    public static final float DEFAULT_RECALL_SPACETIME_HARMONIC_WEIGHT = 0.15f;
+
+    public static final String RECALL_ALLOW_FUTURE = "spector.recall.allow-future";
+    public static final boolean DEFAULT_RECALL_ALLOW_FUTURE = false;
+
     // Server
     public static final String SERVER_PORT = "spector.server.port";
     public static final int DEFAULT_SERVER_PORT = 7070;
@@ -1288,3 +1298,4 @@ public final class SpectorPropertyConstants {
     public static final String SERVER_DATA_DIR = "spector.server.data-dir";
     public static final String DEFAULT_SERVER_DATA_DIR = "./spector-data";
 }
+

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/Time2VecProjector.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/Time2VecProjector.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.spacetime;
+
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
+
+/**
+ * High-performance harmonic basis projector implementing Bochner's Theorem for temporal vector search.
+ *
+ * <p>Maps an epoch millisecond timestamp into a stationary 8-dimensional unit-norm harmonic Fourier basis
+ * vector across 4 non-overlapping octave period bands (1 hour, 1 day, 7 days, 365 days):</p>
+ *
+ * <pre>
+ *   τ(t) = (1 / √n_P) ⨁ [cos(2π t / P_k), sin(2π t / P_k)] ∈ ℝ^8
+ * </pre>
+ *
+ * <h3>Key Properties (ADR-0030 v1)</h3>
+ * <ul>
+ *   <li><b>Strict Unit Norm</b>: {@code ‖τ(t)‖₂ ≡ 1.0} identically for all timestamps without runtime normalization.</li>
+ *   <li><b>Stationary Kernel</b>: {@code ⟨τ(t_q), τ(t_i)⟩ = ψ(t_q - t_i)} depends solely on elapsed time difference.</li>
+ *   <li><b>Exact Zero Peak</b>: {@code ⟨τ(t), τ(t)⟩ ≡ 1.0}.</li>
+ *   <li><b>Numerical Stability</b>: Time is evaluated in double-precision days since Unix epoch, preventing 64-bit float precision loss.</li>
+ * </ul>
+ */
+public final class Time2VecProjector {
+
+    /** Number of periodic harmonic pairs. */
+    public static final int PERIOD_PAIRS = 4;
+
+    /** Total dimensionality of the harmonic basis vector (2 * PERIOD_PAIRS). */
+    public static final int DIMENSIONS = 8;
+
+    /** Scale factor (1 / √4 = 0.5f) ensuring unit vector norm. */
+    public static final float NORM_SCALE = 0.5f;
+
+    /** Number of milliseconds in one standard solar day. */
+    private static final double MS_PER_DAY = 86_400_000.0;
+
+    /** Harmonic periods expressed in standard day units: 1 hour, 1 day, 7 days, 365 days. */
+    private static final double[] PERIODS_DAYS = {
+            1.0 / 24.0,  // 1 hour
+            1.0,         // 1 day (circadian)
+            7.0,         // 7 days (weekly)
+            365.0        // 365 days (annual)
+    };
+
+    /** Pre-calculated angular frequencies ω_k = 2π / P_k. */
+    private static final double[] OMEGAS = new double[PERIOD_PAIRS];
+
+    static {
+        for (int k = 0; k < PERIOD_PAIRS; k++) {
+            OMEGAS[k] = (2.0 * Math.PI) / PERIODS_DAYS[k];
+        }
+    }
+
+    private Time2VecProjector() {
+        // utility class
+    }
+
+    /**
+     * Projects an epoch millisecond timestamp into the 8-dimensional unit-norm harmonic basis vector.
+     *
+     * @param timestampMs epoch timestamp in milliseconds
+     * @return 8-element float array representing τ(t) with strict ‖τ(t)‖₂ = 1.0
+     */
+    public static float[] project(final long timestampMs) {
+        final float[] tau = new float[DIMENSIONS];
+        projectInto(timestampMs, tau, 0);
+        return tau;
+    }
+
+    /**
+     * Projects an epoch millisecond timestamp directly into an existing float array.
+     *
+     * @param timestampMs epoch timestamp in milliseconds
+     * @param target      target float array
+     * @param offset      starting index in target array
+     */
+    public static void projectInto(final long timestampMs, final float[] target, final int offset) {
+        if (target == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "Target array cannot be null");
+        }
+        if (offset < 0 || offset + DIMENSIONS > target.length) {
+            throw new SpectorValidationException(
+                    ErrorCode.ARGUMENT_INVALID,
+                    "Target array cannot accommodate " + DIMENSIONS + " elements at offset " + offset);
+        }
+
+        final double tDays = (double) timestampMs / MS_PER_DAY;
+
+        for (int k = 0; k < PERIOD_PAIRS; k++) {
+            final double angle = OMEGAS[k] * tDays;
+            target[offset + 2 * k] = (float) (NORM_SCALE * Math.cos(angle));
+            target[offset + 2 * k + 1] = (float) (NORM_SCALE * Math.sin(angle));
+        }
+    }
+
+    /**
+     * Computes the harmonic alignment inner product ⟨τ_q, τ_i⟩ between two 8-dimensional harmonic basis vectors.
+     *
+     * @param tauA first harmonic vector
+     * @param tauB second harmonic vector
+     * @return inner product in [-1.0, 1.0] (1.0 = identical periodic phase)
+     */
+    public static float dot(final float[] tauA, final float[] tauB) {
+        if (tauA == null || tauB == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "Harmonic vectors cannot be null");
+        }
+        if (tauA.length < DIMENSIONS || tauB.length < DIMENSIONS) {
+            throw new SpectorValidationException(
+                    ErrorCode.ARGUMENT_INVALID,
+                    "Harmonic vectors must contain at least " + DIMENSIONS + " elements");
+        }
+
+        return tauA[0] * tauB[0] + tauA[1] * tauB[1]
+             + tauA[2] * tauB[2] + tauA[3] * tauB[3]
+             + tauA[4] * tauB[4] + tauA[5] * tauB[5]
+             + tauA[6] * tauB[6] + tauA[7] * tauB[7];
+    }
+
+    /**
+     * Fuses a normalized semantic vector with a temporal harmonic vector into a unified (D + 8)-dimensional embedding.
+     *
+     * @param vector   semantic embedding vector (D dimensions)
+     * @param tau      harmonic temporal vector (8 dimensions)
+     * @param betaTime temporal weight in [0.0, 1.0]
+     * @return concatenated fused vector of length (D + 8)
+     */
+    public static float[] fuse(final float[] vector, final float[] tau, final float betaTime) {
+        if (vector == null || tau == null) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_NULL, "Input vectors cannot be null");
+        }
+        final float clampedBeta = Math.max(0.0f, Math.min(1.0f, betaTime));
+        final float spatialScale = (float) Math.sqrt(1.0f - clampedBeta);
+        final float temporalScale = (float) Math.sqrt(clampedBeta);
+
+        final float[] fused = new float[vector.length + DIMENSIONS];
+        for (int i = 0; i < vector.length; i++) {
+            fused[i] = vector[i] * spatialScale;
+        }
+        for (int k = 0; k < DIMENSIONS; k++) {
+            fused[vector.length + k] = tau[k] * temporalScale;
+        }
+        return fused;
+    }
+}

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/package-info.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spatiotemporal projection and harmonic basis kernels for spacetime vector search.
+ */
+package com.spectrayan.spector.core.spacetime;

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/spacetime/Time2VecProjectorTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/spacetime/Time2VecProjectorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.spacetime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("Time2VecProjector Mathematical Properties (ADR-0030 v1)")
+class Time2VecProjectorTest {
+
+    private static final float EPSILON = 1e-5f;
+
+    @Nested
+    @DisplayName("Unit Norm Properties")
+    class UnitNormTests {
+
+        @Test
+        @DisplayName("Strict Unit Norm: ‖τ(t)‖₂ == 1.0 across 10,000 random timestamps")
+        void testUnitNormProperty() {
+            final Random rng = new Random(42);
+            final long now = System.currentTimeMillis();
+            final long fiftyYearsMs = 50L * 365 * 86_400_000L;
+
+            for (int i = 0; i < 10_000; i++) {
+                final long t = now + (rng.nextLong() % fiftyYearsMs);
+                final float[] tau = Time2VecProjector.project(t);
+
+                assertThat(tau).hasSize(Time2VecProjector.DIMENSIONS);
+
+                float normSq = 0.0f;
+                for (float v : tau) {
+                    normSq += v * v;
+                }
+                assertThat(normSq).isCloseTo(1.0f, within(EPSILON));
+            }
+        }
+
+        @Test
+        @DisplayName("Self inner product ⟨τ(t), τ(t)⟩ ≡ 1.0")
+        void testSelfDotProduct() {
+            final long now = 1774900000000L;
+            final float[] tau = Time2VecProjector.project(now);
+            final float dot = Time2VecProjector.dot(tau, tau);
+
+            assertThat(dot).isCloseTo(1.0f, within(EPSILON));
+        }
+    }
+
+    @Nested
+    @DisplayName("Stationarity & Periodicity Properties")
+    class StationarityTests {
+
+        @Test
+        @DisplayName("Stationary Kernel: ⟨τ(t), τ(t + Δ)⟩ depends only on Δ, not t")
+        void testStationaryProperty() {
+            final long delta = 3_600_000L; // 1 hour elapsed
+            final long t1 = 1700000000000L;
+            final long t2 = 1750000000000L;
+            final long t3 = 1800000000000L;
+
+            final float dot1 = Time2VecProjector.dot(
+                    Time2VecProjector.project(t1), Time2VecProjector.project(t1 + delta));
+            final float dot2 = Time2VecProjector.dot(
+                    Time2VecProjector.project(t2), Time2VecProjector.project(t2 + delta));
+            final float dot3 = Time2VecProjector.dot(
+                    Time2VecProjector.project(t3), Time2VecProjector.project(t3 + delta));
+
+            assertThat(dot1).isCloseTo(dot2, within(EPSILON));
+            assertThat(dot2).isCloseTo(dot3, within(EPSILON));
+        }
+
+        @Test
+        @DisplayName("Harmonic periodicity: Peak correlation at exact harmonic octave boundaries")
+        void testCircadianHarmonicCorrelation() {
+            final long t0 = 1774900000000L;
+            final long oneDayMs = 86_400_000L;
+
+            final float[] tau0 = Time2VecProjector.project(t0);
+            final float[] tauOneDay = Time2VecProjector.project(t0 + oneDayMs);
+
+            // After exactly 24 hours (1 day), 1-hour and 1-day harmonics have exact phase match (2 of 4 octaves)
+            final float dot = Time2VecProjector.dot(tau0, tauOneDay);
+            assertThat(dot).isGreaterThan(0.4f);
+        }
+    }
+
+    @Nested
+    @DisplayName("Vector Fusion Properties")
+    class FusionTests {
+
+        @Test
+        @DisplayName("Fused vector concatenation preserves dimension (D + 8)")
+        void testFusedVectorDimension() {
+            final float[] semanticVec = new float[]{0.6f, 0.8f}; // D = 2
+            final float[] tau = Time2VecProjector.project(System.currentTimeMillis());
+
+            final float[] fused = Time2VecProjector.fuse(semanticVec, tau, 0.1f);
+            assertThat(fused).hasSize(2 + 8);
+        }
+
+        @Test
+        @DisplayName("Fused vector norm is preserved when spatial and temporal vectors are unit-norm")
+        void testFusedNormPreservation() {
+            final float[] unitSpatial = new float[]{0.6f, 0.8f}; // norm = 1.0
+            final float[] tau = Time2VecProjector.project(System.currentTimeMillis());
+
+            final float[] fused = Time2VecProjector.fuse(unitSpatial, tau, 0.25f);
+
+            float normSq = 0.0f;
+            for (float v : fused) {
+                normSq += v * v;
+            }
+            assertThat(normSq).isCloseTo(1.0f, within(EPSILON));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements Spacetime Vector Search and Synaptic Relay Architecture in full accordance with ADR-0030 v1 and RND-2026-030 v2.0 (#719).

### Key Components & Changes:
1. **Time2Vec Harmonic Projector (`nucleus/spector-core`)**:
   - Computes 8-dimensional harmonic basis vector across 4 non-overlapping octave period bands (1h, 1d, 7d, 365d) with $1/\sqrt{n_P}$ norm scaling.
   - Pure stationary periodic representation without linear progression term ($\|\vec{\tau}(t)\|_2 \equiv 1.0$).
2. **Phase 6 Continuous Mass-Dilated Log Recency (`memory/spector-memory`)**:
   - $R(\Delta t, M_i) = \frac{1}{1 + \ln(1 + \Delta t_{\text{days}}) / (1 + M_i)} \cdot \text{arousalModifier}(A)$.
   - Continuous $\Delta t$ scaling with raw timestamps and live $M_i = (I_i/10)(1 + A_i/128)S_i^{0.3}$.
   - Stale memory pruning threshold calibrated to `FLASHBULB_MASS_FLOOR = 0.30f` (configured via `spector.recall.flashbulb.mass-floor`).
3. **Precision Timestamp Propagation**:
   - Carried explicit `timestampMs` on `CognitiveResult`, eliminating floating-point `ageDays` smearing on the 1-hour/1-day harmonic projections.
   - Preserved original timestamp across all pipeline gatherers and reranking relays via `withScore` / `withScoreAndBreakdown`.
4. **Recency Curve Alignment & Scoring Mixtures**:
   - **Fused Segment Scan**: $s = \text{sim} \cdot \left(1 + \beta \cdot \frac{I_i}{10} \cdot R(\Delta t, M_i) \cdot S_i^{0.3}\right)$.
   - **Semantic HNSW**: $s = \left(\alpha \cdot \text{sim} + \beta \cdot \frac{I_i}{10} \cdot R(\Delta t, M_i)\right) \cdot (1 + \text{tagOverlap} \cdot \text{boost})$. Both evaluate continuous mass-dilated recency $R(\Delta t, M_i)$.
5. **Clock Synchronization**:
   - Aligned `CorticalTierScanRelay`, Phase 1b future horizon gate, and `SpacetimeScoringRelay` on `signal.queryTimeMs()` (with replay timestamp support).
6. **Layout Version-Aware Arousal & Contradiction Short-Circuit**:
   - Fixed `hasArousal = layout.headerLayout().version() >= 2`.
   - Short-circuited `cFlags` reads during scan when contradiction filtering is bypassed.
7. **Shortlist Harmonic Re-Ranking & Observability**:
   - `SpacetimeScoringRelay` evaluates harmonic alignment $\langle \vec{\tau}_q, \vec{\tau}_i \rangle$ only on surviving top candidates ($N \le 200$, latency $\le 35\,\mu\text{s}$) without score flattening.
   - Records `SPACETIME_SCORING` step in `RecallTrace` with full decomposition.
   - Supports dependency injection in `RecallPathwayFactory`.
   - Gated by default (`DEFAULT_RECALL_SPACETIME_ENABLED = false`).
8. **Regression Fixtures & Parity**:
   - `SpacetimeScoringFixtureTest`: Fixture A (low importance $I = 0.8 < 1.0$, high mass $M = 0.349 \ge 0.30$ flashbulb retention vs control $I = 0.5, M = 0.05$ drop), Fixture E (future causal horizon drop / DMN admit), Phase 6 continuous mass dilation, and harmonic re-ranking.
   - `CognitivePathwayParityTest`: 100% parity preserved across all profiles and recall modes.

Closes #719