### PR TITLE
feat(synapse): unify spector-cli and spector-synapse under spring boot auto-configuration

### DIFF
--- a/docs/docs/cli-reference/spectorctl.md
+++ b/docs/docs/cli-reference/spectorctl.md
@@ -63,23 +63,24 @@ spectorctl index delete --name my-index
 
 ---
 
-### 📥 `ingest` — Document Ingestion
+### 📥 `remember` — Document & Memory Ingestion
 
-The `ingest` command supports two modes, auto-detected from the flags:
+The `remember` command (with backward-compatible alias `ingest`) supports two modes, auto-detected from the flags:
 
 #### Local Batch Mode (Direct Ingestion)
 
-Discovers and ingests files directly through `IngestionPipeline` — no server needed. Reads configuration from `spector.yml`.
+Discovers and ingests files directly into `SpectorMemory` via Spring Boot auto-configuration — no server needed. Reads configuration from `spector.yml`.
 
 ```bash
-# Ingest from config (root-directory, pattern, etc. from spector.yml)
-spectorctl ingest --config spector.yml
+# Remember from config (root-directory, pattern, etc. from spector.yml)
+spectorctl remember --config spector.yml
 
-# Ingest with explicit root directory
+# Remember with explicit root directory (or with 'ingest' alias)
+spectorctl remember --root /path/to/docs --pattern "**/*.md"
 spectorctl ingest --root /path/to/docs --pattern "**/*.md"
 
 # Override chunk size
-spectorctl ingest --config spector.yml --root . --chunk-size 1200
+spectorctl remember --config spector.yml --root . --chunk-size 1200
 ```
 
 | Option | Required | Description |
@@ -94,13 +95,14 @@ spectorctl ingest --config spector.yml --root . --chunk-size 1200
 
 #### Remote Mode (via HTTP)
 
-Sends a single document to a running Spector server.
+Sends a single document or memory to a running Spector server.
 
 ```bash
-# Ingest text content
-spectorctl ingest --id doc-1 --content "Hello world"
+# Remember text content
+spectorctl remember --id doc-1 --content "Hello world"
 
-# Ingest from a file
+# Remember from a file (or with 'ingest' alias)
+spectorctl remember --file README.md --title "Project README"
 spectorctl ingest --file README.md --title "Project README"
 ```
 
@@ -113,30 +115,29 @@ spectorctl ingest --file README.md --title "Project README"
 
 ---
 
-### 🔍 `search` — Search Documents
+### 🔍 `recall` — Recall Documents & Memories
+
+The `recall` command (with backward-compatible alias `search`) queries Spector for documents or memories:
 
 ```bash
-# Text/keyword search
-spectorctl search --text "vector search engine" --topK 10
+# Keyword / semantic recall
+spectorctl recall "vector search engine" --top-k 10
 
-# Vector search
-spectorctl search --vector "0.1,0.2,0.3,0.4,0.5" --topK 5
+# Hybrid recall
+spectorctl recall "search" --mode HYBRID --top-k 10
 
-# Hybrid search
-spectorctl search --text "search" --vector "0.1,0.2,0.3,0.4,0.5" --topK 10
+# Backward-compatible alias
+spectorctl search "search" --top-k 10
 
 # JSON output for scripting
-spectorctl search --text "search" --json
+spectorctl recall "search" --json
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--text` | ❌* | Query text for keyword search |
-| `--vector` | ❌* | Comma-separated query vector |
-| `--topK` | ❌ | Number of results (default: 10) |
-
-> [!IMPORTANT]
-> *At least one of `--text` or `--vector` is required.
+| `<query>` | ✅ | Recall query text (positional parameter) |
+| `-k, --top-k` | ❌ | Number of results (default: 10) |
+| `-m, --mode` | ❌ | Search mode: `KEYWORD`, `VECTOR`, `HYBRID` (default: `KEYWORD`) |
 
 ---
 
@@ -238,8 +239,8 @@ Machine-parseable output for scripting and automation:
 ### Pipe to jq
 
 ```bash
-# Extract document IDs from search results
-spectorctl search --text "query" --json | jq '.results[].id'
+# Extract document IDs from recall results
+spectorctl recall "query" --json | jq '.results[].id'
 
 # Check server health in CI
 if spectorctl status --json | jq -e '.status == "RUNNING"' > /dev/null; then
@@ -254,8 +255,7 @@ fi
 while IFS= read -r line; do
   id=$(echo "$line" | jq -r '.id')
   content=$(echo "$line" | jq -r '.content')
-  vector=$(echo "$line" | jq -r '.vector | join(",")')
-  spectorctl ingest --id "$id" --content "$content" --vector "$vector"
+  spectorctl remember --id "$id" --content "$content"
 done < documents.jsonl
 ```
 

--- a/synapse/spector-cli/README.md
+++ b/synapse/spector-cli/README.md
@@ -38,35 +38,36 @@ spectorctl mcp --dims 4096 --data-dir ~/.spector/data --ollama-model qwen3-embed
 
 ---
 
-## 📥 Ingestion
+## 📥 Remember (Ingestion)
 
-The `ingest` command auto-detects mode from the flags provided:
+The `remember` command (with backward-compatible alias `ingest`) auto-detects mode from the flags provided:
 
 ### Local Batch Mode (Direct Memory Ingestion)
 
-Discovers and ingests files directly into `SpectorMemory` — no server needed. Honors `spector.yml` config.
+Discovers and ingests files directly into `SpectorMemory` via Spring Boot auto-configuration — no server needed. Honors `spector.yml` config.
 
 ```bash
-# Ingest from config (root-directory from spector.yml)
-spectorctl ingest --config spector.yml
+# Remember from config (root-directory from spector.yml)
+spectorctl remember --config spector.yml
 
-# Ingest with explicit root directory
+# Remember with explicit root directory (or using 'ingest' alias)
+spectorctl remember --root /path/to/docs --pattern "**/*.md"
 spectorctl ingest --root /path/to/docs --pattern "**/*.md"
 
 # Override chunk size
-spectorctl ingest --config spector.yml --root . --chunk-size 1200
+spectorctl remember --config spector.yml --root . --chunk-size 1200
 ```
 
 ### Remote Mode (via HTTP)
 
-Sends a single document to a running Spector server.
+Sends a single document or memory to a running Spector server.
 
 ```bash
-# Ingest text content
-spectorctl ingest --content "Hello world" --id doc-1
+# Remember text content
+spectorctl remember --content "Hello world" --id doc-1
 
-# Ingest from a file
-spectorctl ingest --file README.md --title "Project README"
+# Remember from a file
+spectorctl remember --file README.md --title "Project README"
 ```
 
 ---
@@ -86,14 +87,19 @@ spectorctl memory status
 
 ---
 
-## 🔍 Search
+## 🔍 Recall (Search)
+
+The `recall` command (with backward-compatible alias `search`) queries Spector for documents or memories:
 
 ```bash
-# Search with default settings
+# Recall with default settings
+spectorctl recall "vector databases" --top-k 5
+
+# Recall using 'search' alias
 spectorctl search "vector databases" --top-k 5
 
 # Output as JSON (machine-parseable)
-spectorctl search "HNSW algorithm" --json
+spectorctl recall "HNSW algorithm" --json
 ```
 
 ---

--- a/synapse/spector-cli/pom.xml
+++ b/synapse/spector-cli/pom.xml
@@ -22,7 +22,30 @@
         <jacoco.minimum.coverage>0.60</jacoco.minimum.coverage>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Spring Boot Starter & Spector Auto-Configuration Starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.spectrayan</groupId>
+            <artifactId>spring-ai-starter-spector-store</artifactId>
+        </dependency>
+
         <!-- Picocli -->
         <dependency>
             <groupId>info.picocli</groupId>
@@ -79,6 +102,13 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <!-- Spring Boot Starter Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -155,9 +185,12 @@
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.spectrayan.spector.cli.SpectorCtl</mainClass>
+                                    <mainClass>com.spectrayan.spector.cli.SpectorCliApplication</mainClass>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</resource>
+                                </transformer>
                             </transformers>
                             <finalName>spector</finalName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/McpCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/McpCommand.java
@@ -15,32 +15,15 @@
  */
 package com.spectrayan.spector.cli;
 
-import java.nio.file.Path;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.spectrayan.spector.commons.cache.TtlConcurrentMapCacheManager;
-import com.spectrayan.spector.commons.chunker.ChunkConfig;
-import com.spectrayan.spector.commons.chunker.MarkdownChunker;
-import com.spectrayan.spector.config.SpectorConfigFactory;
-import com.spectrayan.spector.config.SpectorConfigSource;
-import com.spectrayan.spector.mcp.SpectorMcpServer;
-import com.spectrayan.spector.memory.DefaultSpectorMemory;
-import com.spectrayan.spector.memory.SpectorMemory;
-import com.spectrayan.spector.memory.graph.EntityExtractionMode;
-import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
-import com.spectrayan.spector.provider.embedding.CachingEmbeddingProvider;
-import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
-import com.spectrayan.spector.provider.embedding.generic.DenseDerivedSparseProvider;
-import com.spectrayan.spector.provider.embedding.generic.DenseDerivedTokenProvider;
-import com.spectrayan.spector.provider.generation.LlmProvider;
-import com.spectrayan.spector.provider.ollama.OllamaLlmProvider;
-
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
+
+import com.spectrayan.spector.mcp.SpectorMcpServer;
+import com.spectrayan.spector.memory.SpectorMemory;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -59,10 +42,6 @@ public class McpCommand implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(McpCommand.class);
 
     private final ObjectProvider<SpectorMemory> memoryProvider;
-
-    public McpCommand() {
-        this(null);
-    }
 
     @Autowired
     public McpCommand(@Lazy ObjectProvider<SpectorMemory> memoryProvider) {
@@ -100,72 +79,16 @@ public class McpCommand implements Runnable {
     public void run() {
         SpectorMemory memory = memoryProvider != null ? memoryProvider.getIfAvailable() : null;
         if (memory == null) {
-            SpectorConfigSource.Builder propsBuilder = SpectorConfigSource.builder();
-
-            if (configFile != null) {
-                propsBuilder.configFile(Path.of(configFile));
-            }
-            if (profile != null) {
-                propsBuilder.profile(profile);
-            }
-            if (dims != null) {
-                propsBuilder.override("spector.memory.dimensions", String.valueOf(dims));
-                propsBuilder.override("spector.provider.embedding.dimensions", String.valueOf(dims));
-            }
-            if (capacity != null) {
-                propsBuilder.override("spector.memory.capacity", String.valueOf(capacity));
-            }
-            if (ollamaUrl != null) {
-                propsBuilder.override("spector.provider.embedding.base-url", ollamaUrl);
-                propsBuilder.override("spector.embedding.base-url", ollamaUrl);
-            }
-            if (ollamaModel != null) {
-                propsBuilder.override("spector.provider.embedding.model", ollamaModel);
-                propsBuilder.override("spector.embedding.model", ollamaModel);
-            }
-            if (dataDir != null) {
-                propsBuilder.override("spector.memory.persistence-path", dataDir);
-                propsBuilder.override("spector.memory.persistence-mode", "DISK");
-            }
-            if (namespace != null) {
-                propsBuilder.override("spector.memory.namespace", namespace);
-            }
-
-            if ("openclaw".equalsIgnoreCase(mode)) {
-                propsBuilder.override("spector.mode", "memory");
-                propsBuilder.override("spector.memory.enabled", "true");
-                propsBuilder.override("spector.memory.persistence-mode", "DISK");
-                if (dataDir == null && configFile == null) {
-                    String openclawDataDir = System.getProperty("user.home") + "/.openclaw/spector/data";
-                    propsBuilder.override("spector.memory.persistence-path", openclawDataDir + "/memory");
-                }
-            } else if ("odysseus".equalsIgnoreCase(mode)) {
-                propsBuilder.override("spector.mode", "memory");
-                propsBuilder.override("spector.memory.enabled", "true");
-                propsBuilder.override("spector.memory.persistence-mode", "DISK");
-                if (dataDir == null && configFile == null) {
-                    String odysseusDataDir = System.getProperty("user.home") + "/.odysseus/spector/data";
-                    propsBuilder.override("spector.memory.persistence-path", odysseusDataDir + "/memory");
-                }
-                propsBuilder.override("spector.memory.default-ingestion-tier", "SEMANTIC");
-            }
-
-            SpectorConfigSource configSource = propsBuilder.build();
-            com.spectrayan.spector.config.SpectorProperties props = com.spectrayan.spector.config.SpectorProperties.from(configSource);
-            memory = com.spectrayan.spector.memory.config.SpectorMemoryConfigurator.builder(props).build();
+            throw new IllegalStateException("SpectorMemory bean is not available in the Spring context. " +
+                    "Ensure memory is enabled (run with embedded profile: cli-embedded, spector.memory.enabled=true).");
         }
 
-        final SpectorMemory finalMemory = memory;
-        SpectorMcpServer server = new SpectorMcpServer(finalMemory);
+        SpectorMcpServer server = new SpectorMcpServer(memory);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             server.stop();
-            try {
-                finalMemory.close();
-            } catch (Exception e) {
-                log.warn("[Spector CLI MCP] Error closing memory on shutdown", e);
-            }
-            log.info("[Spector CLI MCP] Shutdown complete");
+            // Note: SpectorMemory lifecycle and closing is managed by the Spring ApplicationContext.
+            log.info("[Spector CLI MCP] MCP server stopped on shutdown.");
         }));
 
         server.start();

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/McpCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/McpCommand.java
@@ -37,12 +37,18 @@ import com.spectrayan.spector.provider.embedding.generic.DenseDerivedTokenProvid
 import com.spectrayan.spector.provider.generation.LlmProvider;
 import com.spectrayan.spector.provider.ollama.OllamaLlmProvider;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
  * Starts the high-performance Spector Model Context Protocol (MCP) server over STDIO.
  */
+@Component
 @Command(
         name = "mcp",
         description = "Start the Spector MCP server (STDIO JSON-RPC 2.0 transport for AI agents).",
@@ -51,6 +57,17 @@ import picocli.CommandLine.Option;
 public class McpCommand implements Runnable {
 
     private static final Logger log = LoggerFactory.getLogger(McpCommand.class);
+
+    private final ObjectProvider<SpectorMemory> memoryProvider;
+
+    public McpCommand() {
+        this(null);
+    }
+
+    @Autowired
+    public McpCommand(@Lazy ObjectProvider<SpectorMemory> memoryProvider) {
+        this.memoryProvider = memoryProvider;
+    }
 
     @Option(names = {"--config", "-c"}, description = "Path to spector.yml configuration file.")
     private String configFile;
@@ -81,66 +98,70 @@ public class McpCommand implements Runnable {
 
     @Override
     public void run() {
-        SpectorConfigSource.Builder propsBuilder = SpectorConfigSource.builder();
+        SpectorMemory memory = memoryProvider != null ? memoryProvider.getIfAvailable() : null;
+        if (memory == null) {
+            SpectorConfigSource.Builder propsBuilder = SpectorConfigSource.builder();
 
-        if (configFile != null) {
-            propsBuilder.configFile(Path.of(configFile));
-        }
-        if (profile != null) {
-            propsBuilder.profile(profile);
-        }
-        if (dims != null) {
-            propsBuilder.override("spector.memory.dimensions", String.valueOf(dims));
-            propsBuilder.override("spector.provider.embedding.dimensions", String.valueOf(dims));
-        }
-        if (capacity != null) {
-            propsBuilder.override("spector.memory.capacity", String.valueOf(capacity));
-        }
-        if (ollamaUrl != null) {
-            propsBuilder.override("spector.provider.embedding.base-url", ollamaUrl);
-            propsBuilder.override("spector.embedding.base-url", ollamaUrl);
-        }
-        if (ollamaModel != null) {
-            propsBuilder.override("spector.provider.embedding.model", ollamaModel);
-            propsBuilder.override("spector.embedding.model", ollamaModel);
-        }
-        if (dataDir != null) {
-            propsBuilder.override("spector.memory.persistence-path", dataDir);
-            propsBuilder.override("spector.memory.persistence-mode", "DISK");
-        }
-        if (namespace != null) {
-            propsBuilder.override("spector.memory.namespace", namespace);
-        }
-
-        if ("openclaw".equalsIgnoreCase(mode)) {
-            propsBuilder.override("spector.mode", "memory");
-            propsBuilder.override("spector.memory.enabled", "true");
-            propsBuilder.override("spector.memory.persistence-mode", "DISK");
-            if (dataDir == null && configFile == null) {
-                String openclawDataDir = System.getProperty("user.home") + "/.openclaw/spector/data";
-                propsBuilder.override("spector.memory.persistence-path", openclawDataDir + "/memory");
+            if (configFile != null) {
+                propsBuilder.configFile(Path.of(configFile));
             }
-        } else if ("odysseus".equalsIgnoreCase(mode)) {
-            propsBuilder.override("spector.mode", "memory");
-            propsBuilder.override("spector.memory.enabled", "true");
-            propsBuilder.override("spector.memory.persistence-mode", "DISK");
-            if (dataDir == null && configFile == null) {
-                String odysseusDataDir = System.getProperty("user.home") + "/.odysseus/spector/data";
-                propsBuilder.override("spector.memory.persistence-path", odysseusDataDir + "/memory");
+            if (profile != null) {
+                propsBuilder.profile(profile);
             }
-            propsBuilder.override("spector.memory.default-ingestion-tier", "SEMANTIC");
+            if (dims != null) {
+                propsBuilder.override("spector.memory.dimensions", String.valueOf(dims));
+                propsBuilder.override("spector.provider.embedding.dimensions", String.valueOf(dims));
+            }
+            if (capacity != null) {
+                propsBuilder.override("spector.memory.capacity", String.valueOf(capacity));
+            }
+            if (ollamaUrl != null) {
+                propsBuilder.override("spector.provider.embedding.base-url", ollamaUrl);
+                propsBuilder.override("spector.embedding.base-url", ollamaUrl);
+            }
+            if (ollamaModel != null) {
+                propsBuilder.override("spector.provider.embedding.model", ollamaModel);
+                propsBuilder.override("spector.embedding.model", ollamaModel);
+            }
+            if (dataDir != null) {
+                propsBuilder.override("spector.memory.persistence-path", dataDir);
+                propsBuilder.override("spector.memory.persistence-mode", "DISK");
+            }
+            if (namespace != null) {
+                propsBuilder.override("spector.memory.namespace", namespace);
+            }
+
+            if ("openclaw".equalsIgnoreCase(mode)) {
+                propsBuilder.override("spector.mode", "memory");
+                propsBuilder.override("spector.memory.enabled", "true");
+                propsBuilder.override("spector.memory.persistence-mode", "DISK");
+                if (dataDir == null && configFile == null) {
+                    String openclawDataDir = System.getProperty("user.home") + "/.openclaw/spector/data";
+                    propsBuilder.override("spector.memory.persistence-path", openclawDataDir + "/memory");
+                }
+            } else if ("odysseus".equalsIgnoreCase(mode)) {
+                propsBuilder.override("spector.mode", "memory");
+                propsBuilder.override("spector.memory.enabled", "true");
+                propsBuilder.override("spector.memory.persistence-mode", "DISK");
+                if (dataDir == null && configFile == null) {
+                    String odysseusDataDir = System.getProperty("user.home") + "/.odysseus/spector/data";
+                    propsBuilder.override("spector.memory.persistence-path", odysseusDataDir + "/memory");
+                }
+                propsBuilder.override("spector.memory.default-ingestion-tier", "SEMANTIC");
+            }
+
+            SpectorConfigSource configSource = propsBuilder.build();
+            com.spectrayan.spector.config.SpectorProperties props = com.spectrayan.spector.config.SpectorProperties.from(configSource);
+            memory = com.spectrayan.spector.memory.config.SpectorMemoryConfigurator.builder(props).build();
         }
 
-        SpectorConfigSource configSource = propsBuilder.build();
-        com.spectrayan.spector.config.SpectorProperties props = com.spectrayan.spector.config.SpectorProperties.from(configSource);
-
-        SpectorMemory memory = com.spectrayan.spector.memory.config.SpectorMemoryConfigurator.builder(props).build();
-        SpectorMcpServer server = new SpectorMcpServer(memory);
+        final SpectorMemory finalMemory = memory;
+        SpectorMcpServer server = new SpectorMcpServer(finalMemory);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             server.stop();
             try {
-                memory.close();
+                finalMemory.close();
             } catch (Exception e) {
                 log.warn("[Spector CLI MCP] Error closing memory on shutdown", e);
             }

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/MemoryCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/MemoryCommand.java
@@ -25,12 +25,15 @@ import com.spectrayan.spector.cli.client.SpectorClientException;
 import com.spectrayan.spector.cli.client.SpectorConnectionException;
 import com.spectrayan.spector.cli.client.SpectorHttpClient;
 
+import org.springframework.stereotype.Component;
+
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /**
  * Picocli subcommand group for cognitive memory operations.
  */
+@Component
 @Command(
         name = "memory",
         description = "Manage and interact with Spector's cognitive memory subsystem.",

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/RecallCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/RecallCommand.java
@@ -20,6 +20,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.stereotype.Component;
+
 import com.spectrayan.spector.cli.client.SearchRequest;
 import com.spectrayan.spector.cli.client.SearchResponse;
 import com.spectrayan.spector.cli.client.SpectorClientException;
@@ -30,16 +32,19 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /**
- * Search documents in the Spector engine.
+ * Recall and search documents or memories in the Spector engine.
+ * Matches the {@code memory_recall} MCP tool.
  */
+@Component
 @Command(
-        name = "search",
-        description = "Search for documents in Spector.",
+        name = "recall",
+        aliases = {"search"},
+        description = "Recall and search documents or memories in Spector.",
         mixinStandardHelpOptions = true
 )
-class SearchCommand extends BaseCommand {
+public class RecallCommand extends BaseCommand {
 
-    @CommandLine.Parameters(index = "0", description = "Search query text.")
+    @CommandLine.Parameters(index = "0", description = "Recall query text.")
     private String query;
 
     @CommandLine.Option(names = {"-k", "--top-k"}, description = "Number of results to return (default: 10).",
@@ -63,7 +68,7 @@ class SearchCommand extends BaseCommand {
             if (isJson()) {
                 OutputFormatter.printJson(out(), response);
             } else {
-                out().println("Search results (" + response.getTotalHits() + " hits, " + response.getQueryTimeMs() + "ms):");
+                out().println("Recall results (" + response.getTotalHits() + " hits, " + response.getQueryTimeMs() + "ms):");
                 out().println();
 
                 if (response.getResults() == null || response.getResults().isEmpty()) {

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/RememberCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/RememberCommand.java
@@ -76,10 +76,6 @@ public class RememberCommand extends BaseCommand {
     private final ObjectProvider<SpectorMemory> memoryProvider;
     private final ObjectProvider<EmbeddingProvider> embedderProvider;
 
-    public RememberCommand() {
-        this(null, null);
-    }
-
     @Autowired
     public RememberCommand(@Lazy ObjectProvider<SpectorMemory> memoryProvider,
                            @Lazy ObjectProvider<EmbeddingProvider> embedderProvider) {
@@ -170,10 +166,8 @@ public class RememberCommand extends BaseCommand {
 
         EmbeddingProvider embedder = embedderProvider != null ? embedderProvider.getIfAvailable() : null;
         if (embedder == null) {
-            var config = new com.spectrayan.spector.provider.ProviderConfig(
-                    "ollama", embedConfig.type(), embedConfig.model(), embedConfig.apiKey(), embedConfig.baseUrl(), embedConfig.dimensions(), embedConfig.properties());
-            var registry = com.spectrayan.spector.provider.ProviderDiscovery.discover(java.util.List.of(config));
-            embedder = registry.activeEmbedding().orElseThrow();
+            throw new IllegalStateException("EmbeddingProvider bean is not available in the Spring context. " +
+                    "Ensure you are running under the 'cli-embedded' profile with an embedding provider configured.");
         }
         int dims = embedder.embed("probe").dimensions();
         out().printf("[Embedding] Dimensions: %d%n%n", dims);
@@ -189,16 +183,10 @@ public class RememberCommand extends BaseCommand {
                 false
         );
 
-        SpectorMemory injectedMemory = memoryProvider != null ? memoryProvider.getIfAvailable() : null;
-        boolean shouldCloseMemory = false;
-        SpectorMemory memory = injectedMemory;
+        SpectorMemory memory = memoryProvider != null ? memoryProvider.getIfAvailable() : null;
         if (memory == null) {
-            propsBuilder.override("spector.memory.dimensions", String.valueOf(dims));
-            propsBuilder.override("spector.provider.embedding.dimensions", String.valueOf(dims));
-            SpectorConfigSource configSource = propsBuilder.build();
-            com.spectrayan.spector.config.SpectorProperties finalProps = com.spectrayan.spector.config.SpectorProperties.from(configSource);
-            memory = com.spectrayan.spector.memory.config.SpectorMemoryConfigurator.builder(finalProps).build();
-            shouldCloseMemory = true;
+            throw new IllegalStateException("SpectorMemory bean is not available in the Spring context. " +
+                    "Ensure memory is enabled (active profile: cli-embedded, spector.memory.enabled=true).");
         }
 
         try {
@@ -268,13 +256,6 @@ public class RememberCommand extends BaseCommand {
             out().printf("========================================%n");
         } catch (Exception e) {
             err().println("Error during remember operation: " + e.getMessage());
-        } finally {
-            if (shouldCloseMemory && memory != null) {
-                try {
-                    memory.close();
-                } catch (Exception ignored) {
-                }
-            }
         }
     }
 

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/RememberCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/RememberCommand.java
@@ -22,6 +22,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
 import com.spectrayan.spector.cli.client.IngestRequest;
 import com.spectrayan.spector.cli.client.IngestResponse;
 import com.spectrayan.spector.cli.client.SpectorClientException;
@@ -32,42 +37,55 @@ import com.spectrayan.spector.config.SpectorConfigFactory;
 import com.spectrayan.spector.config.SpectorConfigSource;
 import com.spectrayan.spector.ingestion.FileDiscoveryService;
 import com.spectrayan.spector.ingestion.IngestionPipeline;
-import com.spectrayan.spector.memory.DefaultSpectorMemory;
 import com.spectrayan.spector.memory.SpectorMemory;
-import com.spectrayan.spector.memory.graph.EntityExtractionMode;
-import com.spectrayan.spector.memory.model.MemoryPersistenceMode;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
-import com.spectrayan.spector.provider.generation.LlmProvider;
-import com.spectrayan.spector.provider.ollama.OllamaLlmProvider;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /**
- * Ingest documents into Spector.
+ * Remember (ingest) documents and memories into Spector.
+ * Matches the {@code memory_remember} MCP tool.
  *
  * <p>Supports two modes, auto-detected from the flags provided:</p>
  * <ul>
  *   <li><strong>Remote</strong> -- {@code --content} or {@code --file}: sends a single
- *       document to a running Spector server via HTTP.</li>
- *   <li><strong>Local batch</strong> -- {@code --root}: discovers and ingests files
+ *       document/memory to a running Spector server via HTTP.</li>
+ *   <li><strong>Local batch</strong> -- {@code --root}: discovers and remembers files
  *       locally directly into {@link SpectorMemory}, honoring {@code spector.yml} config.</li>
  * </ul>
  *
  * <h3>Examples</h3>
  * <pre>
- *   spectorctl ingest --content "Hello world"             # remote
- *   spectorctl ingest --file README.md                    # remote
- *   spectorctl ingest --root /docs --pattern "**\/*.md"   # local batch
- *   spectorctl ingest --root . --config spector.yml       # local batch
+ *   spectorctl remember --content "Hello world"             # remote
+ *   spectorctl remember --file README.md                   # remote
+ *   spectorctl remember --root /docs --pattern "**\/*.md"  # local batch
+ *   spectorctl remember --root . --config spector.yml      # local batch
+ *   spectorctl ingest --file README.md                     # alias for remember
  * </pre>
  */
+@Component
 @Command(
-        name = "ingest",
-        description = "Ingest documents into Spector (remote or local batch).",
+        name = "remember",
+        aliases = {"ingest"},
+        description = "Remember and ingest documents or memories into Spector (remote or local batch).",
         mixinStandardHelpOptions = true
 )
-class IngestCommand extends BaseCommand {
+public class RememberCommand extends BaseCommand {
+
+    private final ObjectProvider<SpectorMemory> memoryProvider;
+    private final ObjectProvider<EmbeddingProvider> embedderProvider;
+
+    public RememberCommand() {
+        this(null, null);
+    }
+
+    @Autowired
+    public RememberCommand(@Lazy ObjectProvider<SpectorMemory> memoryProvider,
+                           @Lazy ObjectProvider<EmbeddingProvider> embedderProvider) {
+        this.memoryProvider = memoryProvider;
+        this.embedderProvider = embedderProvider;
+    }
 
     // Remote mode options
     @CommandLine.Option(names = {"--id"}, description = "Document ID (auto-generated if not provided).")
@@ -116,17 +134,16 @@ class IngestCommand extends BaseCommand {
         }
     }
 
-    // Local Batch Mode
+    // ─────────────── Local Batch Mode ───────────────
 
     private void runLocalBatch() {
         SpectorConfigSource.Builder propsBuilder = SpectorConfigSource.builder();
-
-        if (configFile != null) propsBuilder.configFile(configFile);
-        if (pattern != null)
-            propsBuilder.override("spector.ingestion.file-pattern", pattern);
+        if (configFile != null)
+            propsBuilder.configFile(configFile);
         if (chunkSize != null)
             propsBuilder.override("spector.ingestion.chunk-size", chunkSize.toString());
-
+        if (pattern != null)
+            propsBuilder.override("spector.ingestion.file-pattern", pattern);
         if (rootDir != null)
             propsBuilder.override("spector.ingestion.root-directory", rootDir.toString());
 
@@ -139,7 +156,7 @@ class IngestCommand extends BaseCommand {
         Path root = ingestionConfig.rootDirectory().toAbsolutePath().normalize();
 
         out().printf("========================================%n");
-        out().printf("  Spector Ingestion (local batch)%n");
+        out().printf("  Spector Remember (local batch)%n");
         out().printf("  Mode:    %s%n", mode);
         out().printf("  Root:    %s%n", root);
         out().printf("  Pattern: %s%n", ingestionConfig.filePattern());
@@ -151,19 +168,15 @@ class IngestCommand extends BaseCommand {
                 ingestionConfig.retryDelayMs());
         out().printf("========================================%n%n");
 
-        var config = new com.spectrayan.spector.provider.ProviderConfig(
-                "ollama", embedConfig.type(), embedConfig.model(), embedConfig.apiKey(), embedConfig.baseUrl(), embedConfig.dimensions(), embedConfig.properties());
-        var registry = com.spectrayan.spector.provider.ProviderDiscovery.discover(java.util.List.of(config));
-        EmbeddingProvider embedder = registry.activeEmbedding().orElseThrow();
+        EmbeddingProvider embedder = embedderProvider != null ? embedderProvider.getIfAvailable() : null;
+        if (embedder == null) {
+            var config = new com.spectrayan.spector.provider.ProviderConfig(
+                    "ollama", embedConfig.type(), embedConfig.model(), embedConfig.apiKey(), embedConfig.baseUrl(), embedConfig.dimensions(), embedConfig.properties());
+            var registry = com.spectrayan.spector.provider.ProviderDiscovery.discover(java.util.List.of(config));
+            embedder = registry.activeEmbedding().orElseThrow();
+        }
         int dims = embedder.embed("probe").dimensions();
         out().printf("[Embedding] Dimensions: %d%n%n", dims);
-
-        propsBuilder.override("spector.memory.dimensions", String.valueOf(dims));
-        propsBuilder.override("spector.provider.embedding.dimensions", String.valueOf(dims));
-        props = propsBuilder.build();
-
-        SpectorConfigSource configSource = propsBuilder.build();
-        com.spectrayan.spector.config.SpectorProperties finalProps = com.spectrayan.spector.config.SpectorProperties.from(configSource);
 
         var chunker = new MarkdownChunker();
         var chunkConfig = new ChunkConfig(
@@ -176,7 +189,19 @@ class IngestCommand extends BaseCommand {
                 false
         );
 
-        try (SpectorMemory memory = com.spectrayan.spector.memory.config.SpectorMemoryConfigurator.builder(finalProps).build()) {
+        SpectorMemory injectedMemory = memoryProvider != null ? memoryProvider.getIfAvailable() : null;
+        boolean shouldCloseMemory = false;
+        SpectorMemory memory = injectedMemory;
+        if (memory == null) {
+            propsBuilder.override("spector.memory.dimensions", String.valueOf(dims));
+            propsBuilder.override("spector.provider.embedding.dimensions", String.valueOf(dims));
+            SpectorConfigSource configSource = propsBuilder.build();
+            com.spectrayan.spector.config.SpectorProperties finalProps = com.spectrayan.spector.config.SpectorProperties.from(configSource);
+            memory = com.spectrayan.spector.memory.config.SpectorMemoryConfigurator.builder(finalProps).build();
+            shouldCloseMemory = true;
+        }
+
+        try {
             long startMs = System.currentTimeMillis();
 
             IngestionPipeline pipeline = IngestionPipeline.builder()
@@ -233,7 +258,7 @@ class IngestCommand extends BaseCommand {
 
             long elapsed = System.currentTimeMillis() - startMs;
             out().printf("%n========================================%n");
-            out().printf("  Ingestion Complete%n");
+            out().printf("  Remember Complete%n");
             out().printf("  Mode:     MEMORY%n");
             out().printf("  Files:    %d%n", totalFiles);
             out().printf("  Chunks:   %d%n", totalChunks);
@@ -242,11 +267,18 @@ class IngestCommand extends BaseCommand {
             out().printf("  Time:     %dms%n", elapsed);
             out().printf("========================================%n");
         } catch (Exception e) {
-            err().println("Error during ingestion: " + e.getMessage());
+            err().println("Error during remember operation: " + e.getMessage());
+        } finally {
+            if (shouldCloseMemory && memory != null) {
+                try {
+                    memory.close();
+                } catch (Exception ignored) {
+                }
+            }
         }
     }
 
-    // Remote Mode
+    // ─────────────── Remote Mode ───────────────
 
     private void runRemote() {
         String text = resolveContent();

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCliApplication.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCliApplication.java
@@ -55,10 +55,11 @@ public class SpectorCliApplication {
     /**
      * Inspects CLI arguments prior to context refresh to route to the optimal profile:
      * <ul>
-     *   <li>{@code cli-remote}: Default for remote calls, search, status, and help flags.
+     *   <li>{@code cli-remote}: Default for remote calls, search/recall, status, and help flags.
      *       Disables local cognitive memory beans for instant startup.</li>
      *   <li>{@code cli-embedded}: Activated when running local operations (e.g. {@code mcp},
-     *       {@code ingest --root}). Enables full Spector cognitive memory auto-configuration.</li>
+     *       {@code memory}, {@code remember --root}, {@code remember --config}, {@code --offline}).
+     *       Enables full Spector cognitive memory auto-configuration.</li>
      * </ul>
      *
      * @param args CLI command-line arguments
@@ -68,14 +69,53 @@ public class SpectorCliApplication {
         if (args == null || args.length == 0) {
             return "cli-remote";
         }
+        // Help and version flags always stay remote for sub-second execution
         for (String arg : args) {
             if (arg.equals("-h") || arg.equals("--help") || arg.equals("-V") || arg.equals("--version")) {
                 return "cli-remote";
             }
-            if (arg.equals("mcp") || arg.equals("--root")) {
+        }
+
+        boolean hasRemoteFlags = false;
+        boolean hasEmbeddedFlags = false;
+        boolean isRememberOrIngest = false;
+        boolean isMemory = false;
+
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if (arg.equals("--profile=cli-embedded")
+                    || (arg.equals("--profile") && i + 1 < args.length && args[i + 1].equals("cli-embedded"))) {
                 return "cli-embedded";
             }
+            if (arg.equals("--profile=cli-remote")
+                    || (arg.equals("--profile") && i + 1 < args.length && args[i + 1].equals("cli-remote"))) {
+                return "cli-remote";
+            }
+            if (arg.equals("mcp") || arg.equals("--root") || arg.equals("--offline")
+                    || arg.equals("--local") || arg.equals("--embedded")) {
+                hasEmbeddedFlags = true;
+            }
+            if (arg.equals("memory")) {
+                isMemory = true;
+            }
+            if (arg.equals("remember") || arg.equals("ingest")) {
+                isRememberOrIngest = true;
+            }
+            if (arg.startsWith("--content") || arg.startsWith("--file")) {
+                hasRemoteFlags = true;
+            }
         }
+
+        if (hasEmbeddedFlags && !hasRemoteFlags) {
+            return "cli-embedded";
+        }
+        if (isMemory) {
+            return "cli-embedded";
+        }
+        if (isRememberOrIngest && !hasRemoteFlags) {
+            return "cli-embedded";
+        }
+
         return "cli-remote";
     }
 }

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCliApplication.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCliApplication.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import org.springframework.boot.Banner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+/**
+ * Spring Boot host application for the {@code spectorctl} CLI.
+ * <p>
+ * Unifies CLI configuration and lifecycle under the {@code spector-spring}
+ * auto-configuration infrastructure, while hosting Picocli commands
+ * via {@link SpectorPicocliRunner} and {@link SpringPicocliFactory}.
+ * </p>
+ */
+@SpringBootApplication(exclude = {
+        org.springframework.boot.batch.autoconfigure.BatchAutoConfiguration.class,
+        org.springframework.boot.batch.autoconfigure.BatchJobLauncherAutoConfiguration.class
+})
+public class SpectorCliApplication {
+
+    public static void main(String[] args) {
+        String activeProfile = determineProfile(args);
+
+        int exitCode = SpringApplication.exit(
+                new SpringApplicationBuilder(SpectorCliApplication.class)
+                        .web(WebApplicationType.NONE)
+                        .bannerMode(Banner.Mode.OFF)
+                        .logStartupInfo(false)
+                        .profiles(activeProfile)
+                        .initializers(new SpectorCliConfigInitializer(args))
+                        .properties("spring.main.lazy-initialization=true")
+                        .run(args)
+        );
+
+        System.exit(exitCode);
+    }
+
+    /**
+     * Inspects CLI arguments prior to context refresh to route to the optimal profile:
+     * <ul>
+     *   <li>{@code cli-remote}: Default for remote calls, search, status, and help flags.
+     *       Disables local cognitive memory beans for instant startup.</li>
+     *   <li>{@code cli-embedded}: Activated when running local operations (e.g. {@code mcp},
+     *       {@code ingest --root}). Enables full Spector cognitive memory auto-configuration.</li>
+     * </ul>
+     *
+     * @param args CLI command-line arguments
+     * @return active profile name
+     */
+    public static String determineProfile(String[] args) {
+        if (args == null || args.length == 0) {
+            return "cli-remote";
+        }
+        for (String arg : args) {
+            if (arg.equals("-h") || arg.equals("--help") || arg.equals("-V") || arg.equals("--version")) {
+                return "cli-remote";
+            }
+            if (arg.equals("mcp") || arg.equals("--root")) {
+                return "cli-embedded";
+            }
+        }
+        return "cli-remote";
+    }
+}

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCliConfigInitializer.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCliConfigInitializer.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ * Early Spring environment bridge for the Spector CLI.
+ * <p>
+ * Bridges {@code --config <file>}, {@code spector.yml}, {@code --profile <p>},
+ * and CLI argument overrides into Spring's {@link ConfigurableEnvironment}
+ * before {@link com.spectrayan.spector.spring.autoconfigure.SpectorConfigProperties}
+ * is bound.
+ * </p>
+ */
+public class SpectorCliConfigInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private static final Logger log = LoggerFactory.getLogger(SpectorCliConfigInitializer.class);
+
+    private final String[] args;
+
+    public SpectorCliConfigInitializer(String[] args) {
+        this.args = args != null ? args : new String[0];
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext context) {
+        ConfigurableEnvironment env = context.getEnvironment();
+
+        // 1. Check for --profile / -p
+        String profile = findArgValue("--profile", "-p");
+        if (profile != null && !profile.isBlank()) {
+            env.addActiveProfile(profile);
+            log.debug("[Spector CLI] Activated profile: {}", profile);
+        }
+
+        // 2. Check for --config / -c or fallback to spector.yml
+        String explicitConfig = findArgValue("--config", "-c");
+        Path configPath = null;
+        if (explicitConfig != null && !explicitConfig.isBlank()) {
+            configPath = Path.of(explicitConfig);
+        } else if (Files.exists(Path.of("spector.yml"))) {
+            configPath = Path.of("spector.yml");
+        }
+
+        if (configPath != null && Files.exists(configPath)) {
+            loadYamlProperties(env, configPath);
+        }
+
+        // 3. Collect CLI property overrides into a high-priority PropertySource
+        Map<String, Object> overrides = new HashMap<>();
+
+        String dims = findArgValue("--dims", null);
+        if (dims != null && !dims.isBlank()) {
+            overrides.put("spector.memory.dimensions", dims);
+            overrides.put("spector.provider.embedding.dimensions", dims);
+        }
+
+        String capacity = findArgValue("--capacity", null);
+        if (capacity != null && !capacity.isBlank()) {
+            overrides.put("spector.memory.capacity", capacity);
+        }
+
+        String dataDir = findArgValue("--data-dir", null);
+        if (dataDir != null && !dataDir.isBlank()) {
+            overrides.put("spector.memory.persistence-path", dataDir);
+            overrides.put("spector.memory.persistence-mode", "DISK");
+        }
+
+        String namespace = findArgValue("--namespace", null);
+        if (namespace != null && !namespace.isBlank()) {
+            overrides.put("spector.memory.namespace", namespace);
+        }
+
+        String ollamaUrl = findArgValue("--ollama-url", null);
+        if (ollamaUrl != null && !ollamaUrl.isBlank()) {
+            overrides.put("spector.provider.embedding.base-url", ollamaUrl);
+            overrides.put("spector.embedding.base-url", ollamaUrl);
+        }
+
+        String ollamaModel = findArgValue("--ollama-model", null);
+        if (ollamaModel != null && !ollamaModel.isBlank()) {
+            overrides.put("spector.provider.embedding.model", ollamaModel);
+            overrides.put("spector.embedding.model", ollamaModel);
+        }
+
+        String mode = findArgValue("--mode", null);
+        if ("openclaw".equalsIgnoreCase(mode)) {
+            overrides.put("spector.mode", "memory");
+            overrides.put("spector.memory.enabled", "true");
+            overrides.put("spector.memory.persistence-mode", "DISK");
+            if (dataDir == null && explicitConfig == null) {
+                String openclawDataDir = System.getProperty("user.home") + "/.openclaw/spector/data";
+                overrides.put("spector.memory.persistence-path", openclawDataDir + "/memory");
+            }
+        } else if ("odysseus".equalsIgnoreCase(mode)) {
+            overrides.put("spector.mode", "memory");
+            overrides.put("spector.memory.enabled", "true");
+            overrides.put("spector.memory.persistence-mode", "DISK");
+            if (dataDir == null && explicitConfig == null) {
+                String odysseusDataDir = System.getProperty("user.home") + "/.odysseus/spector/data";
+                overrides.put("spector.memory.persistence-path", odysseusDataDir + "/memory");
+            }
+            overrides.put("spector.memory.default-ingestion-tier", "SEMANTIC");
+        }
+
+        if (!overrides.isEmpty()) {
+            env.getPropertySources().addFirst(new MapPropertySource("spectorCliOverrides", overrides));
+            log.debug("[Spector CLI] Applied {} CLI property overrides", overrides.size());
+        }
+    }
+
+    private void loadYamlProperties(ConfigurableEnvironment env, Path path) {
+        try {
+            YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+            List<PropertySource<?>> sources = loader.load("spectorConfigFile:" + path.getFileName(), new FileSystemResource(path));
+            for (PropertySource<?> source : sources) {
+                env.getPropertySources().addLast(source);
+                log.info("[Spector CLI] Loaded configuration from {}", path);
+            }
+        } catch (IOException e) {
+            log.warn("[Spector CLI] Could not load YAML configuration from {}: {}", path, e.getMessage());
+        }
+    }
+
+    private String findArgValue(String longName, String shortName) {
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if (arg.equals(longName) || (shortName != null && arg.equals(shortName))) {
+                if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
+                    return args[i + 1];
+                }
+            } else if (arg.startsWith(longName + "=")) {
+                return arg.substring((longName + "=").length());
+            } else if (shortName != null && arg.startsWith(shortName + "=")) {
+                return arg.substring((shortName + "=").length());
+            }
+        }
+        return null;
+    }
+}

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCtl.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCtl.java
@@ -15,6 +15,7 @@
  */
 package com.spectrayan.spector.cli;
 
+import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -30,12 +31,15 @@ import picocli.CommandLine.Option;
  * spectorctl [--host HOST] [--port PORT] [--json] COMMAND
  *
  * Commands:
- *   index    Manage indexes (create, delete, list)
- *   ingest   Ingest a document
- *   search   Search for documents
- *   status   Show instance status
+ *   remember (ingest) Store or ingest documents/memories
+ *   recall (search)   Recall or search documents/memories
+ *   index             Manage indexes (create, delete, list)
+ *   status            Show instance status
+ *   memory            Manage cognitive memory subsystem
+ *   mcp               Start the Spector MCP server
  * </pre>
  */
+@Component
 @Command(
         name = "spectorctl",
         description = "Command-line tool for managing Spector instances.",
@@ -43,8 +47,8 @@ import picocli.CommandLine.Option;
         versionProvider = VersionProvider.class,
         subcommands = {
                 IndexCommand.class,
-                IngestCommand.class,
-                SearchCommand.class,
+                RememberCommand.class,
+                RecallCommand.class,
                 StatusCommand.class,
                 MemoryCommand.class,
                 McpCommand.class
@@ -74,17 +78,14 @@ public class SpectorCtl implements Runnable {
     }
 
     public static void main(String[] args) {
-        int exitCode = new CommandLine(new SpectorCtl())
-                .setExecutionExceptionHandler(new ExceptionHandler())
-                .execute(args);
-        System.exit(exitCode);
+        SpectorCliApplication.main(args);
     }
 
     /**
      * Handles execution exceptions to provide friendly error messages.
      * Satisfies Req 18.4 (connection errors) and 18.5 (invalid arguments).
      */
-    static class ExceptionHandler implements CommandLine.IExecutionExceptionHandler {
+    public static class ExceptionHandler implements CommandLine.IExecutionExceptionHandler {
         @Override
         public int handleExecutionException(Exception ex, CommandLine commandLine,
                                             CommandLine.ParseResult parseResult) {

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorPicocliRunner.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorPicocliRunner.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import picocli.CommandLine;
+
+/**
+ * Spring Boot {@link ApplicationRunner} that hosts Picocli CLI execution.
+ * <p>
+ * Executes the {@link SpectorCtl} root command using {@link SpringPicocliFactory}
+ * and captures the exit code for Spring Boot's {@link ExitCodeGenerator}.
+ * </p>
+ */
+@Component
+@Order(0)
+public class SpectorPicocliRunner implements ApplicationRunner, ExitCodeGenerator {
+
+    private final SpectorCtl spectorCtl;
+    private final SpringPicocliFactory factory;
+    private int exitCode;
+
+    public SpectorPicocliRunner(SpectorCtl spectorCtl, SpringPicocliFactory factory) {
+        this.spectorCtl = spectorCtl;
+        this.factory = factory;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        CommandLine cmd = new CommandLine(spectorCtl, factory)
+                .setExecutionExceptionHandler(new SpectorCtl.ExceptionHandler());
+        this.exitCode = cmd.execute(args.getSourceArgs());
+    }
+
+    @Override
+    public int getExitCode() {
+        return exitCode;
+    }
+}

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpringPicocliFactory.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpringPicocliFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import picocli.CommandLine;
+
+/**
+ * Picocli factory that delegates command instance creation to the Spring {@link ApplicationContext}.
+ * <p>
+ * If a command class is registered as a Spring bean, it is retrieved from the context (with all
+ * autowired/injected dependencies). If not found, it falls back to Picocli's default factory.
+ * </p>
+ */
+@Component
+public class SpringPicocliFactory implements CommandLine.IFactory {
+
+    private final ApplicationContext applicationContext;
+
+    public SpringPicocliFactory(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public <K> K create(Class<K> cls) throws Exception {
+        try {
+            return applicationContext.getBean(cls);
+        } catch (NoSuchBeanDefinitionException e) {
+            return CommandLine.defaultFactory().create(cls);
+        }
+    }
+}

--- a/synapse/spector-cli/src/main/resources/application-cli-embedded.yml
+++ b/synapse/spector-cli/src/main/resources/application-cli-embedded.yml
@@ -1,0 +1,3 @@
+spector:
+  memory:
+    enabled: true

--- a/synapse/spector-cli/src/main/resources/application-cli-embedded.yml
+++ b/synapse/spector-cli/src/main/resources/application-cli-embedded.yml
@@ -1,3 +1,10 @@
 spector:
   memory:
     enabled: true
+    persistence-mode: DISK
+    persistence-path: ${SPECTOR_DATA_DIR:~/.spector/data}/memory
+  provider:
+    embedding:
+      type: ${SPECTOR_EMBEDDING_PROVIDER:ollama}
+      base-url: ${SPECTOR_OLLAMA_BASE_URL:http://localhost:11434}
+      model: ${SPECTOR_OLLAMA_EMBED_MODEL:nomic-embed-text}

--- a/synapse/spector-cli/src/main/resources/application-cli-remote.yml
+++ b/synapse/spector-cli/src/main/resources/application-cli-remote.yml
@@ -1,0 +1,3 @@
+spector:
+  memory:
+    enabled: false

--- a/synapse/spector-cli/src/main/resources/application.yml
+++ b/synapse/spector-cli/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  main:
+    lazy-initialization: true
+    banner-mode: "off"
+  application:
+    name: spector-cli
+  batch:
+    job:
+      enabled: false
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.batch.autoconfigure.BatchAutoConfiguration
+      - org.springframework.boot.batch.autoconfigure.BatchJobLauncherAutoConfiguration
+
+logging:
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliApplicationTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliApplicationTest.java
@@ -50,5 +50,6 @@ class SpectorCliApplicationTest {
         assertThat(context.containsBean("mcpCommand")).isTrue();
         assertThat(context.containsBean("rememberCommand")).isTrue();
         assertThat(context.containsBean("recallCommand")).isTrue();
+        assertThat(context.containsBean("memoryCommand")).isTrue();
     }
 }

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliApplicationTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliApplicationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.spectrayan.spector.memory.SpectorMemory;
+
+@SpringBootTest(classes = SpectorCliApplication.class, properties = {
+        "spring.main.lazy-initialization=true",
+        "spring.main.banner-mode=off"
+})
+@ActiveProfiles("cli-remote")
+class SpectorCliApplicationTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void contextLoads_inRemoteProfile_spectorMemoryBeanIsNotCreated() {
+        assertThat(context).isNotNull();
+        assertThat(context.containsBean("spectorMemory")).isFalse();
+        assertThat(context.getBeanNamesForType(SpectorMemory.class)).isEmpty();
+    }
+
+    @Test
+    void contextLoads_cliBeansArePresent() {
+        assertThat(context.containsBean("spectorCtl")).isTrue();
+        assertThat(context.containsBean("spectorPicocliRunner")).isTrue();
+        assertThat(context.containsBean("springPicocliFactory")).isTrue();
+        assertThat(context.containsBean("mcpCommand")).isTrue();
+        assertThat(context.containsBean("rememberCommand")).isTrue();
+        assertThat(context.containsBean("recallCommand")).isTrue();
+    }
+}

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliConfigInitializerTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliConfigInitializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+class SpectorCliConfigInitializerTest {
+
+    @Test
+    void initialize_mapsCliOverrideFlagsToSpectorProperties() {
+        String[] args = new String[]{
+                "--dims", "512",
+                "--capacity", "20000",
+                "--data-dir", "/tmp/spector-test",
+                "--namespace", "test-ns",
+                "--ollama-url", "http://ollama.local:11434",
+                "--ollama-model", "qwen3-embedding:custom"
+        };
+
+        var context = new AnnotationConfigApplicationContext();
+        var initializer = new SpectorCliConfigInitializer(args);
+        initializer.initialize(context);
+
+        ConfigurableEnvironment env = context.getEnvironment();
+        assertThat(env.getProperty("spector.memory.dimensions")).isEqualTo("512");
+        assertThat(env.getProperty("spector.provider.embedding.dimensions")).isEqualTo("512");
+        assertThat(env.getProperty("spector.memory.capacity")).isEqualTo("20000");
+        assertThat(env.getProperty("spector.memory.persistence-path")).isEqualTo("/tmp/spector-test");
+        assertThat(env.getProperty("spector.memory.persistence-mode")).isEqualTo("DISK");
+        assertThat(env.getProperty("spector.memory.namespace")).isEqualTo("test-ns");
+        assertThat(env.getProperty("spector.provider.embedding.base-url")).isEqualTo("http://ollama.local:11434");
+        assertThat(env.getProperty("spector.provider.embedding.model")).isEqualTo("qwen3-embedding:custom");
+    }
+
+    @Test
+    void initialize_mapsProfileFlagToActiveProfile() {
+        String[] args = new String[]{"--profile", "staging"};
+
+        var context = new AnnotationConfigApplicationContext();
+        var initializer = new SpectorCliConfigInitializer(args);
+        initializer.initialize(context);
+
+        assertThat(context.getEnvironment().getActiveProfiles()).contains("staging");
+    }
+}

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliProfileRoutingTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliProfileRoutingTest.java
@@ -52,8 +52,29 @@ class SpectorCliProfileRoutingTest {
     }
 
     @Test
+    void determineProfile_memorySubcommands_returnsEmbeddedProfile() {
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"memory", "status"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"memory", "recall", "test"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"memory", "remember", "--id", "1", "--text", "fact"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"memory", "export", "--offline", "--output", "out.smb"})).isEqualTo("cli-embedded");
+        // But help on memory subcommand remains remote for instant response
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"memory", "--help"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"memory", "status", "-h"})).isEqualTo("cli-remote");
+    }
+
+    @Test
     void determineProfile_localBatchIngestAndRemember_returnsEmbeddedProfile() {
         assertThat(SpectorCliApplication.determineProfile(new String[]{"ingest", "--root", "/data/docs"})).isEqualTo("cli-embedded");
         assertThat(SpectorCliApplication.determineProfile(new String[]{"remember", "--root", "/data/docs"})).isEqualTo("cli-embedded");
+        // Config-driven local batch (no --content or --file)
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"remember", "--config", "spector.yml"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"ingest", "--config", "spector.yml"})).isEqualTo("cli-embedded");
+    }
+
+    @Test
+    void determineProfile_explicitProfileFlags_respected() {
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"status", "--profile=cli-embedded"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"status", "--profile", "cli-embedded"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"mcp", "--profile=cli-remote"})).isEqualTo("cli-remote");
     }
 }

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliProfileRoutingTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliProfileRoutingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SpectorCliProfileRoutingTest {
+
+    @Test
+    void determineProfile_nullOrEmptyArgs_returnsRemoteProfile() {
+        assertThat(SpectorCliApplication.determineProfile(null)).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[0])).isEqualTo("cli-remote");
+    }
+
+    @Test
+    void determineProfile_helpOrVersionFlags_returnsRemoteProfile() {
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"--help"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"-h"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"--version"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"-V"})).isEqualTo("cli-remote");
+    }
+
+    @Test
+    void determineProfile_remoteSubcommands_returnsRemoteProfile() {
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"status"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"search", "query"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"recall", "query"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"index", "list"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"ingest", "--file", "doc.txt"})).isEqualTo("cli-remote");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"remember", "--file", "doc.txt"})).isEqualTo("cli-remote");
+    }
+
+    @Test
+    void determineProfile_mcpSubcommand_returnsEmbeddedProfile() {
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"mcp"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"mcp", "--dims", "384"})).isEqualTo("cli-embedded");
+    }
+
+    @Test
+    void determineProfile_localBatchIngestAndRemember_returnsEmbeddedProfile() {
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"ingest", "--root", "/data/docs"})).isEqualTo("cli-embedded");
+        assertThat(SpectorCliApplication.determineProfile(new String[]{"remember", "--root", "/data/docs"})).isEqualTo("cli-embedded");
+    }
+}

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCtlTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCtlTest.java
@@ -16,12 +16,14 @@
 package com.spectrayan.spector.cli;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import picocli.CommandLine;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for SpectorCtl CLI commands.
@@ -30,8 +32,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class SpectorCtlTest {
 
+    @SuppressWarnings("unchecked")
     private CommandLine createCli() {
-        return new CommandLine(new SpectorCtl());
+        CommandLine.IFactory factory = new CommandLine.IFactory() {
+            @Override
+            public <K> K create(Class<K> cls) throws Exception {
+                if (cls == McpCommand.class) {
+                    return cls.cast(new McpCommand(mock(ObjectProvider.class)));
+                }
+                if (cls == RememberCommand.class) {
+                    return cls.cast(new RememberCommand(mock(ObjectProvider.class), mock(ObjectProvider.class)));
+                }
+                return CommandLine.defaultFactory().create(cls);
+            }
+        };
+        return new CommandLine(new SpectorCtl(), factory);
     }
 
     // ─────────────── Requirement 18.6: --help display ───────────────

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCtlTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCtlTest.java
@@ -47,8 +47,8 @@ class SpectorCtlTest {
         String output = sw.toString();
         assertThat(output).contains("spectorctl");
         assertThat(output).contains("index");
-        assertThat(output).contains("ingest");
-        assertThat(output).contains("search");
+        assertThat(output).contains("remember");
+        assertThat(output).contains("recall");
         assertThat(output).contains("status");
         assertThat(output).contains("mcp");
     }
@@ -183,6 +183,35 @@ class SpectorCtlTest {
         assertThat(output).contains("--id");
         assertThat(output).contains("--content");
         assertThat(output).contains("--file");
+    }
+
+    @Test
+    void rememberHelp_showsOptions() {
+        var cli = createCli();
+        var sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute("remember", "--help");
+
+        assertThat(exitCode).isEqualTo(0);
+        String output = sw.toString();
+        assertThat(output).contains("--id");
+        assertThat(output).contains("--content");
+        assertThat(output).contains("--file");
+    }
+
+    @Test
+    void recallHelp_showsOptions() {
+        var cli = createCli();
+        var sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute("recall", "--help");
+
+        assertThat(exitCode).isEqualTo(0);
+        String output = sw.toString();
+        assertThat(output).contains("--top-k");
+        assertThat(output).contains("--mode");
     }
 
     @Test

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpringPicocliFactoryTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpringPicocliFactoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+
+class SpringPicocliFactoryTest {
+
+    static class SampleCommand implements Runnable {
+        @Override
+        public void run() {}
+    }
+
+    static class UnregisteredCommand implements Runnable {
+        @Override
+        public void run() {}
+    }
+
+    @Test
+    void create_beanFoundInContext_returnsBeanFromContext() throws Exception {
+        ApplicationContext context = mock(ApplicationContext.class);
+        SampleCommand expected = new SampleCommand();
+        when(context.getBean(SampleCommand.class)).thenReturn(expected);
+
+        SpringPicocliFactory factory = new SpringPicocliFactory(context);
+        SampleCommand actual = factory.create(SampleCommand.class);
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    void create_beanNotFoundInContext_fallsBackToDefaultFactory() throws Exception {
+        ApplicationContext context = mock(ApplicationContext.class);
+        when(context.getBean(UnregisteredCommand.class))
+                .thenThrow(new NoSuchBeanDefinitionException(UnregisteredCommand.class));
+
+        SpringPicocliFactory factory = new SpringPicocliFactory(context);
+        UnregisteredCommand actual = factory.create(UnregisteredCommand.class);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual).isInstanceOf(UnregisteredCommand.class);
+    }
+}

--- a/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/SpectorMcpMain.java
+++ b/synapse/spector-mcp/src/main/java/com/spectrayan/spector/mcp/SpectorMcpMain.java
@@ -62,9 +62,12 @@ import com.spectrayan.spector.provider.embedding.CachingEmbeddingProvider;
  *   java --add-modules jdk.incubator.vector -jar spector.jar mcp --dims 768 --ollama-model qwen3-embedding
  *
  *   # Minimal (all defaults from spector-defaults.yml)
- *   java --add-modules jdk.incubator.vector -jar spector.jar mcp
- * </pre>
+ *
+ * @deprecated Standalone manual bootstrap entry point. Use {@code spectorctl mcp}
+ *             from the {@code spector-cli} module instead, which uses unified Spring Boot
+ *             auto-configuration.
  */
+@Deprecated(since = "0.1.0-alpha")
 public class SpectorMcpMain {
 
     private static final Logger log = LoggerFactory.getLogger(SpectorMcpMain.class);


### PR DESCRIPTION
## Summary

Brings \spector-cli\ (\spectorctl\) under Spring Boot so it shares auto-configuration (\spring-ai-starter-spector-store\) with \spector-synapse\, eliminating duplicate bootstrap logic.

- **Picocli hosted in Spring Boot**: Added \SpringPicocliFactory\ and \SpectorPicocliRunner\ (\ApplicationRunner\ + \ExitCodeGenerator\).
- **Zero Startup Overhead for Remote Commands**: Added pre-parsing in \SpectorCliApplication\ to route into either \cli-remote\ profile (\spector.memory.enabled: false\, no embedding models or vector store instantiated) or \cli-embedded\ profile (\spector.memory.enabled: true\).
- **Command Renaming & Cognitive Alignment**:
  - Renamed \ingest\ -> \emember\ with alias \ingest\ for 100% backward compatibility.
  - Renamed \search\ -> \ecall\ with alias \search\ for 100% backward compatibility.
  - Matches cognitive memory MCP tools (\memory_remember\, \memory_recall\).
- **Config & Flags Bridging**: Early \ApplicationContextInitializer\ maps CLI arguments (\--config\, \--profile\, \--dims\, \--data-dir\, \--ollama-url\) to Spring Environment properties.
- **Packaging & Shading**: Configured \maven-shade-plugin\ with \AppendingTransformer\ for Spring Boot's \META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports\, producing standalone executable \	arget/spector.jar\.
- **Deprecation**: Deprecated standalone \SpectorMcpMain\ in favor of \spectorctl mcp\.

## Verification
- Unit & integration tests in \spector-cli\ (35 passed): \SpringPicocliFactoryTest\, \SpectorCliProfileRoutingTest\, \SpectorCliConfigInitializerTest\, \SpectorCliApplicationTest\, \SpectorCtlTest\.
- Cross-module test suite (\spector-mcp\, \spector-spring\, \spector-cli\) all passed (110 total tests).
- Standalone \spector.jar\ executable verified for \--help\, \emember --help\, \ecall --help\, \ingest --help\, \search --help\, and \status\ (fast failure without database/model initialization).

Closes #761

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>