### PR TITLE
feat(core): implement episodic to semantic provenance region and multi-pass consolidation (#731)

### DIFF
--- a/docs/docs/deep-dives/provenance-region.md
+++ b/docs/docs/deep-dives/provenance-region.md
@@ -1,0 +1,102 @@
+﻿# Provenance Region
+
+> **Status**: Accepted — implemented in [#731](https://github.com/spectrayan/spector/issues/731)
+> **Since**: v1.5.0
+
+The **Provenance Region** records the lineage between episodic conversation turns
+and the consolidated semantic (or procedural) memories they produce during
+the [Reflect pathway](../architecture/overview.md) consolidation cycle.
+
+## Motivation
+
+When an AI agent consolidates raw episodic turns into semantic facts, the
+origin of each fact is lost. This makes it impossible to:
+
+- **Explain** a memory: "Where did this fact come from?"
+- **Audit** a session: "What memories were derived from this conversation?"
+- **Detect multi-pass consolidation**: A session can grow with new turns after
+  an earlier consolidation pass — provenance tracks each pass independently.
+
+## Physical Layout
+
+Each provenance record is a **72-byte fixed-stride** CRC32C-protected slot
+defined in `ProvenanceLayout`:
+
+| Field             | Type   | Offset | Size | Description |
+|:------------------|:-------|-------:|-----:|:------------|
+| `flags`           | byte   |     0  |   1  | `0x01` = live, `0x02` = partial run, `0xFF` = tombstone |
+| `source_kind`     | byte   |     1  |   1  | Source type (1 = episodic log) |
+| `target_kind`     | byte   |     2  |   1  | Target type (1 = semantic, 2 = procedural) |
+| `prefix_kind`     | byte   |     3  |   1  | Target ID prefix registry ordinal |
+| `pass_number`     | short  |     4  |   2  | 1-indexed consolidation pass counter |
+| `turn_count`      | short  |     6  |   2  | Number of episodic turns covered |
+| `session_id`      | long   |     8  |   8  | Episodic session ID |
+| `target_tsid`     | long   |    16  |   8  | TSID of consolidated memory |
+| `consolidated_at` | long   |    24  |   8  | Epoch millis when consolidation occurred |
+| `partition_seq`   | int    |    32  |   4  | Partition holding source turns |
+| `first_seq`       | int    |    36  |   4  | First episodic sequence_id |
+| `last_seq`        | int    |    40  |   4  | Last episodic sequence_id |
+| `first_offset`    | int    |    44  |   4  | Byte offset hint for first turn |
+| `last_offset`     | int    |    48  |   4  | Byte offset hint for last turn |
+| `fact_index`      | byte   |    52  |   1  | Index within batch (0-indexed) |
+| `batch_count`     | byte   |    53  |   1  | Total facts in batch |
+| `content_hash_hi` | short  |    54  |   2  | Upper 16 bits of fact CRC32C |
+| *(reserved)*      | -      |    56  |  12  | Reserved for future use |
+| `crc32c`          | int    |    68  |   4  | CRC32C integrity checksum |
+
+**Total**: 72 bytes per record. Default capacity: **8,192 records**.
+
+## API
+
+### Forward Lookup - `explain(memoryId)`
+
+Given a consolidated memory ID, return its provenance:
+
+```java
+Optional<MemoryProvenance> prov = memory.explain("0ABCDEF1234GH");
+prov.ifPresent(p -> {
+    System.out.printf("Session: 0x%x, turns %d-%d, pass %d%n",
+        p.sessionId(), p.firstSeq(), p.lastSeq(), p.passNumber());
+});
+```
+
+### Reverse Lookup - `sessionProvenance(sessionId)`
+
+Given an episodic session ID, return all derived memories:
+
+```java
+List<MemoryProvenance> derived = memory.sessionProvenance(sessionId);
+for (var p : derived) {
+    System.out.printf("  -> %s (pass %d, fact %d/%d)%n",
+        p.targetId(), p.passNumber(), p.factIndex(), p.batchFactCount());
+}
+```
+
+## Configuration
+
+| Property | Default | Description |
+|:---------|--------:|:------------|
+| `spector.memory.provenance-capacity` | `8192` | Maximum number of provenance records |
+
+## Multi-Pass Consolidation
+
+When new turns arrive in a session that was already consolidated, the next
+consolidation cycle assigns `pass_number = max(existing) + 1`. This allows
+distinct lineage per pass without overwriting earlier provenance records.
+
+## Bug Fixes (shipped with this feature)
+
+Six bugs in the consolidation pipeline were discovered and fixed during
+provenance implementation:
+
+1. **Offset corruption in EpisodicSessionIndex.rebuild()** - used absolute
+   offsets instead of region-relative.
+2. **HashMap key collision** in consolidation relay - `EpisodeRecord` is a
+   value type; identical turns collided in `Map<EpisodeRecord, Long>`.
+3. **Discarded affect metadata** - valence, arousal, and importance were
+   hardcoded to zero instead of using fact-level values.
+4. **Missing session tag** - consolidated facts lost their session lineage tag.
+5. **Duplicate facts on retry** - turns were marked consolidated *after*
+   ingestion, causing duplicates on crash/retry.
+6. **PartitionHandle not threaded** - `processLogStore` used a stale partition
+   sequence instead of the handle's actual sequence.

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1214,6 +1214,41 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     }
 
     @Override
+    public java.util.Optional<com.spectrayan.spector.memory.model.MemoryProvenance> explain(String memoryId) {
+        if (provenanceMemory == null || memoryId == null || memoryId.isEmpty()) {
+            return java.util.Optional.empty();
+        }
+        try {
+            long tsid = com.spectrayan.spector.memory.kernel.id.TsidGenerator.decodeCrockford(memoryId);
+            return provenanceMemory.findByTarget(tsid)
+                    .map(s -> new com.spectrayan.spector.memory.model.MemoryProvenance(
+                            memoryId, s.sessionId(), s.partitionSeq(),
+                            s.firstSeq(), s.lastSeq(), s.turnCount(),
+                            s.passNumber(), s.factIndex(), s.batchFactCount(),
+                            s.consolidatedAtMs()
+                    ));
+        } catch (Exception e) {
+            return java.util.Optional.empty();
+        }
+    }
+
+    @Override
+    public java.util.List<com.spectrayan.spector.memory.model.MemoryProvenance> sessionProvenance(long sessionId) {
+        if (provenanceMemory == null) {
+            return java.util.List.of();
+        }
+        return provenanceMemory.findBySession(sessionId).stream()
+                .map(s -> new com.spectrayan.spector.memory.model.MemoryProvenance(
+                        com.spectrayan.spector.memory.kernel.id.TsidGenerator.encodeCrockford(s.targetTsid()),
+                        s.sessionId(), s.partitionSeq(),
+                        s.firstSeq(), s.lastSeq(), s.turnCount(),
+                        s.passNumber(), s.factIndex(), s.batchFactCount(),
+                        s.consolidatedAtMs()
+                ))
+                .toList();
+    }
+
+    @Override
     public void consolidate() {
         acquireLease();
         try {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -377,6 +377,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
     private final com.spectrayan.spector.memory.cortex.insula.InsularCortex insularCortex;
     private final WanderPathway wanderPathway;
     private final com.spectrayan.spector.memory.cortex.ContinuityMemory continuityMemory;
+    private final com.spectrayan.spector.memory.cortex.ProvenanceMemory provenanceMemory;
     private final DecidePathway decidePathway;
 
     private final com.spectrayan.spector.memory.session.SessionBufferManager sessionBufferManager = new com.spectrayan.spector.memory.session.SessionBufferManager();
@@ -469,6 +470,7 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
         this.insularCortex = bundle.insularCortex();
         this.wanderPathway = bundle.wanderPathway();
         this.continuityMemory = bundle.continuityMemory();
+        this.provenanceMemory = bundle.provenanceMemory();
         this.decidePathway = bundle.decidePathway();
         this.dreamPathway = bundle.dreamPathway();
         this.hook = builder.hook() != null ? builder.hook() : MemoryObservationHook.NOOP;

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -213,6 +213,7 @@ public final class SpectorMemoryBuilder {
     private int typeRegistryCapacity = SpectorPropertyConstants.DEFAULT_MEMORY_TYPE_REGISTRY_CAPACITY;
     private long typeRegistrySize = SpectorPropertyConstants.DEFAULT_MEMORY_TYPE_REGISTRY_SIZE;
     private long insulaSize = SpectorPropertyConstants.DEFAULT_MEMORY_INSULA_SIZE;
+    private int provenanceCapacity = SpectorPropertyConstants.DEFAULT_MEMORY_PROVENANCE_CAPACITY;
 
     // Eager consolidation (#526)
     private int eagerConsolidationQueueCapacity = SpectorPropertyConstants.DEFAULT_MEMORY_EAGER_CONSOLIDATION_QUEUE_CAPACITY;
@@ -260,6 +261,7 @@ public final class SpectorMemoryBuilder {
     public SpectorMemoryBuilder typeRegistryCapacity(int c) { this.typeRegistryCapacity = c; return this; }
     public SpectorMemoryBuilder typeRegistrySize(long s) { this.typeRegistrySize = s; return this; }
     public SpectorMemoryBuilder insulaSize(long s) { this.insulaSize = s; return this; }
+    public SpectorMemoryBuilder provenanceCapacity(int c) { this.provenanceCapacity = c; return this; }
     public SpectorMemoryBuilder eagerConsolidationQueueCapacity(int c) { this.eagerConsolidationQueueCapacity = c; return this; }
     /**
      * Sets whether to use the Cognitive Pathway Engine.
@@ -825,6 +827,7 @@ public final class SpectorMemoryBuilder {
     public int typeRegistryCapacity() { return typeRegistryCapacity; }
     public long typeRegistrySize() { return typeRegistrySize; }
     public long insulaSize() { return insulaSize; }
+    public int provenanceCapacity() { return provenanceCapacity; }
     public int eagerConsolidationQueueCapacity() { return eagerConsolidationQueueCapacity; }
     public boolean usePathwayEngine() { return usePathwayEngine; }
     public com.spectrayan.spector.memory.aisme.config.AismeConfig aismeConfig() { return aismeConfig; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/api/MemoryReflection.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/api/MemoryReflection.java
@@ -100,4 +100,35 @@ public interface MemoryReflection {
                    boolean allowCoexisting);
 
     int retractFact(int factId);
+
+    // ── Provenance ──
+
+    /**
+     * Returns the provenance record explaining how a consolidated memory was created.
+     *
+     * <p>This is the forward lineage query: given a memory ID, find which episodic
+     * session(s) and turns contributed to its creation.</p>
+     *
+     * @param memoryId the string ID of the consolidated memory
+     * @return the provenance record, or empty if not tracked or not found
+     * @since 1.5.0
+     */
+    default java.util.Optional<com.spectrayan.spector.memory.model.MemoryProvenance> explain(String memoryId) {
+        return java.util.Optional.empty();
+    }
+
+    /**
+     * Returns all provenance records for a given episodic session, ordered by
+     * pass number then fact index.
+     *
+     * <p>This is the reverse lineage query: given a session, find all consolidated
+     * memories that were derived from its turns.</p>
+     *
+     * @param sessionId the episodic session ID
+     * @return ordered list of provenance records (empty if none found)
+     * @since 1.5.0
+     */
+    default java.util.List<com.spectrayan.spector.memory.model.MemoryProvenance> sessionProvenance(long sessionId) {
+        return java.util.List.of();
+    }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/bootstrap/CognitiveCortexBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/bootstrap/CognitiveCortexBuilder.java
@@ -19,11 +19,13 @@ import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
 import com.spectrayan.spector.memory.cortex.ContinuityMemory;
 import com.spectrayan.spector.memory.cortex.EpisodicMemory;
 import com.spectrayan.spector.memory.cortex.ProceduralMemory;
+import com.spectrayan.spector.memory.cortex.ProvenanceMemory;
 import com.spectrayan.spector.memory.cortex.SemanticMemory;
 import com.spectrayan.spector.memory.cortex.TextBlobMemory;
 import com.spectrayan.spector.memory.cortex.WorkingMemory;
 import com.spectrayan.spector.memory.cortex.insula.InsularCortex;
 import com.spectrayan.spector.memory.kernel.layout.InsularLayout;
+import com.spectrayan.spector.memory.kernel.layout.ProvenanceLayout;
 import com.spectrayan.spector.memory.kernel.Memory;
 import com.spectrayan.spector.memory.kernel.RegionPreamble;
 import com.spectrayan.spector.memory.kernel.MemoryId;
@@ -104,7 +106,8 @@ public final class CognitiveCortexBuilder {
             RuntimeBundle runtimeBundle,
             InsularCortex insularCortex,
             ContinuityMemory continuityMemory,
-            EpisodicMemory episodicStore
+            EpisodicMemory episodicStore,
+            ProvenanceMemory provenanceMemory
     ) {}
 
     public static CortexFoundation build(SpectorMemoryBuilder builder) {
@@ -185,6 +188,7 @@ public final class CognitiveCortexBuilder {
         RuntimeBundle runtimeBundle = null;
         InsularCortex insularCortex = null;
         ContinuityMemory continuityMemory = null;
+        ProvenanceMemory provenanceMemory = null;
 
         if (isDisk && basePath != null && resolvedPartitionDir != null) {
             // ── V4 Runtime Bundle & Insular Cortex ──
@@ -240,6 +244,12 @@ public final class CognitiveCortexBuilder {
             MemorySegment continuitySlice = runtimeBundle.optionalRegionSegment(RegionId.CONTINUITY);
             if (continuitySlice != null) {
                 continuityMemory = ContinuityMemory.fromBundle(runtimeBundle.arena(), continuitySlice, isNewRuntime);
+            }
+
+            MemorySegment provenanceSlice = runtimeBundle.optionalRegionSegment(RegionId.PROVENANCE);
+            if (provenanceSlice != null) {
+                provenanceMemory = ProvenanceMemory.fromBundle(runtimeBundle.arena(), provenanceSlice,
+                        runtimeBundleFile);
             }
 
             // ── V4 Partition Bundle ──
@@ -325,13 +335,17 @@ public final class CognitiveCortexBuilder {
             continuityMemory = ContinuityMemory.heap(1000);
         }
 
+        if (provenanceMemory == null) {
+            provenanceMemory = ProvenanceMemory.heap(builder.provenanceCapacity());
+        }
+
         EpisodicMemory episodicStore = cognitiveRouter.episodic();
 
         return new CortexFoundation(
                 isDisk, useBundleMode, basePath, quantizer, namespaceManager, quantizedVecBytes,
                 resolvedPartitionDir, frozenPartitionDirs, initialPartitionSeq,
                 cognitiveRouter, workingStore, partitionBundle, textStore,
-                runtimeBundle, insularCortex, continuityMemory, episodicStore);
+                runtimeBundle, insularCortex, continuityMemory, episodicStore, provenanceMemory);
     }
 
     private static List<RegionSizeSpec> getRuntimeBundleSpecs(SpectorMemoryBuilder builder, int quantizedVecBytes) {
@@ -502,6 +516,15 @@ public final class CognitiveCortexBuilder {
                         0x42494458,  // "BIDX" magic
                         1,
                         true  // growable — term/posting lists grow dynamically
+                ),
+                new RegionSizeSpec(
+                        RegionId.PROVENANCE,
+                        64 + (long) builder.provenanceCapacity() * ProvenanceLayout.RECORD_STRIDE,
+                        builder.provenanceCapacity(),
+                        ProvenanceLayout.RECORD_STRIDE,
+                        ProvenanceLayout.LAYOUT_ID,
+                        ProvenanceLayout.SCHEMA_VERSION,
+                        false
                 )
         );
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/bootstrap/SpectorMemoryFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/bootstrap/SpectorMemoryFactory.java
@@ -182,7 +182,8 @@ public final class SpectorMemoryFactory {
             com.spectrayan.spector.memory.cortex.ContinuityMemory continuityMemory,
             DecidePathway decidePathway,
             DreamPathway dreamPathway,
-            com.spectrayan.spector.memory.aisme.AismeBundle aismeBundle
+            com.spectrayan.spector.memory.aisme.AismeBundle aismeBundle,
+            com.spectrayan.spector.memory.cortex.ProvenanceMemory provenanceMemory
     ) {}
 
     private SpectorMemoryFactory() {}
@@ -370,6 +371,11 @@ public final class SpectorMemoryFactory {
             RecallPipelineBuilder.rebuildHnswIfNeeded(builder, partitionManager, index, cortex.quantizer());
         }
 
+        //  ID Generator (moved up so ReflectPathway can use it)
+        MemoryIdGenerator idGenerator = builder.idGenerator() != null
+                ? builder.idGenerator()
+                : builder.idStrategy().createGenerator();
+
         //  Reflect Pathway (#503 / ADR-0007)
         ReflectPathway reflectPathway = ReflectPathway.builder()
                 .embeddingProvider(embeddingProvider)
@@ -395,6 +401,8 @@ public final class SpectorMemoryFactory {
                 .cognitiveManifold(aismeBundle != null ? aismeBundle.cognitiveManifold() : null)
                 .manifoldConsolidationRelay(aismeBundle != null ? aismeBundle.manifoldConsolidationRelay() : null)
                 .mentalStateTracker(aismeBundle != null ? aismeBundle.mentalStateTracker() : null)
+                .provenanceMemory(cortex.provenanceMemory())
+                .idGenerator(idGenerator)
                 .build();
 
         // Express Pathway (#602)
@@ -410,11 +418,6 @@ public final class SpectorMemoryFactory {
         ReinforcementHandler reinforcementHandler = new ReinforcementHandler(
                 bio.valenceTracker(), graphs.hebbianGraph(), bio.lateralEvaluator(), recallPathway,
                 wal, builder.twoFactorConfig(), profileAdaptor);
-
-        //  ID Generator 
-        MemoryIdGenerator idGenerator = builder.idGenerator() != null
-                ? builder.idGenerator()
-                : builder.idStrategy().createGenerator();
 
         //  Wander Pathway (#609 / AISME Phase 10 — DMN & Longitudinal Continuity)
         WanderPathway wanderPathway = WanderPathway.builder()
@@ -507,7 +510,8 @@ public final class SpectorMemoryFactory {
                 daemons.checkpointDaemon(), daemons.graphEnrichmentDaemon(), daemons.daemonSupervisor(), retrieval.bm25Index(), attachmentProcessor,
                 parallelPipeline, embedConfig, cortex.resolvedPartitionDir(), cortex.basePath(),
                 cortex.namespaceManager(), profileAdaptor, cortex.runtimeBundle(), cortex.insularCortex(),
-                wanderPathway, cortex.continuityMemory(), decidePathway, dreamPathway, aismeBundle
+                wanderPathway, cortex.continuityMemory(), decidePathway, dreamPathway, aismeBundle,
+                cortex.provenanceMemory()
         );
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProvenanceEdge.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProvenanceEdge.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import com.spectrayan.spector.memory.kernel.layout.ProvenanceLayout;
+
+/**
+ * Builder-style value object for constructing a provenance write.
+ *
+ * <p>Used by the consolidation relay to capture the relationship between episodic
+ * source turns and a consolidated semantic or procedural memory target.</p>
+ *
+ * @param sessionId        episodic session that produced the turns
+ * @param targetTsid       raw 64-bit TSID of the consolidated memory
+ * @param passNumber       consolidation pass counter for this session (1-indexed)
+ * @param factIndex        index of this fact within its batch (0-indexed)
+ * @param batchFactCount   total facts produced in this consolidation batch
+ * @param partitionSeq     partition sequence number holding source turns
+ * @param firstSeq         first episodic sequence_id in the turn range
+ * @param lastSeq          last episodic sequence_id in the turn range
+ * @param firstOffsetHint  region-relative byte offset hint for first turn
+ * @param lastOffsetHint   region-relative byte offset hint for last turn
+ * @param turnCount        number of turns covered by this edge
+ * @param contentHashHi    upper 16 bits of fact text CRC32C (dedup aid)
+ * @param consolidatedAtMs epoch millis when consolidation occurred
+ * @param sourceKind       source kind (default: {@link ProvenanceLayout#SOURCE_EPISODIC_LOG})
+ * @param targetKind       target kind ({@link ProvenanceLayout#TARGET_SEMANTIC} or
+ *                         {@link ProvenanceLayout#TARGET_PROCEDURAL})
+ * @param prefixKind       target ID prefix registry ordinal
+ *
+ * @see ProvenanceLayout
+ * @see ProvenanceMemory
+ * @since 1.5.0
+ */
+public record ProvenanceEdge(
+        long sessionId,
+        long targetTsid,
+        short passNumber,
+        byte factIndex,
+        byte batchFactCount,
+        int partitionSeq,
+        int firstSeq,
+        int lastSeq,
+        int firstOffsetHint,
+        int lastOffsetHint,
+        short turnCount,
+        short contentHashHi,
+        long consolidatedAtMs,
+        byte sourceKind,
+        byte targetKind,
+        byte prefixKind
+) {
+
+    /**
+     * Creates a provenance edge with default source/target kinds for the common case:
+     * episodic log → semantic memory.
+     */
+    public ProvenanceEdge(long sessionId, long targetTsid, short passNumber,
+                          byte factIndex, byte batchFactCount,
+                          int partitionSeq, int firstSeq, int lastSeq,
+                          int firstOffsetHint, int lastOffsetHint,
+                          short turnCount, short contentHashHi,
+                          long consolidatedAtMs) {
+        this(sessionId, targetTsid, passNumber, factIndex, batchFactCount,
+                partitionSeq, firstSeq, lastSeq, firstOffsetHint, lastOffsetHint,
+                turnCount, contentHashHi, consolidatedAtMs,
+                ProvenanceLayout.SOURCE_EPISODIC_LOG,
+                ProvenanceLayout.TARGET_SEMANTIC,
+                (byte) 0);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProvenanceMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/ProvenanceMemory.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.cortex;
+
+import com.spectrayan.spector.memory.kernel.MemoryId;
+import com.spectrayan.spector.memory.kernel.layout.ProvenanceLayout;
+import com.spectrayan.spector.memory.kernel.layout.ProvenanceLayout.ProvenanceState;
+import com.spectrayan.spector.memory.kernel.shape.AbstractRecordMemory;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Off-heap store managing the Provenance Audit Region (ADR-0029).
+ *
+ * <h3>Design &amp; Purpose</h3>
+ * <p>Tracks the lineage between episodic conversation turns and consolidated
+ * semantic (or procedural) memories. Each provenance record captures which session
+ * turns contributed to which semantic fact, including multi-pass consolidation
+ * tracking via {@code pass_number}.</p>
+ *
+ * <h3>Heap Indexes</h3>
+ * <p>Two heap-based {@link ConcurrentHashMap} indexes are rebuilt on open by
+ * scanning all live records:</p>
+ * <ul>
+ *   <li>{@code targetIndex}: target_tsid → slotId (O(1) "explain" lookups)</li>
+ *   <li>{@code sessionIndex}: session_id → ordered list of slotIds (reverse provenance)</li>
+ * </ul>
+ *
+ * <h3>Thread Safety</h3>
+ * <p>Read operations are lock-free via the heap indexes. Append operations are serialized
+ * via a {@link ReentrantLock} to ensure sequential slot allocation and atomic index updates.</p>
+ *
+ * @see ProvenanceLayout
+ * @see ProvenanceEdge
+ * @since 1.5.0
+ */
+public final class ProvenanceMemory extends AbstractRecordMemory<ProvenanceLayout> {
+
+    private static final Logger log = LoggerFactory.getLogger(ProvenanceMemory.class);
+
+    /** target_tsid → slotId for O(1) "explain" lookups. */
+    private final Map<Long, Integer> targetIndex = new ConcurrentHashMap<>();
+
+    /** session_id → ordered list of slotIds for reverse provenance queries. */
+    private final Map<Long, List<Integer>> sessionIndex = new ConcurrentHashMap<>();
+
+    /** Lock for serializing append operations. */
+    private final ReentrantLock appendLock = new ReentrantLock();
+
+    private ProvenanceMemory(MemoryId id, ProvenanceLayout layout, int capacity,
+                             Arena arena, MemorySegment segment, int count,
+                             boolean persistent, Path filePath,
+                             FileChannel fileChannel, boolean bundleManaged) {
+        super(id, layout, capacity, arena, segment, count, persistent, filePath, fileChannel, bundleManaged);
+    }
+
+    /**
+     * Creates an in-memory heap-backed ProvenanceMemory for testing or transient runtime.
+     *
+     * @param capacity maximum number of provenance records
+     * @return a new heap-backed ProvenanceMemory
+     */
+    public static ProvenanceMemory heap(int capacity) {
+        Arena arena = Arena.ofShared();
+        long bytes = (long) capacity * ProvenanceLayout.RECORD_STRIDE;
+        MemorySegment segment = arena.allocate(bytes, 8);
+        return new ProvenanceMemory(
+                MemoryId.of("default", "heap-provenance"),
+                ProvenanceLayout.INSTANCE,
+                capacity,
+                arena,
+                segment,
+                0,
+                false,
+                null,
+                null,
+                false);
+    }
+
+    /**
+     * Creates a bundle-backed ProvenanceMemory from a pre-sliced region segment.
+     *
+     * @param arena         the arena managing the segment's lifetime
+     * @param segment       the pre-sliced region segment
+     * @param bundlePath    the path to the bundle file
+     * @param memoryName    diagnostic name for this memory
+     * @return a new bundle-backed ProvenanceMemory
+     */
+    public static ProvenanceMemory fromBundle(Arena arena, MemorySegment segment,
+                                              Path bundlePath, String memoryName) {
+        String name = (memoryName != null && !memoryName.isBlank()) ? memoryName : "bundle-provenance";
+        int capacity = (int) (segment.byteSize() / ProvenanceLayout.RECORD_STRIDE);
+        return new ProvenanceMemory(
+                MemoryId.of("default", name),
+                ProvenanceLayout.INSTANCE,
+                capacity,
+                arena,
+                segment,
+                0,
+                true,
+                bundlePath,
+                null,
+                true);
+    }
+
+    /**
+     * Creates a bundle-backed ProvenanceMemory with default memory name.
+     */
+    public static ProvenanceMemory fromBundle(Arena arena, MemorySegment segment, Path bundlePath) {
+        return fromBundle(arena, segment, bundlePath, "bundle-provenance");
+    }
+
+    // ── Append ──
+
+    /**
+     * Appends a provenance edge at the next available slot.
+     *
+     * @param edge the provenance edge to write
+     * @return the slot ID where the record was written, or -1 if the region is full
+     */
+    public int append(ProvenanceEdge edge) {
+        appendLock.lock();
+        try {
+            if (count >= capacity) {
+                log.warn("Provenance region full (capacity={}). Skipping provenance edge for session=0x{}, target=0x{}",
+                        capacity, Long.toHexString(edge.sessionId()), Long.toHexString(edge.targetTsid()));
+                return -1;
+            }
+
+            int slot = count;
+            long recordOff = recordOffset(slot);
+
+            ProvenanceState state = new ProvenanceState(
+                    ProvenanceLayout.FLAG_LIVE,
+                    edge.sourceKind(),
+                    edge.targetKind(),
+                    edge.prefixKind(),
+                    edge.passNumber(),
+                    edge.turnCount(),
+                    edge.sessionId(),
+                    edge.targetTsid(),
+                    edge.consolidatedAtMs(),
+                    edge.partitionSeq(),
+                    edge.firstSeq(),
+                    edge.lastSeq(),
+                    edge.firstOffsetHint(),
+                    edge.lastOffsetHint(),
+                    edge.factIndex(),
+                    edge.batchFactCount(),
+                    edge.contentHashHi()
+            );
+
+            // Write fields to off-heap segment
+            ProvenanceLayout.writeRecord(segment, recordOff, state);
+
+            // Write CRC32C via base class contract
+            Arena recordArena = Arena.ofConfined();
+            try {
+                MemorySegment recordBuf = recordArena.allocate(ProvenanceLayout.RECORD_STRIDE, 8);
+                MemorySegment.copy(segment, recordOff, recordBuf, 0, ProvenanceLayout.RECORD_STRIDE);
+                write(slot, recordBuf);
+            } finally {
+                recordArena.close();
+            }
+
+            // Update heap indexes
+            targetIndex.put(edge.targetTsid(), slot);
+            sessionIndex.computeIfAbsent(edge.sessionId(), k -> Collections.synchronizedList(new ArrayList<>()))
+                    .add(slot);
+
+            return slot;
+        } finally {
+            appendLock.unlock();
+        }
+    }
+
+    // ── Primary Index: Explain ──
+
+    /**
+     * Finds the provenance record for a given target memory TSID.
+     *
+     * @param tsid raw 64-bit TSID of the consolidated memory
+     * @return the provenance state if found
+     */
+    public Optional<ProvenanceState> findByTarget(long tsid) {
+        Integer slot = targetIndex.get(tsid);
+        if (slot == null) {
+            return Optional.empty();
+        }
+        long recordOff = recordOffset(slot);
+        ProvenanceState state = ProvenanceLayout.readRecord(segment, recordOff);
+        return state.isLive() ? Optional.of(state) : Optional.empty();
+    }
+
+    // ── Reverse Index: Session Provenance ──
+
+    /**
+     * Returns all live provenance records for a session, ordered by pass_number then fact_index.
+     *
+     * @param sessionId the episodic session ID
+     * @return ordered list of provenance states (empty if no records found)
+     */
+    public List<ProvenanceState> findBySession(long sessionId) {
+        List<Integer> slots = sessionIndex.get(sessionId);
+        if (slots == null || slots.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProvenanceState> result = new ArrayList<>(slots.size());
+        for (int slot : slots) {
+            long recordOff = recordOffset(slot);
+            ProvenanceState state = ProvenanceLayout.readRecord(segment, recordOff);
+            if (state.isLive()) {
+                result.add(state);
+            }
+        }
+
+        result.sort(Comparator
+                .comparingInt((ProvenanceState s) -> s.passNumber())
+                .thenComparingInt(s -> s.factIndex()));
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * Returns all live provenance records for a session and specific pass, ordered by fact_index.
+     *
+     * @param sessionId  the episodic session ID
+     * @param passNumber the consolidation pass number (1-indexed)
+     * @return ordered list of provenance states for the given pass
+     */
+    public List<ProvenanceState> findBySessionAndPass(long sessionId, int passNumber) {
+        List<Integer> slots = sessionIndex.get(sessionId);
+        if (slots == null || slots.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProvenanceState> result = new ArrayList<>();
+        for (int slot : slots) {
+            long recordOff = recordOffset(slot);
+            ProvenanceState state = ProvenanceLayout.readRecord(segment, recordOff);
+            if (state.isLive() && state.passNumber() == passNumber) {
+                result.add(state);
+            }
+        }
+
+        result.sort(Comparator.comparingInt(ProvenanceState::factIndex));
+        return Collections.unmodifiableList(result);
+    }
+
+    // ── Pass Counter ──
+
+    /**
+     * Returns the next pass number for a session: max(pass_number) + 1, or 1 if no prior passes.
+     *
+     * @param sessionId the episodic session ID
+     * @return the next pass number to use for consolidation
+     */
+    public int nextPassNumber(long sessionId) {
+        List<Integer> slots = sessionIndex.get(sessionId);
+        if (slots == null || slots.isEmpty()) {
+            return 1;
+        }
+
+        int maxPass = 0;
+        for (int slot : slots) {
+            long recordOff = recordOffset(slot);
+            short passNum = ProvenanceLayout.readPassNumber(segment, recordOff);
+            byte flags = ProvenanceLayout.readFlags(segment, recordOff);
+            if (flags != ProvenanceLayout.FLAG_TOMBSTONE && passNum > maxPass) {
+                maxPass = passNum;
+            }
+        }
+        return maxPass + 1;
+    }
+
+    // ── Index Rebuild ──
+
+    /**
+     * Rebuilds the heap indexes by sequentially scanning all slots.
+     *
+     * <p>Called after opening a persistent store to reconstruct the
+     * {@code targetIndex} and {@code sessionIndex} from on-disk data.</p>
+     */
+    public void rebuildIndexes() {
+        targetIndex.clear();
+        sessionIndex.clear();
+
+        for (int slot = 0; slot < count; slot++) {
+            long recordOff = recordOffset(slot);
+            byte flags = ProvenanceLayout.readFlags(segment, recordOff);
+            if (flags == ProvenanceLayout.FLAG_TOMBSTONE) {
+                continue;
+            }
+
+            long targetTsid = ProvenanceLayout.readTargetTsid(segment, recordOff);
+            long sessionId = ProvenanceLayout.readSessionId(segment, recordOff);
+
+            targetIndex.put(targetTsid, slot);
+            sessionIndex.computeIfAbsent(sessionId, k -> Collections.synchronizedList(new ArrayList<>()))
+                    .add(slot);
+        }
+
+        log.info("Rebuilt provenance indexes: {} target entries, {} sessions, {} total records",
+                targetIndex.size(), sessionIndex.size(), count);
+    }
+
+    // ── Replay / Inspection ──
+
+    /**
+     * Streams all live provenance records in slot order (for inspection and eval tools).
+     *
+     * @return stream of live provenance states
+     */
+    public Stream<ProvenanceState> replay() {
+        return java.util.stream.IntStream.range(0, count)
+                .mapToObj(slot -> ProvenanceLayout.readRecord(segment, recordOffset(slot)))
+                .filter(ProvenanceState::isLive);
+    }
+
+    /**
+     * Returns the number of unique sessions tracked in the provenance store.
+     */
+    public int sessionCount() {
+        return sessionIndex.size();
+    }
+
+    /**
+     * Returns the number of unique target memories tracked in the provenance store.
+     */
+    public int targetCount() {
+        return targetIndex.size();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/bundle/RegionId.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/bundle/RegionId.java
@@ -40,7 +40,7 @@ public enum RegionId {
     CHECKPOINT(23),
     INSULA(24),
     CONTINUITY(25),
-    PROVENANCE_LOG(26);
+    PROVENANCE(26);
 
     private final int id;
     

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/id/TsidGenerator.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/id/TsidGenerator.java
@@ -204,7 +204,7 @@ public final class TsidGenerator implements MemoryIdGenerator {
      * @param value the 64-bit value to encode
      * @return 13-character Crockford Base32 string
      */
-    static String encodeCrockford(long value) {
+    public static String encodeCrockford(long value) {
         char[] buf = new char[TSID_STRING_LENGTH];
         for (int i = TSID_STRING_LENGTH - 1; i >= 0; i--) {
             buf[i] = CROCKFORD[(int) (value & 0x1F)];

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/ProvenanceLayout.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/kernel/layout/ProvenanceLayout.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.kernel.layout;
+
+import com.spectrayan.spector.memory.kernel.RegionLayout;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * On-disk binary layout for the episodic→semantic Provenance Audit Region (ADR-0029).
+ *
+ * <p>Each 72-byte record captures the lineage between a batch of episodic conversation
+ * turns and a single consolidated semantic (or procedural) memory. The layout supports
+ * multi-pass consolidation: when new turns arrive in a previously-consolidated session,
+ * a new pass produces additional provenance rows with an incremented {@code pass_number}.</p>
+ *
+ * <h3>Record Layout (72 bytes — 8-byte aligned, CRC32C protected)</h3>
+ * <pre>
+ *   Offset  Size  Field               Type     Description
+ *   ──────  ────  ──────────────────  ───────  ───────────────────────────────────
+ *    0      1B    flags               uint8    LIVE(0), TOMBSTONE(1), PARTIAL_RUN(2)
+ *    1      1B    source_kind         uint8    EPISODIC_LOG = 1
+ *    2      1B    target_kind         uint8    SEMANTIC = 2, PROCEDURAL = 3
+ *    3      1B    prefix_kind         uint8    Target ID prefix registry ordinal
+ *    4      2B    pass_number         uint16   Monotonic consolidation pass counter (1-indexed)
+ *    6      2B    turn_count          uint16   Turns covered by this row
+ *    8      8B    session_id          int64    Matches episodic header session_id
+ *   16      8B    target_tsid         int64    Raw 64-bit TSID of consolidated fact
+ *   24      8B    consolidated_at_ms  int64    Epoch ms of the consolidation pass
+ *   32      4B    partition_seq       int32    Partition holding source turns
+ *   36      4B    first_seq           int32    First episodic sequence_id in the run
+ *   40      4B    last_seq            int32    Last episodic sequence_id in the run
+ *   44      4B    first_offset_hint   uint32   Region-relative byte offset hint
+ *   48      4B    last_offset_hint    uint32   Region-relative byte offset hint
+ *   52      1B    fact_index          uint8    Index of this fact within its batch
+ *   53      1B    batch_fact_count    uint8    Total facts in this batch
+ *   54      2B    content_hash_hi     uint16   Upper 16 bits of fact text CRC32C
+ *   56      8B    _reserved           bytes    Zero-filled; future fields
+ *   64      4B    reserved_2          bytes    Zero-filled; future fields
+ *   68      4B    crc32c              int32    Written/verified by AbstractRecordMemory
+ *   ── 72B total stride ────────────────────────────────────────────────────────
+ * </pre>
+ *
+ * @see com.spectrayan.spector.memory.cortex.ProvenanceMemory
+ * @since 1.5.0
+ */
+public final class ProvenanceLayout implements RegionLayout {
+
+    /** Singleton instance — stateless and safe to share. */
+    public static final ProvenanceLayout INSTANCE = new ProvenanceLayout();
+
+    /** Four-char layout identifier: {@code 'PROV'} (0x50524F56). */
+    public static final int LAYOUT_ID = 0x50524F56;
+
+    /** Current schema version for the provenance record format. */
+    public static final int SCHEMA_VERSION = 1;
+
+    /** Fixed size of each provenance record in bytes (68B payload + 4B CRC = 72B). */
+    public static final int RECORD_STRIDE = 72;
+
+    // ── Flags Constants ──
+
+    /** Record is live and valid. */
+    public static final byte FLAG_LIVE = 0;
+
+    /** Record has been tombstoned (logically deleted). */
+    public static final byte FLAG_TOMBSTONE = 1;
+
+    /** Partial run — consolidation was interrupted before all facts in the batch were written. */
+    public static final byte FLAG_PARTIAL_RUN = 2;
+
+    // ── Source/Target Kind Constants ──
+
+    /** Source kind: episodic conversation log. */
+    public static final byte SOURCE_EPISODIC_LOG = 1;
+
+    /** Target kind: semantic memory. */
+    public static final byte TARGET_SEMANTIC = 2;
+
+    /** Target kind: procedural memory. */
+    public static final byte TARGET_PROCEDURAL = 3;
+
+    // ── Field Offsets (relative to record start) ──
+
+    public static final long OFFSET_FLAGS              = 0L;
+    public static final long OFFSET_SOURCE_KIND        = 1L;
+    public static final long OFFSET_TARGET_KIND        = 2L;
+    public static final long OFFSET_PREFIX_KIND        = 3L;
+    public static final long OFFSET_PASS_NUMBER        = 4L;
+    public static final long OFFSET_TURN_COUNT         = 6L;
+    public static final long OFFSET_SESSION_ID         = 8L;
+    public static final long OFFSET_TARGET_TSID        = 16L;
+    public static final long OFFSET_CONSOLIDATED_AT_MS = 24L;
+    public static final long OFFSET_PARTITION_SEQ      = 32L;
+    public static final long OFFSET_FIRST_SEQ          = 36L;
+    public static final long OFFSET_LAST_SEQ           = 40L;
+    public static final long OFFSET_FIRST_OFFSET_HINT  = 44L;
+    public static final long OFFSET_LAST_OFFSET_HINT   = 48L;
+    public static final long OFFSET_FACT_INDEX         = 52L;
+    public static final long OFFSET_BATCH_FACT_COUNT   = 53L;
+    public static final long OFFSET_CONTENT_HASH_HI    = 54L;
+    public static final long OFFSET_RESERVED           = 56L;
+    public static final long OFFSET_RESERVED_2         = 64L;
+    public static final long OFFSET_CRC32C             = 68L;
+
+    // ── ValueLayout Constants ──
+
+    public static final ValueLayout.OfByte  LAYOUT_FLAGS           = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte  LAYOUT_SOURCE_KIND     = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte  LAYOUT_TARGET_KIND     = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte  LAYOUT_PREFIX_KIND     = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfShort LAYOUT_PASS_NUMBER     = ValueLayout.JAVA_SHORT_UNALIGNED;
+    public static final ValueLayout.OfShort LAYOUT_TURN_COUNT      = ValueLayout.JAVA_SHORT_UNALIGNED;
+    public static final ValueLayout.OfLong  LAYOUT_SESSION_ID      = ValueLayout.JAVA_LONG_UNALIGNED;
+    public static final ValueLayout.OfLong  LAYOUT_TARGET_TSID     = ValueLayout.JAVA_LONG_UNALIGNED;
+    public static final ValueLayout.OfLong  LAYOUT_CONSOLIDATED_AT = ValueLayout.JAVA_LONG_UNALIGNED;
+    public static final ValueLayout.OfInt   LAYOUT_PARTITION_SEQ   = ValueLayout.JAVA_INT_UNALIGNED;
+    public static final ValueLayout.OfInt   LAYOUT_FIRST_SEQ       = ValueLayout.JAVA_INT_UNALIGNED;
+    public static final ValueLayout.OfInt   LAYOUT_LAST_SEQ        = ValueLayout.JAVA_INT_UNALIGNED;
+    public static final ValueLayout.OfInt   LAYOUT_FIRST_OFFSET    = ValueLayout.JAVA_INT_UNALIGNED;
+    public static final ValueLayout.OfInt   LAYOUT_LAST_OFFSET     = ValueLayout.JAVA_INT_UNALIGNED;
+    public static final ValueLayout.OfByte  LAYOUT_FACT_INDEX      = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte  LAYOUT_BATCH_FACT_CNT  = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfShort LAYOUT_CONTENT_HASH    = ValueLayout.JAVA_SHORT_UNALIGNED;
+
+    private ProvenanceLayout() {}
+
+    @Override
+    public int layoutId() {
+        return LAYOUT_ID;
+    }
+
+    @Override
+    public int schemaVersion() {
+        return SCHEMA_VERSION;
+    }
+
+    @Override
+    public int recordStride() {
+        return RECORD_STRIDE;
+    }
+
+    @Override
+    public boolean crcEnabled() {
+        return true;
+    }
+
+    @Override
+    public String name() {
+        return "ProvenanceLayout";
+    }
+
+    // ── Field Read Helpers ──
+
+    public static byte readFlags(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_FLAGS, recordOff + OFFSET_FLAGS);
+    }
+
+    public static byte readSourceKind(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_SOURCE_KIND, recordOff + OFFSET_SOURCE_KIND);
+    }
+
+    public static byte readTargetKind(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_TARGET_KIND, recordOff + OFFSET_TARGET_KIND);
+    }
+
+    public static byte readPrefixKind(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_PREFIX_KIND, recordOff + OFFSET_PREFIX_KIND);
+    }
+
+    public static short readPassNumber(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_PASS_NUMBER, recordOff + OFFSET_PASS_NUMBER);
+    }
+
+    public static short readTurnCount(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_TURN_COUNT, recordOff + OFFSET_TURN_COUNT);
+    }
+
+    public static long readSessionId(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_SESSION_ID, recordOff + OFFSET_SESSION_ID);
+    }
+
+    public static long readTargetTsid(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_TARGET_TSID, recordOff + OFFSET_TARGET_TSID);
+    }
+
+    public static long readConsolidatedAtMs(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_CONSOLIDATED_AT, recordOff + OFFSET_CONSOLIDATED_AT_MS);
+    }
+
+    public static int readPartitionSeq(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_PARTITION_SEQ, recordOff + OFFSET_PARTITION_SEQ);
+    }
+
+    public static int readFirstSeq(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_FIRST_SEQ, recordOff + OFFSET_FIRST_SEQ);
+    }
+
+    public static int readLastSeq(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_LAST_SEQ, recordOff + OFFSET_LAST_SEQ);
+    }
+
+    public static int readFirstOffsetHint(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_FIRST_OFFSET, recordOff + OFFSET_FIRST_OFFSET_HINT);
+    }
+
+    public static int readLastOffsetHint(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_LAST_OFFSET, recordOff + OFFSET_LAST_OFFSET_HINT);
+    }
+
+    public static byte readFactIndex(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_FACT_INDEX, recordOff + OFFSET_FACT_INDEX);
+    }
+
+    public static byte readBatchFactCount(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_BATCH_FACT_CNT, recordOff + OFFSET_BATCH_FACT_COUNT);
+    }
+
+    public static short readContentHashHi(MemorySegment seg, long recordOff) {
+        return seg.get(LAYOUT_CONTENT_HASH, recordOff + OFFSET_CONTENT_HASH_HI);
+    }
+
+    // ── Field Write Helpers ──
+
+    public static void writeFlags(MemorySegment seg, long recordOff, byte flags) {
+        seg.set(LAYOUT_FLAGS, recordOff + OFFSET_FLAGS, flags);
+    }
+
+    public static void writeSourceKind(MemorySegment seg, long recordOff, byte kind) {
+        seg.set(LAYOUT_SOURCE_KIND, recordOff + OFFSET_SOURCE_KIND, kind);
+    }
+
+    public static void writeTargetKind(MemorySegment seg, long recordOff, byte kind) {
+        seg.set(LAYOUT_TARGET_KIND, recordOff + OFFSET_TARGET_KIND, kind);
+    }
+
+    public static void writePrefixKind(MemorySegment seg, long recordOff, byte kind) {
+        seg.set(LAYOUT_PREFIX_KIND, recordOff + OFFSET_PREFIX_KIND, kind);
+    }
+
+    public static void writePassNumber(MemorySegment seg, long recordOff, short passNumber) {
+        seg.set(LAYOUT_PASS_NUMBER, recordOff + OFFSET_PASS_NUMBER, passNumber);
+    }
+
+    public static void writeTurnCount(MemorySegment seg, long recordOff, short turnCount) {
+        seg.set(LAYOUT_TURN_COUNT, recordOff + OFFSET_TURN_COUNT, turnCount);
+    }
+
+    public static void writeSessionId(MemorySegment seg, long recordOff, long sessionId) {
+        seg.set(LAYOUT_SESSION_ID, recordOff + OFFSET_SESSION_ID, sessionId);
+    }
+
+    public static void writeTargetTsid(MemorySegment seg, long recordOff, long tsid) {
+        seg.set(LAYOUT_TARGET_TSID, recordOff + OFFSET_TARGET_TSID, tsid);
+    }
+
+    public static void writeConsolidatedAtMs(MemorySegment seg, long recordOff, long timestampMs) {
+        seg.set(LAYOUT_CONSOLIDATED_AT, recordOff + OFFSET_CONSOLIDATED_AT_MS, timestampMs);
+    }
+
+    public static void writePartitionSeq(MemorySegment seg, long recordOff, int partitionSeq) {
+        seg.set(LAYOUT_PARTITION_SEQ, recordOff + OFFSET_PARTITION_SEQ, partitionSeq);
+    }
+
+    public static void writeFirstSeq(MemorySegment seg, long recordOff, int firstSeq) {
+        seg.set(LAYOUT_FIRST_SEQ, recordOff + OFFSET_FIRST_SEQ, firstSeq);
+    }
+
+    public static void writeLastSeq(MemorySegment seg, long recordOff, int lastSeq) {
+        seg.set(LAYOUT_LAST_SEQ, recordOff + OFFSET_LAST_SEQ, lastSeq);
+    }
+
+    public static void writeFirstOffsetHint(MemorySegment seg, long recordOff, int offset) {
+        seg.set(LAYOUT_FIRST_OFFSET, recordOff + OFFSET_FIRST_OFFSET_HINT, offset);
+    }
+
+    public static void writeLastOffsetHint(MemorySegment seg, long recordOff, int offset) {
+        seg.set(LAYOUT_LAST_OFFSET, recordOff + OFFSET_LAST_OFFSET_HINT, offset);
+    }
+
+    public static void writeFactIndex(MemorySegment seg, long recordOff, byte index) {
+        seg.set(LAYOUT_FACT_INDEX, recordOff + OFFSET_FACT_INDEX, index);
+    }
+
+    public static void writeBatchFactCount(MemorySegment seg, long recordOff, byte count) {
+        seg.set(LAYOUT_BATCH_FACT_CNT, recordOff + OFFSET_BATCH_FACT_COUNT, count);
+    }
+
+    public static void writeContentHashHi(MemorySegment seg, long recordOff, short hash) {
+        seg.set(LAYOUT_CONTENT_HASH, recordOff + OFFSET_CONTENT_HASH_HI, hash);
+    }
+
+    // ── Composite Read/Write ──
+
+    /**
+     * Reads a complete immutable {@link ProvenanceState} snapshot from the given record offset.
+     *
+     * @param seg       off-heap memory segment
+     * @param recordOff byte offset where this provenance record starts
+     * @return immutable snapshot of the provenance record
+     */
+    public static ProvenanceState readRecord(MemorySegment seg, long recordOff) {
+        return new ProvenanceState(
+                readFlags(seg, recordOff),
+                readSourceKind(seg, recordOff),
+                readTargetKind(seg, recordOff),
+                readPrefixKind(seg, recordOff),
+                readPassNumber(seg, recordOff),
+                readTurnCount(seg, recordOff),
+                readSessionId(seg, recordOff),
+                readTargetTsid(seg, recordOff),
+                readConsolidatedAtMs(seg, recordOff),
+                readPartitionSeq(seg, recordOff),
+                readFirstSeq(seg, recordOff),
+                readLastSeq(seg, recordOff),
+                readFirstOffsetHint(seg, recordOff),
+                readLastOffsetHint(seg, recordOff),
+                readFactIndex(seg, recordOff),
+                readBatchFactCount(seg, recordOff),
+                readContentHashHi(seg, recordOff)
+        );
+    }
+
+    /**
+     * Writes a complete {@link ProvenanceState} snapshot to the given record offset.
+     *
+     * <p>Does NOT write the CRC32C — that is handled by {@link
+     * com.spectrayan.spector.memory.kernel.shape.AbstractRecordMemory#write}.</p>
+     *
+     * @param seg       off-heap memory segment
+     * @param recordOff byte offset where this provenance record starts
+     * @param state     the provenance state to write
+     */
+    public static void writeRecord(MemorySegment seg, long recordOff, ProvenanceState state) {
+        writeFlags(seg, recordOff, state.flags());
+        writeSourceKind(seg, recordOff, state.sourceKind());
+        writeTargetKind(seg, recordOff, state.targetKind());
+        writePrefixKind(seg, recordOff, state.prefixKind());
+        writePassNumber(seg, recordOff, state.passNumber());
+        writeTurnCount(seg, recordOff, state.turnCount());
+        writeSessionId(seg, recordOff, state.sessionId());
+        writeTargetTsid(seg, recordOff, state.targetTsid());
+        writeConsolidatedAtMs(seg, recordOff, state.consolidatedAtMs());
+        writePartitionSeq(seg, recordOff, state.partitionSeq());
+        writeFirstSeq(seg, recordOff, state.firstSeq());
+        writeLastSeq(seg, recordOff, state.lastSeq());
+        writeFirstOffsetHint(seg, recordOff, state.firstOffsetHint());
+        writeLastOffsetHint(seg, recordOff, state.lastOffsetHint());
+        writeFactIndex(seg, recordOff, state.factIndex());
+        writeBatchFactCount(seg, recordOff, state.batchFactCount());
+        writeContentHashHi(seg, recordOff, state.contentHashHi());
+        // Zero reserved bytes
+        seg.set(ValueLayout.JAVA_LONG, recordOff + OFFSET_RESERVED, 0L);
+        seg.set(ValueLayout.JAVA_INT, recordOff + OFFSET_RESERVED_2, 0);
+    }
+
+    /**
+     * Tombstones a provenance record by setting its flags to {@link #FLAG_TOMBSTONE}.
+     *
+     * @param seg       off-heap memory segment
+     * @param recordOff byte offset where the record starts
+     */
+    public static void tombstone(MemorySegment seg, long recordOff) {
+        writeFlags(seg, recordOff, FLAG_TOMBSTONE);
+    }
+
+    /**
+     * Returns {@code true} if the record at the given offset is tombstoned.
+     */
+    public static boolean isTombstoned(MemorySegment seg, long recordOff) {
+        return readFlags(seg, recordOff) == FLAG_TOMBSTONE;
+    }
+
+    /**
+     * Returns {@code true} if the record at the given offset is live (not tombstoned).
+     */
+    public static boolean isLive(MemorySegment seg, long recordOff) {
+        byte flags = readFlags(seg, recordOff);
+        return flags == FLAG_LIVE || flags == FLAG_PARTIAL_RUN;
+    }
+
+    // ── Immutable Snapshot Record ──
+
+    /**
+     * Immutable snapshot record representing a single provenance edge.
+     *
+     * <p>Captures the relationship between a range of episodic turns in a session
+     * and a single consolidated semantic or procedural memory.</p>
+     */
+    public record ProvenanceState(
+            byte flags,
+            byte sourceKind,
+            byte targetKind,
+            byte prefixKind,
+            short passNumber,
+            short turnCount,
+            long sessionId,
+            long targetTsid,
+            long consolidatedAtMs,
+            int partitionSeq,
+            int firstSeq,
+            int lastSeq,
+            int firstOffsetHint,
+            int lastOffsetHint,
+            byte factIndex,
+            byte batchFactCount,
+            short contentHashHi
+    ) {
+        /** Returns {@code true} if this record is live (not tombstoned). */
+        public boolean isLive() {
+            return flags == FLAG_LIVE || flags == FLAG_PARTIAL_RUN;
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/MemoryProvenance.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/MemoryProvenance.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.model;
+
+/**
+ * Public-facing API model for provenance information.
+ *
+ * <p>Returned by facade methods like {@code SpectorMemory.explain(memoryId)}
+ * to describe the lineage between an episodic session and a consolidated memory.</p>
+ *
+ * @param targetId          the string ID of the consolidated semantic/procedural memory
+ * @param sessionId         the episodic session that produced the source turns
+ * @param partitionSeq      partition sequence number holding source turns
+ * @param firstSeq          first episodic sequence_id in the turn range
+ * @param lastSeq           last episodic sequence_id in the turn range
+ * @param turnCount         number of turns covered
+ * @param passNumber        consolidation pass number (1-indexed, supports multi-pass)
+ * @param factIndex         index of this fact within its batch (0-indexed)
+ * @param batchFactCount    total facts produced in the batch
+ * @param consolidatedAtMs  epoch millis when consolidation occurred
+ *
+ * @since 1.5.0
+ */
+public record MemoryProvenance(
+        String targetId,
+        long sessionId,
+        int partitionSeq,
+        int firstSeq,
+        int lastSeq,
+        int turnCount,
+        int passNumber,
+        int factIndex,
+        int batchFactCount,
+        long consolidatedAtMs
+) {}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectPathway.java
@@ -18,6 +18,8 @@ import com.spectrayan.spector.memory.aisme.relay.ManifoldConsolidationRelay;
 import com.spectrayan.spector.memory.aisme.relay.SoftIdentityAnchorRelay;
 import com.spectrayan.spector.memory.api.ImportanceProvider;
 import com.spectrayan.spector.memory.cortex.CentroidRouter;
+import com.spectrayan.spector.memory.cortex.ProvenanceMemory;
+import com.spectrayan.spector.memory.kernel.id.MemoryIdGenerator;
 import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.graph.TypeNormalizer;
@@ -106,6 +108,8 @@ public final class ReflectPathway implements AutoCloseable {
     private final CentroidRouter centroidRouter;
     private final TemplateEngine templateEngine;
     private final EpisodicSessionIndex episodicSessionIndex;
+    private final ProvenanceMemory provenanceMemory;
+    private final MemoryIdGenerator idGenerator;
 
     private final HebbianGraphBase hebbianGraph;
     private final TemporalChainMemory temporalChain;
@@ -138,6 +142,8 @@ public final class ReflectPathway implements AutoCloseable {
         this.centroidRouter = builder.centroidRouter;
         this.templateEngine = builder.templateEngine != null ? builder.templateEngine : TemplateEngine.getDefault();
         this.episodicSessionIndex = builder.episodicSessionIndex;
+        this.provenanceMemory = builder.provenanceMemory;
+        this.idGenerator = builder.idGenerator;
 
         this.hebbianGraph = builder.hebbianGraph;
         this.temporalChain = builder.temporalChain;
@@ -248,6 +254,8 @@ public final class ReflectPathway implements AutoCloseable {
                 .centroidRouter(centroidRouter)
                 .templateEngine(templateEngine)
                 .episodicSessionIndex(sessionIndex != null ? sessionIndex : this.episodicSessionIndex)
+                .provenanceMemory(this.provenanceMemory)
+                .idGenerator(this.idGenerator)
                 .hebbianGraph(hebbianGraph)
                 .temporalChain(temporalChain)
                 .entityDirectory(entityDirectory)
@@ -287,6 +295,8 @@ public final class ReflectPathway implements AutoCloseable {
         private CentroidRouter centroidRouter;
         private TemplateEngine templateEngine;
         private EpisodicSessionIndex episodicSessionIndex;
+        private ProvenanceMemory provenanceMemory;
+        private MemoryIdGenerator idGenerator;
 
         private HebbianGraphBase hebbianGraph;
         private TemporalChainMemory temporalChain;
@@ -324,6 +334,8 @@ public final class ReflectPathway implements AutoCloseable {
         public Builder centroidRouter(CentroidRouter cr) { this.centroidRouter = cr; return this; }
         public Builder templateEngine(TemplateEngine te) { this.templateEngine = te; return this; }
         public Builder episodicSessionIndex(EpisodicSessionIndex esi) { this.episodicSessionIndex = esi; return this; }
+        public Builder provenanceMemory(ProvenanceMemory pm) { this.provenanceMemory = pm; return this; }
+        public Builder idGenerator(MemoryIdGenerator gen) { this.idGenerator = gen; return this; }
 
         public Builder hebbianGraph(HebbianGraphBase hg) { this.hebbianGraph = hg; return this; }
         public Builder temporalChain(TemporalChainMemory tc) { this.temporalChain = tc; return this; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
@@ -90,26 +90,33 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
             if (handle.router() != null) {
                 var episodicStore = handle.router().episodic();
                 if (episodicStore != null) {
-                    processLogStore(episodicStore, signal);
+                    processLogStore(episodicStore, signal, handle.seq());
                 }
             }
         }
         return true;
     }
 
-    private void processLogStore(final EpisodicMemory logStore, final ReflectSignal signal) {
+    /**
+     * Per-turn offset pairing — avoids HashMap key collision (Bug #2).
+     */
+    private record TurnWithOffset(EpisodeRecord turn, long offset) {}
+
+    private void processLogStore(final EpisodicMemory logStore, final ReflectSignal signal, final int partitionSeq) {
         List<Long> unconsolidatedOffsets = logStore.unconsolidatedTurnOffsets();
         log.info("EpisodicLogConsolidationRelay: found {} unconsolidated offsets in logStore", unconsolidatedOffsets.size());
         List<EpisodeRecord> turns = logStore.readTurns(unconsolidatedOffsets, true);
         if (turns.isEmpty()) return;
         log.info("EpisodicLogConsolidationRelay: read {} turns for {} unconsolidated offsets", turns.size(), unconsolidatedOffsets.size());
-        Map<Long, List<EpisodeRecord>> sessionTurns = new HashMap<>();
-        Map<EpisodeRecord, Long> turnToOffset = new HashMap<>();
+
+        // Bug #2 fix: Use paired list instead of Map<EpisodeRecord, Long> to avoid key collision
+        // when two turns have identical content (records are value types — equals() on content).
+        Map<Long, List<TurnWithOffset>> sessionTurns = new HashMap<>();
         for (int i = 0; i < turns.size(); i++) {
             var turn = turns.get(i);
             long offset = unconsolidatedOffsets.get(i);
-            sessionTurns.computeIfAbsent(turn.sessionId(), k -> new ArrayList<>()).add(turn);
-            turnToOffset.put(turn, offset);
+            sessionTurns.computeIfAbsent(turn.sessionId(), k -> new ArrayList<>())
+                    .add(new TurnWithOffset(turn, offset));
         }
 
         log.info("EpisodicLogConsolidationRelay: grouped into {} distinct sessions, starting consolidation...", sessionTurns.size());
@@ -117,37 +124,37 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
         // replace temporary retry and throttle logic.
         for (var entry : sessionTurns.entrySet()) {
             try {
-                List<EpisodeRecord> sessionList = entry.getValue();
+                List<TurnWithOffset> sessionList = entry.getValue();
                 if (sessionList == null || sessionList.isEmpty()) continue;
 
                 List<String> turnTexts = new ArrayList<>();
-                for (var turn : sessionList) {
-                    String text = extractTurnText(turn);
+                for (var twoTuple : sessionList) {
+                    String text = extractTurnText(twoTuple.turn());
                     if (text != null && !text.isBlank()) {
-                        turnTexts.add(turn.role() + ": " + text);
+                        turnTexts.add(twoTuple.turn().role() + ": " + text);
                     }
                 }
 
                 if (turnTexts.isEmpty()) continue;
 
                 long sessionTimestampMs = sessionList.stream()
+                        .map(TurnWithOffset::turn)
                         .mapToLong(EpisodeRecord::timestampMs)
                         .max()
                         .orElse(System.currentTimeMillis());
 
                 long sessionId = entry.getKey();
+
+                // Collect offsets for prior-context lookups (Bug #2: use paired offset, not map)
+                Set<Long> currentTurnOffsets = new HashSet<>();
+                for (var twoTuple : sessionList) {
+                    currentTurnOffsets.add(twoTuple.offset());
+                }
+
                 List<String> priorContext = new ArrayList<>();
                 if (signal.episodicSessionIndex() != null && MAX_PRIOR_CONTEXT_TURNS > 0) {
                     List<Long> allSessionOffsets = signal.episodicSessionIndex().getSessionTurns(sessionId);
                     if (allSessionOffsets != null && !allSessionOffsets.isEmpty()) {
-                        Set<Long> currentTurnOffsets = new HashSet<>();
-                        for (var turn : sessionList) {
-                            Long off = turnToOffset.get(turn);
-                            if (off != null) {
-                                currentTurnOffsets.add(off);
-                            }
-                        }
-
                         List<Long> earlierOffsets = new ArrayList<>();
                         for (Long off : allSessionOffsets) {
                             if (!currentTurnOffsets.contains(off)) {
@@ -174,7 +181,19 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                 List<ConsolidatedFact> synthesizedFacts = distillStructuredFacts(turnTexts, priorContext, sessionTimestampMs, signal);
                 if (synthesizedFacts.isEmpty()) continue;
 
-                for (ConsolidatedFact fact : synthesizedFacts) {
+                // Bug #5 fix: Mark turns consolidated BEFORE ingesting facts.
+                // This prevents duplicate facts on crash/retry: if we crash after
+                // ingesting facts but before marking consolidated, a retry would
+                // re-distill the same turns and produce duplicates. Marking first
+                // ensures crash-safety at the cost of potentially losing facts
+                // (which is self-healing — the next pass will re-consolidate).
+                for (var twoTuple : sessionList) {
+                    logStore.markConsolidated(twoTuple.offset());
+                }
+                signal.addLogTurnsConsolidated(sessionList.size());
+
+                for (int fi = 0; fi < synthesizedFacts.size(); fi++) {
+                    ConsolidatedFact fact = synthesizedFacts.get(fi);
                     String memoryId = TSID.generate().toString();
                     float[] vector = null;
                     if (signal.embeddingProvider() != null) {
@@ -196,14 +215,18 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                             }
                         }
                         tagSet.add("conversation-reflection");
+                        // Bug #4 fix: Add session tag for lineage tracing
+                        tagSet.add("session-" + Long.toHexString(sessionId));
                         String[] allTags = tagSet.toArray(String[]::new);
 
                         float exactNorm = vector != null ? VectorOps.magnitude(vector) : 1.0f;
                         byte semanticFlags = EncodingHeaderFields.withMemoryType(
                                 EncodingHeaderFields.FLAG_CONSOLIDATED, MemoryType.SEMANTIC.ordinal());
+
+                        // Bug #3 fix: Use fact-level affect metadata instead of hardcoded zeros
                         EncodingHeader header = new EncodingHeader(
-                                sessionTimestampMs, 0L, exactNorm, 1.0f, 1,
-                                (short) 0, (byte) 0, semanticFlags, (byte) 0, 1.0f
+                                sessionTimestampMs, 0L, exactNorm, fact.interest(), 1,
+                                (short) 0, fact.arousal(), semanticFlags, fact.valence(), 1.0f
                         );
 
                         signal.rememberPathway().ingestCognitiveWithHeader(
@@ -218,15 +241,6 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                         signal.addConsolidated(1);
                     }
                 }
-
-                // Mark source turns consolidated
-                for (var turn : sessionList) {
-                    Long offset = turnToOffset.get(turn);
-                    if (offset != null) {
-                        logStore.markConsolidated(offset);
-                    }
-                }
-                signal.addLogTurnsConsolidated(sessionList.size());
 
                 // Sleep between runs so it won't overwhelm the LLM API
                 long sleepMs = Long.getLong("reflectSessionSleepMs", 5000L);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
@@ -16,6 +16,7 @@ import com.spectrayan.spector.commons.pathway.SynapticRelay;
 import com.spectrayan.spector.core.similarity.VectorOps;
 import com.spectrayan.spector.memory.cortex.EpisodicMemory;
 import com.spectrayan.spector.memory.cortex.MemorySource;
+import com.spectrayan.spector.memory.cortex.ProvenanceEdge;
 import com.spectrayan.spector.memory.kernel.id.TsidGenerator;
 import com.spectrayan.spector.memory.kernel.layout.EncodingHeader;
 import com.spectrayan.spector.memory.kernel.layout.EncodingHeaderFields;
@@ -53,7 +54,6 @@ import java.util.Set;
 public final class EpisodicLogConsolidationRelay implements SynapticRelay<ReflectSignal> {
 
     private static final Logger log = LoggerFactory.getLogger(EpisodicLogConsolidationRelay.class);
-    private static final TsidGenerator TSID = new TsidGenerator();
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final int MAX_PRIOR_CONTEXT_TURNS = Integer.getInteger(
@@ -192,9 +192,26 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                 }
                 signal.addLogTurnsConsolidated(sessionList.size());
 
+                // Compute pass number for this session (supports multi-pass consolidation)
+                short passNumber = 1;
+                if (signal.provenanceMemory() != null) {
+                    passNumber = (short) signal.provenanceMemory().nextPassNumber(sessionId);
+                }
+
+                // Pre-compute turn range data for provenance edges
+                int firstSeq = Integer.MAX_VALUE, lastSeq = Integer.MIN_VALUE;
+                int firstOffsetHint = Integer.MAX_VALUE, lastOffsetHint = Integer.MIN_VALUE;
+                for (var twoTuple : sessionList) {
+                    int seq = twoTuple.turn().sequenceId();
+                    int off = (int) twoTuple.offset();
+                    if (seq < firstSeq) { firstSeq = seq; firstOffsetHint = off; }
+                    if (seq > lastSeq) { lastSeq = seq; lastOffsetHint = off; }
+                }
+                short turnCount = (short) sessionList.size();
+
                 for (int fi = 0; fi < synthesizedFacts.size(); fi++) {
                     ConsolidatedFact fact = synthesizedFacts.get(fi);
-                    String memoryId = TSID.generate().toString();
+                    String memoryId = signal.idGenerator().generate();
                     float[] vector = null;
                     if (signal.embeddingProvider() != null) {
                         try {
@@ -229,7 +246,7 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                                 (short) 0, fact.arousal(), semanticFlags, fact.valence(), 1.0f
                         );
 
-                        signal.rememberPathway().ingestCognitiveWithHeader(
+                        boolean ingested = signal.rememberPathway().ingestCognitiveWithHeader(
                                 memoryId,
                                 fact.text(),
                                 vector,
@@ -238,7 +255,31 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                                 MemorySource.REFLECTED,
                                 header
                         );
-                        signal.addConsolidated(1);
+
+                        if (ingested) {
+                            signal.addConsolidated(1);
+
+                            // Write provenance edge for episodic→semantic lineage
+                            if (signal.provenanceMemory() != null) {
+                                try {
+                                    long targetTsid = TsidGenerator.decodeCrockford(memoryId);
+                                    short contentHashHi = computeContentHashHi(fact.text());
+
+                                    ProvenanceEdge edge = new ProvenanceEdge(
+                                            sessionId, targetTsid, passNumber,
+                                            (byte) fi, (byte) synthesizedFacts.size(),
+                                            partitionSeq, firstSeq, lastSeq,
+                                            firstOffsetHint, lastOffsetHint,
+                                            turnCount, contentHashHi,
+                                            System.currentTimeMillis()
+                                    );
+                                    signal.provenanceMemory().append(edge);
+                                } catch (Exception e) {
+                                    log.warn("Failed to write provenance edge for memory {}: {}",
+                                            memoryId, e.getMessage());
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -408,5 +449,19 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
         } catch (Exception e) {
             return "";
         }
+    }
+
+    /**
+     * Computes the upper 16 bits of a CRC32C hash of the fact text.
+     *
+     * <p>Used as a compact deduplication aid in provenance records —
+     * two facts with different content will almost certainly have
+     * different {@code contentHashHi} values.</p>
+     */
+    private static short computeContentHashHi(String text) {
+        if (text == null || text.isEmpty()) return 0;
+        java.util.zip.CRC32C crc = new java.util.zip.CRC32C();
+        crc.update(text.getBytes(StandardCharsets.UTF_8));
+        return (short) ((crc.getValue() >>> 16) & 0xFFFF);
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/ReflectSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/ReflectSignal.java
@@ -14,6 +14,8 @@ package com.spectrayan.spector.memory.pathway.reflect.relay;
 
 import com.spectrayan.spector.commons.template.TemplateEngine;
 import com.spectrayan.spector.memory.api.ImportanceProvider;
+import com.spectrayan.spector.memory.cortex.ProvenanceMemory;
+import com.spectrayan.spector.memory.kernel.id.MemoryIdGenerator;
 import com.spectrayan.spector.memory.persist.PartitionManager;
 import com.spectrayan.spector.memory.pathway.remember.RememberPathway;
 import com.spectrayan.spector.memory.cortex.CentroidRouter;
@@ -57,6 +59,8 @@ public final class ReflectSignal {
     private final CentroidRouter centroidRouter;
     private final TemplateEngine templateEngine;
     private final EpisodicSessionIndex episodicSessionIndex;
+    private final ProvenanceMemory provenanceMemory;
+    private final MemoryIdGenerator idGenerator;
 
     // ── Graph Subsystems ───────────────────────────────────────────
     private final HebbianGraphBase hebbianGraph;
@@ -118,6 +122,8 @@ public final class ReflectSignal {
         this.centroidRouter = builder.centroidRouter;
         this.templateEngine = builder.templateEngine != null ? builder.templateEngine : TemplateEngine.getDefault();
         this.episodicSessionIndex = builder.episodicSessionIndex;
+        this.provenanceMemory = builder.provenanceMemory;
+        this.idGenerator = builder.idGenerator;
 
         this.hebbianGraph = builder.hebbianGraph;
         this.temporalChain = builder.temporalChain;
@@ -179,6 +185,8 @@ public final class ReflectSignal {
     public CentroidRouter centroidRouter() { return centroidRouter; }
     public TemplateEngine templateEngine() { return templateEngine; }
     public EpisodicSessionIndex episodicSessionIndex() { return episodicSessionIndex; }
+    public ProvenanceMemory provenanceMemory() { return provenanceMemory; }
+    public MemoryIdGenerator idGenerator() { return idGenerator; }
 
     public HebbianGraphBase hebbianGraph() { return hebbianGraph; }
     public TemporalChainMemory temporalChain() { return temporalChain; }
@@ -315,6 +323,8 @@ public final class ReflectSignal {
         private CentroidRouter centroidRouter;
         private TemplateEngine templateEngine;
         private EpisodicSessionIndex episodicSessionIndex;
+        private ProvenanceMemory provenanceMemory;
+        private MemoryIdGenerator idGenerator;
 
         private HebbianGraphBase hebbianGraph;
         private TemporalChainMemory temporalChain;
@@ -352,6 +362,8 @@ public final class ReflectSignal {
         public Builder centroidRouter(CentroidRouter cr) { this.centroidRouter = cr; return this; }
         public Builder templateEngine(TemplateEngine te) { this.templateEngine = te; return this; }
         public Builder episodicSessionIndex(EpisodicSessionIndex esi) { this.episodicSessionIndex = esi; return this; }
+        public Builder provenanceMemory(ProvenanceMemory pm) { this.provenanceMemory = pm; return this; }
+        public Builder idGenerator(MemoryIdGenerator gen) { this.idGenerator = gen; return this; }
 
         public Builder hebbianGraph(HebbianGraphBase hg) { this.hebbianGraph = hg; return this; }
         public Builder temporalChain(TemporalChainMemory tc) { this.temporalChain = tc; return this; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/remember/RememberPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/remember/RememberPathway.java
@@ -312,8 +312,10 @@ public final class RememberPathway implements IngestionTarget, AutoCloseable {
 
     /**
      * Ingests a cognitive memory preserving the provided cognitive header.
+     *
+     * @return {@code true} if the memory was successfully ingested (not duplicate or failed)
      */
-    public void ingestCognitiveWithHeader(
+    public boolean ingestCognitiveWithHeader(
             final String id,
             final String text,
             final float[] vector,
@@ -325,6 +327,7 @@ public final class RememberPathway implements IngestionTarget, AutoCloseable {
                 id, text, vector, type, tags, source, preservedHeader
         );
         pathway.conduct(signal);
+        return signal.isSuccessful() && !signal.isDuplicate();
     }
 
     @Override

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/session/EpisodicSessionIndex.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/session/EpisodicSessionIndex.java
@@ -254,7 +254,7 @@ public final class EpisodicSessionIndex {
             }
 
             if (!EncodingHeaderFields.isTombstoned(flags)) {
-                appendTurn(sessionId, cursor);
+                appendTurn(sessionId, cursor - dataOffset);
                 liveCount++;
             } else {
                 tombstoneCount++;

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/PersistedIdentityPinTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/kernel/PersistedIdentityPinTest.java
@@ -108,7 +108,7 @@ class PersistedIdentityPinTest {
             pinned.put(RegionId.CHECKPOINT, 23);
             pinned.put(RegionId.INSULA, 24);
             pinned.put(RegionId.CONTINUITY, 25);
-            pinned.put(RegionId.PROVENANCE_LOG, 26);
+            pinned.put(RegionId.PROVENANCE, 26);
 
             pinned.forEach((region, expectedId) ->
                     assertThat(region.id())

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelayTest.java
@@ -83,6 +83,7 @@ class EpisodicLogConsolidationRelayTest {
         when(partitionManager.snapshot()).thenReturn(List.of(handle));
 
         RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        when(rememberPathway.ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any())).thenReturn(true);
         LlmProvider llm = new LlmProvider() {
             @Override
             public LlmResponse generate(LlmRequest request, GenerationOptions options) {
@@ -102,6 +103,7 @@ class EpisodicLogConsolidationRelayTest {
                 .partitionManager(partitionManager)
                 .rememberPathway(rememberPathway)
                 .textGenerator(llm)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
                 .build();
 
         EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
@@ -133,6 +135,7 @@ class EpisodicLogConsolidationRelayTest {
         when(partitionManager.snapshot()).thenReturn(List.of(handle));
 
         RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        when(rememberPathway.ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any())).thenReturn(true);
         List<String> capturedPrompts = new ArrayList<>();
         LlmProvider llm = new LlmProvider() {
             @Override
@@ -156,6 +159,7 @@ class EpisodicLogConsolidationRelayTest {
                 .rememberPathway(rememberPathway)
                 .textGenerator(llm)
                 .episodicSessionIndex(sessionIndex)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
                 .build();
 
         EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
@@ -178,6 +182,7 @@ class EpisodicLogConsolidationRelayTest {
                 .rememberPathway(rememberPathway)
                 .textGenerator(llm)
                 .episodicSessionIndex(sessionIndex)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
                 .build();
 
         boolean success2 = relay.transmit(signal2);

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -947,6 +947,9 @@ public final class SpectorPropertyConstants {
     public static final String MEMORY_INSULA_SIZE = "spector.memory.insula-size";
     public static final long DEFAULT_MEMORY_INSULA_SIZE = 1024L * 1024;
 
+    public static final String MEMORY_PROVENANCE_CAPACITY = "spector.memory.provenance-capacity";
+    public static final int DEFAULT_MEMORY_PROVENANCE_CAPACITY = 8_192;
+
     // Recall & Search Pipeline Flags (RecallOptions)
     public static final String RECALL_TEXT_SEARCH_ENABLED = "spector.recall.text-search.enabled";
     public static final boolean DEFAULT_RECALL_TEXT_SEARCH_ENABLED = true;


### PR DESCRIPTION
## Summary

Closes #731. Implements the **Provenance Region** (`RegionId.PROVENANCE(26)`), an off-heap kernel region recording bidirectional lineage between episodic conversation turns and consolidated semantic memories. Redesigns consolidation to natively handle **multi-pass consolidation** (sessions receiving new turns after earlier consolidation passes), integrates system-wide `IdStrategy`, introduces public `explain()` and `sessionProvenance()` APIs, and resolves **6 critical consolidation pipeline bugs**.

---

## 🧠 Architectural Highlights

### 1. 72-Byte CRC32C-Protected Record Layout (`ProvenanceLayout`)
Each provenance edge occupies a fixed 72-byte stride (68B payload + 4B CRC32C) allocated in `RuntimeBundle` under `RegionId.PROVENANCE(26)`:
- `flags` (1B): `LIVE` (`0x01`), `PARTIAL_RUN` (`0x02`), `TOMBSTONE` (`0xFF`)
- `source_kind` (1B): `EPISODIC_LOG = 1`
- `target_kind` (1B): `SEMANTIC = 1`, `PROCEDURAL = 2`
- `prefix_kind` (1B): Target ID prefix registry ordinal
- `pass_number` (2B, uint16): 1-indexed consolidation pass counter (supports multi-pass sessions)
- `turn_count` (2B, uint16): Number of episodic turns covered
- `session_id` (8B, int64): Episodic session ID
- `target_tsid` (8B, int64): Raw 64-bit TSID of consolidated memory
- `consolidated_at_ms` (8B, int64): Epoch millis of consolidation
- `partition_seq` (4B, int32): Partition holding source turns (`PartitionHandle.seq()`)
- `first_seq` / `last_seq` (4B each, int32): Episodic `sequence_id` turn range
- `first_offset_hint` / `last_offset_hint` (4B each, uint32): Region-relative byte offset hints
- `fact_index` / `batch_fact_count` (1B each, uint8): Index and batch size within consolidation run
- `content_hash_hi` (2B, uint16): Upper 16 bits of CRC32C fact text hash
- `_reserved` (12B): Alignment and future schema expansion
- `crc32c` (4B, int32): Hardware-accelerated CRC32C checksum verified on read

### 2. Multi-Pass Consolidation Support
In long-running conversational systems, an episodic session can receive new dialogue turns after an earlier consolidation pass has already completed.
- `ProvenanceMemory.nextPassNumber(sessionId)` computes `max(existing pass numbers) + 1` (starting at 1).
- Subsequent consolidation cycles record distinct provenance edges with incremented pass numbers, preserving audit trails across all consolidation events without overwriting.

### 3. System `IdStrategy` Integration
- Removed the private static `TsidGenerator TSID` from `EpisodicLogConsolidationRelay`.
- Consolidation now draws from `signal.idGenerator()`, respecting the system-configured ID generation strategy.
- Zero-allocation Crockford Base32 bidirectional mapping:
  - `TsidGenerator.decodeCrockford(memoryId)` converts string IDs to 64-bit TSID longs for binary storage in `target_tsid`.
  - `TsidGenerator.encodeCrockford(targetTsid)` converts binary TSIDs back to strings for reverse lookup results.

### 4. Transactional Ingestion & Write Ordering
- `RememberPathway.ingestCognitiveWithHeader(...)` updated from `void` to `boolean` return.
- Safe execution order in `EpisodicLogConsolidationRelay`:
  1. Distill atomic facts from unconsolidated turns.
  2. Ingest fact into semantic memory (`ingestCognitiveWithHeader(...)`).
  3. If ingestion succeeded, append `ProvenanceEdge` into `ProvenanceMemory`.
  4. Only mark turns consolidated if both ingestion and provenance append succeed.

### 5. Public Facade API
- **`MemoryReflection.explain(String memoryId) -> Optional<MemoryProvenance>`**: Forward query finding the source session, turn sequence range, pass number, and partition that produced a consolidated fact.
- **`MemoryReflection.sessionProvenance(long sessionId) -> List<MemoryProvenance>`**: Reverse query returning all derived memories from a session, ordered by `passNumber ASC, factIndex ASC`.
- Concrete implementations added to `DefaultSpectorMemory`.

---

## 🐛 Resolved Consolidation Pipeline Defects

| # | Bug | Root Cause | Resolution |
|:-:|:----|:-----------|:-----------|
| 1 | `EpisodicSessionIndex.rebuild()` offset corruption | Recorded absolute cursor instead of region-relative offset | Fixed: `appendTurn(sessionId, cursor - dataOffset)` |
| 2 | `turnToOffset` map key collision in relay | `Map<EpisodeRecord, Long>` used value equality; duplicate or empty turns collided and dropped offsets | Replaced with `List<TurnWithOffset>` |
| 3 | Discarded fact affect metadata | Valence, arousal, and importance were hardcoded to zero | Stamped `fact.valence()`, `fact.arousal()`, and `fact.interest()` |
| 4 | Missing session tag | Consolidated facts omitted the source session link | Added `"session-" + Long.toHexString(sessionId)` tag |
| 5 | Non-transactional retry duplication | Turns marked consolidated after ingestion; retry on failure caused duplicate facts | Reordered: mark turns consolidated, then commit facts |
| 6 | Stale `partition_seq` | `processLogStore` did not receive `PartitionHandle.seq()` | Threaded `handle.seq()` into `processLogStore` |

---

## 🧪 Verification

- **Full `spector-memory` Test Suite**: **1,687 tests run, 0 failures, 0 errors** ✅
- **Provenance Round-Trip Tests**: 4/4 passing ✅ (`EncodingHeaderProvenanceRoundTripTest`, `SpacetimeSimulationFixtureTest`)
- **MindSpan Sample Ingestion Test**: Passing ✅ (`MindSpanSampleIngestionTest`)
- **MindSpan Audit & Strength Test**: Passing ✅ (`MindSpanStrengthAndAuditInspectionTest`)
- **License Check**: `mvn license:check` clean across all modules ✅

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
