### PR TITLE
feat(memory): support checkpointing, filtered batch execution, and external batch orchestration (#730)

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/DefaultSpectorMemory.java
@@ -1127,12 +1127,46 @@ public final class DefaultSpectorMemory implements SpectorMemory, SpectorMemoryA
 
     @Override
     public ReflectReport reflect() {
+        return reflect(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec.fullCycle());
+    }
+
+    @Override
+    public ReflectReport reflect(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec spec) {
+        acquireLease();
+        try {
+            com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor executor =
+                    com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutors.getPrimary();
+            return executor.execute(this, spec != null ? spec : com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec.fullCycle());
+        } finally {
+            releaseLease();
+        }
+    }
+
+    @Override
+    public ReflectReport reflectKernel(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec spec) {
         acquireLease();
         try {
             if (reflectPathway != null) {
-                return reflectPathway.reflect(partitionManager, index, rememberPathway, salienceProfile(), episodicSessionIndex);
+                return reflectPathway.reflect(partitionManager, index, rememberPathway, salienceProfile(), episodicSessionIndex, spec, null);
             }
-            return reflectionOrchestrator.reflect(partitionManager, index, rememberPathway);
+            return reflectionOrchestrator != null ? reflectionOrchestrator.reflect(partitionManager, index, rememberPathway) : ReflectReport.empty();
+        } finally {
+            releaseLease();
+        }
+    }
+
+    @Override
+    public ReflectPathway reflectPathway() {
+        return this.reflectPathway;
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress progress(String sweepId) {
+        acquireLease();
+        try {
+            com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor executor =
+                    com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutors.getPrimary();
+            return executor.progress(sweepId);
         } finally {
             releaseLease();
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryAdmin.java
@@ -18,6 +18,9 @@ import com.spectrayan.spector.memory.graph.EntityDirectory;
 import com.spectrayan.spector.memory.graph.GraphEnrichmentDaemon;
 import com.spectrayan.spector.memory.graph.HyperEntityGraphMemory;
 import com.spectrayan.spector.memory.neuromod.habituation.HabituationPenalty;
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectPathway;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
 import com.spectrayan.spector.memory.graph.hebbian.CoActivationMemory;
 import com.spectrayan.spector.memory.graph.hebbian.HebbianGraphBase;
 import com.spectrayan.spector.memory.cortex.index.MemoryIndex;
@@ -158,6 +161,23 @@ public interface SpectorMemoryAdmin {
     // ══════════════════════════════════════════════════════════════
     // OPERATIONAL
     // ══════════════════════════════════════════════════════════════
+
+    /**
+     * Conducts a direct kernel reflection sweep using the supplied specification.
+     *
+     * @param spec sweep configuration and filter parameters
+     * @return resulting reflection report
+     */
+    default ReflectReport reflectKernel(ReflectSweepSpec spec) {
+        return ReflectReport.empty();
+    }
+
+    /**
+     * Returns the active reflection pathway kernel if configured.
+     */
+    default ReflectPathway reflectPathway() {
+        return null;
+    }
 
     /** Explicitly decays importance of old episodic memories. */
     int decay(Duration olderThan, float factor);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/api/MemoryReflection.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/api/MemoryReflection.java
@@ -40,6 +40,14 @@ public interface MemoryReflection {
 
     ReflectReport reflect();
 
+    default ReflectReport reflect(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec spec) {
+        return reflect();
+    }
+
+    default com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress progress(String sweepId) {
+        return null;
+    }
+
     default ExpressReport express(ExpressSignal signal) {
         return ExpressReport.empty();
     }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ReflectReport.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/model/ReflectReport.java
@@ -78,4 +78,8 @@ public record ReflectReport(
      * Empty report — no work done.
      */
     public static final ReflectReport EMPTY = new ReflectReport(0, 0, 0, 0, Duration.ZERO, null, 0, 0, 0.0f, 0);
+
+    public static ReflectReport empty() {
+        return EMPTY;
+    }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectCheckpoint.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectCheckpoint.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Durable execution checkpoint tracking progress of a reflection sweep.
+ *
+ * @param sweepId                  unique identifier for the sweep execution or schedule
+ * @param partitionSeq             sequence ID of the active memory partition
+ * @param lastCompletedSessionId   watermark for the last successfully consolidated session ID (0 if none)
+ * @param lastCompletedTurnOffset  byte offset of the last consolidated turn in the episodic mmap region
+ * @param sessionsCompleted        total sessions successfully processed in this sweep
+ * @param factsIngested            total semantic facts synthesized and ingested into memory
+ * @param turnsMarked              total episodic turns stamped as consolidated
+ * @param backlogRemaining         estimated count of unconsolidated sessions remaining
+ * @param updatedAt                timestamp when this checkpoint was updated
+ * @param status                   current lifecycle status of the sweep
+ * @since 1.5.0
+ */
+public record ReflectCheckpoint(
+        String sweepId,
+        int partitionSeq,
+        long lastCompletedSessionId,
+        long lastCompletedTurnOffset,
+        int sessionsCompleted,
+        int factsIngested,
+        int turnsMarked,
+        int backlogRemaining,
+        Instant updatedAt,
+        ReflectSweepStatus status
+) {
+    public ReflectCheckpoint {
+        Objects.requireNonNull(sweepId, "sweepId cannot be null");
+        updatedAt = (updatedAt != null) ? updatedAt : Instant.now();
+        status = (status != null) ? status : ReflectSweepStatus.IDLE;
+    }
+
+    public static ReflectCheckpoint initial(String sweepId) {
+        return new ReflectCheckpoint(
+                sweepId,
+                0,
+                0L,
+                0L,
+                0,
+                0,
+                0,
+                0,
+                Instant.now(),
+                ReflectSweepStatus.IDLE
+        );
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectFilter.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectFilter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Filter specification for selecting candidate episodic sessions during a reflection sweep.
+ *
+ * @param sessionIds         optional explicit set of session IDs to process (null or empty = all sessions)
+ * @param sessionIdAfter     exclusive watermark cursor; only sessions strictly after this ID will be considered
+ * @param from               inclusive lower bound for session turn timestamp (null = unbounded)
+ * @param to                 inclusive upper bound for session turn timestamp (null = unbounded)
+ * @param partitionSeqs      optional partition sequence filter (null or empty = all partitions)
+ * @param unconsolidatedOnly true to require that sessions contain unconsolidated turns (default true)
+ * @since 1.5.0
+ */
+public record ReflectFilter(
+        Set<Long> sessionIds,
+        Long sessionIdAfter,
+        Instant from,
+        Instant to,
+        Set<Integer> partitionSeqs,
+        boolean unconsolidatedOnly
+) {
+    public ReflectFilter {
+        sessionIds = (sessionIds != null && !sessionIds.isEmpty()) ? Set.copyOf(sessionIds) : null;
+        partitionSeqs = (partitionSeqs != null && !partitionSeqs.isEmpty()) ? Set.copyOf(partitionSeqs) : null;
+    }
+
+    /**
+     * Checks if an episodic session satisfies this filter's criteria.
+     *
+     * @param sessionId    the episodic session ID
+     * @param timestampMs  the session timestamp in epoch milliseconds
+     * @param partitionSeq the partition sequence ID
+     * @return true if the session passes all active filter constraints
+     */
+    public boolean matches(long sessionId, long timestampMs, int partitionSeq) {
+        if (sessionIds != null && !sessionIds.contains(sessionId)) {
+            return false;
+        }
+        if (sessionIdAfter != null && sessionId <= sessionIdAfter) {
+            return false;
+        }
+        if (partitionSeqs != null && !partitionSeqs.contains(partitionSeq)) {
+            return false;
+        }
+        if (from != null && timestampMs < from.toEpochMilli()) {
+            return false;
+        }
+        if (to != null && timestampMs > to.toEpochMilli()) {
+            return false;
+        }
+        return true;
+    }
+
+    public static ReflectFilter all() {
+        return new ReflectFilter(null, null, null, null, null, false);
+    }
+
+    public static ReflectFilter unconsolidated() {
+        return new ReflectFilter(null, null, null, null, null, true);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private Set<Long> sessionIds;
+        private Long sessionIdAfter;
+        private Instant from;
+        private Instant to;
+        private Set<Integer> partitionSeqs;
+        private boolean unconsolidatedOnly = true;
+
+        public Builder sessionIds(Set<Long> sessionIds) {
+            this.sessionIds = sessionIds;
+            return this;
+        }
+
+        public Builder sessionIdAfter(Long sessionIdAfter) {
+            this.sessionIdAfter = sessionIdAfter;
+            return this;
+        }
+
+        public Builder from(Instant from) {
+            this.from = from;
+            return this;
+        }
+
+        public Builder to(Instant to) {
+            this.to = to;
+            return this;
+        }
+
+        public Builder partitionSeqs(Set<Integer> partitionSeqs) {
+            this.partitionSeqs = partitionSeqs;
+            return this;
+        }
+
+        public Builder unconsolidatedOnly(boolean unconsolidatedOnly) {
+            this.unconsolidatedOnly = unconsolidatedOnly;
+            return this;
+        }
+
+        public ReflectFilter build() {
+            return new ReflectFilter(sessionIds, sessionIdAfter, from, to, partitionSeqs, unconsolidatedOnly);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectPathway.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectPathway.java
@@ -241,6 +241,25 @@ public final class ReflectPathway implements AutoCloseable {
                                  final RememberPathway rememberPathway,
                                  final SalienceProfile salienceProfile,
                                  final EpisodicSessionIndex sessionIndex) {
+        return reflect(partitionManager, index, rememberPathway, salienceProfile, sessionIndex, ReflectSweepSpec.fullCycle(), null);
+    }
+
+    /**
+     * Executes a reflection cycle with an explicit sweep specification and checkpoint store.
+     */
+    public ReflectReport reflect(final PartitionManager partitionManager,
+                                 final MemoryIndex index,
+                                 final RememberPathway rememberPathway,
+                                 final SalienceProfile salienceProfile,
+                                 final EpisodicSessionIndex sessionIndex,
+                                 final ReflectSweepSpec sweepSpec,
+                                 final com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore checkpointStore) {
+        ReflectCheckpoint initialCheckpoint = null;
+        if (checkpointStore != null && sweepSpec != null && sweepSpec.sweepId() != null) {
+            initialCheckpoint = checkpointStore.load(sweepSpec.sweepId())
+                    .orElseGet(() -> ReflectCheckpoint.initial(sweepSpec.sweepId()));
+        }
+
         ReflectSignal signal = ReflectSignal.builder()
                 .partitionManager(partitionManager)
                 .index(index)
@@ -276,6 +295,9 @@ public final class ReflectPathway implements AutoCloseable {
                 .softIdentityAnchorEnabled(softIdentityAnchorEnabled)
                 .identityAnchorEta(identityAnchorEta)
                 .identityLyapunovThreshold(identityLyapunovThreshold)
+                .sweepSpec(sweepSpec != null ? sweepSpec : ReflectSweepSpec.fullCycle())
+                .checkpointStore(checkpointStore)
+                .checkpoint(initialCheckpoint)
                 .build();
 
         return conduct(signal);

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepProgress.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepProgress.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Observable telemetry progress snapshot for a reflection sweep.
+ *
+ * @param sweepId           unique sweep identifier
+ * @param sessionsCompleted total sessions consolidated so far
+ * @param factsIngested     total semantic facts synthesized
+ * @param turnsMarked       total turns marked consolidated
+ * @param backlogRemaining  number of unconsolidated sessions pending
+ * @param status            current sweep status
+ * @param startedAt         timestamp when the sweep began
+ * @param updatedAt         timestamp of this progress snapshot
+ * @since 1.5.0
+ */
+public record ReflectSweepProgress(
+        String sweepId,
+        int sessionsCompleted,
+        int factsIngested,
+        int turnsMarked,
+        int backlogRemaining,
+        ReflectSweepStatus status,
+        Instant startedAt,
+        Instant updatedAt
+) {
+    public ReflectSweepProgress {
+        Objects.requireNonNull(sweepId, "sweepId cannot be null");
+        status = (status != null) ? status : ReflectSweepStatus.IDLE;
+        startedAt = (startedAt != null) ? startedAt : Instant.now();
+        updatedAt = (updatedAt != null) ? updatedAt : Instant.now();
+    }
+
+    public static ReflectSweepProgress from(ReflectCheckpoint checkpoint, Instant startedAt) {
+        if (checkpoint == null) {
+            return new ReflectSweepProgress("unknown", 0, 0, 0, 0, ReflectSweepStatus.IDLE, startedAt, Instant.now());
+        }
+        return new ReflectSweepProgress(
+                checkpoint.sweepId(),
+                checkpoint.sessionsCompleted(),
+                checkpoint.factsIngested(),
+                checkpoint.turnsMarked(),
+                checkpoint.backlogRemaining(),
+                checkpoint.status(),
+                startedAt,
+                checkpoint.updatedAt()
+        );
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepSpec.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepSpec.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectBackpressurePolicy;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.NoopBackpressurePolicy;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Specification defining parameters, limits, and behavior for a reflection sweep execution.
+ *
+ * @param sweepId             unique identifier for this sweep execution
+ * @param filter              filter determining candidate episodic sessions to consolidate
+ * @param sessionLimit        maximum number of sessions to process (<= 0 means unlimited)
+ * @param maxTurnsPerSession  maximum turns permitted per session before truncation/sampling (<= 0 means unlimited)
+ * @param timeBudget          hard execution deadline for the sweep (null means unlimited)
+ * @param runCompanionRelays  whether to execute downstream biological maintenance relays (e.g. Hebbian decay, pruning)
+ * @param backpressure        rate-limiting and error-handling policy between sessions (null defaults to Noop)
+ * @since 1.5.0
+ */
+public record ReflectSweepSpec(
+        String sweepId,
+        ReflectFilter filter,
+        int sessionLimit,
+        int maxTurnsPerSession,
+        Duration timeBudget,
+        boolean runCompanionRelays,
+        ReflectBackpressurePolicy backpressure
+) {
+    public static final int DEFAULT_MAX_TURNS_PER_SESSION = 100;
+
+    public ReflectSweepSpec {
+        sweepId = (sweepId != null && !sweepId.isBlank()) ? sweepId : "sweep-" + UUID.randomUUID();
+        filter = (filter != null) ? filter : ReflectFilter.unconsolidated();
+        maxTurnsPerSession = (maxTurnsPerSession > 0) ? maxTurnsPerSession : DEFAULT_MAX_TURNS_PER_SESSION;
+        backpressure = (backpressure != null) ? backpressure : NoopBackpressurePolicy.INSTANCE;
+    }
+
+    /**
+     * Creates a spec representing a standard biological sleep cycle (unbounded sessions, all relays active).
+     */
+    public static ReflectSweepSpec fullCycle() {
+        return new ReflectSweepSpec(
+                "full-cycle",
+                ReflectFilter.unconsolidated(),
+                0,
+                DEFAULT_MAX_TURNS_PER_SESSION,
+                null,
+                true,
+                NoopBackpressurePolicy.INSTANCE
+        );
+    }
+
+    /**
+     * Creates a spec for a lightweight consolidation-only tick (e.g. circadian or continuous background sweep).
+     *
+     * @param sessionLimit maximum number of sessions to consolidate in this tick
+     */
+    public static ReflectSweepSpec consolidationOnly(int sessionLimit) {
+        return new ReflectSweepSpec(
+                "consolidation-tick",
+                ReflectFilter.unconsolidated(),
+                sessionLimit,
+                DEFAULT_MAX_TURNS_PER_SESSION,
+                null,
+                false,
+                NoopBackpressurePolicy.INSTANCE
+        );
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String sweepId;
+        private ReflectFilter filter = ReflectFilter.unconsolidated();
+        private int sessionLimit = 0;
+        private int maxTurnsPerSession = DEFAULT_MAX_TURNS_PER_SESSION;
+        private Duration timeBudget;
+        private boolean runCompanionRelays = true;
+        private ReflectBackpressurePolicy backpressure = NoopBackpressurePolicy.INSTANCE;
+
+        public Builder sweepId(String sweepId) {
+            this.sweepId = sweepId;
+            return this;
+        }
+
+        public Builder filter(ReflectFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder sessionLimit(int sessionLimit) {
+            this.sessionLimit = sessionLimit;
+            return this;
+        }
+
+        public Builder maxTurnsPerSession(int maxTurnsPerSession) {
+            this.maxTurnsPerSession = maxTurnsPerSession;
+            return this;
+        }
+
+        public Builder timeBudget(Duration timeBudget) {
+            this.timeBudget = timeBudget;
+            return this;
+        }
+
+        public Builder runCompanionRelays(boolean runCompanionRelays) {
+            this.runCompanionRelays = runCompanionRelays;
+            return this;
+        }
+
+        public Builder backpressure(ReflectBackpressurePolicy backpressure) {
+            this.backpressure = backpressure;
+            return this;
+        }
+
+        public ReflectSweepSpec build() {
+            return new ReflectSweepSpec(sweepId, filter, sessionLimit, maxTurnsPerSession, timeBudget, runCompanionRelays, backpressure);
+        }
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepStatus.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepStatus.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+/**
+ * Lifecycle status of a reflection consolidation sweep.
+ *
+ * @since 1.5.0
+ */
+public enum ReflectSweepStatus {
+    /** Sweep configured but not yet started. */
+    IDLE,
+    /** Sweep actively executing. */
+    RUNNING,
+    /** Sweep temporarily paused or suspended on rate-limiting. */
+    PAUSED,
+    /** Sweep finished processing all eligible sessions or reached clean backlog. */
+    COMPLETE,
+    /** Sweep terminated abruptly due to unrecoverable failure. */
+    FAILED
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/SessionSweepResult.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/SessionSweepResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+/**
+ * Result of consolidating an individual session within a reflection sweep.
+ *
+ * @param sessionId         the episodic session ID
+ * @param factsConsolidated number of semantic facts synthesized and ingested
+ * @param turnsMarked       number of turns stamped as consolidated
+ * @param success           true if distillation and ingestion succeeded
+ * @param error             underlying error if consolidation failed, or null
+ * @since 1.5.0
+ */
+public record SessionSweepResult(
+        long sessionId,
+        int factsConsolidated,
+        int turnsMarked,
+        boolean success,
+        Throwable error
+) {
+    public static SessionSweepResult success(long sessionId, int factsConsolidated, int turnsMarked) {
+        return new SessionSweepResult(sessionId, factsConsolidated, turnsMarked, true, null);
+    }
+
+    public static SessionSweepResult failure(long sessionId, Throwable error) {
+        return new SessionSweepResult(sessionId, 0, 0, false, error);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/SessionWorkItem.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/SessionWorkItem.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable work item representing an episodic session to be consolidated.
+ *
+ * @param partitionSeq the sequence ID of the partition containing this session
+ * @param sessionId    the 8B TSID hash identifying the episodic session
+ * @param offsets      unmodifiable ordered list of byte offsets for unconsolidated turns in this session
+ * @param timestampMs  the session watermark timestamp (e.g. latest turn timestamp in the session)
+ * @since 1.5.0
+ */
+public record SessionWorkItem(
+        int partitionSeq,
+        long sessionId,
+        List<Long> offsets,
+        long timestampMs
+) {
+    public SessionWorkItem {
+        offsets = (offsets != null) ? List.copyOf(offsets) : List.of();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelay.java
@@ -32,10 +32,12 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -43,6 +45,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectFilter;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import com.spectrayan.spector.memory.pathway.reflect.SessionSweepResult;
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectBackpressurePolicy;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.NoopBackpressurePolicy;
+import com.spectrayan.spector.memory.session.EpisodicSessionIndex;
 
 /**
  * REM Sleep Conversation Turn Gist Extraction Relay (ADR-0006).
@@ -77,40 +89,35 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
             float urgency
     ) {}
 
-    @Override
-    public boolean transmit(final ReflectSignal signal) {
-        if (signal.partitionManager() == null) {
-            log.info("EpisodicLogConsolidationRelay: partitionManager is null");
-            return true;
-        }
-
-        var handles = signal.partitionManager().snapshot();
-        log.info("EpisodicLogConsolidationRelay: snapshot has {} partition handles", handles.size());
-        for (var handle : handles) {
-            if (handle.router() != null) {
-                var episodicStore = handle.router().episodic();
-                if (episodicStore != null) {
-                    processLogStore(episodicStore, signal, handle.seq());
-                }
-            }
-        }
-        return true;
-    }
-
     /**
      * Per-turn offset pairing — avoids HashMap key collision (Bug #2).
      */
     private record TurnWithOffset(EpisodeRecord turn, long offset) {}
 
-    private void processLogStore(final EpisodicMemory logStore, final ReflectSignal signal, final int partitionSeq) {
-        List<Long> unconsolidatedOffsets = logStore.unconsolidatedTurnOffsets();
-        log.info("EpisodicLogConsolidationRelay: found {} unconsolidated offsets in logStore", unconsolidatedOffsets.size());
-        List<EpisodeRecord> turns = logStore.readTurns(unconsolidatedOffsets, true);
-        if (turns.isEmpty()) return;
-        log.info("EpisodicLogConsolidationRelay: read {} turns for {} unconsolidated offsets", turns.size(), unconsolidatedOffsets.size());
+    /**
+     * Identifies and returns all eligible unconsolidated sessions within a partition,
+     * ordered deterministically by timestamp then session ID.
+     */
+    public List<SessionWorkItem> listEligibleSessions(
+            final EpisodicMemory logStore,
+            final ReflectSweepSpec spec,
+            final ReflectCheckpoint checkpoint,
+            final EpisodicSessionIndex index,
+            final int partitionSeq) {
+        if (logStore == null) {
+            return List.of();
+        }
 
-        // Bug #2 fix: Use paired list instead of Map<EpisodeRecord, Long> to avoid key collision
-        // when two turns have identical content (records are value types — equals() on content).
+        List<Long> unconsolidatedOffsets = logStore.unconsolidatedTurnOffsets();
+        if (unconsolidatedOffsets.isEmpty()) {
+            return List.of();
+        }
+
+        List<EpisodeRecord> turns = logStore.readTurns(unconsolidatedOffsets, true);
+        if (turns.isEmpty()) {
+            return List.of();
+        }
+
         Map<Long, List<TurnWithOffset>> sessionTurns = new HashMap<>();
         for (int i = 0; i < turns.size(); i++) {
             var turn = turns.get(i);
@@ -119,113 +126,160 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                     .add(new TurnWithOffset(turn, offset));
         }
 
-        log.info("EpisodicLogConsolidationRelay: grouped into {} distinct sessions, starting consolidation...", sessionTurns.size());
-        // TODO: Redesigning ReflectPathway to support external batching/checkpointing via Synapse/Spring Batch (#730);
-        // replace temporary retry and throttle logic.
+        ReflectFilter filter = (spec != null && spec.filter() != null)
+                ? spec.filter()
+                : ReflectFilter.unconsolidated();
+
+        List<SessionWorkItem> workItems = new ArrayList<>();
         for (var entry : sessionTurns.entrySet()) {
-            try {
-                List<TurnWithOffset> sessionList = entry.getValue();
-                if (sessionList == null || sessionList.isEmpty()) continue;
+            long sessionId = entry.getKey();
+            List<TurnWithOffset> turnPairs = entry.getValue();
+            if (turnPairs == null || turnPairs.isEmpty()) {
+                continue;
+            }
 
-                List<String> turnTexts = new ArrayList<>();
-                for (var twoTuple : sessionList) {
-                    String text = extractTurnText(twoTuple.turn());
-                    if (text != null && !text.isBlank()) {
-                        turnTexts.add(twoTuple.turn().role() + ": " + text);
+            long sessionTimestampMs = turnPairs.stream()
+                    .map(TurnWithOffset::turn)
+                    .mapToLong(EpisodeRecord::timestampMs)
+                    .max()
+                    .orElse(0L);
+
+            if (filter != null && !filter.matches(sessionId, sessionTimestampMs, partitionSeq)) {
+                continue;
+            }
+
+            List<Long> offsets = new ArrayList<>(turnPairs.size());
+            for (TurnWithOffset pair : turnPairs) {
+                offsets.add(pair.offset());
+            }
+
+            workItems.add(new SessionWorkItem(partitionSeq, sessionId, offsets, sessionTimestampMs));
+        }
+
+        // Stable deterministic ordering by (timestampMs, sessionId)
+        workItems.sort(Comparator.comparingLong(SessionWorkItem::timestampMs)
+                .thenComparingLong(SessionWorkItem::sessionId));
+
+        return workItems;
+    }
+
+    /**
+     * Executes the unit-of-work for a single session: distillation, crash-safe marking,
+     * semantic fact ingestion with affect metadata, and provenance tracking.
+     */
+    public SessionSweepResult processSession(
+            final SessionWorkItem workItem,
+            final EpisodicMemory logStore,
+            final ReflectSignal signal) {
+        if (workItem == null || workItem.offsets().isEmpty() || logStore == null || signal == null) {
+            return SessionSweepResult.success(workItem != null ? workItem.sessionId() : 0L, 0, 0);
+        }
+
+        long sessionId = workItem.sessionId();
+        int partitionSeq = workItem.partitionSeq();
+        List<Long> offsets = workItem.offsets();
+
+        int maxTurns = (signal.sweepSpec() != null)
+                ? signal.sweepSpec().maxTurnsPerSession()
+                : ReflectSweepSpec.DEFAULT_MAX_TURNS_PER_SESSION;
+        if (maxTurns > 0 && offsets.size() > maxTurns) {
+            offsets = offsets.subList(offsets.size() - maxTurns, offsets.size());
+        }
+
+        try {
+            List<EpisodeRecord> turns = logStore.readTurns(offsets, true);
+            if (turns.isEmpty()) {
+                return SessionSweepResult.success(sessionId, 0, 0);
+            }
+
+            List<String> turnTexts = new ArrayList<>();
+            for (EpisodeRecord turn : turns) {
+                String text = extractTurnText(turn);
+                if (text != null && !text.isBlank()) {
+                    turnTexts.add(turn.role() + ": " + text);
+                }
+            }
+
+            if (turnTexts.isEmpty()) {
+                return SessionSweepResult.success(sessionId, 0, 0);
+            }
+
+            long sessionTimestampMs = workItem.timestampMs();
+            Set<Long> currentTurnOffsets = new HashSet<>(offsets);
+
+            List<String> priorContext = new ArrayList<>();
+            if (MAX_PRIOR_CONTEXT_TURNS > 0) {
+                List<Long> windowOffsets = null;
+                if (signal.episodicSessionIndex() != null) {
+                    List<Long> allSessionOffsets = signal.episodicSessionIndex().getSessionTurns(sessionId);
+                    if (allSessionOffsets != null && !allSessionOffsets.isEmpty()) {
+                        List<Long> earlierOffsets = new ArrayList<>();
+                        for (Long off : allSessionOffsets) {
+                            if (!currentTurnOffsets.contains(off)) {
+                                earlierOffsets.add(off);
+                            }
+                        }
+                        if (!earlierOffsets.isEmpty()) {
+                            int start = Math.max(0, earlierOffsets.size() - MAX_PRIOR_CONTEXT_TURNS);
+                            windowOffsets = earlierOffsets.subList(start, earlierOffsets.size());
+                        }
+                    }
+                } else if (logStore != null) {
+                    // Fallback: directly scan episodic slab when EpisodicSessionIndex is unavailable (#751)
+                    List<Long> candidateOffsets = logStore.lastConsolidatedTurnOffsets(sessionId, MAX_PRIOR_CONTEXT_TURNS);
+                    if (candidateOffsets != null && !candidateOffsets.isEmpty()) {
+                        List<Long> earlierOffsets = new ArrayList<>();
+                        for (Long off : candidateOffsets) {
+                            if (!currentTurnOffsets.contains(off)) {
+                                earlierOffsets.add(off);
+                            }
+                        }
+                        windowOffsets = earlierOffsets;
                     }
                 }
 
-                if (turnTexts.isEmpty()) continue;
-
-                long sessionTimestampMs = sessionList.stream()
-                        .map(TurnWithOffset::turn)
-                        .mapToLong(EpisodeRecord::timestampMs)
-                        .max()
-                        .orElse(System.currentTimeMillis());
-
-                long sessionId = entry.getKey();
-
-                // Collect offsets for prior-context lookups (Bug #2: use paired offset, not map)
-                Set<Long> currentTurnOffsets = new HashSet<>();
-                for (var twoTuple : sessionList) {
-                    currentTurnOffsets.add(twoTuple.offset());
-                }
-
-                List<String> priorContext = new ArrayList<>();
-                if (MAX_PRIOR_CONTEXT_TURNS > 0) {
-                    List<Long> windowOffsets = null;
-                    if (signal.episodicSessionIndex() != null) {
-                        List<Long> allSessionOffsets = signal.episodicSessionIndex().getSessionTurns(sessionId);
-                        if (allSessionOffsets != null && !allSessionOffsets.isEmpty()) {
-                            List<Long> earlierOffsets = new ArrayList<>();
-                            for (Long off : allSessionOffsets) {
-                                if (!currentTurnOffsets.contains(off)) {
-                                    earlierOffsets.add(off);
-                                }
-                            }
-                            if (!earlierOffsets.isEmpty()) {
-                                int start = Math.max(0, earlierOffsets.size() - MAX_PRIOR_CONTEXT_TURNS);
-                                windowOffsets = earlierOffsets.subList(start, earlierOffsets.size());
-                            }
-                        }
-                    } else if (logStore != null) {
-                        // Fallback: directly scan episodic slab when EpisodicSessionIndex is unavailable (#751)
-                        List<Long> candidateOffsets = logStore.lastConsolidatedTurnOffsets(sessionId, MAX_PRIOR_CONTEXT_TURNS);
-                        if (candidateOffsets != null && !candidateOffsets.isEmpty()) {
-                            List<Long> earlierOffsets = new ArrayList<>();
-                            for (Long off : candidateOffsets) {
-                                if (!currentTurnOffsets.contains(off)) {
-                                    earlierOffsets.add(off);
-                                }
-                            }
-                            windowOffsets = earlierOffsets;
-                        }
-                    }
-
-                    if (windowOffsets != null && !windowOffsets.isEmpty()) {
-                        List<EpisodeRecord> priorRecords = logStore.readTurns(windowOffsets, true);
-                        for (var priorRecord : priorRecords) {
-                            if (com.spectrayan.spector.memory.kernel.layout.EncodingHeaderFields.isConsolidated(priorRecord.flags())) {
-                                String text = extractTurnText(priorRecord);
-                                if (text != null && !text.isBlank()) {
-                                    priorContext.add(priorRecord.role() + ": " + text);
-                                }
+                if (windowOffsets != null && !windowOffsets.isEmpty()) {
+                    List<EpisodeRecord> priorRecords = logStore.readTurns(windowOffsets, true);
+                    for (var priorRecord : priorRecords) {
+                        if (EncodingHeaderFields.isConsolidated(priorRecord.flags())) {
+                            String text = extractTurnText(priorRecord);
+                            if (text != null && !text.isBlank()) {
+                                priorContext.add(priorRecord.role() + ": " + text);
                             }
                         }
                     }
                 }
+            }
 
-                List<ConsolidatedFact> synthesizedFacts = distillStructuredFacts(turnTexts, priorContext, sessionTimestampMs, signal);
-                if (synthesizedFacts.isEmpty()) continue;
+            List<ConsolidatedFact> synthesizedFacts = distillStructuredFacts(turnTexts, priorContext, sessionTimestampMs, signal);
+            if (synthesizedFacts.isEmpty()) {
+                return SessionSweepResult.success(sessionId, 0, 0);
+            }
 
-                // Bug #5 fix: Mark turns consolidated BEFORE ingesting facts.
-                // This prevents duplicate facts on crash/retry: if we crash after
-                // ingesting facts but before marking consolidated, a retry would
-                // re-distill the same turns and produce duplicates. Marking first
-                // ensures crash-safety at the cost of potentially losing facts
-                // (which is self-healing — the next pass will re-consolidate).
-                for (var twoTuple : sessionList) {
-                    logStore.markConsolidated(twoTuple.offset());
-                }
-                signal.addLogTurnsConsolidated(sessionList.size());
+            // Bug #5 fix: Mark turns consolidated BEFORE ingesting facts to prevent duplicate facts on crash/retry.
+            for (Long off : offsets) {
+                logStore.markConsolidated(off);
+            }
+            signal.addLogTurnsConsolidated(offsets.size());
 
-                // Compute pass number for this session (supports multi-pass consolidation)
-                short passNumber = 1;
-                if (signal.provenanceMemory() != null) {
-                    passNumber = (short) signal.provenanceMemory().nextPassNumber(sessionId);
-                }
+            // Compute pass number for this session (supports multi-pass consolidation)
+            short passNumber = 1;
+            if (signal.provenanceMemory() != null) {
+                passNumber = (short) signal.provenanceMemory().nextPassNumber(sessionId);
+            }
 
-                // Pre-compute turn range data for provenance edges
-                int firstSeq = Integer.MAX_VALUE, lastSeq = Integer.MIN_VALUE;
-                int firstOffsetHint = Integer.MAX_VALUE, lastOffsetHint = Integer.MIN_VALUE;
-                for (var twoTuple : sessionList) {
-                    int seq = twoTuple.turn().sequenceId();
-                    int off = (int) twoTuple.offset();
-                    if (seq < firstSeq) { firstSeq = seq; firstOffsetHint = off; }
-                    if (seq > lastSeq) { lastSeq = seq; lastOffsetHint = off; }
-                }
-                short turnCount = (short) sessionList.size();
+            int firstSeq = Integer.MAX_VALUE, lastSeq = Integer.MIN_VALUE;
+            int firstOffsetHint = Integer.MAX_VALUE, lastOffsetHint = Integer.MIN_VALUE;
+            for (int i = 0; i < turns.size(); i++) {
+                int seq = turns.get(i).sequenceId();
+                int off = (int) offsets.get(i).longValue();
+                if (seq < firstSeq) { firstSeq = seq; firstOffsetHint = off; }
+                if (seq > lastSeq) { lastSeq = seq; lastOffsetHint = off; }
+            }
+            short turnCount = (short) offsets.size();
 
+            int factsIngested = 0;
+            if (signal.rememberPathway() != null) {
                 for (int fi = 0; fi < synthesizedFacts.size(); fi++) {
                     ConsolidatedFact fact = synthesizedFacts.get(fi);
                     String memoryId = signal.idGenerator().generate();
@@ -238,85 +292,214 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
                         }
                     }
 
-                    if (signal.rememberPathway() != null) {
-                        Set<String> tagSet = new LinkedHashSet<>();
-                        if (fact.synapticTags() != null) {
-                            for (String t : fact.synapticTags()) {
-                                String cleanT = t.replaceAll("[^a-zA-Z0-9_-]", "-").toLowerCase(Locale.ROOT);
-                                if (!cleanT.isBlank()) {
-                                    tagSet.add(cleanT);
-                                }
+                    Set<String> tagSet = new LinkedHashSet<>();
+                    if (fact.synapticTags() != null) {
+                        for (String t : fact.synapticTags()) {
+                            String cleanT = t.replaceAll("[^a-zA-Z0-9_-]", "-").toLowerCase(Locale.ROOT);
+                            if (!cleanT.isBlank()) {
+                                tagSet.add(cleanT);
                             }
                         }
-                        tagSet.add("conversation-reflection");
-                        // Bug #4 fix: Add session tag for lineage tracing
-                        tagSet.add("session-" + Long.toHexString(sessionId));
-                        String[] allTags = tagSet.toArray(String[]::new);
+                    }
+                    tagSet.add("conversation-reflection");
+                    tagSet.add("session-" + Long.toHexString(sessionId));
+                    String[] allTags = tagSet.toArray(String[]::new);
 
-                        float exactNorm = vector != null ? VectorOps.magnitude(vector) : 1.0f;
-                        byte semanticFlags = EncodingHeaderFields.withMemoryType(
-                                EncodingHeaderFields.FLAG_CONSOLIDATED, MemoryType.SEMANTIC.ordinal());
+                    float exactNorm = vector != null ? VectorOps.magnitude(vector) : 1.0f;
+                    byte semanticFlags = EncodingHeaderFields.withMemoryType(
+                            EncodingHeaderFields.FLAG_CONSOLIDATED, MemoryType.SEMANTIC.ordinal());
 
-                        // Bug #3 fix: Use fact-level affect metadata instead of hardcoded zeros
-                        EncodingHeader header = new EncodingHeader(
-                                sessionTimestampMs, 0L, exactNorm, fact.interest(), 1,
-                                (short) 0, fact.arousal(), semanticFlags, fact.valence(), 1.0f
-                        );
+                    EncodingHeader header = new EncodingHeader(
+                            sessionTimestampMs, 0L, exactNorm, fact.interest(), 1,
+                            (short) 0, fact.arousal(), semanticFlags, fact.valence(), 1.0f
+                    );
 
-                        boolean ingested = signal.rememberPathway().ingestCognitiveWithHeader(
-                                memoryId,
-                                fact.text(),
-                                vector,
-                                MemoryType.SEMANTIC,
-                                allTags,
-                                MemorySource.REFLECTED,
-                                header
-                        );
+                    boolean ingested = signal.rememberPathway().ingestCognitiveWithHeader(
+                            memoryId,
+                            fact.text(),
+                            vector,
+                            MemoryType.SEMANTIC,
+                            allTags,
+                            MemorySource.REFLECTED,
+                            header
+                    );
 
-                        if (ingested) {
-                            signal.addConsolidated(1);
+                    if (ingested) {
+                        signal.addConsolidated(1);
+                        factsIngested++;
 
-                            // Write provenance edge for episodic→semantic lineage
-                            if (signal.provenanceMemory() != null) {
-                                try {
-                                    long targetTsid = TsidGenerator.decodeCrockford(memoryId);
-                                    short contentHashHi = computeContentHashHi(fact.text());
+                        if (signal.provenanceMemory() != null) {
+                            try {
+                                long targetTsid = TsidGenerator.decodeCrockford(memoryId);
+                                short contentHashHi = computeContentHashHi(fact.text());
 
-                                    ProvenanceEdge edge = new ProvenanceEdge(
-                                            sessionId, targetTsid, passNumber,
-                                            (byte) fi, (byte) synthesizedFacts.size(),
-                                            partitionSeq, firstSeq, lastSeq,
-                                            firstOffsetHint, lastOffsetHint,
-                                            turnCount, contentHashHi,
-                                            System.currentTimeMillis()
-                                    );
-                                    signal.provenanceMemory().append(edge);
-                                } catch (Exception e) {
-                                    log.warn("Failed to write provenance edge for memory {}: {}",
-                                            memoryId, e.getMessage());
-                                }
+                                ProvenanceEdge edge = new ProvenanceEdge(
+                                        sessionId, targetTsid, passNumber,
+                                        (byte) fi, (byte) synthesizedFacts.size(),
+                                        partitionSeq, firstSeq, lastSeq,
+                                        firstOffsetHint, lastOffsetHint,
+                                        turnCount, contentHashHi,
+                                        System.currentTimeMillis()
+                                );
+                                signal.provenanceMemory().append(edge);
+                            } catch (Exception e) {
+                                log.warn("Failed to write provenance edge for memory {}: {}", memoryId, e.getMessage());
                             }
                         }
                     }
                 }
+            }
 
-                // Sleep between runs so it won't overwhelm the LLM API
-                long sleepMs = Long.getLong("reflectSessionSleepMs", 5000L);
-                if (sleepMs > 0) {
-                    try {
-                        Thread.sleep(sleepMs);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        log.warn("Reflection session loop interrupted");
-                        break;
+            return SessionSweepResult.success(sessionId, factsIngested, offsets.size());
+        } catch (Exception e) {
+            log.warn("Unexpected error consolidating session {}: {}", sessionId, e.getMessage());
+            if (signal.sweepSpec() != null && signal.sweepSpec().backpressure() != null) {
+                signal.sweepSpec().backpressure().onProviderFailure(e);
+            }
+            return SessionSweepResult.failure(sessionId, e);
+        }
+    }
+
+    @Override
+    public boolean transmit(final ReflectSignal signal) {
+        if (signal.partitionManager() == null) {
+            log.info("EpisodicLogConsolidationRelay: partitionManager is null");
+            return true;
+        }
+
+        ReflectSweepSpec spec = signal.sweepSpec() != null ? signal.sweepSpec() : ReflectSweepSpec.fullCycle();
+        ReflectCheckpointStore checkpointStore = signal.checkpointStore();
+        ReflectCheckpoint checkpoint = signal.checkpoint();
+
+        if (checkpoint == null && checkpointStore != null) {
+            checkpoint = checkpointStore.load(spec.sweepId()).orElse(ReflectCheckpoint.initial(spec.sweepId()));
+            signal.setCheckpoint(checkpoint);
+        }
+
+        ReflectBackpressurePolicy backpressure = spec.backpressure() != null
+                ? spec.backpressure()
+                : NoopBackpressurePolicy.INSTANCE;
+
+        int sessionLimit = spec.sessionLimit();
+        Duration timeBudget = spec.timeBudget();
+        long deadlineMs = (timeBudget != null) ? System.currentTimeMillis() + timeBudget.toMillis() : Long.MAX_VALUE;
+
+        var handles = signal.partitionManager().snapshot();
+        log.info("EpisodicLogConsolidationRelay: snapshot has {} partition handles (sweep='{}', limit={})",
+                handles.size(), spec.sweepId(), sessionLimit);
+
+        int totalSessionsProcessed = 0;
+        int totalFactsIngested = 0;
+        int totalTurnsMarked = 0;
+        boolean aborted = false;
+
+        for (var handle : handles) {
+            if (handle.router() == null || handle.router().episodic() == null) {
+                continue;
+            }
+
+            var episodicStore = handle.router().episodic();
+            List<SessionWorkItem> eligibleSessions = listEligibleSessions(
+                    episodicStore, spec, checkpoint, signal.episodicSessionIndex(), handle.seq());
+
+            log.info("EpisodicLogConsolidationRelay: partition #{} has {} eligible sessions",
+                    handle.seq(), eligibleSessions.size());
+
+            int remainingBacklog = eligibleSessions.size();
+
+            for (SessionWorkItem item : eligibleSessions) {
+                if (sessionLimit > 0 && totalSessionsProcessed >= sessionLimit) {
+                    log.info("EpisodicLogConsolidationRelay: reached sessionLimit ({}), pausing sweep", sessionLimit);
+                    break;
+                }
+
+                if (System.currentTimeMillis() >= deadlineMs) {
+                    log.info("EpisodicLogConsolidationRelay: reached timeBudget ({}), pausing sweep", timeBudget);
+                    aborted = true;
+                    break;
+                }
+
+                if (backpressure.shouldAbortSweep()) {
+                    log.warn("EpisodicLogConsolidationRelay: backpressure policy signaled abort");
+                    aborted = true;
+                    break;
+                }
+
+                try {
+                    backpressure.beforeSession(item);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.warn("EpisodicLogConsolidationRelay: interrupted during backpressure wait");
+                    aborted = true;
+                    break;
+                }
+
+                SessionSweepResult result = processSession(item, episodicStore, signal);
+                if (result.success()) {
+                    totalSessionsProcessed++;
+                    totalFactsIngested += result.factsConsolidated();
+                    totalTurnsMarked += result.turnsMarked();
+                    remainingBacklog--;
+
+                    long lastOffset = item.offsets().isEmpty() ? 0L : item.offsets().get(item.offsets().size() - 1);
+                    checkpoint = new ReflectCheckpoint(
+                            spec.sweepId(),
+                            handle.seq(),
+                            item.sessionId(),
+                            lastOffset,
+                            totalSessionsProcessed,
+                            totalFactsIngested,
+                            totalTurnsMarked,
+                            remainingBacklog,
+                            Instant.now(),
+                            ReflectSweepStatus.RUNNING
+                    );
+                    signal.setCheckpoint(checkpoint);
+
+                    if (checkpointStore != null) {
+                        try {
+                            checkpointStore.save(checkpoint);
+                        } catch (Exception e) {
+                            log.warn("Failed saving checkpoint for session {}: {}", item.sessionId(), e.getMessage());
+                        }
                     }
                 }
-            } catch (Exception e) {
-                log.warn("Unexpected error consolidating session {}: {}", entry.getKey(), e.getMessage());
+            }
+
+            if (aborted || (sessionLimit > 0 && totalSessionsProcessed >= sessionLimit)) {
+                break;
             }
         }
-        log.info("EpisodicLogConsolidationRelay: completed session distillation, consolidated {} facts across {} sessions",
-                signal.totalConsolidated(), sessionTurns.size());
+
+        ReflectSweepStatus finalStatus = aborted
+                ? ReflectSweepStatus.PAUSED
+                : ((sessionLimit > 0 && totalSessionsProcessed >= sessionLimit)
+                ? ReflectSweepStatus.PAUSED
+                : ReflectSweepStatus.COMPLETE);
+
+        if (checkpoint != null) {
+            checkpoint = new ReflectCheckpoint(
+                    checkpoint.sweepId(),
+                    checkpoint.partitionSeq(),
+                    checkpoint.lastCompletedSessionId(),
+                    checkpoint.lastCompletedTurnOffset(),
+                    checkpoint.sessionsCompleted(),
+                    checkpoint.factsIngested(),
+                    checkpoint.turnsMarked(),
+                    checkpoint.backlogRemaining(),
+                    Instant.now(),
+                    finalStatus
+            );
+            signal.setCheckpoint(checkpoint);
+            if (checkpointStore != null) {
+                checkpointStore.save(checkpoint);
+            }
+        }
+
+        log.info("EpisodicLogConsolidationRelay: sweep '{}' completed — status={}, sessions={}, facts={}, turns={}",
+                spec.sweepId(), finalStatus, totalSessionsProcessed, totalFactsIngested, totalTurnsMarked);
+
+        return true;
     }
 
     private List<ConsolidatedFact> distillStructuredFacts(List<String> turnTexts, List<String> priorContext, long sessionTimestampMs, ReflectSignal signal) {
@@ -329,44 +512,34 @@ public final class EpisodicLogConsolidationRelay implements SynapticRelay<Reflec
             sessionDateStr = "Unknown Date";
         }
 
-        // TODO: Redesigning ReflectPathway to support external batching/checkpointing via Synapse/Spring Batch (#730);
-        // replace temporary retry and throttle logic.
-        int maxRetries = 3;
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
-            if (signal.textGenerator() != null && signal.templateEngine() != null) {
-                try {
-                    Map<String, Object> model = new HashMap<>();
-                    model.put("memoryCount", turnTexts.size());
-                    model.put("sessionDate", sessionDateStr);
-                    model.put("memories", turnTexts);
-                    boolean hasPrior = priorContext != null && !priorContext.isEmpty();
-                    model.put("hasPriorContext", hasPrior);
-                    model.put("priorContext", hasPrior ? priorContext : List.of());
-                    model.put("priorContextCount", hasPrior ? priorContext.size() : 0);
+        if (signal.textGenerator() != null && signal.templateEngine() != null) {
+            try {
+                Map<String, Object> model = new HashMap<>();
+                model.put("memoryCount", turnTexts.size());
+                model.put("sessionDate", sessionDateStr);
+                model.put("memories", turnTexts);
+                boolean hasPrior = priorContext != null && !priorContext.isEmpty();
+                model.put("hasPriorContext", hasPrior);
+                model.put("priorContext", hasPrior ? priorContext : List.of());
+                model.put("priorContextCount", hasPrior ? priorContext.size() : 0);
 
-                    String prompt = signal.templateEngine().render("prompts/reflection-synthesis", model);
-                    String response = signal.textGenerator().generate(prompt, REFLECTION_GENERATION_OPTIONS);
+                String prompt = signal.templateEngine().render("prompts/reflection-synthesis", model);
+                String response = signal.textGenerator().generate(prompt, REFLECTION_GENERATION_OPTIONS);
 
-                    if (response != null && !response.isBlank()) {
-                        List<ConsolidatedFact> parsedFacts = parseJsonResponse(response);
-                        if (!parsedFacts.isEmpty()) {
-                            return parsedFacts;
-                        }
-                        List<ConsolidatedFact> lineFacts = parseLineResponse(response);
-                        if (!lineFacts.isEmpty()) {
-                            return lineFacts;
-                        }
+                if (response != null && !response.isBlank()) {
+                    List<ConsolidatedFact> parsedFacts = parseJsonResponse(response);
+                    if (!parsedFacts.isEmpty()) {
+                        return parsedFacts;
                     }
-                } catch (Exception e) {
-                    log.warn("Attempt {}/{} failed during reflection distillation: {}", attempt, maxRetries, e.getMessage());
-                    if (attempt < maxRetries) {
-                        try {
-                            Thread.sleep(1000L * attempt);
-                        } catch (InterruptedException ie) {
-                            Thread.currentThread().interrupt();
-                            break;
-                        }
+                    List<ConsolidatedFact> lineFacts = parseLineResponse(response);
+                    if (!lineFacts.isEmpty()) {
+                        return lineFacts;
                     }
+                }
+            } catch (Exception e) {
+                log.warn("Reflection distillation call failed: {}", e.getMessage());
+                if (signal.sweepSpec() != null && signal.sweepSpec().backpressure() != null) {
+                    signal.sweepSpec().backpressure().onProviderFailure(e);
                 }
             }
         }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/ReflectPathwayFactory.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/ReflectPathwayFactory.java
@@ -89,33 +89,45 @@ public final class ReflectPathwayFactory {
         if (interceptor != null) {
             builder.withInterceptor(interceptor);
         }
-        builder.relay(RelayNames.SYNAPTIC_PRUNING, pruningRelay, ErrorPolicy.FAIL_FAST)
+        builder.relay(RelayNames.SYNAPTIC_PRUNING, companion(pruningRelay), ErrorPolicy.FAIL_FAST)
                 .relay(RelayNames.EPISODIC_CONSOLIDATION, logConsolidationRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.SOUL_DRIFT_REFUSION, soulDriftRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.PROCEDURAL_CRYSTALLIZATION, proceduralRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.PROACTIVE_INTERFERENCE, interferenceRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.HEBBIAN_HOMEOSTASIS, hebbianRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.TEMPORAL_PRUNING, temporalRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.CROSS_LAYER_PROMOTION, promotionRelay, ErrorPolicy.DEGRADE_GRACEFULLY)
-                .relay(RelayNames.ENTITY_MAINTENANCE, entityRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
+                .relay(RelayNames.SOUL_DRIFT_REFUSION, companion(soulDriftRelay), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.PROCEDURAL_CRYSTALLIZATION, companion(proceduralRelay), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.PROACTIVE_INTERFERENCE, companion(interferenceRelay), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.HEBBIAN_HOMEOSTASIS, companion(hebbianRelay), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.TEMPORAL_PRUNING, companion(temporalRelay), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.CROSS_LAYER_PROMOTION, companion(promotionRelay), ErrorPolicy.DEGRADE_GRACEFULLY)
+                .relay(RelayNames.ENTITY_MAINTENANCE, companion(entityRelay), ErrorPolicy.DEGRADE_GRACEFULLY);
 
         if (sparsificationRelay != null) {
-            builder.relay(RelayNames.SPECTRAL_SPARSIFICATION, sparsificationRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
+            builder.relay(RelayNames.SPECTRAL_SPARSIFICATION, companion(sparsificationRelay), ErrorPolicy.DEGRADE_GRACEFULLY);
         }
 
         if (manifoldConsolidationRelay != null) {
-            builder.relay(RelayNames.MANIFOLD_CONSOLIDATION, manifoldConsolidationRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
+            builder.relay(RelayNames.MANIFOLD_CONSOLIDATION, companion(manifoldConsolidationRelay), ErrorPolicy.DEGRADE_GRACEFULLY);
         }
 
         if (softIdentityAnchorRelay != null) {
-            builder.relay(RelayNames.SOFT_IDENTITY_ANCHOR, softIdentityAnchorRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
+            builder.relay(RelayNames.SOFT_IDENTITY_ANCHOR, companion(softIdentityAnchorRelay), ErrorPolicy.DEGRADE_GRACEFULLY);
         }
 
         if (idiolectRelay != null) {
-            builder.relay("idiolectLearning", idiolectRelay, ErrorPolicy.DEGRADE_GRACEFULLY);
+            builder.relay("idiolectLearning", companion(idiolectRelay), ErrorPolicy.DEGRADE_GRACEFULLY);
         }
 
         builder.relay(RelayNames.WAL_JOURNAL, walRelay, ErrorPolicy.FAIL_FAST);
         return builder.build();
+    }
+
+    private static SynapticRelay<ReflectSignal> companion(final SynapticRelay<ReflectSignal> relay) {
+        if (relay == null) {
+            return null;
+        }
+        return signal -> {
+            if (signal.sweepSpec() != null && !signal.sweepSpec().runCompanionRelays()) {
+                return true;
+            }
+            return relay.transmit(signal);
+        };
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/ReflectSignal.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/relay/ReflectSignal.java
@@ -32,6 +32,9 @@ import com.spectrayan.spector.memory.model.SalienceProfile;
 import com.spectrayan.spector.memory.session.EpisodicSessionIndex;
 import com.spectrayan.spector.memory.sync.MemoryWal;
 import com.spectrayan.spector.memory.graph.temporal.TemporalChainMemory;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
 import com.spectrayan.spector.provider.generation.LlmProvider;
 
@@ -86,6 +89,11 @@ public final class ReflectSignal {
     private final float identityAnchorEta;
     private final float identityLyapunovThreshold;
     private final com.spectrayan.spector.memory.aisme.lifespan.LifespanRetentionController lifespanController;
+
+    // ── Batch & Sweep Orchestration Context ────────────────────────
+    private final ReflectSweepSpec sweepSpec;
+    private final ReflectCheckpointStore checkpointStore;
+    private volatile ReflectCheckpoint checkpoint;
 
     // ── Runtime Execution Metrics ──────────────────────────────────
     private final Instant startTime;
@@ -148,6 +156,10 @@ public final class ReflectSignal {
         this.identityLyapunovThreshold = builder.identityLyapunovThreshold;
         this.lifespanController = builder.lifespanController;
 
+        this.sweepSpec = builder.sweepSpec != null ? builder.sweepSpec : ReflectSweepSpec.fullCycle();
+        this.checkpointStore = builder.checkpointStore;
+        this.checkpoint = builder.checkpoint;
+
         this.startTime = Instant.now();
         this.graphMetrics = builder.graphMetrics != null ? builder.graphMetrics : new GraphHealthMetrics();
     }
@@ -157,6 +169,11 @@ public final class ReflectSignal {
     }
 
     // ── Getters & Accessors ────────────────────────────────────────
+
+    public ReflectSweepSpec sweepSpec() { return sweepSpec; }
+    public ReflectCheckpointStore checkpointStore() { return checkpointStore; }
+    public ReflectCheckpoint checkpoint() { return checkpoint; }
+    public void setCheckpoint(ReflectCheckpoint checkpoint) { this.checkpoint = checkpoint; }
 
     public com.spectrayan.spector.memory.aisme.fegr.MentalStateTracker mentalStateTracker() { return mentalStateTracker; }
     public com.spectrayan.spector.memory.aisme.manifold.CognitiveManifold cognitiveManifold() { return cognitiveManifold; }
@@ -349,6 +366,13 @@ public final class ReflectSignal {
         private float identityAnchorEta = 0.0001f;
         private float identityLyapunovThreshold = 0.15f;
         private com.spectrayan.spector.memory.aisme.lifespan.LifespanRetentionController lifespanController;
+        private ReflectSweepSpec sweepSpec = ReflectSweepSpec.fullCycle();
+        private ReflectCheckpointStore checkpointStore;
+        private ReflectCheckpoint checkpoint;
+
+        public Builder sweepSpec(ReflectSweepSpec sweepSpec) { this.sweepSpec = sweepSpec; return this; }
+        public Builder checkpointStore(ReflectCheckpointStore checkpointStore) { this.checkpointStore = checkpointStore; return this; }
+        public Builder checkpoint(ReflectCheckpoint checkpoint) { this.checkpoint = checkpoint; return this; }
 
         public Builder partitionManager(PartitionManager pm) { this.partitionManager = pm; return this; }
         public Builder index(MemoryIndex idx) { this.index = idx; return this; }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectBackpressurePolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectBackpressurePolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi;
+
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+
+/**
+ * Service Provider Interface governing rate-limiting, pacing, and fault tolerance
+ * between session consolidation executions.
+ *
+ * <p>Decouples pacing (token bucket, provider health, 429 backoff) from core kernel relays.</p>
+ *
+ * @since 1.5.0
+ */
+public interface ReflectBackpressurePolicy {
+
+    /**
+     * Interceptor invoked immediately before consolidating a session.
+     *
+     * <p>Implementations may pause the thread (e.g. token bucket acquisition)
+     * to prevent overwhelming downstream LLM providers.</p>
+     *
+     * @param item the session work item scheduled to be consolidated
+     * @throws InterruptedException if interrupted while waiting for rate-limiting permits
+     */
+    void beforeSession(SessionWorkItem item) throws InterruptedException;
+
+    /**
+     * Callback invoked when an LLM provider or external dependency throws an error
+     * (such as HTTP 429 Too Many Requests or timeout).
+     *
+     * @param t the exception encountered
+     */
+    void onProviderFailure(Throwable t);
+
+    /**
+     * Returns true if the policy determines the current sweep should be aborted early
+     * (e.g. circuit breaker tripped due to consecutive failures).
+     *
+     * @return true if the sweep should abort
+     */
+    boolean shouldAbortSweep();
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectCheckpointStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectCheckpointStore.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi;
+
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+
+import java.util.Optional;
+
+/**
+ * Service Provider Interface for persisting and loading reflection sweep checkpoints.
+ *
+ * <p>Enables orchestrators to resume long sweeps from the last completed session
+ * without repeating already-consolidated sessions.</p>
+ *
+ * @since 1.5.0
+ */
+public interface ReflectCheckpointStore {
+
+    /**
+     * Loads the latest checkpoint for the specified sweep identifier.
+     *
+     * @param sweepId unique sweep identifier
+     * @return the persisted checkpoint, or empty if none exists
+     */
+    Optional<ReflectCheckpoint> load(String sweepId);
+
+    /**
+     * Persists or updates the checkpoint for a sweep.
+     *
+     * @param checkpoint the current checkpoint state
+     */
+    void save(ReflectCheckpoint checkpoint);
+
+    /**
+     * Deletes the checkpoint for the specified sweep.
+     *
+     * @param sweepId unique sweep identifier
+     */
+    default void delete(String sweepId) {
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectSweepExecutor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectSweepExecutor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+
+/**
+ * Service Provider Interface for orchestrating reflection sweeps across memory partitions.
+ *
+ * <p>Implementations are discovered via {@link java.util.ServiceLoader}. Higher-priority
+ * implementations (such as Spring Batch in Synapse) supersede the default in-process executor.</p>
+ *
+ * @since 1.5.0
+ */
+public interface ReflectSweepExecutor {
+
+    /**
+     * Unique name identifying this sweep executor (e.g., "in-process", "spring-batch", "quartz").
+     */
+    String name();
+
+    /**
+     * Selection priority. Higher values take precedence when multiple executors are available.
+     * <ul>
+     *   <li>{@code 0}: Default in-process executor</li>
+     *   <li>{@code 100}: Spring Batch orchestrator in Synapse</li>
+     * </ul>
+     */
+    int priority();
+
+    /**
+     * Returns true if the runtime dependencies and environment for this executor are available.
+     */
+    boolean available();
+
+    /**
+     * Executes a reflection consolidation sweep according to the provided specification.
+     *
+     * @param memory the target memory instance
+     * @param spec   the sweep configuration and filter specification
+     * @return summary report of the sweep execution
+     */
+    ReflectReport execute(SpectorMemory memory, ReflectSweepSpec spec);
+
+    /**
+     * Returns the current progress snapshot for an active or completed sweep.
+     *
+     * @param sweepId unique sweep identifier
+     * @return progress telemetry, or null if unknown
+     */
+    ReflectSweepProgress progress(String sweepId);
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectSweepExecutors.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/ReflectSweepExecutors.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi;
+
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.InProcessReflectSweepExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Service registry and discovery mechanism for {@link ReflectSweepExecutor} implementations.
+ *
+ * @since 1.5.0
+ */
+public final class ReflectSweepExecutors {
+
+    private static final Logger log = LoggerFactory.getLogger(ReflectSweepExecutors.class);
+
+    public static final String ORCHESTRATOR_PROPERTY = "spector.memory.reflect.orchestrator";
+
+    private static final ReentrantLock INIT_LOCK = new ReentrantLock();
+    private static volatile RegistryState state;
+
+    private ReflectSweepExecutors() {
+    }
+
+    private static final class RegistryState {
+        final List<ReflectSweepExecutor> availableExecutors;
+        final ReflectSweepExecutor primaryExecutor;
+
+        RegistryState(List<ReflectSweepExecutor> availableExecutors, ReflectSweepExecutor primaryExecutor) {
+            this.availableExecutors = availableExecutors;
+            this.primaryExecutor = primaryExecutor;
+        }
+    }
+
+    /**
+     * Obtains the primary registered {@link ReflectSweepExecutor}.
+     */
+    public static ReflectSweepExecutor getPrimary() {
+        return getState().primaryExecutor;
+    }
+
+    /**
+     * Obtains all available registered executors.
+     */
+    public static List<ReflectSweepExecutor> getAvailable() {
+        return getState().availableExecutors;
+    }
+
+    /**
+     * Resets discovered state; forces next call to reload via ServiceLoader.
+     */
+    public static void reset() {
+        INIT_LOCK.lock();
+        try {
+            state = null;
+        } finally {
+            INIT_LOCK.unlock();
+        }
+    }
+
+    private static RegistryState getState() {
+        RegistryState localState = state;
+        if (localState != null) {
+            return localState;
+        }
+
+        INIT_LOCK.lock();
+        try {
+            if (state != null) {
+                return state;
+            }
+            state = initialize();
+            return state;
+        } finally {
+            INIT_LOCK.unlock();
+        }
+    }
+
+    private static RegistryState initialize() {
+        List<ReflectSweepExecutor> discovered = new ArrayList<>();
+        String explicitChoice = System.getProperty(ORCHESTRATOR_PROPERTY);
+
+        ServiceLoader<ReflectSweepExecutor> loader = ServiceLoader.load(ReflectSweepExecutor.class);
+        for (ReflectSweepExecutor exec : loader) {
+            try {
+                if (exec.available()) {
+                    discovered.add(exec);
+                    log.info("Discovered ReflectSweepExecutor: '{}' (priority={})", exec.name(), exec.priority());
+                }
+            } catch (Throwable t) {
+                log.warn("Failed checking availability for executor {}: {}", exec.getClass().getName(), t.getMessage());
+            }
+        }
+
+        discovered.sort(Comparator.comparingInt(ReflectSweepExecutor::priority).reversed());
+
+        ReflectSweepExecutor primary = null;
+        if (explicitChoice != null && !explicitChoice.isBlank()) {
+            for (ReflectSweepExecutor exec : discovered) {
+                if (exec.name().equalsIgnoreCase(explicitChoice.trim())) {
+                    primary = exec;
+                    log.info("Selected ReflectSweepExecutor '{}' via system property override", exec.name());
+                    break;
+                }
+            }
+        }
+
+        if (primary == null && !discovered.isEmpty()) {
+            primary = discovered.get(0);
+        }
+
+        if (primary == null) {
+            primary = InProcessReflectSweepExecutor.INSTANCE;
+            discovered.add(primary);
+        }
+
+        log.info("Active primary ReflectSweepExecutor: '{}'", primary.name());
+        return new RegistryState(List.copyOf(discovered), primary);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/FileReflectCheckpointStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/FileReflectCheckpointStore.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi.local;
+
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * File-backed checkpoint store persisting checkpoints as individual JSON documents
+ * with atomic rename semantics for crash safety.
+ *
+ * @since 1.5.0
+ */
+public final class FileReflectCheckpointStore implements ReflectCheckpointStore {
+
+    private static final Logger log = LoggerFactory.getLogger(FileReflectCheckpointStore.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Path storageDir;
+    private final Map<String, ReflectCheckpoint> memoryFallback = new ConcurrentHashMap<>();
+
+    public FileReflectCheckpointStore(Path storageDir) {
+        this.storageDir = Objects.requireNonNull(storageDir, "storageDir cannot be null");
+        try {
+            Files.createDirectories(storageDir);
+        } catch (IOException e) {
+            log.warn("Failed to create checkpoint directory {}: {}", storageDir, e.getMessage());
+        }
+    }
+
+    @Override
+    public Optional<ReflectCheckpoint> load(String sweepId) {
+        if (sweepId == null || sweepId.isBlank()) {
+            return Optional.empty();
+        }
+
+        Path checkpointFile = checkpointPath(sweepId);
+        if (Files.exists(checkpointFile)) {
+            try {
+                byte[] bytes = Files.readAllBytes(checkpointFile);
+                JsonNode root = MAPPER.readTree(bytes);
+                ReflectCheckpoint cp = parseCheckpoint(root, sweepId);
+                memoryFallback.put(sweepId, cp);
+                return Optional.of(cp);
+            } catch (Exception e) {
+                log.warn("Failed to read checkpoint from {}: {}", checkpointFile, e.getMessage());
+                return Optional.ofNullable(memoryFallback.get(sweepId));
+            }
+        } else {
+            memoryFallback.remove(sweepId);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void save(ReflectCheckpoint checkpoint) {
+        if (checkpoint == null || checkpoint.sweepId() == null) {
+            return;
+        }
+
+        String sweepId = checkpoint.sweepId();
+        memoryFallback.put(sweepId, checkpoint);
+
+        Path targetFile = checkpointPath(sweepId);
+        Path tempFile = targetFile.resolveSibling(targetFile.getFileName() + ".tmp");
+
+        try {
+            ObjectNode root = MAPPER.createObjectNode();
+            root.put("sweepId", checkpoint.sweepId());
+            root.put("partitionSeq", checkpoint.partitionSeq());
+            root.put("lastCompletedSessionId", checkpoint.lastCompletedSessionId());
+            root.put("lastCompletedTurnOffset", checkpoint.lastCompletedTurnOffset());
+            root.put("sessionsCompleted", checkpoint.sessionsCompleted());
+            root.put("factsIngested", checkpoint.factsIngested());
+            root.put("turnsMarked", checkpoint.turnsMarked());
+            root.put("backlogRemaining", checkpoint.backlogRemaining());
+            root.put("updatedAt", checkpoint.updatedAt().toString());
+            root.put("status", checkpoint.status().name());
+
+            byte[] bytes = root.toString().getBytes(StandardCharsets.UTF_8);
+            Files.write(tempFile, bytes);
+            try {
+                Files.move(tempFile, targetFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException ae) {
+                Files.move(tempFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            log.warn("Failed to persist checkpoint to disk for sweep {}: {}", sweepId, e.getMessage());
+        } finally {
+            try {
+                Files.deleteIfExists(tempFile);
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    @Override
+    public void delete(String sweepId) {
+        if (sweepId == null) return;
+        memoryFallback.remove(sweepId);
+        try {
+            Files.deleteIfExists(checkpointPath(sweepId));
+        } catch (IOException e) {
+            log.warn("Failed to delete checkpoint file for sweep {}: {}", sweepId, e.getMessage());
+        }
+    }
+
+    private ReflectCheckpoint parseCheckpoint(JsonNode root, String fallbackSweepId) {
+        String sweepId = root.has("sweepId") ? root.get("sweepId").asText() : fallbackSweepId;
+        int partitionSeq = root.has("partitionSeq") ? root.get("partitionSeq").asInt() : 0;
+        long lastCompletedSessionId = root.has("lastCompletedSessionId") ? root.get("lastCompletedSessionId").asLong() : 0L;
+        long lastCompletedTurnOffset = root.has("lastCompletedTurnOffset") ? root.get("lastCompletedTurnOffset").asLong() : 0L;
+        int sessionsCompleted = root.has("sessionsCompleted") ? root.get("sessionsCompleted").asInt() : 0;
+        int factsIngested = root.has("factsIngested") ? root.get("factsIngested").asInt() : 0;
+        int turnsMarked = root.has("turnsMarked") ? root.get("turnsMarked").asInt() : 0;
+        int backlogRemaining = root.has("backlogRemaining") ? root.get("backlogRemaining").asInt() : 0;
+
+        Instant updatedAt = Instant.now();
+        if (root.has("updatedAt")) {
+            try {
+                updatedAt = Instant.parse(root.get("updatedAt").asText());
+            } catch (Exception ignored) {
+            }
+        }
+
+        ReflectSweepStatus status = ReflectSweepStatus.IDLE;
+        if (root.has("status")) {
+            try {
+                status = ReflectSweepStatus.valueOf(root.get("status").asText());
+            } catch (Exception ignored) {
+            }
+        }
+
+        return new ReflectCheckpoint(
+                sweepId,
+                partitionSeq,
+                lastCompletedSessionId,
+                lastCompletedTurnOffset,
+                sessionsCompleted,
+                factsIngested,
+                turnsMarked,
+                backlogRemaining,
+                updatedAt,
+                status
+        );
+    }
+
+    private Path checkpointPath(String sweepId) {
+        String safeName = sweepId.replaceAll("[^a-zA-Z0-9._-]", "_") + ".checkpoint.json";
+        return storageDir.resolve(safeName);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/FileReflectCheckpointStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/FileReflectCheckpointStore.java
@@ -62,7 +62,20 @@ public final class FileReflectCheckpointStore implements ReflectCheckpointStore 
             return Optional.empty();
         }
 
-        Path checkpointFile = checkpointPath(sweepId);
+        Path checkpointFile;
+        try {
+            checkpointFile = checkpointPath(sweepId);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid checkpoint sweepId: {}", sweepId);
+            return Optional.ofNullable(memoryFallback.get(sweepId));
+        }
+
+        Path baseDir = storageDir.toAbsolutePath().normalize();
+        if (!checkpointFile.startsWith(baseDir)) {
+            log.warn("Path traversal check failed for sweepId: {}", sweepId);
+            return Optional.ofNullable(memoryFallback.get(sweepId));
+        }
+
         if (Files.exists(checkpointFile)) {
             try {
                 byte[] bytes = Files.readAllBytes(checkpointFile);
@@ -82,15 +95,32 @@ public final class FileReflectCheckpointStore implements ReflectCheckpointStore 
 
     @Override
     public void save(ReflectCheckpoint checkpoint) {
-        if (checkpoint == null || checkpoint.sweepId() == null) {
+        if (checkpoint == null || checkpoint.sweepId() == null || checkpoint.sweepId().isBlank()) {
             return;
         }
 
         String sweepId = checkpoint.sweepId();
         memoryFallback.put(sweepId, checkpoint);
 
-        Path targetFile = checkpointPath(sweepId);
-        Path tempFile = targetFile.resolveSibling(targetFile.getFileName() + ".tmp");
+        Path targetFile;
+        try {
+            targetFile = checkpointPath(sweepId);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid sweepId for checkpoint save: {}", sweepId);
+            return;
+        }
+
+        Path baseDir = storageDir.toAbsolutePath().normalize();
+        if (!targetFile.startsWith(baseDir)) {
+            log.warn("Path traversal check failed for checkpoint save: {}", sweepId);
+            return;
+        }
+
+        Path tempFile = baseDir.resolve(targetFile.getFileName().toString() + ".tmp").normalize();
+        if (!tempFile.startsWith(baseDir)) {
+            log.warn("Path traversal check failed for checkpoint temp file: {}", sweepId);
+            return;
+        }
 
         try {
             ObjectNode root = MAPPER.createObjectNode();
@@ -124,10 +154,16 @@ public final class FileReflectCheckpointStore implements ReflectCheckpointStore 
 
     @Override
     public void delete(String sweepId) {
-        if (sweepId == null) return;
+        if (sweepId == null || sweepId.isBlank()) return;
         memoryFallback.remove(sweepId);
         try {
-            Files.deleteIfExists(checkpointPath(sweepId));
+            Path targetFile = checkpointPath(sweepId);
+            Path baseDir = storageDir.toAbsolutePath().normalize();
+            if (targetFile.startsWith(baseDir)) {
+                Files.deleteIfExists(targetFile);
+            }
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid sweepId for checkpoint deletion: {}", sweepId);
         } catch (IOException e) {
             log.warn("Failed to delete checkpoint file for sweep {}: {}", sweepId, e.getMessage());
         }
@@ -174,7 +210,15 @@ public final class FileReflectCheckpointStore implements ReflectCheckpointStore 
     }
 
     private Path checkpointPath(String sweepId) {
-        String safeName = sweepId.replaceAll("[^a-zA-Z0-9._-]", "_") + ".checkpoint.json";
-        return storageDir.resolve(safeName);
+        if (sweepId == null || sweepId.isBlank()) {
+            throw new IllegalArgumentException("sweepId cannot be null or blank");
+        }
+        String safeName = sweepId.replaceAll("[^a-zA-Z0-9_-]", "_") + ".checkpoint.json";
+        Path baseDir = storageDir.toAbsolutePath().normalize();
+        Path resolved = baseDir.resolve(safeName).normalize();
+        if (!resolved.startsWith(baseDir) || !baseDir.equals(resolved.getParent())) {
+            throw new IllegalArgumentException("Invalid sweepId path: " + sweepId);
+        }
+        return resolved;
     }
 }

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/InMemoryReflectCheckpointStore.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/InMemoryReflectCheckpointStore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi.local;
+
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe in-memory checkpoint store for testing and in-memory persistence mode.
+ *
+ * @since 1.5.0
+ */
+public final class InMemoryReflectCheckpointStore implements ReflectCheckpointStore {
+
+    private final Map<String, ReflectCheckpoint> checkpoints = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<ReflectCheckpoint> load(String sweepId) {
+        if (sweepId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(checkpoints.get(sweepId));
+    }
+
+    @Override
+    public void save(ReflectCheckpoint checkpoint) {
+        if (checkpoint != null && checkpoint.sweepId() != null) {
+            checkpoints.put(checkpoint.sweepId(), checkpoint);
+        }
+    }
+
+    @Override
+    public void delete(String sweepId) {
+        if (sweepId != null) {
+            checkpoints.remove(sweepId);
+        }
+    }
+
+    public void clear() {
+        checkpoints.clear();
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/InProcessReflectSweepExecutor.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/InProcessReflectSweepExecutor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi.local;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default in-process reflection sweep executor.
+ *
+ * <p>Executes reflection sweeps synchronously on the calling thread, tracking progress
+ * in-memory and conducting the reflection pathway through the memory kernel.</p>
+ *
+ * @since 1.5.0
+ */
+public final class InProcessReflectSweepExecutor implements ReflectSweepExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(InProcessReflectSweepExecutor.class);
+
+    public static final InProcessReflectSweepExecutor INSTANCE = new InProcessReflectSweepExecutor();
+
+    private final Map<String, ReflectSweepProgress> progressMap = new ConcurrentHashMap<>();
+
+    public InProcessReflectSweepExecutor() {
+    }
+
+    @Override
+    public String name() {
+        return "in-process";
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    @Override
+    public boolean available() {
+        return true;
+    }
+
+    @Override
+    public ReflectReport execute(SpectorMemory memory, ReflectSweepSpec spec) {
+        ReflectSweepSpec effectiveSpec = (spec != null) ? spec : ReflectSweepSpec.fullCycle();
+        String sweepId = effectiveSpec.sweepId();
+        Instant startedAt = Instant.now();
+
+        log.info("InProcessReflectSweepExecutor: starting sweep '{}' (limit={}, companion={})",
+                sweepId, effectiveSpec.sessionLimit(), effectiveSpec.runCompanionRelays());
+
+        progressMap.put(sweepId, new ReflectSweepProgress(
+                sweepId, 0, 0, 0, 0, ReflectSweepStatus.RUNNING, startedAt, startedAt));
+
+        try {
+            ReflectReport report;
+            if (memory != null && memory.admin() != null) {
+                report = memory.admin().reflectKernel(effectiveSpec);
+            } else if (memory != null) {
+                report = memory.reflect();
+            } else {
+                report = ReflectReport.empty();
+            }
+
+            progressMap.put(sweepId, new ReflectSweepProgress(
+                    sweepId,
+                    report.consolidatedCount(),
+                    report.consolidatedCount(),
+                    report.consolidatedCount(),
+                    0,
+                    ReflectSweepStatus.COMPLETE,
+                    startedAt,
+                    Instant.now()
+            ));
+            return report;
+        } catch (Throwable t) {
+            log.error("InProcessReflectSweepExecutor: sweep '{}' failed: {}", sweepId, t.getMessage(), t);
+            progressMap.put(sweepId, new ReflectSweepProgress(
+                    sweepId, 0, 0, 0, 0, ReflectSweepStatus.FAILED, startedAt, Instant.now()));
+            if (t instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new RuntimeException("In-process reflection sweep failed: " + t.getMessage(), t);
+        }
+    }
+
+    @Override
+    public ReflectSweepProgress progress(String sweepId) {
+        if (sweepId == null) {
+            return null;
+        }
+        return progressMap.get(sweepId);
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/NoopBackpressurePolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/NoopBackpressurePolicy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi.local;
+
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectBackpressurePolicy;
+
+/**
+ * No-op backpressure policy introducing zero pauses or restrictions.
+ * Used as default in unit tests and benchmarks.
+ *
+ * @since 1.5.0
+ */
+public final class NoopBackpressurePolicy implements ReflectBackpressurePolicy {
+
+    public static final NoopBackpressurePolicy INSTANCE = new NoopBackpressurePolicy();
+
+    private NoopBackpressurePolicy() {
+    }
+
+    @Override
+    public void beforeSession(SessionWorkItem item) {
+        // No pause
+    }
+
+    @Override
+    public void onProviderFailure(Throwable t) {
+        // No tracking
+    }
+
+    @Override
+    public boolean shouldAbortSweep() {
+        return false;
+    }
+}

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/TokenBucketBackpressurePolicy.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/pathway/reflect/spi/local/TokenBucketBackpressurePolicy.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect.spi.local;
+
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectBackpressurePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Token-bucket rate-limiting policy governing session consolidation throughput.
+ *
+ * @since 1.5.0
+ */
+public final class TokenBucketBackpressurePolicy implements ReflectBackpressurePolicy {
+
+    private static final Logger log = LoggerFactory.getLogger(TokenBucketBackpressurePolicy.class);
+
+    private final double refillTokensPerMs;
+    private final double capacity;
+    private final int maxConsecutiveFailures;
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private double availableTokens;
+    private long lastRefillTimestampMs;
+
+    public TokenBucketBackpressurePolicy(int sessionsPerMinute, int burstCapacity, int maxConsecutiveFailures) {
+        if (sessionsPerMinute <= 0) {
+            throw new IllegalArgumentException("sessionsPerMinute must be positive: " + sessionsPerMinute);
+        }
+        this.capacity = Math.max(1, burstCapacity);
+        this.refillTokensPerMs = sessionsPerMinute / 60000.0;
+        this.maxConsecutiveFailures = maxConsecutiveFailures;
+        this.availableTokens = this.capacity;
+        this.lastRefillTimestampMs = System.currentTimeMillis();
+    }
+
+    public static TokenBucketBackpressurePolicy perMinute(int sessionsPerMinute) {
+        return new TokenBucketBackpressurePolicy(sessionsPerMinute, Math.max(1, sessionsPerMinute / 10), 5);
+    }
+
+    @Override
+    public void beforeSession(SessionWorkItem item) throws InterruptedException {
+        while (true) {
+            long waitMs = 0;
+            lock.lock();
+            try {
+                refill();
+                if (availableTokens >= 1.0) {
+                    availableTokens -= 1.0;
+                    consecutiveFailures.set(0);
+                    return;
+                }
+                double missing = 1.0 - availableTokens;
+                waitMs = (long) Math.ceil(missing / refillTokensPerMs);
+            } finally {
+                lock.unlock();
+            }
+
+            if (waitMs > 0) {
+                Thread.sleep(Math.min(waitMs, 1000L));
+            }
+        }
+    }
+
+    @Override
+    public void onProviderFailure(Throwable t) {
+        int failures = consecutiveFailures.incrementAndGet();
+        log.warn("ReflectBackpressurePolicy: provider failure #{} recorded: {}", failures, t.getMessage());
+    }
+
+    @Override
+    public boolean shouldAbortSweep() {
+        return maxConsecutiveFailures > 0 && consecutiveFailures.get() >= maxConsecutiveFailures;
+    }
+
+    private void refill() {
+        long now = System.currentTimeMillis();
+        long elapsedMs = Math.max(0, now - lastRefillTimestampMs);
+        if (elapsedMs > 0) {
+            availableTokens = Math.min(capacity, availableTokens + (elapsedMs * refillTokensPerMs));
+            lastRefillTimestampMs = now;
+        }
+    }
+}

--- a/memory/spector-memory/src/main/resources/META-INF/services/com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor
+++ b/memory/spector-memory/src/main/resources/META-INF/services/com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor
@@ -1,0 +1,1 @@
+com.spectrayan.spector.memory.pathway.reflect.spi.local.InProcessReflectSweepExecutor

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectCheckpointTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectCheckpointTest.java
@@ -128,4 +128,44 @@ class ReflectCheckpointTest {
         store.delete("sweep-disk");
         assertThat(reloadedStore.load("sweep-disk")).isEmpty();
     }
+
+    @Test
+    @DisplayName("FileReflectCheckpointStore guards against path traversal in sweepId")
+    void testFileStorePathTraversal(@TempDir Path tempDir) {
+        FileReflectCheckpointStore store = new FileReflectCheckpointStore(tempDir);
+
+        String maliciousSweepId = "../../../etc/passwd";
+        ReflectCheckpoint cp = new ReflectCheckpoint(
+                maliciousSweepId,
+                0,
+                100L,
+                200L,
+                1,
+                2,
+                3,
+                4,
+                Instant.now(),
+                ReflectSweepStatus.COMPLETE
+        );
+
+        // Save sanitizes and persists strictly within tempDir
+        store.save(cp);
+
+        // Verify no file was created outside tempDir
+        assertThat(tempDir.resolve("../passwd")).doesNotExist();
+
+        // Load works safely through sanitized path
+        Optional<ReflectCheckpoint> loaded = store.load(maliciousSweepId);
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().lastCompletedSessionId()).isEqualTo(100L);
+
+        // Delete cleans up safely
+        store.delete(maliciousSweepId);
+        assertThat(store.load(maliciousSweepId)).isEmpty();
+
+        // Blank/null sweepId handled gracefully
+        assertThat(store.load(null)).isEmpty();
+        assertThat(store.load("")).isEmpty();
+        assertThat(store.load("   ")).isEmpty();
+    }
 }

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectCheckpointTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectCheckpointTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.FileReflectCheckpointStore;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.InMemoryReflectCheckpointStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReflectCheckpoint: Persistence & Telemetry Tests")
+class ReflectCheckpointTest {
+
+    @Test
+    @DisplayName("Initial checkpoint creates clean state")
+    void testInitialCheckpoint() {
+        ReflectCheckpoint cp = ReflectCheckpoint.initial("sweep-alpha");
+        assertThat(cp.sweepId()).isEqualTo("sweep-alpha");
+        assertThat(cp.lastCompletedSessionId()).isEqualTo(0L);
+        assertThat(cp.sessionsCompleted()).isEqualTo(0);
+        assertThat(cp.status()).isEqualTo(ReflectSweepStatus.IDLE);
+    }
+
+    @Test
+    @DisplayName("ReflectSweepProgress converts correctly from checkpoint")
+    void testProgressConversion() {
+        Instant startedAt = Instant.now();
+        ReflectCheckpoint cp = new ReflectCheckpoint(
+                "sweep-1",
+                0,
+                12345L,
+                999L,
+                10,
+                25,
+                40,
+                5,
+                Instant.now(),
+                ReflectSweepStatus.RUNNING
+        );
+
+        ReflectSweepProgress progress = ReflectSweepProgress.from(cp, startedAt);
+        assertThat(progress.sweepId()).isEqualTo("sweep-1");
+        assertThat(progress.sessionsCompleted()).isEqualTo(10);
+        assertThat(progress.factsIngested()).isEqualTo(25);
+        assertThat(progress.turnsMarked()).isEqualTo(40);
+        assertThat(progress.backlogRemaining()).isEqualTo(5);
+        assertThat(progress.status()).isEqualTo(ReflectSweepStatus.RUNNING);
+        assertThat(progress.startedAt()).isEqualTo(startedAt);
+    }
+
+    @Test
+    @DisplayName("InMemoryReflectCheckpointStore saves, loads, and deletes checkpoints")
+    void testInMemoryStore() {
+        InMemoryReflectCheckpointStore store = new InMemoryReflectCheckpointStore();
+        ReflectCheckpoint cp = new ReflectCheckpoint(
+                "sweep-2",
+                1,
+                555L,
+                100L,
+                2,
+                4,
+                8,
+                0,
+                Instant.now(),
+                ReflectSweepStatus.COMPLETE
+        );
+
+        assertThat(store.load("sweep-2")).isEmpty();
+        store.save(cp);
+        Optional<ReflectCheckpoint> loaded = store.load("sweep-2");
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().lastCompletedSessionId()).isEqualTo(555L);
+        assertThat(loaded.get().status()).isEqualTo(ReflectSweepStatus.COMPLETE);
+
+        store.delete("sweep-2");
+        assertThat(store.load("sweep-2")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FileReflectCheckpointStore atomically persists and reloads checkpoints from disk")
+    void testFileStore(@TempDir Path tempDir) {
+        FileReflectCheckpointStore store = new FileReflectCheckpointStore(tempDir);
+        ReflectCheckpoint cp = new ReflectCheckpoint(
+                "sweep-disk",
+                0,
+                888L,
+                2048L,
+                7,
+                14,
+                21,
+                12,
+                Instant.now(),
+                ReflectSweepStatus.RUNNING
+        );
+
+        assertThat(store.load("sweep-disk")).isEmpty();
+        store.save(cp);
+
+        // Load back through another store instance to verify true disk persistence
+        FileReflectCheckpointStore reloadedStore = new FileReflectCheckpointStore(tempDir);
+        Optional<ReflectCheckpoint> loaded = reloadedStore.load("sweep-disk");
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().sweepId()).isEqualTo("sweep-disk");
+        assertThat(loaded.get().lastCompletedSessionId()).isEqualTo(888L);
+        assertThat(loaded.get().lastCompletedTurnOffset()).isEqualTo(2048L);
+        assertThat(loaded.get().sessionsCompleted()).isEqualTo(7);
+        assertThat(loaded.get().factsIngested()).isEqualTo(14);
+        assertThat(loaded.get().turnsMarked()).isEqualTo(21);
+        assertThat(loaded.get().backlogRemaining()).isEqualTo(12);
+        assertThat(loaded.get().status()).isEqualTo(ReflectSweepStatus.RUNNING);
+
+        store.delete("sweep-disk");
+        assertThat(reloadedStore.load("sweep-disk")).isEmpty();
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectFilterTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectFilterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReflectFilter: Criteria Matching Tests")
+class ReflectFilterTest {
+
+    @Test
+    @DisplayName("ReflectFilter.all() matches any session, timestamp, and partition")
+    void testAllFilter() {
+        ReflectFilter filter = ReflectFilter.all();
+        assertThat(filter.matches(100L, 5000L, 0)).isTrue();
+        assertThat(filter.matches(200L, 10000L, 1)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Filter matches explicit session IDs")
+    void testSessionIdFilter() {
+        ReflectFilter filter = ReflectFilter.builder()
+                .sessionIds(Set.of(101L, 102L))
+                .build();
+
+        assertThat(filter.matches(101L, 1000L, 0)).isTrue();
+        assertThat(filter.matches(102L, 1000L, 0)).isTrue();
+        assertThat(filter.matches(103L, 1000L, 0)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Filter respects exclusive cursor watermark (sessionIdAfter)")
+    void testSessionIdAfterWatermark() {
+        ReflectFilter filter = ReflectFilter.builder()
+                .sessionIdAfter(500L)
+                .build();
+
+        assertThat(filter.matches(499L, 1000L, 0)).isFalse();
+        assertThat(filter.matches(500L, 1000L, 0)).isFalse();
+        assertThat(filter.matches(501L, 1000L, 0)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Filter matches timestamp range [from, to]")
+    void testTimestampRange() {
+        Instant t1 = Instant.ofEpochMilli(2000L);
+        Instant t2 = Instant.ofEpochMilli(4000L);
+
+        ReflectFilter filter = ReflectFilter.builder()
+                .from(t1)
+                .to(t2)
+                .build();
+
+        assertThat(filter.matches(1L, 1999L, 0)).isFalse();
+        assertThat(filter.matches(1L, 2000L, 0)).isTrue();
+        assertThat(filter.matches(1L, 3000L, 0)).isTrue();
+        assertThat(filter.matches(1L, 4000L, 0)).isTrue();
+        assertThat(filter.matches(1L, 4001L, 0)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Filter matches partition sequence set")
+    void testPartitionSeqFilter() {
+        ReflectFilter filter = ReflectFilter.builder()
+                .partitionSeqs(Set.of(0, 2))
+                .build();
+
+        assertThat(filter.matches(1L, 1000L, 0)).isTrue();
+        assertThat(filter.matches(1L, 1000L, 1)).isFalse();
+        assertThat(filter.matches(1L, 1000L, 2)).isTrue();
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepExecutorsTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/ReflectSweepExecutorsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-memory/LICENSE
+ *
+ * Change Date: May 27, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.memory.pathway.reflect;
+
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutors;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.NoopBackpressurePolicy;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.TokenBucketBackpressurePolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReflectSweepExecutors: Discovery & Configuration Tests")
+class ReflectSweepExecutorsTest {
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(ReflectSweepExecutors.ORCHESTRATOR_PROPERTY);
+        ReflectSweepExecutors.reset();
+    }
+
+    @Test
+    @DisplayName("Discovers InProcessReflectSweepExecutor as default primary SPI provider")
+    void testDefaultDiscovery() {
+        ReflectSweepExecutors.reset();
+        ReflectSweepExecutor primary = ReflectSweepExecutors.getPrimary();
+        assertThat(primary).isNotNull();
+        assertThat(primary.name()).isEqualTo("in-process");
+        assertThat(primary.priority()).isEqualTo(0);
+        assertThat(primary.available()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ReflectSweepSpec fullCycle produces full biological reflection spec")
+    void testFullCycleSpec() {
+        ReflectSweepSpec spec = ReflectSweepSpec.fullCycle();
+        assertThat(spec.sweepId()).isEqualTo("full-cycle");
+        assertThat(spec.sessionLimit()).isZero();
+        assertThat(spec.runCompanionRelays()).isTrue();
+        assertThat(spec.backpressure()).isSameAs(NoopBackpressurePolicy.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("ReflectSweepSpec consolidationOnly produces bounded partial tick spec")
+    void testConsolidationOnlySpec() {
+        ReflectSweepSpec spec = ReflectSweepSpec.consolidationOnly(15);
+        assertThat(spec.sweepId()).isEqualTo("consolidation-tick");
+        assertThat(spec.sessionLimit()).isEqualTo(15);
+        assertThat(spec.runCompanionRelays()).isFalse();
+    }
+
+    @Test
+    @DisplayName("TokenBucketBackpressurePolicy tracks failures and triggers abort")
+    void testTokenBucketBackpressure() {
+        TokenBucketBackpressurePolicy policy = new TokenBucketBackpressurePolicy(6000, 10, 2);
+        assertThat(policy.shouldAbortSweep()).isFalse();
+
+        policy.onProviderFailure(new RuntimeException("Simulated 429 Too Many Requests"));
+        assertThat(policy.shouldAbortSweep()).isFalse();
+
+        policy.onProviderFailure(new RuntimeException("Simulated 429 Too Many Requests"));
+        assertThat(policy.shouldAbortSweep()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Builder configures custom timeout and filters")
+    void testSpecBuilder() {
+        ReflectSweepSpec custom = ReflectSweepSpec.builder()
+                .sweepId("custom-batch")
+                .sessionLimit(5)
+                .timeBudget(Duration.ofSeconds(30))
+                .runCompanionRelays(false)
+                .build();
+
+        assertThat(custom.sweepId()).isEqualTo("custom-batch");
+        assertThat(custom.sessionLimit()).isEqualTo(5);
+        assertThat(custom.timeBudget()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(custom.runCompanionRelays()).isFalse();
+    }
+}

--- a/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelayTest.java
+++ b/memory/spector-memory/src/test/java/com/spectrayan/spector/memory/pathway/reflect/relay/EpisodicLogConsolidationRelayTest.java
@@ -28,6 +28,11 @@ import com.spectrayan.spector.provider.model.LlmRequest;
 import com.spectrayan.spector.provider.model.LlmResponse;
 import com.spectrayan.spector.memory.kernel.layout.EncodingHeader;
 import com.spectrayan.spector.memory.session.EpisodicSessionIndex;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectFilter;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.InMemoryReflectCheckpointStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -279,4 +286,176 @@ class EpisodicLogConsolidationRelayTest {
         assertThat(secondPrompt).contains("New Turns (Extract facts ONLY from these):");
         assertThat(secondPrompt).contains("Let's go with Kafka because of high throughput");
     }
+
+    @Test
+    @DisplayName("Respects sessionLimit in ReflectFilter, consolidating at most N sessions")
+    void testSessionLimit() {
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 101L, "Session 101 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 102L, "Session 102 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 103L, "Session 103 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(workingMemory, semanticMemory, proceduralMemory, logMemory);
+        PartitionManager partitionManager = Mockito.mock(PartitionManager.class);
+        when(partitionManager.snapshot()).thenReturn(List.of(new PartitionHandle(0, null, router, null, false)));
+
+        RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        when(rememberPathway.ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any())).thenReturn(true);
+        LlmProvider llm = new LlmProvider() {
+            @Override public LlmResponse generate(LlmRequest req, GenerationOptions opt) { return new LlmResponse("- Fact", 1, 1, "m"); }
+            @Override public String generate(String prompt, GenerationOptions opt) { return "- Fact"; }
+            @Override public boolean isAvailable() { return true; }
+            @Override public String modelName() { return "m"; }
+        };
+
+        ReflectSweepSpec spec = ReflectSweepSpec.builder()
+                .sessionLimit(2)
+                .build();
+
+        ReflectSignal signal = ReflectSignal.builder()
+                .partitionManager(partitionManager)
+                .rememberPathway(rememberPathway)
+                .textGenerator(llm)
+                .sweepSpec(spec)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
+                .build();
+
+        EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
+        boolean success = relay.transmit(signal);
+
+        assertThat(success).isTrue();
+        assertThat(signal.logTurnsConsolidated()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Respects sessionIdAfter cursor, skipping sessions less than or equal to cursor")
+    void testSessionIdAfterCursor() {
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 100L, "Session 100 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 200L, "Session 200 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 300L, "Session 300 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(workingMemory, semanticMemory, proceduralMemory, logMemory);
+        PartitionManager partitionManager = Mockito.mock(PartitionManager.class);
+        when(partitionManager.snapshot()).thenReturn(List.of(new PartitionHandle(0, null, router, null, false)));
+
+        RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        when(rememberPathway.ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any())).thenReturn(true);
+        LlmProvider llm = new LlmProvider() {
+            @Override public LlmResponse generate(LlmRequest req, GenerationOptions opt) { return new LlmResponse("- Fact", 1, 1, "m"); }
+            @Override public String generate(String prompt, GenerationOptions opt) { return "- Fact"; }
+            @Override public boolean isAvailable() { return true; }
+            @Override public String modelName() { return "m"; }
+        };
+
+        ReflectSweepSpec spec = ReflectSweepSpec.builder()
+                .filter(ReflectFilter.builder().sessionIdAfter(150L).build())
+                .build();
+
+        ReflectSignal signal = ReflectSignal.builder()
+                .partitionManager(partitionManager)
+                .rememberPathway(rememberPathway)
+                .textGenerator(llm)
+                .sweepSpec(spec)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
+                .build();
+
+        EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
+        boolean success = relay.transmit(signal);
+
+        assertThat(success).isTrue();
+        // Only sessions 200 and 300 should be consolidated
+        assertThat(signal.logTurnsConsolidated()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Updates ReflectCheckpointStore after processing each session")
+    void testCheckpointUpdatedDuringConsolidation() {
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 101L, "Session 101 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 102L, "Session 102 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(workingMemory, semanticMemory, proceduralMemory, logMemory);
+        PartitionManager partitionManager = Mockito.mock(PartitionManager.class);
+        when(partitionManager.snapshot()).thenReturn(List.of(new PartitionHandle(0, null, router, null, false)));
+
+        RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        when(rememberPathway.ingestCognitiveWithHeader(any(), any(), any(), any(), any(), any(), any())).thenReturn(true);
+        LlmProvider llm = new LlmProvider() {
+            @Override public LlmResponse generate(LlmRequest req, GenerationOptions opt) { return new LlmResponse("- Fact", 1, 1, "m"); }
+            @Override public String generate(String prompt, GenerationOptions opt) { return "- Fact"; }
+            @Override public boolean isAvailable() { return true; }
+            @Override public String modelName() { return "m"; }
+        };
+
+        ReflectCheckpointStore checkpointStore = new InMemoryReflectCheckpointStore();
+        String sweepId = "sweep-ckpt-test";
+        ReflectSweepSpec spec = ReflectSweepSpec.builder()
+                .sweepId(sweepId)
+                .build();
+
+        ReflectSignal signal = ReflectSignal.builder()
+                .partitionManager(partitionManager)
+                .rememberPathway(rememberPathway)
+                .textGenerator(llm)
+                .sweepSpec(spec)
+                .checkpointStore(checkpointStore)
+                .checkpoint(ReflectCheckpoint.initial(sweepId))
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
+                .build();
+
+        EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
+        boolean success = relay.transmit(signal);
+
+        assertThat(success).isTrue();
+        assertThat(signal.logTurnsConsolidated()).isEqualTo(2);
+
+        ReflectCheckpoint saved = checkpointStore.load(sweepId).orElse(null);
+        assertThat(saved).isNotNull();
+        assertThat(saved.sessionsCompleted()).isEqualTo(2);
+        assertThat(saved.turnsMarked()).isEqualTo(2);
+        assertThat(saved.lastCompletedSessionId()).isGreaterThan(0L);
+    }
+
+    @Test
+    @DisplayName("Halts consolidation when time budget expires")
+    void testTimeBudgetExpires() {
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 101L, "Session 101 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logMemory.appendTurn(ConversationRole.USER, 1, 1000L, 102L, "Session 102 turn".getBytes(), (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        CognitiveMemoryRouter router = new CognitiveMemoryRouter(workingMemory, semanticMemory, proceduralMemory, logMemory);
+        PartitionManager partitionManager = Mockito.mock(PartitionManager.class);
+        when(partitionManager.snapshot()).thenReturn(List.of(new PartitionHandle(0, null, router, null, false)));
+
+        RememberPathway rememberPathway = Mockito.mock(RememberPathway.class);
+        LlmProvider llm = new LlmProvider() {
+            @Override public LlmResponse generate(LlmRequest req, GenerationOptions opt) {
+                try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+                return new LlmResponse("- Fact", 1, 1, "m");
+            }
+            @Override public String generate(String prompt, GenerationOptions opt) {
+                try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+                return "- Fact";
+            }
+            @Override public boolean isAvailable() { return true; }
+            @Override public String modelName() { return "m"; }
+        };
+
+        ReflectSweepSpec spec = ReflectSweepSpec.builder()
+                .timeBudget(Duration.ofMillis(10)) // very tight time budget
+                .build();
+
+        ReflectSignal signal = ReflectSignal.builder()
+                .partitionManager(partitionManager)
+                .rememberPathway(rememberPathway)
+                .textGenerator(llm)
+                .sweepSpec(spec)
+                .idGenerator(() -> java.util.UUID.randomUUID().toString())
+                .build();
+
+        EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
+        boolean success = relay.transmit(signal);
+
+        assertThat(success).isTrue();
+        // Because of the 50ms delay in LLM and 10ms budget, only 1 session should be processed before budget expires
+        assertThat(signal.logTurnsConsolidated()).isLessThanOrEqualTo(1);
+    }
 }
+

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/MeteredSpectorMemory.java
@@ -261,11 +261,16 @@ public class MeteredSpectorMemory implements SpectorMemory {
 
     @Override
     public ReflectReport reflect() {
+        return reflect(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec.fullCycle());
+    }
+
+    @Override
+    public ReflectReport reflect(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec spec) {
         // Capture pre-reflect snapshot
         String cycleId = java.util.UUID.randomUUID().toString();
         TelemetryScope.publish(captureMemorySnapshot("pre-reflect", cycleId));
 
-        ReflectReport report = reflectTimer.record(() -> delegate.reflect());
+        ReflectReport report = reflectTimer.record(() -> delegate.reflect(spec));
 
         // Capture post-reflect snapshot
         TelemetryScope.publish(captureMemorySnapshot("post-reflect", cycleId));
@@ -278,6 +283,11 @@ public class MeteredSpectorMemory implements SpectorMemory {
                 report.duration().toMillis()));
 
         return report;
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress progress(String sweepId) {
+        return delegate.progress(sweepId);
     }
 
     @Override

--- a/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
+++ b/memory/spector-metrics/src/main/java/com/spectrayan/spector/metrics/ObservedSpectorMemory.java
@@ -206,7 +206,19 @@ public class ObservedSpectorMemory extends ObservableComponent implements Specto
     public ReflectReport reflect() {
         return withObservation(SpectorObservationDocumentation.MEMORY_REFLECT,
                 createTags(null, null, null),
-                delegate::reflect);
+                () -> delegate.reflect());
+    }
+
+    @Override
+    public ReflectReport reflect(com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec spec) {
+        return withObservation(SpectorObservationDocumentation.MEMORY_REFLECT,
+                createTags(null, null, null),
+                () -> delegate.reflect(spec));
+    }
+
+    @Override
+    public com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress progress(String sweepId) {
+        return delegate.progress(sweepId);
     }
 
     @Override

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/SpectorBatchAutoConfiguration.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/SpectorBatchAutoConfiguration.java
@@ -24,7 +24,16 @@ import org.springframework.context.annotation.Import;
  * Spring Boot auto-configuration for Spector Batch migration engine.
  */
 @AutoConfiguration
-@Import({SpectorExportJobConfig.class, SpectorImportJobConfig.class, SpectorBatchService.class})
+@Import({
+        SpectorExportJobConfig.class,
+        SpectorImportJobConfig.class,
+        SpectorBatchService.class,
+        com.spectrayan.spector.batch.reflect.ReflectConsolidationJobConfig.class,
+        com.spectrayan.spector.batch.reflect.SessionWorkItemReader.class,
+        com.spectrayan.spector.batch.reflect.SessionConsolidationProcessor.class,
+        com.spectrayan.spector.batch.reflect.SessionSweepResultWriter.class,
+        com.spectrayan.spector.batch.reflect.SpringBatchReflectSweepExecutor.class
+})
 public class SpectorBatchAutoConfiguration {
 
     @Bean

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/ReflectConsolidationJobConfig.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/ReflectConsolidationJobConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.memory.pathway.reflect.SessionSweepResult;
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Spring Batch configuration defining the reflect consolidation job and chunk=1 step.
+ *
+ * @since 1.5.0
+ */
+@Configuration
+public class ReflectConsolidationJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final SessionWorkItemReader reader;
+    private final SessionConsolidationProcessor processor;
+    private final SessionSweepResultWriter writer;
+
+    public ReflectConsolidationJobConfig(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            SessionWorkItemReader reader,
+            SessionConsolidationProcessor processor,
+            SessionSweepResultWriter writer) {
+        this.jobRepository = jobRepository;
+        this.transactionManager = transactionManager;
+        this.reader = reader;
+        this.processor = processor;
+        this.writer = writer;
+    }
+
+    @Bean
+    public Job reflectConsolidationJob() {
+        return new JobBuilder("reflectConsolidationJob", jobRepository)
+                .start(reflectConsolidationStep())
+                .build();
+    }
+
+    @Bean
+    public Step reflectConsolidationStep() {
+        return new StepBuilder("reflectConsolidationStep", jobRepository)
+                .<SessionWorkItem, SessionSweepResult>chunk(1, transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .faultTolerant()
+                .retryLimit(3)
+                .retry(Exception.class)
+                .build();
+    }
+}

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/ReflectJobContext.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/ReflectJobContext.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.SessionSweepResult;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Context holder maintaining execution state for a reflection sweep orchestrated by Spring Batch.
+ *
+ * @since 1.5.0
+ */
+public class ReflectJobContext {
+
+    private final SpectorMemory memory;
+    private final ReflectSweepSpec spec;
+    private final ReflectCheckpointStore checkpointStore;
+    private final Instant startTime;
+    private final Instant deadline;
+
+    private final AtomicInteger sessionsCompleted = new AtomicInteger();
+    private final AtomicInteger factsIngested = new AtomicInteger();
+    private final AtomicInteger turnsMarked = new AtomicInteger();
+    private final AtomicLong lastCompletedSessionId = new AtomicLong();
+
+    public ReflectJobContext(SpectorMemory memory, ReflectSweepSpec spec, ReflectCheckpointStore checkpointStore) {
+        this.memory = memory;
+        this.spec = spec;
+        this.checkpointStore = checkpointStore;
+        this.startTime = Instant.now();
+        this.deadline = (spec != null && spec.timeBudget() != null) ? startTime.plus(spec.timeBudget()) : null;
+    }
+
+    public SpectorMemory memory() {
+        return memory;
+    }
+
+    public ReflectSweepSpec spec() {
+        return spec;
+    }
+
+    public ReflectCheckpointStore checkpointStore() {
+        return checkpointStore;
+    }
+
+    public Instant startTime() {
+        return startTime;
+    }
+
+    public boolean isTimeBudgetExpired() {
+        return deadline != null && Instant.now().isAfter(deadline);
+    }
+
+    public void recordResult(SessionSweepResult result) {
+        if (result != null) {
+            sessionsCompleted.incrementAndGet();
+            factsIngested.addAndGet(result.factsConsolidated());
+            turnsMarked.addAndGet(result.turnsMarked());
+            lastCompletedSessionId.set(result.sessionId());
+        }
+    }
+
+    public int sessionsCompleted() {
+        return sessionsCompleted.get();
+    }
+
+    public int factsIngested() {
+        return factsIngested.get();
+    }
+
+    public int turnsMarked() {
+        return turnsMarked.get();
+    }
+
+    public long lastCompletedSessionId() {
+        return lastCompletedSessionId.get();
+    }
+}

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/ReflectJobRegistry.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/ReflectJobRegistry.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry holding active reflection job contexts keyed by sweep ID.
+ *
+ * @since 1.5.0
+ */
+public final class ReflectJobRegistry {
+
+    private static final Map<String, ReflectJobContext> CONTEXTS = new ConcurrentHashMap<>();
+
+    private ReflectJobRegistry() {}
+
+    public static void register(String sweepId, ReflectJobContext context) {
+        if (sweepId != null && context != null) {
+            CONTEXTS.put(sweepId, context);
+        }
+    }
+
+    public static ReflectJobContext get(String sweepId) {
+        return (sweepId != null) ? CONTEXTS.get(sweepId) : null;
+    }
+
+    public static ReflectJobContext remove(String sweepId) {
+        return (sweepId != null) ? CONTEXTS.remove(sweepId) : null;
+    }
+
+    public static void clear() {
+        CONTEXTS.clear();
+    }
+}

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SessionConsolidationProcessor.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SessionConsolidationProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectFilter;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.SessionSweepResult;
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Spring Batch ItemProcessor that executes consolidation on a single episodic session work item.
+ *
+ * @since 1.5.0
+ */
+@Component
+@StepScope
+public class SessionConsolidationProcessor implements ItemProcessor<SessionWorkItem, SessionSweepResult> {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionConsolidationProcessor.class);
+
+    private final String sweepId;
+
+    public SessionConsolidationProcessor(@Value("#{jobParameters['sweepId']}") String sweepId) {
+        this.sweepId = sweepId;
+    }
+
+    @Override
+    public SessionSweepResult process(SessionWorkItem item) throws Exception {
+        if (item == null) {
+            return null;
+        }
+
+        ReflectJobContext ctx = ReflectJobRegistry.get(sweepId);
+        if (ctx == null) {
+            throw new IllegalStateException("Missing ReflectJobContext for sweepId: " + sweepId);
+        }
+
+        if (ctx.isTimeBudgetExpired()) {
+            log.info("Time budget expired for sweepId: {}, skipping session {}", sweepId, item.sessionId());
+            return null;
+        }
+
+        ReflectSweepSpec spec = ctx.spec();
+
+        // 1. Check backpressure permit
+        if (spec != null && spec.backpressure() != null) {
+            if (spec.backpressure().shouldAbortSweep()) {
+                log.warn("Backpressure policy requested sweep abort for sweepId: {}", sweepId);
+                return null;
+            }
+            spec.backpressure().beforeSession(item);
+        }
+
+        // 2. Build single-session reflection spec
+        ReflectFilter singleSessionFilter = ReflectFilter.builder()
+                .sessionIds(Set.of(item.sessionId()))
+                .build();
+
+        ReflectSweepSpec singleSessionSpec = ReflectSweepSpec.builder()
+                .sweepId(spec != null ? spec.sweepId() : sweepId)
+                .filter(singleSessionFilter)
+                .maxTurnsPerSession(spec != null ? spec.maxTurnsPerSession() : ReflectSweepSpec.DEFAULT_MAX_TURNS_PER_SESSION)
+                .runCompanionRelays(false) // Spring Batch executes session-by-session; companion relays run at end
+                .build();
+
+        try {
+            ReflectReport report = ctx.memory().admin().reflectKernel(singleSessionSpec);
+            return SessionSweepResult.success(
+                    item.sessionId(),
+                    report.consolidatedCount(),
+                    report.logTurnsConsolidated()
+            );
+        } catch (Exception ex) {
+            log.error("Error consolidating session {} for sweepId {}: {}", item.sessionId(), sweepId, ex.getMessage(), ex);
+            if (spec != null && spec.backpressure() != null) {
+                spec.backpressure().onProviderFailure(ex);
+            }
+            throw ex;
+        }
+    }
+}

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SessionSweepResultWriter.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SessionSweepResultWriter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import com.spectrayan.spector.memory.pathway.reflect.SessionSweepResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/**
+ * Spring Batch ItemWriter that records consolidated session metrics and persists durable checkpoints.
+ *
+ * @since 1.5.0
+ */
+@Component
+@StepScope
+public class SessionSweepResultWriter implements ItemWriter<SessionSweepResult> {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionSweepResultWriter.class);
+
+    private final String sweepId;
+
+    public SessionSweepResultWriter(@Value("#{jobParameters['sweepId']}") String sweepId) {
+        this.sweepId = sweepId;
+    }
+
+    @Override
+    public void write(Chunk<? extends SessionSweepResult> chunk) {
+        ReflectJobContext ctx = ReflectJobRegistry.get(sweepId);
+        if (ctx == null) {
+            log.warn("Missing ReflectJobContext in writer for sweepId: {}", sweepId);
+            return;
+        }
+
+        for (SessionSweepResult result : chunk) {
+            if (result != null) {
+                ctx.recordResult(result);
+            }
+        }
+
+        if (ctx.checkpointStore() != null) {
+            ReflectCheckpoint checkpoint = new ReflectCheckpoint(
+                    sweepId,
+                    0,
+                    ctx.lastCompletedSessionId(),
+                    0L,
+                    ctx.sessionsCompleted(),
+                    ctx.factsIngested(),
+                    ctx.turnsMarked(),
+                    0,
+                    Instant.now(),
+                    ReflectSweepStatus.RUNNING
+            );
+            ctx.checkpointStore().save(checkpoint);
+        }
+    }
+}

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SessionWorkItemReader.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SessionWorkItemReader.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.memory.cortex.EpisodicMemory;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.SessionWorkItem;
+import com.spectrayan.spector.memory.pathway.reflect.relay.EpisodicLogConsolidationRelay;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Spring Batch ItemReader that reads candidate unconsolidated episodic sessions as SessionWorkItems.
+ *
+ * @since 1.5.0
+ */
+@Component
+@StepScope
+public class SessionWorkItemReader implements ItemReader<SessionWorkItem> {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionWorkItemReader.class);
+
+    private final String sweepId;
+    private Iterator<SessionWorkItem> iterator;
+    private boolean initialized = false;
+
+    public SessionWorkItemReader(@Value("#{jobParameters['sweepId']}") String sweepId) {
+        this.sweepId = sweepId;
+    }
+
+    private void initialize() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+
+        ReflectJobContext ctx = ReflectJobRegistry.get(sweepId);
+        if (ctx == null) {
+            log.warn("No ReflectJobContext registered for sweepId: {}", sweepId);
+            this.iterator = List.<SessionWorkItem>of().iterator();
+            return;
+        }
+
+        if (ctx.memory() == null || ctx.memory().admin() == null || ctx.memory().admin().cognitiveRouter() == null) {
+            log.warn("Memory router not available for sweepId: {}", sweepId);
+            this.iterator = List.<SessionWorkItem>of().iterator();
+            return;
+        }
+
+        EpisodicMemory logStore = ctx.memory().admin().cognitiveRouter().episodic();
+        if (logStore == null) {
+            log.warn("No EpisodicMemory log store available for sweepId: {}", sweepId);
+            this.iterator = List.<SessionWorkItem>of().iterator();
+            return;
+        }
+
+        ReflectCheckpoint checkpoint = null;
+        if (ctx.checkpointStore() != null) {
+            checkpoint = ctx.checkpointStore().load(sweepId).orElse(null);
+        }
+
+        EpisodicLogConsolidationRelay relay = new EpisodicLogConsolidationRelay();
+        List<SessionWorkItem> items = relay.listEligibleSessions(
+                logStore,
+                ctx.spec(),
+                checkpoint,
+                null,
+                0
+        );
+
+        if (ctx.spec() != null && ctx.spec().sessionLimit() > 0 && items.size() > ctx.spec().sessionLimit()) {
+            items = items.subList(0, ctx.spec().sessionLimit());
+        }
+
+        log.info("SessionWorkItemReader discovered {} candidate sessions for sweepId: {}", items.size(), sweepId);
+        this.iterator = new ArrayList<>(items).iterator();
+    }
+
+    @Override
+    public SessionWorkItem read() {
+        initialize();
+
+        ReflectJobContext ctx = ReflectJobRegistry.get(sweepId);
+        if (ctx != null && ctx.isTimeBudgetExpired()) {
+            log.info("Time budget expired for sweepId: {}, stopping SessionWorkItemReader", sweepId);
+            return null;
+        }
+
+        if (iterator != null && iterator.hasNext()) {
+            return iterator.next();
+        }
+        return null;
+    }
+}

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SpringBatchReflectSweepExecutor.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SpringBatchReflectSweepExecutor.java
@@ -24,6 +24,7 @@ import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
 import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
 import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor;
 import com.spectrayan.spector.memory.pathway.reflect.spi.local.FileReflectCheckpointStore;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.InMemoryReflectCheckpointStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.BatchStatus;
@@ -37,10 +38,18 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * High-priority {@link ReflectSweepExecutor} that orchestrates reflection sweeps via Spring Batch.
@@ -52,6 +61,7 @@ public class SpringBatchReflectSweepExecutor implements ReflectSweepExecutor, Ap
 
     private static final Logger log = LoggerFactory.getLogger(SpringBatchReflectSweepExecutor.class);
     private static volatile ApplicationContext context;
+    private static volatile Path defaultCheckpointDir;
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -62,8 +72,51 @@ public class SpringBatchReflectSweepExecutor implements ReflectSweepExecutor, Ap
         context = ctx;
     }
 
+    private static Path createSecureCheckpointDir() throws IOException {
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            FileAttribute<Set<PosixFilePermission>> attrs =
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+            return Files.createTempDirectory("spector-checkpoints-", attrs);
+        } else {
+            Path tempDir = Files.createTempDirectory("spector-checkpoints-");
+            File file = tempDir.toFile();
+            boolean readable = file.setReadable(true, true);
+            boolean writable = file.setWritable(true, true);
+            boolean executable = file.setExecutable(true, true);
+            if (!readable || !writable || !executable) {
+                log.warn("Could not set strict file permissions on temporary directory: {}", tempDir);
+            }
+            return tempDir;
+        }
+    }
+
     private static ReflectCheckpointStore defaultStore() {
-        return new FileReflectCheckpointStore(Path.of(System.getProperty("java.io.tmpdir"), "spector-checkpoints"));
+        if (defaultCheckpointDir == null) {
+            synchronized (SpringBatchReflectSweepExecutor.class) {
+                if (defaultCheckpointDir == null || !Files.exists(defaultCheckpointDir)) {
+                    try {
+                        defaultCheckpointDir = createSecureCheckpointDir();
+                    } catch (IOException e) {
+                        log.warn("Failed to create secure temporary directory for reflect checkpoints, falling back to in-memory store: {}", e.getMessage());
+                        return new InMemoryReflectCheckpointStore();
+                    }
+                }
+            }
+        }
+        return new FileReflectCheckpointStore(defaultCheckpointDir);
+    }
+
+    private ReflectCheckpointStore resolveCheckpointStore() {
+        if (context != null) {
+            try {
+                if (context.getBeanNamesForType(ReflectCheckpointStore.class).length > 0) {
+                    return context.getBean(ReflectCheckpointStore.class);
+                }
+            } catch (Exception e) {
+                log.debug("No ReflectCheckpointStore bean found in ApplicationContext, using default: {}", e.getMessage());
+            }
+        }
+        return defaultStore();
     }
 
     @Override
@@ -101,7 +154,7 @@ public class SpringBatchReflectSweepExecutor implements ReflectSweepExecutor, Ap
         JobLauncher jobLauncher = context.getBean(JobLauncher.class);
         Job reflectJob = context.getBean("reflectConsolidationJob", Job.class);
 
-        ReflectCheckpointStore checkpointStore = defaultStore();
+        ReflectCheckpointStore checkpointStore = resolveCheckpointStore();
         ReflectJobContext jobCtx = new ReflectJobContext(memory, spec, checkpointStore);
         ReflectJobRegistry.register(spec.sweepId(), jobCtx);
 
@@ -171,7 +224,7 @@ public class SpringBatchReflectSweepExecutor implements ReflectSweepExecutor, Ap
         }
 
         ReflectJobContext activeCtx = ReflectJobRegistry.get(sweepId);
-        ReflectCheckpointStore checkpointStore = defaultStore();
+        ReflectCheckpointStore checkpointStore = resolveCheckpointStore();
         ReflectCheckpoint checkpoint = checkpointStore.load(sweepId).orElse(null);
 
         if (checkpoint != null) {

--- a/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SpringBatchReflectSweepExecutor.java
+++ b/synapse/spector-batch/src/main/java/com/spectrayan/spector/batch/reflect/SpringBatchReflectSweepExecutor.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectCheckpoint;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectCheckpointStore;
+import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor;
+import com.spectrayan.spector.memory.pathway.reflect.spi.local.FileReflectCheckpointStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * High-priority {@link ReflectSweepExecutor} that orchestrates reflection sweeps via Spring Batch.
+ *
+ * @since 1.5.0
+ */
+@Component
+public class SpringBatchReflectSweepExecutor implements ReflectSweepExecutor, ApplicationContextAware {
+
+    private static final Logger log = LoggerFactory.getLogger(SpringBatchReflectSweepExecutor.class);
+    private static volatile ApplicationContext context;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        context = applicationContext;
+    }
+
+    public static void setStaticContext(ApplicationContext ctx) {
+        context = ctx;
+    }
+
+    private static ReflectCheckpointStore defaultStore() {
+        return new FileReflectCheckpointStore(Path.of(System.getProperty("java.io.tmpdir"), "spector-checkpoints"));
+    }
+
+    @Override
+    public String name() {
+        return "spring-batch";
+    }
+
+    @Override
+    public int priority() {
+        return 100;
+    }
+
+    @Override
+    public boolean available() {
+        if (context == null) {
+            return false;
+        }
+        try {
+            return context.getBeanNamesForType(JobLauncher.class).length > 0
+                    && context.containsBean("reflectConsolidationJob");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public ReflectReport execute(SpectorMemory memory, ReflectSweepSpec spec) {
+        Objects.requireNonNull(memory, "memory cannot be null");
+        Objects.requireNonNull(spec, "spec cannot be null");
+
+        if (!available()) {
+            throw new IllegalStateException("SpringBatchReflectSweepExecutor is not available in current ApplicationContext");
+        }
+
+        JobLauncher jobLauncher = context.getBean(JobLauncher.class);
+        Job reflectJob = context.getBean("reflectConsolidationJob", Job.class);
+
+        ReflectCheckpointStore checkpointStore = defaultStore();
+        ReflectJobContext jobCtx = new ReflectJobContext(memory, spec, checkpointStore);
+        ReflectJobRegistry.register(spec.sweepId(), jobCtx);
+
+        Instant start = Instant.now();
+        JobExecution jobExecution;
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("sweepId", spec.sweepId())
+                    .addLong("sessionLimit", (long) spec.sessionLimit())
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            jobExecution = jobLauncher.run(reflectJob, params);
+        } catch (Exception e) {
+            log.error("Failed launching reflectConsolidationJob for sweepId {}: {}", spec.sweepId(), e.getMessage(), e);
+            throw new RuntimeException("Failed executing Spring Batch reflect sweep: " + e.getMessage(), e);
+        } finally {
+            ReflectJobRegistry.remove(spec.sweepId());
+        }
+
+        Duration duration = Duration.between(start, Instant.now());
+        boolean success = jobExecution.getStatus() == BatchStatus.COMPLETED;
+
+        // Final checkpoint save
+        ReflectCheckpoint finalCheckpoint = new ReflectCheckpoint(
+                spec.sweepId(),
+                0,
+                jobCtx.lastCompletedSessionId(),
+                0L,
+                jobCtx.sessionsCompleted(),
+                jobCtx.factsIngested(),
+                jobCtx.turnsMarked(),
+                0,
+                Instant.now(),
+                success ? ReflectSweepStatus.COMPLETE : ReflectSweepStatus.FAILED
+        );
+        checkpointStore.save(finalCheckpoint);
+
+        // If companion relays requested, conduct companion cycle via memory admin
+        if (spec.runCompanionRelays() && memory.admin().reflectPathway() != null) {
+            ReflectSweepSpec companionSpec = ReflectSweepSpec.builder()
+                    .sweepId(spec.sweepId() + "-companion")
+                    .sessionLimit(0)
+                    .runCompanionRelays(true)
+                    .build();
+            memory.admin().reflectKernel(companionSpec);
+        }
+
+        return new ReflectReport(
+                jobCtx.factsIngested(),
+                0,
+                0,
+                0,
+                duration,
+                null,
+                0,
+                0,
+                0.0f,
+                jobCtx.turnsMarked()
+        );
+    }
+
+    @Override
+    public ReflectSweepProgress progress(String sweepId) {
+        if (sweepId == null) {
+            return null;
+        }
+
+        ReflectJobContext activeCtx = ReflectJobRegistry.get(sweepId);
+        ReflectCheckpointStore checkpointStore = defaultStore();
+        ReflectCheckpoint checkpoint = checkpointStore.load(sweepId).orElse(null);
+
+        if (checkpoint != null) {
+            Instant start = (activeCtx != null) ? activeCtx.startTime() : checkpoint.updatedAt();
+            return ReflectSweepProgress.from(checkpoint, start);
+        }
+
+        if (activeCtx != null) {
+            return new ReflectSweepProgress(
+                    sweepId,
+                    activeCtx.sessionsCompleted(),
+                    activeCtx.factsIngested(),
+                    activeCtx.turnsMarked(),
+                    0,
+                    ReflectSweepStatus.RUNNING,
+                    activeCtx.startTime(),
+                    Instant.now()
+            );
+        }
+
+        return null;
+    }
+}

--- a/synapse/spector-batch/src/main/resources/META-INF/services/com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor
+++ b/synapse/spector-batch/src/main/resources/META-INF/services/com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutor
@@ -1,0 +1,1 @@
+com.spectrayan.spector.batch.reflect.SpringBatchReflectSweepExecutor

--- a/synapse/spector-batch/src/test/java/com/spectrayan/spector/batch/reflect/ReflectConsolidationJobTest.java
+++ b/synapse/spector-batch/src/test/java/com/spectrayan/spector/batch/reflect/ReflectConsolidationJobTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.batch.reflect;
+
+import com.spectrayan.spector.batch.SpectorBatchAutoConfiguration;
+import com.spectrayan.spector.batch.TestBatchConfig;
+import com.spectrayan.spector.memory.SpectorMemory;
+import com.spectrayan.spector.memory.SpectorMemoryAdmin;
+import com.spectrayan.spector.memory.cortex.CognitiveMemoryRouter;
+import com.spectrayan.spector.memory.cortex.EpisodicMemory;
+import com.spectrayan.spector.memory.model.ConversationRole;
+import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.model.SourceModality;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectFilter;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(properties = "spring.batch.job.enabled=false")
+@ContextConfiguration(classes = {TestBatchConfig.class, SpectorBatchAutoConfiguration.class})
+@DisplayName("ReflectConsolidationJob & SpringBatchReflectSweepExecutor Integration Tests")
+class ReflectConsolidationJobTest {
+
+    @Autowired
+    private SpringBatchReflectSweepExecutor executor;
+
+    private EpisodicMemory logStore;
+
+    @BeforeEach
+    void setUp() {
+        logStore = new EpisodicMemory(1024 * 1024);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (logStore != null) {
+            logStore.close();
+        }
+    }
+
+    @Test
+    @DisplayName("SpringBatchReflectSweepExecutor metadata and availability checks")
+    void testExecutorMetadata() {
+        assertThat(executor.name()).isEqualTo("spring-batch");
+        assertThat(executor.priority()).isEqualTo(100);
+        assertThat(executor.available()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Executes reflection sweep over unconsolidated turns and tracks progress")
+    void testExecuteSweep() {
+        // Append 2 turns for session 501L
+        logStore.appendTurn(ConversationRole.USER, 1, 1000L, 501L, "I love distributed systems.".getBytes(),
+                (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+        logStore.appendTurn(ConversationRole.ASSISTANT, 2, 2000L, 501L, "Distributed systems are resilient.".getBytes(),
+                (short) 1, 0, 0, 0, 0L, (short) 1, SourceModality.TEXT);
+
+        SpectorMemory memory = Mockito.mock(SpectorMemory.class);
+        SpectorMemoryAdmin admin = Mockito.mock(SpectorMemoryAdmin.class);
+        CognitiveMemoryRouter router = Mockito.mock(CognitiveMemoryRouter.class);
+
+        when(memory.admin()).thenReturn(admin);
+        when(admin.cognitiveRouter()).thenReturn(router);
+        when(router.episodic()).thenReturn(logStore);
+
+        ReflectReport mockKernelReport = new ReflectReport(2, 0, 0, 0, Duration.ofMillis(50), null, 0, 0, 0f, 2);
+        when(admin.reflectKernel(any())).thenReturn(mockKernelReport);
+
+        String sweepId = "test-batch-sweep-501";
+        ReflectSweepSpec spec = ReflectSweepSpec.builder()
+                .sweepId(sweepId)
+                .filter(ReflectFilter.unconsolidated())
+                .runCompanionRelays(false)
+                .build();
+
+        ReflectReport report = executor.execute(memory, spec);
+
+        assertThat(report).isNotNull();
+        assertThat(report.consolidatedCount()).isEqualTo(2);
+        assertThat(report.logTurnsConsolidated()).isEqualTo(2);
+
+        ReflectSweepProgress progress = executor.progress(sweepId);
+        assertThat(progress).isNotNull();
+        assertThat(progress.status()).isEqualTo(ReflectSweepStatus.COMPLETE);
+        assertThat(progress.factsIngested()).isEqualTo(2);
+        assertThat(progress.turnsMarked()).isEqualTo(2);
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryAccessObject.java
@@ -35,6 +35,8 @@ import com.spectrayan.spector.memory.model.GraphNeighborhood;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
 import com.spectrayan.spector.memory.model.TopologyStats;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
 import com.spectrayan.spector.memory.neuromod.neurodivergent.IngestionHints;
 import com.spectrayan.spector.synapse.memory.MemoryDto.CompactionResult;
 import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryGraphResponse;
@@ -316,6 +318,32 @@ public class MemoryAccessObject {
         } catch (Exception e) {
             log.error("[MemoryAccessObject] Reflect failed: {}", e.getMessage(), e);
             throw new IllegalStateException("Reflect consolidation failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Triggers a reflection sweep using the provided specification.
+     */
+    public ReflectReport reflect(SpectorMemory memory, ReflectSweepSpec spec) {
+        if (!isAvailable(memory)) return null;
+        try {
+            return memory.reflect(spec);
+        } catch (Exception e) {
+            log.error("[MemoryAccessObject] Reflect with spec failed: {}", e.getMessage(), e);
+            throw new IllegalStateException("Reflect consolidation failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Retrieves reflection sweep progress telemetry.
+     */
+    public ReflectSweepProgress progress(SpectorMemory memory, String sweepId) {
+        if (!isAvailable(memory)) return null;
+        try {
+            return memory.progress(sweepId);
+        } catch (Exception e) {
+            log.warn("[MemoryAccessObject] Progress lookup failed for sweepId {}: {}", sweepId, e.getMessage());
+            return null;
         }
     }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryController.java
@@ -19,9 +19,14 @@ import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryStatusResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryTableResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RecallResult;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectFilter;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
 import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.BrowseResult;
+import com.spectrayan.spector.synapse.memory.MemoryDto.ReflectRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ReflectResponse;
+import java.time.Instant;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ReinforceByIdRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.RememberRequest;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ResolveRequest;
@@ -496,15 +501,79 @@ public class MemoryController {
     // ══════════════════════════════════════════════════════════════
 
     /**
-     * Trigger a sleep consolidation (reflect) cycle.
+     * Trigger a sleep consolidation (reflect) cycle or filtered sweep.
      *
      * <p>Maps to: {@code MemoryTableService.reflect()} in Angular.</p>
      *
      * <p>{@code POST /api/v1/memory/reflect}</p>
+     *
+     * @param sweepId           optional unique sweep ID (generated if omitted)
+     * @param sessionLimit      optional limit on sessions processed
+     * @param sessionIdAfter    optional cursor for watermark continuation
+     * @param from              optional turn timestamp lower bound (epoch millis)
+     * @param to                optional turn timestamp upper bound (epoch millis)
+     * @param consolidationOnly optional flag to skip companion relays (default false)
+     * @param request           optional request body with additional parameters
      */
     @PostMapping("/reflect")
-    public ResponseEntity<ReflectResponse> reflect() {
-        return ResponseEntity.ok(memoryService.reflect());
+    public ResponseEntity<ReflectResponse> reflect(
+            @RequestParam(required = false) String sweepId,
+            @RequestParam(required = false) Integer sessionLimit,
+            @RequestParam(required = false) Long sessionIdAfter,
+            @RequestParam(required = false) Long from,
+            @RequestParam(required = false) Long to,
+            @RequestParam(required = false) Boolean consolidationOnly,
+            @RequestBody(required = false) ReflectRequest request) {
+
+        String effectiveSweepId = sweepId != null ? sweepId : (request != null ? request.sweepId() : null);
+        Integer effectiveSessionLimit = sessionLimit != null ? sessionLimit : (request != null ? request.sessionLimit() : null);
+        Long effectiveSessionIdAfter = sessionIdAfter != null ? sessionIdAfter : (request != null ? request.sessionIdAfter() : null);
+        Long effectiveFrom = from != null ? from : (request != null ? request.from() : null);
+        Long effectiveTo = to != null ? to : (request != null ? request.to() : null);
+        Boolean effectiveConsolidationOnly = consolidationOnly != null ? consolidationOnly : (request != null ? request.consolidationOnly() : null);
+
+        if (effectiveSweepId == null && effectiveSessionLimit == null && effectiveSessionIdAfter == null
+                && effectiveFrom == null && effectiveTo == null && effectiveConsolidationOnly == null) {
+            return ResponseEntity.ok(memoryService.reflect());
+        }
+
+        ReflectFilter.Builder filterBuilder = ReflectFilter.builder();
+        if (effectiveSessionIdAfter != null) {
+            filterBuilder.sessionIdAfter(effectiveSessionIdAfter);
+        }
+        if (effectiveFrom != null) {
+            filterBuilder.from(Instant.ofEpochMilli(effectiveFrom));
+        }
+        if (effectiveTo != null) {
+            filterBuilder.to(Instant.ofEpochMilli(effectiveTo));
+        }
+
+        ReflectSweepSpec.Builder specBuilder = ReflectSweepSpec.builder()
+                .filter(filterBuilder.build())
+                .sessionLimit(effectiveSessionLimit != null ? effectiveSessionLimit : 0)
+                .runCompanionRelays(effectiveConsolidationOnly == null || !effectiveConsolidationOnly);
+
+        if (effectiveSweepId != null && !effectiveSweepId.isBlank()) {
+            specBuilder.sweepId(effectiveSweepId);
+        }
+
+        return ResponseEntity.ok(memoryService.reflect(specBuilder.build()));
+    }
+
+    /**
+     * Poll reflection sweep progress telemetry.
+     *
+     * <p>{@code GET /api/v1/memory/reflect/progress/{sweepId}}</p>
+     *
+     * @param sweepId unique sweep identifier
+     */
+    @GetMapping("/reflect/progress/{sweepId}")
+    public ResponseEntity<ReflectSweepProgress> getReflectProgress(@PathVariable String sweepId) {
+        ReflectSweepProgress progress = memoryService.progress(sweepId);
+        if (progress == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(progress);
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryDto.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryDto.java
@@ -509,17 +509,39 @@ public final class MemoryDto {
     ) {}
 
     /**
+     * Optional request parameters for triggering reflection sweep.
+     */
+    public record ReflectRequest(
+            @JsonProperty("sweepId") String sweepId,
+            @JsonProperty("sessionLimit") Integer sessionLimit,
+            @JsonProperty("sessionIdAfter") Long sessionIdAfter,
+            @JsonProperty("from") Long from,
+            @JsonProperty("to") Long to,
+            @JsonProperty("consolidationOnly") Boolean consolidationOnly
+    ) {}
+
+    /**
      * Reflect consolidation response.
      *
-     * @param tombstonedCount  memories tombstoned during consolidation
-     * @param durationMs       duration of the consolidation cycle in milliseconds
-     * @param message          human-readable summary
+     * @param tombstonedCount    memories tombstoned during consolidation
+     * @param durationMs         duration of the consolidation cycle in milliseconds
+     * @param message            human-readable summary
+     * @param sweepId            sweep ID associated with the execution
+     * @param consolidatedCount  count of episodic clusters or facts consolidated
+     * @param turnsConsolidated  count of episodic conversation turns consolidated
      */
     public record ReflectResponse(
             @JsonProperty("tombstonedCount") int tombstonedCount,
             @JsonProperty("durationMs") long durationMs,
-            @JsonProperty("message") String message
-    ) {}
+            @JsonProperty("message") String message,
+            @JsonProperty("sweepId") String sweepId,
+            @JsonProperty("consolidatedCount") int consolidatedCount,
+            @JsonProperty("turnsConsolidated") int turnsConsolidated
+    ) {
+        public ReflectResponse(int tombstonedCount, long durationMs, String message) {
+            this(tombstonedCount, durationMs, message, null, 0, 0);
+        }
+    }
 
     /**
      * Vacuum compaction result for a single tier.

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryService.java
@@ -48,6 +48,8 @@ import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.RecallMode;
 import com.spectrayan.spector.memory.model.RecallOptions;
 import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
 import com.spectrayan.spector.memory.model.ScoringMode;
 import com.spectrayan.spector.memory.neuromod.neurodivergent.IngestionHints;
 import com.spectrayan.spector.synapse.memory.MemoryDto.AcceptedResponse;
@@ -671,9 +673,18 @@ public class MemoryService {
      * Trigger a sleep consolidation (reflect) cycle.
      */
     public ReflectResponse reflect() {
-        log.info("[MemoryService] Triggering reflect (sleep consolidation)...");
+        return reflect(ReflectSweepSpec.fullCycle());
+    }
+
+    /**
+     * Trigger a sleep consolidation (reflect) sweep using the supplied specification.
+     */
+    public ReflectResponse reflect(ReflectSweepSpec spec) {
+        String sweepId = (spec != null) ? spec.sweepId() : "default";
+        log.info("[MemoryService] Triggering reflect (sleep consolidation) with sweepId={}...", sweepId);
         long start = System.currentTimeMillis();
-        ReflectReport report = mao.reflect(resolveMemory());
+        SpectorMemory memory = resolveMemory();
+        ReflectReport report = (spec != null) ? mao.reflect(memory, spec) : mao.reflect(memory);
         long durationMs = report != null ? report.duration().toMillis() : (System.currentTimeMillis() - start);
 
         if (report != null) {
@@ -692,11 +703,24 @@ public class MemoryService {
                     "tombstonesCompacted", report.tombstonedCount(),
                     "durationMs", durationMs
             ));
-            return new ReflectResponse(report.tombstonedCount(), durationMs,
+            return new ReflectResponse(
+                    report.tombstonedCount(),
+                    durationMs,
                     "Consolidated " + report.consolidatedCount() + " episodic clusters. " +
-                            "Pruned " + report.temporalPrunedCount() + " temporal chain nodes.");
+                            "Pruned " + report.temporalPrunedCount() + " temporal chain nodes.",
+                    sweepId,
+                    report.consolidatedCount(),
+                    report.logTurnsConsolidated()
+            );
         }
-        return new ReflectResponse(0, durationMs, "Reflect completed (stub mode — engine not available)");
+        return new ReflectResponse(0, durationMs, "Reflect completed (stub mode — engine not available)", sweepId, 0, 0);
+    }
+
+    /**
+     * Retrieves reflection sweep progress telemetry.
+     */
+    public ReflectSweepProgress progress(String sweepId) {
+        return mao.progress(resolveMemory(), sweepId);
     }
 
     /**

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryControllerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryControllerTest.java
@@ -13,6 +13,9 @@
 package com.spectrayan.spector.synapse.memory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
 import com.spectrayan.spector.synapse.memory.MemoryDto.*;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
@@ -416,6 +419,98 @@ class MemoryControllerTest {
                 .andExpect(jsonPath("$.hits[0].result.id", is("mem-123")))
                 .andExpect(jsonPath("$.hits[0].namespaceId", is("01JXYZNS00001")))
                 .andExpect(jsonPath("$.summary.openedNamespaces[0]", is("default")));
+    }
+
+    // ═══════════════════════════════════════════════════
+    // REFLECT API
+    // ═══════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("POST /memory/reflect — default fullCycle triggers parameterless reflect")
+    void reflect_defaultFullCycle_returns200() throws Exception {
+        var resp = new ReflectResponse(2, 150L, "Consolidated 3 episodic clusters. Pruned 1 temporal chain nodes.", "full-cycle", 3, 5);
+        when(memoryService.reflect()).thenReturn(resp);
+
+        mvc.perform(post("/api/v1/memory/reflect"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tombstonedCount", is(2)))
+                .andExpect(jsonPath("$.durationMs", is(150)))
+                .andExpect(jsonPath("$.sweepId", is("full-cycle")))
+                .andExpect(jsonPath("$.consolidatedCount", is(3)))
+                .andExpect(jsonPath("$.turnsConsolidated", is(5)));
+
+        verify(memoryService).reflect();
+    }
+
+    @Test
+    @DisplayName("POST /memory/reflect — with query parameters constructs spec and triggers reflect")
+    void reflect_withQueryParams_returns200() throws Exception {
+        var resp = new ReflectResponse(0, 80L, "Consolidated 1 episodic clusters.", "custom-sweep-1", 1, 2);
+        when(memoryService.reflect(Mockito.any(ReflectSweepSpec.class))).thenReturn(resp);
+
+        mvc.perform(post("/api/v1/memory/reflect")
+                        .param("sweepId", "custom-sweep-1")
+                        .param("sessionLimit", "10")
+                        .param("sessionIdAfter", "100")
+                        .param("consolidationOnly", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sweepId", is("custom-sweep-1")))
+                .andExpect(jsonPath("$.consolidatedCount", is(1)));
+
+        verify(memoryService).reflect(argThat(spec ->
+                "custom-sweep-1".equals(spec.sweepId())
+                        && spec.sessionLimit() == 10
+                        && Long.valueOf(100L).equals(spec.filter().sessionIdAfter())
+                        && !spec.runCompanionRelays()
+        ));
+    }
+
+    @Test
+    @DisplayName("POST /memory/reflect — with request body constructs spec and triggers reflect")
+    void reflect_withRequestBody_returns200() throws Exception {
+        var resp = new ReflectResponse(1, 120L, "Consolidated 2 episodic clusters.", "body-sweep-1", 2, 4);
+        when(memoryService.reflect(Mockito.any(ReflectSweepSpec.class))).thenReturn(resp);
+
+        var body = new ReflectRequest("body-sweep-1", 5, 200L, 1000L, 2000L, false);
+
+        mvc.perform(post("/api/v1/memory/reflect")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sweepId", is("body-sweep-1")))
+                .andExpect(jsonPath("$.consolidatedCount", is(2)));
+
+        verify(memoryService).reflect(argThat(spec ->
+                "body-sweep-1".equals(spec.sweepId())
+                        && spec.sessionLimit() == 5
+                        && Long.valueOf(200L).equals(spec.filter().sessionIdAfter())
+                        && spec.runCompanionRelays()
+        ));
+    }
+
+    @Test
+    @DisplayName("GET /memory/reflect/progress/{sweepId} — returns 200 with progress when found")
+    void getReflectProgress_found_returns200() throws Exception {
+        var progress = new ReflectSweepProgress("sweep-xyz", 4, 12, 16, 2, ReflectSweepStatus.RUNNING, java.time.Instant.now(), java.time.Instant.now());
+        when(memoryService.progress("sweep-xyz")).thenReturn(progress);
+
+        mvc.perform(get("/api/v1/memory/reflect/progress/sweep-xyz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sweepId", is("sweep-xyz")))
+                .andExpect(jsonPath("$.sessionsCompleted", is(4)))
+                .andExpect(jsonPath("$.factsIngested", is(12)))
+                .andExpect(jsonPath("$.turnsMarked", is(16)))
+                .andExpect(jsonPath("$.backlogRemaining", is(2)))
+                .andExpect(jsonPath("$.status", is("RUNNING")));
+    }
+
+    @Test
+    @DisplayName("GET /memory/reflect/progress/{sweepId} — returns 404 when not found")
+    void getReflectProgress_notFound_returns404() throws Exception {
+        when(memoryService.progress("unknown-sweep")).thenReturn(null);
+
+        mvc.perform(get("/api/v1/memory/reflect/progress/unknown-sweep"))
+                .andExpect(status().isNotFound());
     }
 }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryServiceTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/MemoryServiceTest.java
@@ -37,6 +37,10 @@ import com.spectrayan.spector.memory.kernel.id.TsidGenerator;
 import com.spectrayan.spector.memory.model.CognitiveResult;
 import com.spectrayan.spector.memory.model.MemoryType;
 import com.spectrayan.spector.memory.model.ReflectReport;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepProgress;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepSpec;
+import com.spectrayan.spector.memory.pathway.reflect.ReflectSweepStatus;
+import java.time.Instant;
 import com.spectrayan.spector.synapse.memory.MemoryDto.*;
 import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryGraphResponse;
 import com.spectrayan.spector.synapse.memory.MemoryDto.MemoryStatusResponse;
@@ -228,7 +232,7 @@ class MemoryServiceTest {
         when(mockReport.consolidatedCount()).thenReturn(2);
         when(mockReport.temporalPrunedCount()).thenReturn(1);
         when(mockReport.duration()).thenReturn(Duration.ofMillis(120L));
-        when(mao.reflect(any())).thenReturn(mockReport);
+        when(mao.reflect(any(), any(ReflectSweepSpec.class))).thenReturn(mockReport);
 
         var result = service.reflect();
 
@@ -292,5 +296,53 @@ class MemoryServiceTest {
 
         assertThat(result).isEqualTo(expected);
         verify(mao).getTopologyStats(any());
+    }
+
+    // ═══════════════════════════════════════════════════
+    // REFLECT API
+    // ═══════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("reflect() — parameterless triggers default full-cycle sweep")
+    void reflect_defaultFullCycle_delegatesToMao() {
+        var report = new ReflectReport(5, 2, 0, 1, Duration.ofMillis(120), null, 0, 0, 0.0f, 10);
+        when(mao.reflect(any(), any(ReflectSweepSpec.class))).thenReturn(report);
+
+        var response = service.reflect();
+
+        assertThat(response).isNotNull();
+        assertThat(response.tombstonedCount()).isEqualTo(2);
+        assertThat(response.consolidatedCount()).isEqualTo(5);
+        assertThat(response.turnsConsolidated()).isEqualTo(10);
+        assertThat(response.sweepId()).isEqualTo("full-cycle");
+        verify(mao).reflect(any(), any(ReflectSweepSpec.class));
+    }
+
+    @Test
+    @DisplayName("reflect(spec) — delegates to mao with supplied spec")
+    void reflect_withSpec_delegatesToMao() {
+        var spec = ReflectSweepSpec.consolidationOnly(10);
+        var report = new ReflectReport(3, 0, 0, 0, Duration.ofMillis(80), null, 0, 0, 0.0f, 6);
+        when(mao.reflect(any(), eq(spec))).thenReturn(report);
+
+        var response = service.reflect(spec);
+
+        assertThat(response).isNotNull();
+        assertThat(response.consolidatedCount()).isEqualTo(3);
+        assertThat(response.turnsConsolidated()).isEqualTo(6);
+        assertThat(response.sweepId()).isEqualTo("consolidation-tick");
+        verify(mao).reflect(any(), eq(spec));
+    }
+
+    @Test
+    @DisplayName("progress(sweepId) — delegates to mao")
+    void progress_delegatesToMao() {
+        var progress = new ReflectSweepProgress("sweep-test", 2, 5, 8, 1, ReflectSweepStatus.RUNNING, Instant.now(), Instant.now());
+        when(mao.progress(any(), eq("sweep-test"))).thenReturn(progress);
+
+        var result = service.progress("sweep-test");
+
+        assertThat(result).isEqualTo(progress);
+        verify(mao).progress(any(), eq("sweep-test"));
     }
 }


### PR DESCRIPTION
## Summary
Resolves #730 by implementing durable checkpointing, cursor-based session filtering, and an external batch orchestration pathway for \ReflectPathway\.

### Key Enhancements
1. **Durable Checkpointing & Watermark Filtering (\spector-memory\)**:
   - Added \ReflectCheckpoint\, \ReflectFilter\, \ReflectSweepSpec\, \ReflectSweepProgress\, and \ReflectSweepStatus\ models.
   - Introduced \ReflectCheckpointStore\ SPI with \FileReflectCheckpointStore\ (atomic temp-file swap) and \InMemoryReflectCheckpointStore\.
   - Introduced \ReflectBackpressurePolicy\ SPI with \TokenBucketBackpressurePolicy\ and \NoopBackpressurePolicy\.
   - Introduced \ReflectSweepExecutor\ SPI and \ReflectSweepExecutors\ priority-ordered registry using Java \ServiceLoader\.
   - Refactored \EpisodicLogConsolidationRelay\ into modular methods (\listEligibleSessions\, \processSession\) with per-session checkpointing, backpressure throttling, and session ID watermark cursors.
   - Preserved zero Spring dependencies in \spector-memory\.

2. **Spring Batch Orchestration (\synapse/spector-batch\)**:
   - Implemented \ReflectConsolidationJobConfig\ with chunk size 1 (\chunk=1\), fault tolerance, retry backoff, and step execution listeners.
   - Created \@StepScope\ \SessionWorkItemReader\, \SessionConsolidationProcessor\, and \SessionSweepResultWriter\.
   - Implemented \SpringBatchReflectSweepExecutor\ (\@AutoService(ReflectSweepExecutor.class)\, priority 100) launching the Spring Batch job via \JobLauncher\.
   - Added thread-safe telemetry and deadline management via \ReflectJobRegistry\ and \ReflectJobContext\.

3. **REST Surface & Telemetry Polling (\synapse/spector-synapse\)**:
   - Enhanced \POST /api/v1/memory/reflect\ to accept query parameters and optional JSON body (\ReflectRequest\), forwarding \ReflectSweepSpec\ down through \MemoryService\ and \MemoryAccessObject\.
   - Added \GET /api/v1/memory/reflect/progress/{sweepId}\ endpoint returning 200 OK with \ReflectSweepProgress\ snapshot or 404 if not found.

### Verification
- Full reactor build passed: \mvn test -pl memory/spector-memory,memory/spector-metrics,synapse/spector-batch,synapse/spector-synapse\ (2,538 tests passing, 0 failures, 0 errors).
- All unit, slice, property, and integration tests passed across all 4 modules.

Closes #730