### PR TITLE
feat(core): implement episodic slab-scan fallback for consolidation context (#751)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/cortex/EpisodicMemory.java
@@ -419,6 +419,79 @@ public final class EpisodicMemory extends AbstractAppendMemory<EpisodicLayout> i
     }
 
     /**
+     * Directly scans the episodic log slab for consolidated turn offsets belonging to the given session.
+     *
+     * <p>Used as an offline/isolated fallback during REM sleep reflection when {@link EpisodicSessionIndex}
+     * is unavailable or un-rebuilt on the signal. Returns up to {@code maxTurns} relative offsets
+     * ({@code cursor - dataOffset()}) in chronological order.</p>
+     *
+     * @param sessionId the target episodic session ID
+     * @param maxTurns  maximum number of most recent consolidated turn offsets to return (must be > 0)
+     * @return chronological list of relative byte offsets for the session's consolidated turns (at most {@code maxTurns})
+     */
+    public List<Long> lastConsolidatedTurnOffsets(long sessionId, int maxTurns) {
+        if (maxTurns <= 0) {
+            return List.of();
+        }
+        List<Long> matching = new ArrayList<>();
+        long base = dataOffset();
+        long limit = base + this.count;
+        long current = base;
+
+        var headerLayout = layout().headerLayout();
+        while (current + EncodingHeaderFields.HEADER_BYTES <= limit) {
+            byte flags;
+            long recordSessionId;
+            long recordEnd;
+
+            if (headerLayout.isOptionBRecord(segment(), current)) {
+                int payloadBytes = headerLayout.readPayloadBytes(segment(), current);
+                if (payloadBytes < 0) {
+                    break;
+                }
+                recordEnd = current + EpisodicLayout.FIXED_OVERHEAD_BYTES + payloadBytes;
+                if (recordEnd > limit) {
+                    break;
+                }
+                flags = headerLayout.readFlagsRecord(segment(), current);
+                long headerSessionId = headerLayout.readSessionIdRecord(segment(), current);
+                if (headerSessionId != 0L) {
+                    recordSessionId = headerSessionId;
+                } else {
+                    long payloadOffset = current + EpisodicLayout.FIXED_OVERHEAD_BYTES;
+                    recordSessionId = (payloadBytes >= EpisodeCodec.PAYLOAD_METADATA_BYTES)
+                            ? segment().get(ValueLayout.JAVA_LONG_UNALIGNED, payloadOffset + EpisodeCodec.OFFSET_SESSION_ID)
+                            : 0L;
+                }
+            } else {
+                flags = LegacyEpisodeHeaderReader.readFlags(segment(), current);
+                int bodyLength = LegacyEpisodeHeaderReader.readBodyLength(segment(), current);
+                if (bodyLength < 0) {
+                    break;
+                }
+                recordEnd = current + EncodingHeaderFields.HEADER_BYTES + bodyLength;
+                if (recordEnd > limit) {
+                    break;
+                }
+                recordSessionId = LegacyEpisodeHeaderReader.readSessionId(segment(), current);
+            }
+
+            if (recordSessionId == sessionId
+                    && !EncodingHeaderFields.isTombstoned(flags)
+                    && EncodingHeaderFields.isConsolidated(flags)) {
+                matching.add(current - base);
+            }
+
+            current = recordEnd;
+        }
+
+        if (matching.size() > maxTurns) {
+            return matching.subList(matching.size() - maxTurns, matching.size());
+        }
+        return matching;
+    }
+
+    /**
      * Returns the total count of live (non-tombstoned) turns in this episodic store.
      */
     public int liveTurnCount() {

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
@@ -152,26 +152,43 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                 }
 
                 List<String> priorContext = new ArrayList<>();
-                if (signal.episodicSessionIndex() != null && MAX_PRIOR_CONTEXT_TURNS > 0) {
-                    List<Long> allSessionOffsets = signal.episodicSessionIndex().getSessionTurns(sessionId);
-                    if (allSessionOffsets != null && !allSessionOffsets.isEmpty()) {
-                        List<Long> earlierOffsets = new ArrayList<>();
-                        for (Long off : allSessionOffsets) {
-                            if (!currentTurnOffsets.contains(off)) {
-                                earlierOffsets.add(off);
+                if (MAX_PRIOR_CONTEXT_TURNS > 0) {
+                    List<Long> windowOffsets = null;
+                    if (signal.episodicSessionIndex() != null) {
+                        List<Long> allSessionOffsets = signal.episodicSessionIndex().getSessionTurns(sessionId);
+                        if (allSessionOffsets != null && !allSessionOffsets.isEmpty()) {
+                            List<Long> earlierOffsets = new ArrayList<>();
+                            for (Long off : allSessionOffsets) {
+                                if (!currentTurnOffsets.contains(off)) {
+                                    earlierOffsets.add(off);
+                                }
+                            }
+                            if (!earlierOffsets.isEmpty()) {
+                                int start = Math.max(0, earlierOffsets.size() - MAX_PRIOR_CONTEXT_TURNS);
+                                windowOffsets = earlierOffsets.subList(start, earlierOffsets.size());
                             }
                         }
+                    } else if (logStore != null) {
+                        // Fallback: directly scan episodic slab when EpisodicSessionIndex is unavailable (#751)
+                        List<Long> candidateOffsets = logStore.lastConsolidatedTurnOffsets(sessionId, MAX_PRIOR_CONTEXT_TURNS);
+                        if (candidateOffsets != null && !candidateOffsets.isEmpty()) {
+                            List<Long> earlierOffsets = new ArrayList<>();
+                            for (Long off : candidateOffsets) {
+                                if (!currentTurnOffsets.contains(off)) {
+                                    earlierOffsets.add(off);
+                                }
+                            }
+                            windowOffsets = earlierOffsets;
+                        }
+                    }
 
-                        if (!earlierOffsets.isEmpty()) {
-                            int start = Math.max(0, earlierOffsets.size() - MAX_PRIOR_CONTEXT_TURNS);
-                            List<Long> windowOffsets = earlierOffsets.subList(start, earlierOffsets.size());
-                            List<EpisodeRecord> priorRecords = logStore.readTurns(windowOffsets, true);
-                            for (var priorRecord : priorRecords) {
-                                if (com.spectrayan.spector.memory.kernel.layout.EncodingHeaderFields.isConsolidated(priorRecord.flags())) {
-                                    String text = extractTurnText(priorRecord);
-                                    if (text != null && !text.isBlank()) {
-                                        priorContext.add(priorRecord.role() + ": " + text);
-                                    }
+                    if (windowOffsets != null && !windowOffsets.isEmpty()) {
+                        List<EpisodeRecord> priorRecords = logStore.readTurns(windowOffsets, true);
+                        for (var priorRecord : priorRecords) {
+                            if (com.spectrayan.spector.memory.kernel.layout.EncodingHeaderFields.isConsolidated(priorRecord.flags())) {
+                                String text = extractTurnText(priorRecord);
+                                if (text != null && !text.isBlank()) {
+                                    priorContext.add(priorRecord.role() + ": " + text);
                                 }
                             }
                         }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/EpisodicMemoryTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/cortex/EpisodicMemoryTest.java
@@ -332,4 +332,74 @@ class EpisodicMemoryTest {
         assertEquals(sessionId, hl.readSessionIdRecord(episodicMemory.segment(), punnedWriteOffset));
         assertEquals(modelId, hl.readModelIdRecord(episodicMemory.segment(), punnedWriteOffset));
     }
+
+    // ── Issue #751: Slab-scan fallback tests ──
+
+    @Test
+    @DisplayName("lastConsolidatedTurnOffsets should return empty list when memory is empty or maxTurns <= 0")
+    void lastConsolidatedTurnOffsets_emptyOrInvalidArgs() {
+        assertTrue(episodicMemory.lastConsolidatedTurnOffsets(123L, 5).isEmpty());
+        assertTrue(episodicMemory.lastConsolidatedTurnOffsets(123L, 0).isEmpty());
+        assertTrue(episodicMemory.lastConsolidatedTurnOffsets(123L, -1).isEmpty());
+    }
+
+    @Test
+    @DisplayName("lastConsolidatedTurnOffsets should return empty list when turns exist but none are consolidated")
+    void lastConsolidatedTurnOffsets_noConsolidatedTurns() {
+        long sessionId = 100L;
+        episodicMemory.appendTurn(ConversationRole.USER, 1, 1000L, sessionId, "Turn 1".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.appendTurn(ConversationRole.ASSISTANT, 2, 2000L, sessionId, "Turn 2".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+
+        List<Long> offsets = episodicMemory.lastConsolidatedTurnOffsets(sessionId, 5);
+        assertTrue(offsets.isEmpty(), "Unconsolidated turns must not be returned");
+    }
+
+    @Test
+    @DisplayName("lastConsolidatedTurnOffsets should return consolidated turns in chronological order capped to maxTurns")
+    void lastConsolidatedTurnOffsets_withConsolidatedTurnsAndLimit() {
+        long targetSession = 200L;
+        long otherSession = 300L;
+
+        // Turn 1 (target, consolidated)
+        long off1 = episodicMemory.appendTurn(ConversationRole.USER, 1, 1000L, targetSession, "Target 1".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.markConsolidated(off1);
+
+        // Turn 2 (other session, consolidated - should be ignored)
+        long offOther = episodicMemory.appendTurn(ConversationRole.USER, 2, 1500L, otherSession, "Other 1".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.markConsolidated(offOther);
+
+        // Turn 3 (target, consolidated)
+        long off3 = episodicMemory.appendTurn(ConversationRole.ASSISTANT, 3, 2000L, targetSession, "Target 2".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.markConsolidated(off3);
+
+        // Turn 4 (target, unconsolidated - should be ignored)
+        episodicMemory.appendTurn(ConversationRole.USER, 4, 3000L, targetSession, "Target 3".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+
+        // Turn 5 (target, consolidated)
+        long off5 = episodicMemory.appendTurn(ConversationRole.ASSISTANT, 5, 4000L, targetSession, "Target 4".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.markConsolidated(off5);
+
+        // Query all 3 consolidated turns
+        List<Long> allOffsets = episodicMemory.lastConsolidatedTurnOffsets(targetSession, 10);
+        assertEquals(List.of(off1, off3, off5), allOffsets, "Should return all 3 consolidated turns in chronological order");
+
+        // Query with maxTurns = 2 (should return the last 2: off3, off5)
+        List<Long> limitedOffsets = episodicMemory.lastConsolidatedTurnOffsets(targetSession, 2);
+        assertEquals(List.of(off3, off5), limitedOffsets, "Should return only the last 2 consolidated turns");
+    }
+
+    @Test
+    @DisplayName("lastConsolidatedTurnOffsets should ignore tombstoned records")
+    void lastConsolidatedTurnOffsets_ignoresTombstoned() {
+        long sessionId = 400L;
+        long off1 = episodicMemory.appendTurn(ConversationRole.USER, 1, 1000L, sessionId, "Turn 1".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.markConsolidated(off1);
+
+        long off2 = episodicMemory.appendTurn(ConversationRole.ASSISTANT, 2, 2000L, sessionId, "Turn 2".getBytes(), (short) 1, 0, 0, 0, 1L, (short) 1, SourceModality.TEXT);
+        episodicMemory.markConsolidated(off2);
+        episodicMemory.tombstone(off2);
+
+        List<Long> offsets = episodicMemory.lastConsolidatedTurnOffsets(sessionId, 5);
+        assertEquals(List.of(off1), offsets, "Tombstoned record must be excluded");
+    }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelayTest.java
@@ -204,4 +204,79 @@ class EpisodicLogConsolidationRelayTest {
         EncodingHeader latestHeader = headerCaptor.getAllValues().get(headerCaptor.getAllValues().size() - 1);
         assertThat(latestHeader.timestampMs()).isEqualTo(6000L);
     }
+
+    @Test
+    @DisplayName("Fallback: Re-consolidation extracts prior context via episodic slab-scan when EpisodicSessionIndex is null (#751)")
+    void testReconsolidationWithPriorContextWindow_FallbackWhenSessionIndexNull() {
+        long sessionId = 999L;
+
+        // Initial session: turns 1 and 2
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, sessionId, "I want to design an event-driven architecture.".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.ASSISTANT, 2, 2000L, sessionId, "You can use Kafka or RabbitMQ as the message broker.".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(workingMemory, semanticMemory, proceduralMemory, logMemory);
+        PartitionManager partitionManager = Mockito.mock(PartitionManager.class);
+        PartitionHandle handle = new PartitionHandle(0, null, router, null, false);
+        when(partitionManager.snapshot()).thenReturn(List.of(handle));
+
+        RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        when(rememberPathway.ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any())).thenReturn(true);
+        List<String> capturedPrompts = new ArrayList<>();
+        LlmProvider llm = new LlmProvider() {
+            @Override
+            public LlmResponse generate(LlmRequest request, GenerationOptions options) {
+                return new LlmResponse("- User wants event-driven architecture", 10, 10, "mock-llm");
+            }
+
+            @Override
+            public String generate(String prompt, GenerationOptions options) {
+                capturedPrompts.add(prompt);
+                return "- User wants event-driven architecture";
+            }
+
+            @Override public boolean isAvailable() { return true; }
+            @Override public String modelName() { return "mock-llm"; }
+        };
+
+        // First consolidation: consolidates turns 1 and 2 (NO session index provided)
+        ReflectSignal signal1 = ReflectSignal.builder()
+                .partitionManager(partitionManager)
+                .rememberPathway(rememberPathway)
+                .textGenerator(llm)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
+                .build();
+
+        EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
+        boolean success1 = relay.transmit(signal1);
+
+        assertThat(success1).isTrue();
+        assertThat(signal1.logTurnsConsolidated()).isEqualTo(2);
+        assertThat(capturedPrompts).hasSize(1);
+        assertThat(capturedPrompts.get(0)).doesNotContain("Prior Context (Already Consolidated");
+
+        // Now add turns 3 and 4 to the SAME session
+        logMemory.appendTurn(ConversationRole.USER, 3, 5000L, sessionId, "Let's go with Kafka because of high throughput requirements.".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.ASSISTANT, 4, 6000L, sessionId, "Understood, Kafka is chosen for high throughput.".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        // Second consolidation: NO session index provided — MUST fallback to slab scan in EpisodicMemory!
+        ReflectSignal signal2 = ReflectSignal.builder()
+                .partitionManager(partitionManager)
+                .rememberPathway(rememberPathway)
+                .textGenerator(llm)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
+                .build();
+
+        boolean success2 = relay.transmit(signal2);
+
+        assertThat(success2).isTrue();
+        assertThat(signal2.logTurnsConsolidated()).isEqualTo(2); // Only the 2 new turns consolidated!
+        assertThat(capturedPrompts).hasSize(2);
+
+        String secondPrompt = capturedPrompts.get(1);
+        assertThat(secondPrompt).contains("Prior Context (Already Consolidated — DO NOT extract facts from these):");
+        assertThat(secondPrompt).contains("I want to design an event-driven architecture.");
+        assertThat(secondPrompt).contains("You can use Kafka or RabbitMQ");
+        assertThat(secondPrompt).contains("New Turns (Extract facts ONLY from these):");
+        assertThat(secondPrompt).contains("Let's go with Kafka because of high throughput");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #751. Implements an episodic memory slab-scan fallback in `EpisodicMemory` that guarantees prior-context window availability during REM sleep consolidation (`EpisodicLogConsolidationRelay`) even when `EpisodicSessionIndex` is unavailable or omitted on `ReflectSignal`.

---

## 🔍 Problem & Motivation

During REM sleep reflection in `EpisodicLogConsolidationRelay`, conversational continuity across multi-turn sessions requires supplying prior consolidated turns to the LLM distillation prompt as context to resolve co-references (pronouns, references to earlier topics/decisions).

Previously, this prior-context window was only retrieved via `signal.episodicSessionIndex()`. If `episodicSessionIndex` was null (e.g. standalone replay, isolated test runners, direct partition processing, or headless CLI replay where the session index is omitted or un-rebuilt), no prior context was passed to the LLM distillation prompt.

---

## 🛠️ Changes

1. **`EpisodicMemory.lastConsolidatedTurnOffsets(long sessionId, int maxTurns)`**:
   - Performs a bound-checked forward scan from `dataOffset()` to write limit.
   - Dual-read format discrimination: seamlessly parses both **Option B format** (`isOptionBRecord`) and **legacy format** (`LegacyEpisodeHeaderReader`).
   - Filters records by `recordSessionId == sessionId`, `!isTombstoned(flags)`, and `isConsolidated(flags)`.
   - Returns relative offsets (`cursor - dataOffset()`) in chronological order, capped to the last `maxTurns`.

2. **`EpisodicLogConsolidationRelay` Fallback Integration**:
   - When `signal.episodicSessionIndex() != null`, continues to use the \(O(1)\) index lookup path.
   - When `signal.episodicSessionIndex() == null` and `logStore != null`:
     - Invokes `logStore.lastConsolidatedTurnOffsets(sessionId, MAX_PRIOR_CONTEXT_TURNS)`.
     - Filters out turns belonging to the current consolidation batch (`currentTurnOffsets`).
     - Reads turn bodies and formats prior context for the distillation prompt identically to the indexed path.

3. **Automated Testing**:
   - **`EpisodicMemoryTest`**: Added 4 unit tests verifying `lastConsolidatedTurnOffsets`:
     - Returns empty on empty memory or `maxTurns <= 0`.
     - Returns empty when turns exist but none are consolidated.
     - Returns consolidated turns in chronological order capped to `maxTurns`.
     - Ignores tombstoned turns and turns from other sessions.
   - **`EpisodicLogConsolidationRelayTest`**: Added `testReconsolidationWithPriorContextWindow_FallbackWhenSessionIndexNull` verifying that prior context is successfully extracted and supplied to the LLM prompt when `episodicSessionIndex` is omitted from `ReflectSignal`.

---

## 🧪 Verification

- `mvn test -pl memory/spector-memory -Dtest=EpisodicMemoryTest`: 16/16 pass ✅
- `mvn test -pl memory/spector-memory -Dtest=EpisodicLogConsolidationRelayTest`: 3/3 pass ✅
- `mvn test -pl memory/spector-memory`: **1,692 tests run, 0 failures, 0 errors** ✅
- `mvn license:check -pl memory/spector-memory`: All files verified ✅

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
