### PR TITLE
feat(simulation): expand spacetime vector space to wander, dream, and express pathways

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -956,7 +956,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
                         List<CognitiveResult> bufferedResults = buffer.search(queryText, queryVector, options);
                         List<CognitiveResult> merged = new java.util.ArrayList<>(storeResults);
                         merged.addAll(bufferedResults);
-                        merged.sort(java.util.Comparator.comparing(CognitiveResult::score).reversed());
+                        merged.sort(java.util.Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
                         storeResults = merged.stream().limit(options.topK()).collect(java.util.stream.Collectors.toList());
                     }
                 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DreamPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DreamPathway.java
@@ -107,6 +107,9 @@ public final class DreamPathway implements AutoCloseable {
         // 2. Salient Seed Selection (TMR + Soul / Salience Matching)
         pathwayBuilder.gated("salient_seed", DreamGates.DREAMING_ENABLED, new SalientSeedRelay(), ErrorPolicy.DEGRADE_GRACEFULLY);
 
+        // 2b. Spacetime Shortlist Seed Selection (ADR-0031)
+        pathwayBuilder.gated(com.spectrayan.spector.memory.pathway.RelayNames.SPACETIME_SEED, DreamGates.DREAMING_ENABLED, new com.spectrayan.spector.memory.simulation.relay.SpacetimeSeedRelay.DreamSeedRelay(), ErrorPolicy.DEGRADE_GRACEFULLY);
+
         // 3. Fragment Unpack (entity/role/affect decomposition)
         pathwayBuilder.gated("fragment_unpack", DreamGates.HAS_SEEDS, new FragmentUnpackRelay(), ErrorPolicy.DEGRADE_GRACEFULLY);
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/RecallPathway.java
@@ -410,7 +410,7 @@ public final class RecallPathway {
                 }
             }
 
-            results.sort(Comparator.comparing(CognitiveResult::score).reversed());
+            results.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
             if (results.size() > options.topK()) {
                 return new ArrayList<>(results.subList(0, options.topK()));
             }
@@ -483,7 +483,7 @@ public final class RecallPathway {
             }
         }
 
-        associativeResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        associativeResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
         List<CognitiveResult> finalResults = associativeResults;
         if (finalResults.size() > options.topK()) {
             finalResults = new ArrayList<>(finalResults.subList(0, options.topK()));

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/WanderPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/WanderPathway.java
@@ -33,6 +33,8 @@ import com.spectrayan.spector.memory.wander.relay.ManifoldSynergyRelay;
 import com.spectrayan.spector.memory.wander.relay.WanderGates;
 import com.spectrayan.spector.memory.wander.relay.WanderReport;
 import com.spectrayan.spector.memory.wander.relay.WanderSignal;
+import com.spectrayan.spector.memory.pathway.RelayNames;
+import com.spectrayan.spector.memory.simulation.relay.SpacetimeSeedRelay;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 
 import org.slf4j.Logger;
@@ -89,6 +91,9 @@ public final class WanderPathway implements AutoCloseable {
 
         // 2. Autobiographical Sampling
         pathwayBuilder.gated("autobiographical_sampling", WanderGates.DMN_ENABLED, new AutobiographicalSamplingRelay(), ErrorPolicy.DEGRADE_GRACEFULLY);
+
+        // 2b. Spacetime Shortlist Seed Selection (ADR-0031)
+        pathwayBuilder.gated(RelayNames.SPACETIME_SEED, WanderGates.DMN_ENABLED, new SpacetimeSeedRelay.WanderSeedRelay(), ErrorPolicy.DEGRADE_GRACEFULLY);
 
         // 3. Hopfield Mind Wandering
         pathwayBuilder.gated("hopfield_mind_wandering", WanderGates.DMN_ENABLED, new HopfieldMindWanderingRelay(), ErrorPolicy.DEGRADE_GRACEFULLY);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/SemanticRecallStrategy.java
@@ -234,7 +234,7 @@ public final class SemanticRecallStrategy {
         }
 
         // Sort by fused score descending
-        results.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        results.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
 
         log.debug("Semantic partition-aware fused recall: {} HNSW candidates → {} after filtering",
                 hnswResults.length, results.size());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dream/relay/DreamJournalRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dream/relay/DreamJournalRelay.java
@@ -13,6 +13,7 @@
 package com.spectrayan.spector.memory.dream.relay;
 
 import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.memory.dream.DreamJournalMemory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,7 +48,16 @@ public final class DreamJournalRelay implements SynapticRelay<DreamSignal> {
                 signal.mode(), scene.triageOutcome(), scene.qualityScore(), scene.sourceIds(), narrative);
                 
             if (journalEnabled && signal.dreamJournalMemory() != null) {
-                signal.dreamJournalMemory().appendScene(scene);
+                signal.dreamJournalMemory().append(new DreamJournalMemory.DreamJournalEntry(
+                        scene.id(),
+                        java.time.Instant.ofEpochMilli(signal.simulationTimeMs()),
+                        signal.mode(),
+                        scene.triageOutcome(),
+                        scene.qualityScore(),
+                        scene.narrative(),
+                        scene.insightText(),
+                        scene.sourceIds()
+                ));
             }
             written++;
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dream/relay/DreamSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/dream/relay/DreamSignal.java
@@ -91,6 +91,14 @@ public final class DreamSignal {
     private final AtomicInteger dreamsIngested = new AtomicInteger(0);
     private final AtomicInteger failedPairs = new AtomicInteger(0);
 
+    // Spacetime Simulation Fields (ADR-0031)
+    private final long simulationTimeMs;
+    private final float[] queryTau;
+    private final com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode spacetimeMode;
+    private final float recencyLambda;
+    private final boolean allowFuture;
+    private List<com.spectrayan.spector.memory.model.CognitiveResult> candidateSeeds = new ArrayList<>();
+
     private final Instant startTime;
 
     private DreamSignal(Builder builder) {
@@ -132,6 +140,30 @@ public final class DreamSignal {
         this.embeddingProvider = builder.embeddingProvider;
         this.hopfieldNetwork = builder.hopfieldNetwork;
 
+        final long now = System.currentTimeMillis();
+        if (builder.simulationTimeMs > 0L) {
+            this.simulationTimeMs = builder.simulationTimeMs;
+        } else if (this.mode == DreamMode.REM) {
+            this.simulationTimeMs = now + 86_400_000L; // default 1 day prospective horizon for REM
+        } else {
+            this.simulationTimeMs = now;
+        }
+
+        if (builder.spacetimeMode != null) {
+            this.spacetimeMode = builder.spacetimeMode;
+        } else if (this.mode == DreamMode.REM) {
+            this.spacetimeMode = com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode.DREAM_REM;
+        } else {
+            this.spacetimeMode = com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode.DREAM_NREM;
+        }
+
+        this.recencyLambda = builder.recencyLambda >= 0.0f ? builder.recencyLambda : this.spacetimeMode.recencyLambda();
+        this.allowFuture = builder.allowFuture != null ? builder.allowFuture : this.spacetimeMode.allowsFuture();
+        this.queryTau = builder.queryTau != null ? builder.queryTau : com.spectrayan.spector.core.spacetime.Time2VecProjector.project(this.simulationTimeMs);
+        if (builder.candidateSeeds != null) {
+            this.candidateSeeds = new ArrayList<>(builder.candidateSeeds);
+        }
+
         this.startTime = Instant.now();
     }
 
@@ -165,6 +197,16 @@ public final class DreamSignal {
     public List<float[]> seedVectors() { return seedVectors; }
     public List<DreamScene> constructedScenes() { return constructedScenes; }
     public List<DreamScene> survivingScenes() { return survivingScenes; }
+
+    public long simulationTimeMs() { return simulationTimeMs; }
+    public float[] queryTau() { return queryTau; }
+    public com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode spacetimeMode() { return spacetimeMode; }
+    public float recencyLambda() { return recencyLambda; }
+    public boolean allowFuture() { return allowFuture; }
+    public List<com.spectrayan.spector.memory.model.CognitiveResult> candidateSeeds() { return candidateSeeds; }
+    public void setCandidateSeeds(List<com.spectrayan.spector.memory.model.CognitiveResult> seeds) {
+        this.candidateSeeds = seeds != null ? new ArrayList<>(seeds) : new ArrayList<>();
+    }
 
     public List<SceneFragment> fragments() { return fragments; }
     public List<ExtractedInsight> extractedInsights() { return extractedInsights; }
@@ -235,6 +277,13 @@ public final class DreamSignal {
         private ContinuousHopfieldNetwork hopfieldNetwork;
         private MemoryIdGenerator idGenerator;
 
+        private long simulationTimeMs = 0L;
+        private float[] queryTau = null;
+        private com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode spacetimeMode = null;
+        private float recencyLambda = -1.0f;
+        private Boolean allowFuture = null;
+        private List<com.spectrayan.spector.memory.model.CognitiveResult> candidateSeeds = null;
+
         public Builder mode(DreamMode mode) { this.mode = mode; return this; }
         public Builder config(DreamConfig config) { this.config = config; return this; }
         public Builder temperature(float temperature) { this.temperature = temperature; return this; }
@@ -255,6 +304,13 @@ public final class DreamSignal {
         public Builder hyperEntityGraph(HyperEntityGraphMemory graph) { this.hyperEntityGraph = graph; return this; }
         public Builder embeddingProvider(EmbeddingProvider provider) { this.embeddingProvider = provider; return this; }
         public Builder hopfieldNetwork(ContinuousHopfieldNetwork network) { this.hopfieldNetwork = network; return this; }
+
+        public Builder simulationTimeMs(long simTime) { this.simulationTimeMs = simTime; return this; }
+        public Builder queryTau(float[] tau) { this.queryTau = tau; return this; }
+        public Builder spacetimeMode(com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode mode) { this.spacetimeMode = mode; return this; }
+        public Builder recencyLambda(float lambda) { this.recencyLambda = lambda; return this; }
+        public Builder allowFuture(boolean allow) { this.allowFuture = allow; return this; }
+        public Builder candidateSeeds(List<com.spectrayan.spector.memory.model.CognitiveResult> seeds) { this.candidateSeeds = seeds; return this; }
 
         public DreamSignal build() {
             return new DreamSignal(this);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/ExpressSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/ExpressSignal.java
@@ -18,6 +18,10 @@ import com.spectrayan.spector.memory.model.SoulContext;
 import com.spectrayan.spector.memory.model.PersonaContext;
 import com.spectrayan.spector.memory.model.SourceModality;
 
+import com.spectrayan.spector.core.spacetime.ExpressTense;
+import com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode;
+import com.spectrayan.spector.core.spacetime.Time2VecProjector;
+
 import java.util.List;
 import java.util.Set;
 import java.util.Map;
@@ -31,8 +35,35 @@ public record ExpressSignal(
         SoulContext soulContext,
         PersonaContext personaContext,
         Set<SourceModality> requestedModalities,
-        Map<String, Object> attributes
+        Map<String, Object> attributes,
+        ExpressTense expressTense,
+        long simulationTimeMs,
+        float[] queryTau,
+        SpacetimeSimulationMode spacetimeMode
 ) {
+
+    public ExpressSignal(
+            String queryText,
+            List<CognitiveResult> candidates,
+            InteroceptiveState interoceptiveState,
+            SoulContext soulContext,
+            PersonaContext personaContext,
+            Set<SourceModality> requestedModalities,
+            Map<String, Object> attributes) {
+        this(
+                queryText,
+                candidates,
+                interoceptiveState,
+                soulContext,
+                personaContext,
+                requestedModalities,
+                attributes,
+                ExpressTense.FACT,
+                System.currentTimeMillis(),
+                Time2VecProjector.project(System.currentTimeMillis()),
+                SpacetimeSimulationMode.EXPRESS_FACT
+        );
+    }
 
     public static Builder forQuery(String query, InteroceptiveState state, SoulContext soul) {
         return new Builder().queryText(query).interoceptiveState(state).soulContext(soul);
@@ -46,6 +77,10 @@ public record ExpressSignal(
         private PersonaContext personaContext;
         private Set<SourceModality> requestedModalities = Collections.emptySet();
         private Map<String, Object> attributes = new HashMap<>();
+        private ExpressTense expressTense = ExpressTense.FACT;
+        private long simulationTimeMs = 0L;
+        private float[] queryTau = null;
+        private SpacetimeSimulationMode spacetimeMode = null;
 
         public Builder queryText(String queryText) {
             this.queryText = queryText;
@@ -87,8 +122,49 @@ public record ExpressSignal(
             return this;
         }
 
+        public Builder expressTense(ExpressTense tense) {
+            this.expressTense = tense;
+            return this;
+        }
+
+        public Builder simulationTimeMs(long simTime) {
+            this.simulationTimeMs = simTime;
+            return this;
+        }
+
+        public Builder queryTau(float[] tau) {
+            this.queryTau = tau;
+            return this;
+        }
+
+        public Builder spacetimeMode(SpacetimeSimulationMode mode) {
+            this.spacetimeMode = mode;
+            return this;
+        }
+
         public ExpressSignal build() {
-            return new ExpressSignal(queryText, candidates, interoceptiveState, soulContext, personaContext, requestedModalities, attributes);
+            final long simTime = simulationTimeMs > 0L ? simulationTimeMs : System.currentTimeMillis();
+            final ExpressTense tense = expressTense != null ? expressTense : ExpressTense.FACT;
+            final SpacetimeSimulationMode mode = spacetimeMode != null ? spacetimeMode : switch (tense) {
+                case FACT -> SpacetimeSimulationMode.EXPRESS_FACT;
+                case SIM -> SpacetimeSimulationMode.EXPRESS_SIM;
+                case REPLAY -> SpacetimeSimulationMode.EXPRESS_REPLAY;
+            };
+            final float[] tau = queryTau != null ? queryTau : Time2VecProjector.project(simTime);
+
+            return new ExpressSignal(
+                    queryText,
+                    candidates,
+                    interoceptiveState,
+                    soulContext,
+                    personaContext,
+                    requestedModalities,
+                    attributes,
+                    tense,
+                    simTime,
+                    tau,
+                    mode
+            );
         }
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/PhenomenologicalStreamRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/express/relay/PhenomenologicalStreamRelay.java
@@ -46,9 +46,30 @@ public class PhenomenologicalStreamRelay implements SynapticRelay<ExpressSignal>
         ProsodyParameterVector prosodyVector = (ProsodyParameterVector) signal.attributes().get("prosodyVector");
         BlendshapeVector blendshapeVector = (BlendshapeVector) signal.attributes().get("blendshapeVector");
 
-        List<CognitiveResult> groundedMemories = signal.candidates() != null
+        List<CognitiveResult> rawMemories = signal.candidates() != null
                 ? signal.candidates()
                 : List.of();
+
+        List<CognitiveResult> groundedMemories;
+        final com.spectrayan.spector.core.spacetime.ExpressTense tense = signal.expressTense() != null
+                ? signal.expressTense()
+                : com.spectrayan.spector.core.spacetime.ExpressTense.FACT;
+
+        if (tense == com.spectrayan.spector.core.spacetime.ExpressTense.FACT) {
+            final long clock = signal.simulationTimeMs() > 0L ? signal.simulationTimeMs() : System.currentTimeMillis();
+            groundedMemories = rawMemories.stream()
+                    .filter(r -> !r.isSimulated() && !r.isDreamed())
+                    .filter(r -> r.timestampMs() <= 0L || r.timestampMs() <= clock)
+                    .toList();
+        } else {
+            groundedMemories = rawMemories;
+        }
+
+        if (tense == com.spectrayan.spector.core.spacetime.ExpressTense.SIM) {
+            monologue += " [Tense: SIMULATION / COUNTERFACTUAL]";
+        } else if (tense == com.spectrayan.spector.core.spacetime.ExpressTense.REPLAY) {
+            monologue += " [Tense: REPLAY / HISTORICAL]";
+        }
 
         String soulId = signal.soulContext() != null ? signal.soulContext().id() : "default-soul";
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/CognitiveResult.java
@@ -291,4 +291,18 @@ public record CognitiveResult(
     public boolean isHyperfocused() {
         return retrievalMode == RetrievalMode.HYPERFOCUS;
     }
+
+    /**
+     * Returns true if this result was generated via constructive simulation / thought experiment (ADR-0031).
+     */
+    public boolean isSimulated() {
+        return com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.isSimulated(consolidationFlags);
+    }
+
+    /**
+     * Returns true if this result was ingested during a dream cycle (ADR-0031).
+     */
+    public boolean isDreamed() {
+        return com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants.isDreamed(consolidationFlags);
+    }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/RelayNames.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/RelayNames.java
@@ -85,4 +85,7 @@ public final class RelayNames {
     public static final String DIFFERENTIAL_PRIVACY             = "differential_privacy";
     public static final String COMPOSITE_IMPORTANCE             = "composite_importance";
     public static final String LIFESPAN_ADAPTIVE_PRUNING        = "lifespan_adaptive_pruning";
+
+    // Spacetime Simulation Relays (ADR-0031)
+    public static final String SPACETIME_SEED                   = "spacetime_seed";
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -610,7 +610,7 @@ public final class RecallPipeline {
         }
 
         // Sort and limit
-        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
         if (allResults.size() > options.topK()) {
             allResults = new ArrayList<>(allResults.subList(0, options.topK()));
         }
@@ -696,7 +696,7 @@ public final class RecallPipeline {
         temporalFactWeavingStage.weave(allResults, queryVector, options);
 
         // Sort vector candidates by cognitive score descending before RRF rank assignment
-        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
 
         // Step 5f: BM25 text search & fusion (if enabled)
         boolean rrfFused = false;
@@ -751,7 +751,7 @@ public final class RecallPipeline {
         allResults.removeIf(r -> suppressionSet.isSuppressed(r.id()));
 
         // Step 6: Sort by score descending, limit to topK
-        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
         if (allResults.size() > options.topK()) {
             allResults = new ArrayList<>(allResults.subList(0, options.topK()));
         }
@@ -788,7 +788,7 @@ public final class RecallPipeline {
                         }
 
                         // Re-sort after reranking
-                        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+                        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
                         if (allResults.size() > options.topK()) {
                             allResults = new ArrayList<>(allResults.subList(0, options.topK()));
                         }
@@ -820,7 +820,7 @@ public final class RecallPipeline {
         float effectiveTemp = computeEffectiveTemperature(queryVector, options);
         if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
             com.spectrayan.spector.memory.synapse.TemperatureSoftmax.applySoftmaxTemperature(allResults, effectiveTemp);
-            allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+            allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
             if (allResults.size() > options.topK()) {
                 allResults = new ArrayList<>(allResults.subList(0, options.topK()));
             }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/RecallPipeline.java
@@ -1279,7 +1279,7 @@ public final class RecallPipeline {
             }
 
             // Step 4: Sort by importance (score) and limit to topK
-            results.sort(java.util.Comparator.comparing(CognitiveResult::score).reversed());
+            results.sort(java.util.Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
             if (results.size() > options.topK()) {
                 results = new ArrayList<>(results.subList(0, options.topK()));
             }
@@ -1425,7 +1425,7 @@ public final class RecallPipeline {
         }
 
         // Step 6: Sort, topK, record in recallHistory
-        associativeResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        associativeResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
         if (associativeResults.size() > options.topK()) {
             associativeResults = new ArrayList<>(associativeResults.subList(0, options.topK()));
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pipeline/gatherer/RecallCandidateGatherer.java
@@ -171,7 +171,7 @@ public class RecallCandidateGatherer {
             }
         }
 
-        vectorResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+        vectorResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
 
         log.debug("RRF fused {} vector + {} BM25 candidates -> {} unique results",
                 existingById.size(), bm25Hits.size(), vectorResults.size());

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CognitiveRerankRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/CognitiveRerankRelay.java
@@ -75,7 +75,7 @@ public final class CognitiveRerankRelay implements SynapticRelay<RecallSignal> {
                             }
                         }
 
-                        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+                        allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
                         if (allResults.size() > options.topK()) {
                             allResults = new ArrayList<>(allResults.subList(0, options.topK()));
                             signal.setCandidates(allResults);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/TemperatureSoftmaxRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/recall/relay/TemperatureSoftmaxRelay.java
@@ -57,7 +57,7 @@ public final class TemperatureSoftmaxRelay implements SynapticRelay<RecallSignal
         signal.setEffectiveTemperature(effectiveTemp);
         if (Math.abs(effectiveTemp - 1.0f) >= 1e-4f) {
             TemperatureSoftmax.applySoftmaxTemperature(allResults, effectiveTemp);
-            allResults.sort(Comparator.comparing(CognitiveResult::score).reversed());
+            allResults.sort(Comparator.comparing(CognitiveResult::score).reversed().thenComparing(CognitiveResult::id));
             if (allResults.size() > options.topK()) {
                 allResults = new ArrayList<>(allResults.subList(0, options.topK()));
                 signal.setCandidates(allResults);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/simulation/relay/SpacetimeSeedRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/simulation/relay/SpacetimeSeedRelay.java
@@ -9,7 +9,7 @@
  *
  * Change Date: May 27, 2030
  * Change License: Apache License, Version 2.0
- * */
+ */
 package com.spectrayan.spector.memory.simulation.relay;
 
 import com.spectrayan.spector.commons.pathway.SynapticRelay;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/simulation/relay/SpacetimeSeedRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/simulation/relay/SpacetimeSeedRelay.java
@@ -184,6 +184,11 @@ public final class SpacetimeSeedRelay {
             finalResults.add(sc.result().withScore(finalScore));
         }
 
+        if (log.isDebugEnabled()) {
+            log.debug("SPACETIME_SEED trace: t_s={}, mode={}, lambda={}, rho+=({}), rho-=({}), candidate_count={}, selected_seeds={}",
+                    simulationTimeMs, mode, recencyLambda, rhoPlus, rhoMinus, candidates.size(), unionMap.keySet());
+        }
+
         return Collections.unmodifiableList(finalResults);
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/simulation/relay/SpacetimeSeedRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/simulation/relay/SpacetimeSeedRelay.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ * */
+package com.spectrayan.spector.memory.simulation.relay;
+
+import com.spectrayan.spector.commons.pathway.SynapticRelay;
+import com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode;
+import com.spectrayan.spector.core.spacetime.Time2VecProjector;
+import com.spectrayan.spector.memory.dream.relay.DreamSignal;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion;
+import com.spectrayan.spector.memory.synapse.scan.RecordGates;
+import com.spectrayan.spector.memory.wander.relay.WanderSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spacetime Shortlist Seed Selection Relay for generative simulations, mind-wandering (DMN),
+ * and REM/NREM dreaming (ADR-0031 Part C).
+ *
+ * <p>Operates strictly on pre-gathered candidate shortlists (\(K \le 64\)), constructing a deterministic
+ * multi-strategy seed union (spatial relevance, in-phase harmonic alignment, anti-phase divergence,
+ * and high-mass flashbulbs) with continuous \(\lambda\)-scaled recency and single-pass composite scoring.</p>
+ *
+ * <h3>Unified Seed Selection Algorithm:</h3>
+ * <ol>
+ *   <li>Evaluates 8D harmonic basis vector \(\vec{\tau}(t_s)\) at the simulation clock \(t_s\).</li>
+ *   <li>Computes inner product \(\psi_i = \langle \vec{\tau}(t_s), \vec{\tau}(t_i) \rangle \in [-1.0, 1.0]\) for each shortlist candidate.</li>
+ *   <li>Applies continuous mass-dilated logarithmic recency \(R_\lambda(\Delta t, M_i)\).</li>
+ *   <li>Extracts spatial, in-phase (max \(\psi\)), anti-phase (min \(\psi\), if enabled), and flashbulb subsets.</li>
+ *   <li>Deduplicates candidates in insertion order into a {@link LinkedHashMap} capped at \(N \le 16\).</li>
+ *   <li>Computes single non-branching compound score:
+ *       \[ s'_i = s_i + \rho_+ \max(\psi_i, 0) + \rho_- \max(-\psi_i, 0) + \gamma \cdot \mathbf{1}[M_i \ge \texttt{FLASHBULB\_MASS\_FLOOR}] \]
+ *   </li>
+ * </ol>
+ *
+ * @since 1.5.0
+ */
+public final class SpacetimeSeedRelay {
+
+    private static final Logger log = LoggerFactory.getLogger(SpacetimeSeedRelay.class);
+
+    public static final int DEFAULT_N_SPATIAL = 8;
+    public static final int DEFAULT_N_HARMONIC = 4;
+    public static final int DEFAULT_N_ANTI = 4;
+    public static final int DEFAULT_N_FLASH = 2;
+    public static final int DEFAULT_UNION_CAP = 16;
+    public static final float DEFAULT_GAMMA = 0.20f;
+
+    private SpacetimeSeedRelay() {}
+
+    /**
+     * Internal scored seed candidate tracking harmonic metrics.
+     */
+    public record SeedCandidate(
+            CognitiveResult result,
+            float psi,
+            float cognitiveMass,
+            float adjustedScore
+    ) {}
+
+    /**
+     * Executes the ADR-0031 shortlist multi-seed union and compound scoring.
+     *
+     * @param candidates         pre-gathered shortlist candidates
+     * @param simulationTimeMs   simulation clock \(t_s\)
+     * @param queryTau           pre-computed \(\vec{\tau}(t_s)\) basis vector, or null to compute on the fly
+     * @param mode               simulation mode preset (WANDER, DREAM_NREM, DREAM_REM, etc.)
+     * @param recencyLambda      continuous recency scaling factor \(\lambda\)
+     * @param nSpatial           number of spatial candidates to extract
+     * @param nHarmonic          number of in-phase harmonic candidates to extract
+     * @param nAnti              number of anti-phase harmonic candidates to extract
+     * @param nFlash             number of high-mass flashbulb candidates to extract
+     * @param unionCap           maximum number of unique seeds to admit in the final union
+     * @param flashbulbMassFloor minimum cognitive mass required for flashbulb qualification
+     * @param gamma              score boost applied to qualified flashbulb memories
+     * @return deduplicated and compound-scored list of seed candidates
+     */
+    public static List<CognitiveResult> selectSeeds(
+            final List<CognitiveResult> candidates,
+            final long simulationTimeMs,
+            final float[] queryTau,
+            final SpacetimeSimulationMode mode,
+            final float recencyLambda,
+            final int nSpatial,
+            final int nHarmonic,
+            final int nAnti,
+            final int nFlash,
+            final int unionCap,
+            final float flashbulbMassFloor,
+            final float gamma) {
+
+        if (candidates == null || candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final float[] tauS = (queryTau != null && queryTau.length == Time2VecProjector.DIMENSIONS)
+                ? queryTau
+                : Time2VecProjector.project(simulationTimeMs);
+
+        final List<SeedCandidate> evaluated = new ArrayList<>(candidates.size());
+
+        for (final CognitiveResult cr : candidates) {
+            final long itemTimeMs = cr.timestampMs() > 0L ? cr.timestampMs() : simulationTimeMs;
+            final float[] tauI = Time2VecProjector.project(itemTimeMs);
+            final float psi = Time2VecProjector.dot(tauS, tauI);
+
+            final float cognitiveMass = CognitiveScoreFusion.computeCognitiveMass(
+                    cr.importance(), (byte) 0, 1.0f);
+
+            final float rLambda = CognitiveScoreFusion.computeMassDilatedDecay(
+                    itemTimeMs, simulationTimeMs, cognitiveMass, (byte) 0, cr.agentRecallCount(), false, recencyLambda);
+
+            final float baseAdjustedScore = cr.score() * rLambda;
+            evaluated.add(new SeedCandidate(cr, psi, cognitiveMass, baseAdjustedScore));
+        }
+
+        // 1. Spatial Subset (highest baseAdjustedScore)
+        final List<SeedCandidate> spatialSubset = new ArrayList<>(evaluated);
+        spatialSubset.sort(Comparator.comparingDouble(SeedCandidate::adjustedScore).reversed());
+        final List<SeedCandidate> topSpatial = spatialSubset.subList(0, Math.min(nSpatial, spatialSubset.size()));
+
+        // 2. In-Phase Harmonic Subset (highest psi)
+        final List<SeedCandidate> inPhaseSubset = new ArrayList<>(evaluated);
+        inPhaseSubset.sort(Comparator.comparingDouble(SeedCandidate::psi).reversed());
+        final List<SeedCandidate> topInPhase = inPhaseSubset.subList(0, Math.min(nHarmonic, inPhaseSubset.size()));
+
+        // 3. Anti-Phase Harmonic Subset (most negative psi, if permitted by mode)
+        final List<SeedCandidate> topAntiPhase;
+        if (mode != null && mode.allowsAntiPhase()) {
+            final List<SeedCandidate> antiPhaseSubset = new ArrayList<>(evaluated);
+            antiPhaseSubset.sort(Comparator.comparingDouble(SeedCandidate::psi)); // ascending -> lowest / most negative psi
+            topAntiPhase = antiPhaseSubset.subList(0, Math.min(nAnti, antiPhaseSubset.size()));
+        } else {
+            topAntiPhase = Collections.emptyList();
+        }
+
+        // 4. Flashbulb Subset (M_i >= flashbulbMassFloor, sorted by cognitive mass)
+        final List<SeedCandidate> flashSubset = new ArrayList<>();
+        for (final SeedCandidate sc : evaluated) {
+            if (sc.cognitiveMass() >= flashbulbMassFloor) {
+                flashSubset.add(sc);
+            }
+        }
+        flashSubset.sort(Comparator.comparingDouble(SeedCandidate::cognitiveMass).reversed());
+        final List<SeedCandidate> topFlash = flashSubset.subList(0, Math.min(nFlash, flashSubset.size()));
+
+        // 5. Deterministic Insertion-Order Deduplicated Union
+        final Map<String, SeedCandidate> unionMap = new LinkedHashMap<>();
+
+        addCandidatesToUnion(unionMap, topSpatial, unionCap);
+        addCandidatesToUnion(unionMap, topInPhase, unionCap);
+        addCandidatesToUnion(unionMap, topAntiPhase, unionCap);
+        addCandidatesToUnion(unionMap, topFlash, unionCap);
+
+        // 6. Compound Score Calculation
+        final float rhoPlus = mode != null ? mode.rhoPlus() : 0.35f;
+        final float rhoMinus = mode != null ? mode.rhoMinus() : 0.35f;
+
+        final List<CognitiveResult> finalResults = new ArrayList<>(unionMap.size());
+        for (final SeedCandidate sc : unionMap.values()) {
+            final float psi = sc.psi();
+            final float psiPlus = Math.max(0.0f, psi);
+            final float psiMinus = Math.max(0.0f, -psi);
+            final float flashBoost = (sc.cognitiveMass() >= flashbulbMassFloor) ? gamma : 0.0f;
+
+            final float finalScore = sc.adjustedScore() + (rhoPlus * psiPlus) + (rhoMinus * psiMinus) + flashBoost;
+            finalResults.add(sc.result().withScore(finalScore));
+        }
+
+        return Collections.unmodifiableList(finalResults);
+    }
+
+    private static void addCandidatesToUnion(
+            final Map<String, SeedCandidate> unionMap,
+            final List<SeedCandidate> candidates,
+            final int unionCap) {
+        for (final SeedCandidate sc : candidates) {
+            if (unionMap.size() >= unionCap) {
+                break;
+            }
+            final String id = sc.result().id();
+            if (id != null && !unionMap.containsKey(id)) {
+                unionMap.put(id, sc);
+            }
+        }
+    }
+
+    /**
+     * Wander Pathway Synaptic Relay adapter.
+     */
+    public static final class WanderSeedRelay implements SynapticRelay<WanderSignal> {
+        @Override
+        public boolean transmit(final WanderSignal signal) {
+            if (signal == null) {
+                return true;
+            }
+            final List<CognitiveResult> rawCandidates = signal.candidateSeeds();
+            if (rawCandidates == null || rawCandidates.isEmpty()) {
+                return true;
+            }
+
+            final List<CognitiveResult> selected = selectSeeds(
+                    rawCandidates,
+                    signal.simulationTimeMs(),
+                    signal.queryTau(),
+                    signal.spacetimeMode(),
+                    signal.recencyLambda(),
+                    DEFAULT_N_SPATIAL,
+                    DEFAULT_N_HARMONIC,
+                    DEFAULT_N_ANTI,
+                    DEFAULT_N_FLASH,
+                    DEFAULT_UNION_CAP,
+                    RecordGates.FLASHBULB_MASS_FLOOR,
+                    DEFAULT_GAMMA
+            );
+
+            signal.setCandidateSeeds(selected);
+            return true;
+        }
+    }
+
+    /**
+     * Dream Pathway Synaptic Relay adapter.
+     */
+    public static final class DreamSeedRelay implements SynapticRelay<DreamSignal> {
+        @Override
+        public boolean transmit(final DreamSignal signal) {
+            if (signal == null) {
+                return true;
+            }
+            final List<CognitiveResult> rawCandidates = signal.candidateSeeds();
+            if (rawCandidates == null || rawCandidates.isEmpty()) {
+                return true;
+            }
+
+            final List<CognitiveResult> selected = selectSeeds(
+                    rawCandidates,
+                    signal.simulationTimeMs(),
+                    signal.queryTau(),
+                    signal.spacetimeMode(),
+                    signal.recencyLambda(),
+                    DEFAULT_N_SPATIAL,
+                    DEFAULT_N_HARMONIC,
+                    DEFAULT_N_ANTI,
+                    DEFAULT_N_FLASH,
+                    DEFAULT_UNION_CAP,
+                    RecordGates.FLASHBULB_MASS_FLOOR,
+                    DEFAULT_GAMMA
+            );
+
+            signal.setCandidateSeeds(selected);
+            return true;
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/CognitiveScorer.java
@@ -258,7 +258,7 @@ public final class CognitiveScorer {
         if (lateralHeap != null && !lateralHeap.isEmpty()) {
             results.addAll(lateralHeap);
         }
-        results.sort(Comparator.comparing(ScoredRecord::score).reversed());
+        results.sort(Comparator.comparing(ScoredRecord::score).reversed().thenComparingLong(ScoredRecord::offset));
         return results;
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/CognitiveScoreFusion.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/synapse/scan/CognitiveScoreFusion.java
@@ -49,7 +49,7 @@ public final class CognitiveScoreFusion {
     }
 
     /**
-     * Computes the continuous mass-dilated recency decay factor.
+     * Computes the continuous mass-dilated recency decay factor (default λ = 1.0).
      *
      * <p>Formula: R(Δt, M_i) = 1 / (1 + ln(1 + Δt_days) / (1 + M_i)) * arousalModifier</p>
      *
@@ -64,16 +64,39 @@ public final class CognitiveScoreFusion {
     public static float computeMassDilatedDecay(
             final long timestampMs, final long nowMs, final float cognitiveMass,
             final byte arousal, final int agentRecallCount, final boolean zeroTimeDecay) {
+        return computeMassDilatedDecay(
+                timestampMs, nowMs, cognitiveMass, arousal, agentRecallCount, zeroTimeDecay, 1.0f);
+    }
 
-        if (zeroTimeDecay) {
-            return 1.0f * DecayStrategy.arousalModifier(arousal);
+    /**
+     * Computes the continuous mass-dilated recency decay factor with continuous lambda recency scaling (ADR-0031).
+     *
+     * <p>Formula: R_λ(Δt, M_i) = 1 / (1 + λ * ln(1 + Δt_days) / (1 + M_i)) * arousalModifier * reconsolidationBoost</p>
+     *
+     * @param timestampMs       creation timestamp in epoch millis
+     * @param nowMs             reference query clock in epoch millis
+     * @param cognitiveMass     dynamic cognitive mass M_i
+     * @param arousal           arousal intensity byte
+     * @param agentRecallCount  number of prior agent recalls for reconsolidation
+     * @param zeroTimeDecay     true if time decay is suspended (focus match, unpinned/unresolved)
+     * @param lambda            continuous recency scaling factor (1.0 for recall, 0.3 for wander/dream, 0.0 for timeless)
+     * @return decay multiplier in (0.0..1.0]
+     */
+    public static float computeMassDilatedDecay(
+            final long timestampMs, final long nowMs, final float cognitiveMass,
+            final byte arousal, final int agentRecallCount, final boolean zeroTimeDecay,
+            final float lambda) {
+
+        if (zeroTimeDecay || lambda <= 0.0f) {
+            final float reconsolidationBoost = 1.0f + 0.05f * Math.min(agentRecallCount, 10);
+            return Math.min(1.0f, 1.0f * DecayStrategy.arousalModifier(arousal) * reconsolidationBoost);
         }
 
         final double elapsedDays = Math.max(0.0, (nowMs - timestampMs) / MS_PER_DAY);
         final float logTerm = (float) Math.log1p(elapsedDays);
         final float massDenominator = 1.0f + Math.max(0.0f, cognitiveMass);
 
-        final float dilatedDecay = 1.0f / (1.0f + (logTerm / massDenominator));
+        final float dilatedDecay = 1.0f / (1.0f + ((lambda * logTerm) / massDenominator));
         final float reconsolidationBoost = 1.0f + 0.05f * Math.min(agentRecallCount, 10);
         final float finalDecay = dilatedDecay * DecayStrategy.arousalModifier(arousal) * reconsolidationBoost;
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/wander/relay/WanderSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/wander/relay/WanderSignal.java
@@ -63,6 +63,14 @@ public final class WanderSignal {
     private final float hopfieldTemperature;
     private final float[] soulPriorPreference;
 
+    // Spacetime Simulation Fields (ADR-0031)
+    private final long simulationTimeMs;
+    private final float[] queryTau;
+    private final com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode spacetimeMode;
+    private final float recencyLambda;
+    private final boolean allowFuture;
+    private List<com.spectrayan.spector.memory.model.CognitiveResult> candidateSeeds = new ArrayList<>();
+
     private final Instant startTime;
     private final List<float[]> sampledVectors = new ArrayList<>();
     private final List<String> sampledMemoryIds = new ArrayList<>();
@@ -91,6 +99,15 @@ public final class WanderSignal {
         this.hopfieldTemperature = builder.hopfieldTemperature > 0.0f ? builder.hopfieldTemperature : 1.0f;
         this.soulPriorPreference = builder.soulPriorPreference;
 
+        this.simulationTimeMs = builder.simulationTimeMs > 0L ? builder.simulationTimeMs : System.currentTimeMillis();
+        this.spacetimeMode = builder.spacetimeMode != null ? builder.spacetimeMode : com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode.WANDER;
+        this.recencyLambda = builder.recencyLambda >= 0.0f ? builder.recencyLambda : this.spacetimeMode.recencyLambda();
+        this.allowFuture = builder.allowFuture != null ? builder.allowFuture : this.spacetimeMode.allowsFuture();
+        this.queryTau = builder.queryTau != null ? builder.queryTau : com.spectrayan.spector.core.spacetime.Time2VecProjector.project(this.simulationTimeMs);
+        if (builder.candidateSeeds != null) {
+            this.candidateSeeds = new ArrayList<>(builder.candidateSeeds);
+        }
+
         this.startTime = Instant.now();
     }
 
@@ -99,6 +116,16 @@ public final class WanderSignal {
     }
 
     // ── Getters ──
+
+    public long simulationTimeMs() { return simulationTimeMs; }
+    public float[] queryTau() { return queryTau; }
+    public com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode spacetimeMode() { return spacetimeMode; }
+    public float recencyLambda() { return recencyLambda; }
+    public boolean allowFuture() { return allowFuture; }
+    public List<com.spectrayan.spector.memory.model.CognitiveResult> candidateSeeds() { return candidateSeeds; }
+    public void setCandidateSeeds(List<com.spectrayan.spector.memory.model.CognitiveResult> seeds) {
+        this.candidateSeeds = seeds != null ? new ArrayList<>(seeds) : new ArrayList<>();
+    }
 
     public PartitionManager partitionManager() { return partitionManager; }
     public ScalarQuantizer quantizer() { return quantizer; }
@@ -174,6 +201,13 @@ public final class WanderSignal {
         private float hopfieldTemperature = 1.0f;
         private float[] soulPriorPreference = null;
 
+        private long simulationTimeMs = 0L;
+        private float[] queryTau = null;
+        private com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode spacetimeMode = null;
+        private float recencyLambda = -1.0f;
+        private Boolean allowFuture = null;
+        private List<com.spectrayan.spector.memory.model.CognitiveResult> candidateSeeds = null;
+
         public Builder partitionManager(PartitionManager pm) { this.partitionManager = pm; return this; }
         public Builder quantizer(ScalarQuantizer q) { this.quantizer = q; return this; }
         public Builder embeddingProvider(EmbeddingProvider ep) { this.embeddingProvider = ep; return this; }
@@ -191,6 +225,13 @@ public final class WanderSignal {
         public Builder synergyThreshold(float th) { this.synergyThreshold = th; return this; }
         public Builder hopfieldTemperature(float temp) { this.hopfieldTemperature = temp; return this; }
         public Builder soulPriorPreference(float[] prior) { this.soulPriorPreference = prior; return this; }
+
+        public Builder simulationTimeMs(long simTime) { this.simulationTimeMs = simTime; return this; }
+        public Builder queryTau(float[] tau) { this.queryTau = tau; return this; }
+        public Builder spacetimeMode(com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode mode) { this.spacetimeMode = mode; return this; }
+        public Builder recencyLambda(float lambda) { this.recencyLambda = lambda; return this; }
+        public Builder allowFuture(boolean allow) { this.allowFuture = allow; return this; }
+        public Builder candidateSeeds(List<com.spectrayan.spector.memory.model.CognitiveResult> seeds) { this.candidateSeeds = seeds; return this; }
 
         public WanderSignal build() {
             return new WanderSignal(this);

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/simulation/SpacetimeSimulationFixtureTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/simulation/SpacetimeSimulationFixtureTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.simulation;
+
+import com.spectrayan.spector.core.spacetime.ExpressTense;
+import com.spectrayan.spector.core.spacetime.SpacetimeSimulationMode;
+import com.spectrayan.spector.core.spacetime.Time2VecProjector;
+import com.spectrayan.spector.memory.ExpressPathway;
+import com.spectrayan.spector.memory.aisme.homeostasis.InteroceptiveState;
+import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.SemanticRecordMemory;
+import com.spectrayan.spector.memory.express.relay.ExpressReport;
+import com.spectrayan.spector.memory.express.relay.ExpressSignal;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout;
+import com.spectrayan.spector.memory.kernel.layout.CognitiveRecordLayout.CognitiveHeader;
+import com.spectrayan.spector.memory.kernel.layout.SynapticHeaderConstants;
+import com.spectrayan.spector.memory.model.AgentSoul;
+import com.spectrayan.spector.memory.model.CognitiveResult;
+import com.spectrayan.spector.memory.model.MemoryType;
+import com.spectrayan.spector.memory.model.RecallOptions;
+import com.spectrayan.spector.memory.model.SourceModality;
+import com.spectrayan.spector.memory.simulation.relay.SpacetimeSeedRelay;
+import com.spectrayan.spector.memory.synapse.CognitiveScorer;
+import com.spectrayan.spector.memory.synapse.CognitiveScorer.ScoredRecord;
+import com.spectrayan.spector.memory.synapse.scan.CognitiveScoreFusion;
+import com.spectrayan.spector.memory.synapse.scan.RecordGates;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Spacetime Simulation on Wander, Dream, and Express Pathways (ADR-0031)")
+class SpacetimeSimulationFixtureTest {
+
+    private static final int DIMS = 8;
+    private static final long ONE_DAY_MS = 86_400_000L;
+
+    @Nested
+    @DisplayName("Continuous Recency Scaling (λ)")
+    class ContinuousLambdaRecencyTests {
+
+        @Test
+        @DisplayName("λ = 1.0 matches factual recall recency decay")
+        void standardRecallDecay() {
+            final long now = System.currentTimeMillis();
+            final long oneYearAgo = now - (365L * ONE_DAY_MS);
+            final float decayLambda1 = CognitiveScoreFusion.computeMassDilatedDecay(
+                    oneYearAgo, now, 0.5f, (byte) 0, 0, false, 1.0f);
+            final float decayStandard = CognitiveScoreFusion.computeMassDilatedDecay(
+                    oneYearAgo, now, 0.5f, (byte) 0, 0, false);
+
+            assertThat(decayLambda1).isEqualTo(decayStandard);
+            assertThat(decayLambda1).isLessThan(0.30f);
+        }
+
+        @Test
+        @DisplayName("λ = 0.30 flattens decay for Wander and REM dream exploration")
+        void flattenedWanderDecay() {
+            final long now = System.currentTimeMillis();
+            final long oneYearAgo = now - (365L * ONE_DAY_MS);
+
+            final float decayLambda1 = CognitiveScoreFusion.computeMassDilatedDecay(
+                    oneYearAgo, now, 0.5f, (byte) 0, 0, false, 1.0f);
+            final float decayLambda03 = CognitiveScoreFusion.computeMassDilatedDecay(
+                    oneYearAgo, now, 0.5f, (byte) 0, 0, false, 0.30f);
+
+            assertThat(decayLambda03).isGreaterThan(decayLambda1);
+            assertThat(decayLambda03).isGreaterThan(0.40f);
+        }
+
+        @Test
+        @DisplayName("λ = 0.00 removes age decay penalty entirely (timeless prospection)")
+        void timelessProspectionDecay() {
+            final long now = System.currentTimeMillis();
+            final long tenYearsAgo = now - (10L * 365 * ONE_DAY_MS);
+
+            final float decayTimeless = CognitiveScoreFusion.computeMassDilatedDecay(
+                    tenYearsAgo, now, 0.1f, (byte) 0, 0, false, 0.00f);
+
+            assertThat(decayTimeless).isEqualTo(1.0f);
+        }
+    }
+
+    @Nested
+    @DisplayName("Spacetime Seed Selection & Anti-Phase Invariance (Fixture W)")
+    class FixtureW_WanderAndDreamSeedSelectionTests {
+
+        private CognitiveResult createResult(String id, long timestampMs, float baseScore, float importance) {
+            final float ageDays = (float) Math.max(0.0, (System.currentTimeMillis() - timestampMs) / (double) ONE_DAY_MS);
+            return new CognitiveResult(
+                    id, "Memory " + id, baseScore, importance, ageDays, 0, (byte) 0,
+                    MemoryType.EPISODIC, MemorySource.OBSERVED, new String[0],
+                    1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
+                    SourceModality.TEXT, Collections.emptyMap(), (byte) 0, timestampMs
+            );
+        }
+
+        @Test
+        @DisplayName("Fixture W: Anti-phase candidates (negative ψ) are selected in WANDER and DREAM_REM, excluded in DREAM_NREM")
+        void antiPhaseCandidatesSelectedInWanderAndRem() {
+            final long simulationTime = 1_700_000_000_000L; // Fixed epoch reference
+            final float[] queryTau = Time2VecProjector.project(simulationTime);
+
+            // Candidate 0: Exactly in-phase (Δt = 0) -> ψ = +1.0
+            final CognitiveResult inPhase = createResult("in-phase-0", simulationTime, 0.8f, 5.0f);
+
+            // Candidate 1: Exact anti-phase shift (half-day + half-hour offset producing negative harmonic overlap)
+            final long antiPhaseTime = simulationTime - (12L * 3600_000L + 1800_000L);
+            final CognitiveResult antiPhase = createResult("anti-phase-0", antiPhaseTime, 0.7f, 5.0f);
+
+            final float[] tauAnti = Time2VecProjector.project(antiPhaseTime);
+            final float psiAnti = Time2VecProjector.dot(queryTau, tauAnti);
+            assertThat(psiAnti).isLessThan(0.0f); // Assert strictly negative harmonic overlap
+
+            // Candidate 2: Standard spatial candidate
+            final CognitiveResult spatial = createResult("spatial-0", simulationTime - 3600_000L, 0.95f, 5.0f);
+
+            // Candidate 3: High-mass flashbulb memory (I=4.0 -> M = 0.40 >= 0.30)
+            final CognitiveResult flashbulb = createResult("flashbulb-0", simulationTime - (500L * ONE_DAY_MS), 0.5f, 4.0f);
+
+            final List<CognitiveResult> candidates = List.of(inPhase, antiPhase, spatial, flashbulb);
+
+            // 1. WANDER mode: allows anti-phase
+            final List<CognitiveResult> wanderSeeds = SpacetimeSeedRelay.selectSeeds(
+                    candidates, simulationTime, queryTau, SpacetimeSimulationMode.WANDER, 0.30f,
+                    4, 2, 2, 2, 16, RecordGates.FLASHBULB_MASS_FLOOR, 0.20f);
+
+            final List<String> wanderSeedIds = wanderSeeds.stream().map(CognitiveResult::id).toList();
+            assertThat(wanderSeedIds).contains("in-phase-0", "anti-phase-0", "spatial-0", "flashbulb-0");
+
+            // 2. DREAM_REM mode: allows anti-phase
+            final List<CognitiveResult> remSeeds = SpacetimeSeedRelay.selectSeeds(
+                    candidates, simulationTime, queryTau, SpacetimeSimulationMode.DREAM_REM, 0.30f,
+                    4, 2, 2, 2, 16, RecordGates.FLASHBULB_MASS_FLOOR, 0.20f);
+
+            final List<String> remSeedIds = remSeeds.stream().map(CognitiveResult::id).toList();
+            assertThat(remSeedIds).contains("anti-phase-0");
+
+            // 3. DREAM_NREM mode: disables anti-phase (anti-phase candidate excluded if not in spatial top-N)
+            final List<CognitiveResult> nremSeeds = SpacetimeSeedRelay.selectSeeds(
+                    List.of(inPhase, antiPhase), simulationTime, queryTau, SpacetimeSimulationMode.DREAM_NREM, 1.00f,
+                    1, 1, 1, 1, 16, RecordGates.FLASHBULB_MASS_FLOOR, 0.20f);
+
+            final List<String> nremSeedIds = nremSeeds.stream().map(CognitiveResult::id).toList();
+            assertThat(nremSeedIds).contains("in-phase-0");
+            assertThat(nremSeedIds).doesNotContain("anti-phase-0");
+        }
+    }
+
+    @Nested
+    @DisplayName("Dream Provenance & Future Causal Isolation (Fixture D)")
+    class FixtureD_DreamProvenanceAndCausalGatingTests {
+
+        @Test
+        @DisplayName("Fixture D: Dream memory with future timestamp (t_s > now) is dropped by default recall, admitted when allowFuture=true")
+        void syntheticDreamRowDroppedByDefaultRecall() {
+            final SemanticRecordMemory store = new SemanticRecordMemory(DIMS, 10);
+            final CognitiveRecordLayout layout = new CognitiveRecordLayout(DIMS);
+            final long now = System.currentTimeMillis();
+
+            // Record 0: Factual waking memory
+            final CognitiveHeader wakingHeader = new CognitiveHeader(
+                    now - 3600_000L, 0L, 1.0f, 5.0f, 0, (short) 0, (byte) 0, (byte) 0);
+            store.append(wakingHeader, new byte[layout.quantizedVecBytes()]);
+
+            // Record 1: Synthetic future dream memory (t_s = now + 1 day, FLAG_DREAMED | FLAG_SIMULATED)
+            final byte dreamConsolidationFlags = (byte) (SynapticHeaderConstants.FLAG_DREAMED | SynapticHeaderConstants.FLAG_SIMULATED);
+            final CognitiveHeader dreamHeader = new CognitiveHeader(
+                    now + ONE_DAY_MS, 0L, 1.0f, 6.0f, 0, (short) 0, (byte) 0, (byte) 0,
+                    (byte) 0, 1.0f, (byte) 0, (byte) 0, (byte) 0, (short) 0, 0.0f, dreamConsolidationFlags);
+            store.append(dreamHeader, new byte[layout.quantizedVecBytes()]);
+
+            final float[] queryVec = new float[DIMS];
+
+            // 1. Default Waking Recall (allowFuture = false) -> Drops Record 1 (synthetic future dream)
+            final RecallOptions standardOptions = RecallOptions.builder()
+                    .topK(10)
+                    .allowFuture(false)
+                    .build();
+
+            final List<ScoredRecord> standardResults = CognitiveScorer.score(
+                    store.segment(), 2, layout, queryVec, standardOptions, now, 0L, null, null);
+
+            assertThat(standardResults).hasSize(1);
+            assertThat(standardResults.get(0).header().timestampMs()).isEqualTo(wakingHeader.timestampMs());
+
+            // 2. Simulation / Prospective Recall (allowFuture = true) -> Admits Record 1
+            final RecallOptions simOptions = RecallOptions.builder()
+                    .topK(10)
+                    .allowFuture(true)
+                    .build();
+
+            final List<ScoredRecord> simResults = CognitiveScorer.score(
+                    store.segment(), 2, layout, queryVec, simOptions, now, 0L, null, null);
+
+            assertThat(simResults).hasSize(2);
+
+            store.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("Express Tense Filtering (Fixture X)")
+    class FixtureX_ExpressTenseFilteringTests {
+
+        private CognitiveResult createResultWithFlags(String id, byte consolidationFlags, long timestampMs) {
+            return new CognitiveResult(
+                    id, "Memory " + id, 0.9f, 5.0f, 0.1f, 0, (byte) 0,
+                    MemoryType.EPISODIC, MemorySource.OBSERVED, new String[0],
+                    1.0f, 1.0f, CognitiveResult.RetrievalMode.STANDARD, null, null,
+                    SourceModality.TEXT, Collections.emptyMap(), consolidationFlags, timestampMs
+            );
+        }
+
+        @Test
+        @DisplayName("Fixture X: ExpressPathway with FACT tense filters out dreamed/simulated memories; SIM tense admits them")
+        void expressTenseFiltering() {
+            final ExpressPathway pathway = ExpressPathway.builder().build();
+            final long now = System.currentTimeMillis();
+
+            final CognitiveResult factMemory = createResultWithFlags("fact-1", (byte) 0, now - 1000L);
+            final CognitiveResult dreamMemory = createResultWithFlags("dream-1", (byte) (SynapticHeaderConstants.FLAG_DREAMED | SynapticHeaderConstants.FLAG_SIMULATED), now - 500L);
+            final CognitiveResult futureSimMemory = createResultWithFlags("future-sim-1", SynapticHeaderConstants.FLAG_SIMULATED, now + 10_000L);
+
+            final List<CognitiveResult> allCandidates = List.of(factMemory, dreamMemory, futureSimMemory);
+            final AgentSoul testSoul = AgentSoul.builder().id("soul-default").build();
+
+            // 1. Express under FACT tense
+            final ExpressSignal factSignal = new ExpressSignal.Builder()
+                    .queryText("What is the status of the database?")
+                    .candidates(allCandidates)
+                    .expressTense(ExpressTense.FACT)
+                    .simulationTimeMs(now)
+                    .interoceptiveState(InteroceptiveState.NEUTRAL)
+                    .soulContext(testSoul)
+                    .build();
+
+            final ExpressReport factReport = pathway.express(factSignal);
+            assertThat(factReport.contextPack().groundedMemories()).hasSize(1);
+            assertThat(factReport.contextPack().groundedMemories().get(0).id()).isEqualTo("fact-1");
+            assertThat(factReport.internalMonologue()).doesNotContain("SIMULATION");
+
+            // 2. Express under SIM tense
+            final ExpressSignal simSignal = new ExpressSignal.Builder()
+                    .queryText("Simulate future database load scenario")
+                    .candidates(allCandidates)
+                    .expressTense(ExpressTense.SIM)
+                    .simulationTimeMs(now + 20_000L)
+                    .interoceptiveState(InteroceptiveState.NEUTRAL)
+                    .soulContext(testSoul)
+                    .build();
+
+            final ExpressReport simReport = pathway.express(simSignal);
+            assertThat(simReport.contextPack().groundedMemories()).hasSize(3);
+            assertThat(simReport.internalMonologue()).contains("SIMULATION / COUNTERFACTUAL");
+        }
+    }
+}

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -1294,6 +1294,25 @@ public final class SpectorPropertyConstants {
     public static final String RECALL_FLASHBULB_MASS_FLOOR = "spector.recall.flashbulb.mass-floor";
     public static final float DEFAULT_RECALL_FLASHBULB_MASS_FLOOR = 0.30f;
 
+    // Spacetime Simulation (ADR-0031)
+    public static final String RECALL_SPACETIME_SIMULATION_ENABLED = "spector.recall.spacetime.simulation.enabled";
+    public static final boolean DEFAULT_RECALL_SPACETIME_SIMULATION_ENABLED = true;
+
+    public static final String RECALL_SPACETIME_WANDER_RHO_PLUS = "spector.recall.spacetime.wander.rho-plus";
+    public static final float DEFAULT_RECALL_SPACETIME_WANDER_RHO_PLUS = 0.35f;
+
+    public static final String RECALL_SPACETIME_WANDER_RHO_MINUS = "spector.recall.spacetime.wander.rho-minus";
+    public static final float DEFAULT_RECALL_SPACETIME_WANDER_RHO_MINUS = 0.35f;
+
+    public static final String RECALL_SPACETIME_WANDER_LAMBDA = "spector.recall.spacetime.wander.lambda";
+    public static final float DEFAULT_RECALL_SPACETIME_WANDER_LAMBDA = 0.30f;
+
+    public static final String RECALL_SPACETIME_DREAM_REM_LAMBDA = "spector.recall.spacetime.dream.rem.lambda";
+    public static final float DEFAULT_RECALL_SPACETIME_DREAM_REM_LAMBDA = 0.30f;
+
+    public static final String RECALL_SPACETIME_DREAM_NREM_LAMBDA = "spector.recall.spacetime.dream.nrem.lambda";
+    public static final float DEFAULT_RECALL_SPACETIME_DREAM_NREM_LAMBDA = 1.00f;
+
     // Server
     public static final String SERVER_PORT = "spector.server.port";
     public static final int DEFAULT_SERVER_PORT = 7070;

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/ExpressTense.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/ExpressTense.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.spacetime;
+
+/**
+ * Grammatical and epistemic tense context for the Express verbalization pathway (ADR-0031 Part E).
+ *
+ * <ul>
+ *   <li>{@link #FACT}: Factual waking statements as-of-now; synthetic, dreamed, and future rows suppressed.</li>
+ *   <li>{@link #SIM}: Generative simulation and prospective scenarios; passes through dreamed/wandered seeds.</li>
+ *   <li>{@link #REPLAY}: Historical or counterfactual retrospection evaluated at explicit replay clock.</li>
+ * </ul>
+ *
+ * @since 1.5.0
+ */
+public enum ExpressTense {
+
+    /**
+     * Waking factual tense: only verified waking episodic and semantic memories are expressed.
+     */
+    FACT,
+
+    /**
+     * Hypothetical / simulated tense: prospective simulations and dream scenarios labeled as simulated.
+     */
+    SIM,
+
+    /**
+     * Retrospective replay tense: historical reconstruction at a specific historical point in time.
+     */
+    REPLAY
+}

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/SpacetimeSimulationMode.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/spacetime/SpacetimeSimulationMode.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.spacetime;
+
+/**
+ * Operating mode presets for Spacetime Simulation across Wander, Dream, and Express pathways (ADR-0031).
+ *
+ * <p>Configures harmonic in-phase weight (\(\rho_+\)), anti-phase weight (\(\rho_-\)), recency scaling (\(\lambda\)),
+ * anti-phase candidate extraction, and future causal horizon gating.</p>
+ *
+ * @since 1.5.0
+ */
+public enum SpacetimeSimulationMode {
+
+    /**
+     * Spontaneous Default Mode Network (DMN) mind-wandering: balances in-phase and anti-phase exploration
+     * with flattened recency decay (\(\lambda = 0.30\)) and prospective horizon enabled.
+     */
+    WANDER(0.35f, 0.35f, 0.30f, true, true),
+
+    /**
+     * NREM slow-wave sleep memory consolidation: focuses exclusively on in-phase harmonic replay of recent
+     * high-salience traces with strict recency (\(\lambda = 1.00\)) and anti-phase disabled.
+     */
+    DREAM_NREM(0.10f, 0.00f, 1.00f, false, false),
+
+    /**
+     * REM sleep constructive recombination &amp; thought experiments: broad multi-seed juxtaposition
+     * including anti-phase harmonics, flattened recency (\(\lambda = 0.30\)), and future horizon simulation.
+     */
+    DREAM_REM(0.35f, 0.35f, 0.30f, true, true),
+
+    /**
+     * Timeless prospection / unconstrained scenario simulation: completely removes age decay penalties
+     * (\(\lambda = 0.00\)) while evaluating both in-phase and anti-phase harmonics.
+     */
+    TIMELESS_PROSPECTION(0.35f, 0.35f, 0.00f, true, true),
+
+    /**
+     * Factual waking verbalization: strict as-of-now clock, suppresses synthetic/dreamed memories.
+     */
+    EXPRESS_FACT(0.00f, 0.00f, 1.00f, false, false),
+
+    /**
+     * Simulated scenario verbalization: passes through dream/wander candidate seeds with simulation telemetry.
+     */
+    EXPRESS_SIM(0.00f, 0.00f, 0.30f, false, true),
+
+    /**
+     * Historical / counterfactual replay verbalization: evaluated against explicit replay timestamp.
+     */
+    EXPRESS_REPLAY(0.00f, 0.00f, 1.00f, false, true);
+
+    private final float rhoPlus;
+    private final float rhoMinus;
+    private final float recencyLambda;
+    private final boolean allowsAntiPhase;
+    private final boolean allowsFuture;
+
+    SpacetimeSimulationMode(
+            final float rhoPlus,
+            final float rhoMinus,
+            final float recencyLambda,
+            final boolean allowsAntiPhase,
+            final boolean allowsFuture) {
+        this.rhoPlus = rhoPlus;
+        this.rhoMinus = rhoMinus;
+        this.recencyLambda = recencyLambda;
+        this.allowsAntiPhase = allowsAntiPhase;
+        this.allowsFuture = allowsFuture;
+    }
+
+    /**
+     * Weight multiplier for in-phase harmonic resonance (\(\psi > 0\)).
+     */
+    public float rhoPlus() {
+        return rhoPlus;
+    }
+
+    /**
+     * Weight multiplier for anti-phase harmonic divergence (\(\psi < 0\)).
+     */
+    public float rhoMinus() {
+        return rhoMinus;
+    }
+
+    /**
+     * Continuous scaling coefficient \(\lambda\) for mass-dilated logarithmic recency.
+     */
+    public float recencyLambda() {
+        return recencyLambda;
+    }
+
+    /**
+     * Whether this mode extracts anti-phase candidate seeds (most negative \(\psi\)).
+     */
+    public boolean allowsAntiPhase() {
+        return allowsAntiPhase;
+    }
+
+    /**
+     * Whether this mode admits memories timestamped after the query/simulation clock (\(t_i > t_s\)).
+     */
+    public boolean allowsFuture() {
+        return allowsFuture;
+    }
+}


### PR DESCRIPTION
## Summary

Implements **ADR-0031: 4D Spacetime Vector Retrieval for Cognitive Simulation, Mind-Wandering, Dreaming, and Phenomenological Expression** (Fixes #721).

### Key Highlights
1. **Zero Header Schema Mutations**:
   - Reuses standard 64-byte segment layout.
   - Reuses consolidation flags `FLAG_SIMULATED (0x20)` and `FLAG_DREAMED (0x80)` on byte 34 / 40.
2. **Unified Shortlist Seed Selection (`SpacetimeSeedRelay`)**:
   - Decoupled from SIMD scan loop.
   - Deterministic union of Spatial Top-$N$, Harmonic In-Phase ($\psi_i \to +1.0$), Harmonic Anti-Phase ($\psi_i \to -1.0$), and High-Mass Flashbulb candidates ($M_i \ge 0.30$).
   - Deduplicated via `LinkedHashMap` preserving rank order.
3. **Compound Simulation Scoring**:
   - $s'_i = s_i + \rho_+ \max(\psi_i, 0) + \rho_- \max(-\psi_i, 0) + \gamma \cdot \mathbf{1}[M_i \ge 0.30]$.
4. **Continuous $\lambda$ Recency Scaling**:
   - $R_\lambda(\Delta t, M_i) = \frac{1}{1 + \lambda \frac{\ln(1+\Delta t_{\text{days}})}{1+M_i}} \cdot A_{\text{mod}}(A_i)$.
   - Fully parameterized across WANDERING ($\lambda=0.30$), REM DREAMING ($\lambda=0.30$), NREM CONSOLIDATION ($\lambda=1.0$), and TIMELESS PROSPECTION ($\lambda=0.0$).
5. **Pathway Wiring**:
   - `WanderPathway`: `SpacetimeSeedRelay.WanderSeedRelay` wired after autobiographical sampling.
   - `DreamPathway`: `SpacetimeSeedRelay.DreamSeedRelay` wired after salient seed selection.
   - `ExpressPathway`: `ExpressTense.FACT` strictly drops synthetic/dreamed and future candidates; `ExpressTense.SIM` admits counterfactual/prospective candidates.
6. **Fixtures & Tests**:
   - Added `SpacetimeSimulationFixtureTest` covering Fixture W (anti-phase), Fixture D (dream provenance/causal gating), Fixture X (express tense filtering), and continuous $\lambda$ recency.
   - All 1,659 reactor tests pass.