### PR TITLE
feat(core): Phase 1 — Engine & CLI Stabilization (#775)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4713,19 +4713,19 @@ components:
         timestampMs:
           type: integer
           format: int64
-        multimodal:
-          type: boolean
-        negativeOutcome:
-          type: boolean
-        hyperfocused:
-          type: boolean
-        positivelyReinforced:
+        lateral:
           type: boolean
         dreamed:
           type: boolean
-        lateral:
-          type: boolean
         simulated:
+          type: boolean
+        multimodal:
+          type: boolean
+        positivelyReinforced:
+          type: boolean
+        hyperfocused:
+          type: boolean
+        negativeOutcome:
           type: boolean
     FederatedRecallHit:
       type: object

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/SpectorMemoryBuilder.java
@@ -610,8 +610,15 @@ public final class SpectorMemoryBuilder {
         } else {
             this.properties = SpectorProperties.builder().build();
         }
-        if (embeddingProvider != null && embeddingProvider.dimensions() > 0) {
-            this.properties.memory().setDimensions(embeddingProvider.dimensions());
+        if (embeddingProvider != null) {
+            try {
+                int dims = embeddingProvider.dimensions();
+                if (dims > 0) {
+                    this.properties.memory().setDimensions(dims);
+                }
+            } catch (Exception e) {
+                log.debug("[Spector] Could not probe embedding provider dimensions eagerly: {}", e.getMessage());
+            }
         }
         return new DefaultSpectorMemory(this);
     }

--- a/memory/spector-providers/pom.xml
+++ b/memory/spector-providers/pom.xml
@@ -68,6 +68,10 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-ollama</artifactId>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+        </dependency>
 
         <!-- ── Jackson for JSON (Ollama HTTP-based providers) ── -->
         <dependency>

--- a/memory/spector-providers/src/main/java/com/spectrayan/spector/provider/onnx/OnnxProviderFactory.java
+++ b/memory/spector-providers/src/main/java/com/spectrayan/spector/provider/onnx/OnnxProviderFactory.java
@@ -103,18 +103,23 @@ public class OnnxProviderFactory extends AbstractProviderFactory {
             } catch (Exception ignored) {}
         }
 
-        try {
-            Class<?> clazz = Class.forName("dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel");
-            return (EmbeddingModel) clazz.getConstructor().newInstance();
-        } catch (Exception ignored) {}
+        if (lower.contains("all-minilm") || lower.contains("minilm") || lower.isBlank() || lower.equals("default") || lower.equals("onnx")) {
+            try {
+                Class<?> clazz = Class.forName("dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel");
+                return (EmbeddingModel) clazz.getConstructor().newInstance();
+            } catch (Exception ignored) {}
+        }
 
         throw new IllegalStateException("No ONNX embedding model found on classpath for model: " + modelName
                 + ". Please specify 'modelPath' in configuration or add langchain4j-embeddings-all-minilm-l6-v2 dependency.");
     }
 
     public static int resolveDimensions(String model, int configuredDims) {
-        if (configuredDims > 0) return configuredDims;
         String lower = model != null ? model.toLowerCase(Locale.ROOT) : "";
+        if (lower.contains("minilm") || lower.contains("bge-small") || lower.contains("bge_small")) {
+            return 384;
+        }
+        if (configuredDims > 0) return configuredDims;
         if (lower.contains("large") || lower.contains("1024")) return 1024;
         if (lower.contains("base") || lower.contains("768") || lower.contains("nomic") || lower.contains("mpnet")) return 768;
         return 384;

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
         <context-propagation.version>1.1.2</context-propagation.version>
         <armeria.version>1.41.0</armeria.version>
         <langchain4j.version>1.18.1</langchain4j.version>
+        <langchain4j-embeddings.version>1.0.0-beta1</langchain4j-embeddings.version>
         <spring-boot.version>4.1.0</spring-boot.version>
         <flyway.version>12.4.0</flyway.version>
         <spring-ai.version>2.0.0</spring-ai.version>
@@ -382,6 +383,16 @@
                 <version>${langchain4j.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+                <version>${langchain4j-embeddings.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId>
+                <version>${langchain4j-embeddings.version}</version>
             </dependency>
 
             <!-- ── Apache Commons Configuration (hierarchical config) ── -->

--- a/synapse/spector-cli/pom.xml
+++ b/synapse/spector-cli/pom.xml
@@ -87,6 +87,10 @@
             <artifactId>spector-providers</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.spectrayan</groupId>
             <artifactId>spector-commons</artifactId>
         </dependency>

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/BaseCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/BaseCommand.java
@@ -50,15 +50,18 @@ abstract class BaseCommand implements Runnable {
     }
 
     protected String getHost() {
-        return resolveRoot().host;
+        var root = resolveRoot();
+        return root != null && root.host != null ? root.host : "localhost";
     }
 
     protected int getPort() {
-        return resolveRoot().port;
+        var root = resolveRoot();
+        return root != null && root.port > 0 ? root.port : 7070;
     }
 
     protected boolean isJson() {
-        return resolveRoot().json;
+        var root = resolveRoot();
+        return root != null && root.json;
     }
 
     protected PrintWriter out() {
@@ -97,7 +100,6 @@ abstract class BaseCommand implements Runnable {
         if (parent instanceof SpectorCtl root) {
             return root;
         }
-        // Should not happen if Picocli wiring is correct
-        throw new SpectorInternalException(ErrorCode.INTERNAL_ERROR, "Cannot resolve root SpectorCtl command");
+        return null;
     }
 }

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/DoctorCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/DoctorCommand.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Diagnostic command inspecting the local runtime environment, Java 25 & Panama Vector API,
+ * CPU SIMD acceleration, directory permissions, Synapse daemon health, Ollama availability,
+ * and generating AI agent integration snippets.
+ */
+@Component
+@Command(
+        name = "doctor",
+        description = "Diagnose the local environment, SIMD hardware acceleration, and runtime dependencies.",
+        mixinStandardHelpOptions = true
+)
+public class DoctorCommand extends BaseCommand {
+
+    @Option(names = {"--data-dir"}, description = "Target data directory to inspect (default: ~/.spector/data).")
+    private String dataDir;
+
+    @Option(names = {"--snippets"}, description = "Print copy-pasteable AI agent MCP config snippets.", defaultValue = "true")
+    private boolean snippets = true;
+
+    private enum Status {
+        OK("OK"),
+        INFO("INFO"),
+        WARN("WARN"),
+        FAIL("FAIL");
+
+        private final String tag;
+
+        Status(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public String toString() {
+            return tag;
+        }
+    }
+
+    @Override
+    public void run() {
+        Map<String, Object> report = new LinkedHashMap<>();
+
+        // 1. Java Runtime Diagnosis
+        int javaFeature = Runtime.version().feature();
+        String javaVersion = System.getProperty("java.version");
+        String javaVendor = System.getProperty("java.vendor");
+        String javaHome = System.getProperty("java.home");
+        boolean java25OrHigher = javaFeature >= 25;
+
+        Map<String, Object> javaInfo = new LinkedHashMap<>();
+        javaInfo.put("version", javaVersion);
+        javaInfo.put("feature", javaFeature);
+        javaInfo.put("vendor", javaVendor);
+        javaInfo.put("home", javaHome);
+        javaInfo.put("supported", java25OrHigher);
+        report.put("java", javaInfo);
+
+        // 2. SIMD & Vector API Diagnosis
+        boolean panamaVectorAvailable = false;
+        int vectorBitSize = 0;
+        int laneCount = 0;
+        String simdInstructionSet = "None (Scalar Fallback)";
+        try {
+            vectorBitSize = com.spectrayan.spector.core.simd.SimdCapability.vectorBitSize();
+            laneCount = com.spectrayan.spector.core.simd.SimdCapability.laneCount();
+            panamaVectorAvailable = true;
+            if (vectorBitSize >= 512) {
+                simdInstructionSet = "AVX-512 (" + vectorBitSize + "-bit, " + laneCount + " lanes)";
+            } else if (vectorBitSize >= 256) {
+                simdInstructionSet = "AVX2 / NEON (" + vectorBitSize + "-bit, " + laneCount + " lanes)";
+            } else if (vectorBitSize >= 128) {
+                simdInstructionSet = "SSE4.2 / NEON (" + vectorBitSize + "-bit, " + laneCount + " lanes)";
+            } else {
+                simdInstructionSet = "Vector API (" + vectorBitSize + "-bit, " + laneCount + " lanes)";
+            }
+        } catch (Throwable ignored) {}
+
+        Map<String, Object> simdInfo = new LinkedHashMap<>();
+        simdInfo.put("panamaVectorAvailable", panamaVectorAvailable);
+        simdInfo.put("vectorBitSize", vectorBitSize);
+        simdInfo.put("instructionSet", simdInstructionSet);
+        report.put("simd", simdInfo);
+
+        // 3. Storage & Permissions Diagnosis
+        String resolvedDataDir = dataDir != null && !dataDir.isBlank()
+                ? dataDir
+                : System.getProperty("user.home") + File.separator + ".spector" + File.separator + "data";
+        Path storagePath = Paths.get(resolvedDataDir);
+        boolean dirExists = Files.exists(storagePath);
+        boolean canWrite = false;
+        long usableSpaceMb = 0;
+        try {
+            if (!dirExists) {
+                Files.createDirectories(storagePath);
+                dirExists = true;
+            }
+            Path testFile = storagePath.resolve(".doctor_test_" + System.currentTimeMillis());
+            Files.writeString(testFile, "test");
+            Files.deleteIfExists(testFile);
+            canWrite = true;
+            usableSpaceMb = storagePath.toFile().getUsableSpace() / (1024 * 1024);
+        } catch (Exception ignored) {}
+
+        Map<String, Object> storageInfo = new LinkedHashMap<>();
+        storageInfo.put("path", resolvedDataDir);
+        storageInfo.put("exists", dirExists);
+        storageInfo.put("writable", canWrite);
+        storageInfo.put("usableSpaceMb", usableSpaceMb);
+        report.put("storage", storageInfo);
+
+        // 4. In-Process ONNX Fallback Diagnosis
+        boolean onnxAvailable = false;
+        try {
+            Class.forName("dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel");
+            onnxAvailable = true;
+        } catch (Throwable ignored) {}
+
+        Map<String, Object> onnxInfo = new LinkedHashMap<>();
+        onnxInfo.put("available", onnxAvailable);
+        onnxInfo.put("model", "all-MiniLM-L6-v2 (quantized)");
+        onnxInfo.put("dimensions", 384);
+        report.put("onnx", onnxInfo);
+
+        // 5. Synapse Daemon Reachability
+        String synapseUrl = "http://" + getHost() + ":" + getPort();
+        boolean synapseOnline = false;
+        String synapseStatus = "OFFLINE";
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofMillis(800))
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(synapseUrl + "/actuator/health"))
+                    .timeout(Duration.ofMillis(1200))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                synapseOnline = true;
+                synapseStatus = response.body().contains("UP") ? "UP" : "ONLINE";
+            }
+        } catch (Exception ignored) {}
+
+        Map<String, Object> synapseInfo = new LinkedHashMap<>();
+        synapseInfo.put("url", synapseUrl);
+        synapseInfo.put("online", synapseOnline);
+        synapseInfo.put("status", synapseStatus);
+        report.put("synapse", synapseInfo);
+
+        // 6. Ollama Reachability (Optional)
+        String ollamaUrl = "http://localhost:11434";
+        boolean ollamaOnline = false;
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofMillis(800))
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(ollamaUrl + "/api/version"))
+                    .timeout(Duration.ofMillis(1200))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                ollamaOnline = true;
+            }
+        } catch (Exception ignored) {}
+
+        Map<String, Object> ollamaInfo = new LinkedHashMap<>();
+        ollamaInfo.put("url", ollamaUrl);
+        ollamaInfo.put("online", ollamaOnline);
+        report.put("ollama", ollamaInfo);
+
+        // 7. Output Formatting
+        if (isJson()) {
+            OutputFormatter.printJson(out(), report);
+            return;
+        }
+
+        // Pretty Terminal Output
+        out().println();
+        out().println("================================================================================");
+        out().println("                     Spector System Diagnostics (Doctor)                        ");
+        out().println("================================================================================");
+        out().println();
+
+        printCheck("Java Runtime", java25OrHigher ? Status.OK : Status.WARN,
+                javaVersion + " (" + javaVendor + ") [Requires JDK 25+]");
+
+        printCheck("SIMD Vector API", panamaVectorAvailable ? Status.OK : Status.WARN,
+                panamaVectorAvailable ? simdInstructionSet + " via Project Panama" : "Incubator not active (--add-modules jdk.incubator.vector)");
+
+        printCheck("Storage Permissions", (dirExists && canWrite) ? Status.OK : Status.FAIL,
+                resolvedDataDir + " (" + usableSpaceMb + " MB available, writable=" + canWrite + ")");
+
+        printCheck("In-Process ONNX", onnxAvailable ? Status.OK : Status.WARN,
+                onnxAvailable ? "all-MiniLM-L6-v2 (384 dims, zero external dependencies)" : "Model not found on classpath");
+
+        printCheck("Synapse Daemon", synapseOnline ? Status.OK : Status.INFO,
+                synapseOnline ? "ONLINE at " + synapseUrl + " (" + synapseStatus + ")" : "OFFLINE at " + synapseUrl + " (Run 'spector-synapse' to start)");
+
+        printCheck("Ollama Daemon", ollamaOnline ? Status.OK : Status.INFO,
+                ollamaOnline ? "ONLINE at " + ollamaUrl : "OFFLINE (Optional - fallback to ONNX active)");
+
+        out().println();
+        out().println("--------------------------------------------------------------------------------");
+
+        if (snippets) {
+            printSnippets();
+        }
+    }
+
+    private void printCheck(String label, Status status, String detail) {
+        out().printf("  [%-4s]  %-22s : %s%n", status, label, detail);
+    }
+
+    private void printSnippets() {
+        out().println();
+        out().println("  [AI Agent Integration Configuration]");
+        out().println();
+        out().println("  Add to Claude Desktop (claude_desktop_config.json) or Cursor (.cursor/mcp.json):");
+        out().println();
+        out().println("  {");
+        out().println("    \"mcpServers\": {");
+        out().println("      \"spector\": {");
+        out().println("        \"command\": \"java\",");
+        out().println("        \"args\": [");
+        out().println("          \"--add-modules\", \"jdk.incubator.vector\",");
+        out().println("          \"--enable-preview\",");
+        out().println("          \"-jar\", \"<path-to-spector-cli.jar>\",");
+        out().println("          \"mcp\"");
+        out().println("        ]");
+        out().println("      }");
+        out().println("    }");
+        out().println("  }");
+        out().println();
+    }
+}

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/InitCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/InitCommand.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Command initializing local Spector directories and default configuration (spector.yml).
+ */
+@Component
+@Command(
+        name = "init",
+        description = "Initialize local Spector configuration and storage directories.",
+        mixinStandardHelpOptions = true
+)
+public class InitCommand extends BaseCommand {
+
+    @Option(names = {"--config-dir"}, description = "Directory for configuration (default: ~/.spector).")
+    private String configDir;
+
+    @Option(names = {"--data-dir"}, description = "Directory for memory and vector storage (default: ~/.spector/data).")
+    private String dataDir;
+
+    @Option(names = {"--force"}, description = "Overwrite existing configuration file if present.")
+    private boolean force;
+
+    private static final String DEFAULT_CONFIG_CONTENT = """
+            # ─────────────────────────────────────────────────────────────
+            # Spector Local Configuration (~/.spector/spector.yml)
+            # ─────────────────────────────────────────────────────────────
+            spector:
+              port: 7070
+              data-dir: ~/.spector/data
+
+              memory:
+                enabled: true
+                dimensions: 384
+                persistence-mode: DISK
+                persistence-path: ~/.spector/data/cognitive
+                capacity: 10000
+
+              provider:
+                embedding:
+                  # Default: in-process zero-config ONNX model (offline, no external servers)
+                  type: onnx
+                  model: all-MiniLM-L6-v2
+                  dimensions: 384
+
+                  # To switch to local Ollama, uncomment below:
+                  # type: ollama
+                  # model: nomic-embed-text
+                  # base-url: http://localhost:11434
+                  # dimensions: 768
+            """;
+
+    @Override
+    public void run() {
+        String homeDir = System.getProperty("user.home");
+        String resolvedConfigDir = configDir != null && !configDir.isBlank()
+                ? configDir
+                : homeDir + File.separator + ".spector";
+        String resolvedDataDir = dataDir != null && !dataDir.isBlank()
+                ? dataDir
+                : resolvedConfigDir + File.separator + "data";
+
+        Path configDirPath = Paths.get(resolvedConfigDir);
+        Path dataDirPath = Paths.get(resolvedDataDir);
+        Path configFile = configDirPath.resolve("spector.yml");
+
+        boolean createdConfig = false;
+        boolean overwrittenConfig = false;
+        boolean configExists = Files.exists(configFile);
+
+        try {
+            Files.createDirectories(configDirPath);
+            Files.createDirectories(dataDirPath);
+
+            if (!configExists || force) {
+                Files.writeString(configFile, DEFAULT_CONFIG_CONTENT);
+                if (configExists) {
+                    overwrittenConfig = true;
+                } else {
+                    createdConfig = true;
+                }
+            }
+        } catch (Exception e) {
+            err().println("Error initializing Spector environment: " + e.getMessage());
+            return;
+        }
+
+        if (isJson()) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("configDir", resolvedConfigDir);
+            result.put("dataDir", resolvedDataDir);
+            result.put("configFile", configFile.toString());
+            result.put("created", createdConfig);
+            result.put("overwritten", overwrittenConfig);
+            result.put("status", "SUCCESS");
+            OutputFormatter.printJson(out(), result);
+            return;
+        }
+
+        out().println();
+        out().println("================================================================================");
+        out().println("                     Spector Environment Initialized                            ");
+        out().println("================================================================================");
+        out().println();
+        out().println("  [OK] Config Directory : " + configDirPath.toAbsolutePath());
+        out().println("  [OK] Data Directory   : " + dataDirPath.toAbsolutePath());
+
+        if (createdConfig) {
+            out().println("  [OK] Config File       : " + configFile.toAbsolutePath() + " (created)");
+        } else if (overwrittenConfig) {
+            out().println("  [OK] Config File       : " + configFile.toAbsolutePath() + " (overwritten via --force)");
+        } else {
+            out().println("  [INFO] Config File     : " + configFile.toAbsolutePath() + " (already exists; use --force to overwrite)");
+        }
+
+        out().println();
+        out().println("Next Steps:");
+        out().println("  1. Run diagnostics:");
+        out().println("     spectorctl doctor");
+        out().println();
+        out().println("  2. Start stdio MCP server for Claude Desktop / Cursor:");
+        out().println("     spectorctl mcp");
+        out().println();
+        out().println("  3. Start the Synapse daemon server:");
+        out().println("     java -jar spector-synapse.jar");
+        out().println();
+    }
+}

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCtl.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/SpectorCtl.java
@@ -51,7 +51,9 @@ import picocli.CommandLine.Option;
                 RecallCommand.class,
                 StatusCommand.class,
                 MemoryCommand.class,
-                McpCommand.class
+                McpCommand.class,
+                DoctorCommand.class,
+                InitCommand.class
         }
 )
 public class SpectorCtl implements Runnable {

--- a/synapse/spector-cli/src/main/resources/application-cli-embedded.yml
+++ b/synapse/spector-cli/src/main/resources/application-cli-embedded.yml
@@ -5,6 +5,6 @@ spector:
     persistence-path: ${SPECTOR_DATA_DIR:~/.spector/data}/memory
   provider:
     embedding:
-      type: ${SPECTOR_EMBEDDING_PROVIDER:ollama}
+      type: ${SPECTOR_EMBEDDING_PROVIDER:onnx}
       base-url: ${SPECTOR_OLLAMA_BASE_URL:http://localhost:11434}
-      model: ${SPECTOR_OLLAMA_EMBED_MODEL:nomic-embed-text}
+      model: ${SPECTOR_EMBEDDING_MODEL:all-MiniLM-L6-v2}

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/DoctorCommandTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/DoctorCommandTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DoctorCommandTest {
+
+    @Test
+    void doctorCommand_textOutput_containsDiagnostics(@TempDir Path tempDir) {
+        DoctorCommand cmd = new DoctorCommand();
+        CommandLine cli = new CommandLine(cmd);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute("--data-dir=" + tempDir.toAbsolutePath());
+
+        assertThat(exitCode).isEqualTo(0);
+        String output = sw.toString();
+        assertThat(output).contains("Spector System Diagnostics (Doctor)");
+        assertThat(output).contains("Java Runtime");
+        assertThat(output).contains("SIMD Vector API");
+        assertThat(output).contains("Storage Permissions");
+        assertThat(output).contains("In-Process ONNX");
+        assertThat(output).contains("Synapse Daemon");
+        assertThat(output).contains("AI Agent Integration Configuration");
+    }
+
+    @Test
+    void doctorCommand_jsonOutput_containsAllSections(@TempDir Path tempDir) {
+        CommandLine.IFactory factory = new CommandLine.IFactory() {
+            @Override
+            public <K> K create(Class<K> cls) throws Exception {
+                if (cls == McpCommand.class) {
+                    return cls.cast(new McpCommand(org.mockito.Mockito.mock(org.springframework.beans.factory.ObjectProvider.class)));
+                }
+                if (cls == RememberCommand.class) {
+                    return cls.cast(new RememberCommand(org.mockito.Mockito.mock(org.springframework.beans.factory.ObjectProvider.class), org.mockito.Mockito.mock(org.springframework.beans.factory.ObjectProvider.class)));
+                }
+                return CommandLine.defaultFactory().create(cls);
+            }
+        };
+        CommandLine cli = new CommandLine(new SpectorCtl(), factory);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute("--json", "doctor", "--data-dir=" + tempDir.toAbsolutePath());
+
+        assertThat(exitCode).isEqualTo(0);
+        String output = sw.toString();
+        assertThat(output).contains("\"java\"");
+        assertThat(output).contains("\"simd\"");
+        assertThat(output).contains("\"storage\"");
+        assertThat(output).contains("\"onnx\"");
+        assertThat(output).contains("\"synapse\"");
+    }
+
+    @Test
+    void doctorCommand_helpFlag() {
+        DoctorCommand cmd = new DoctorCommand();
+        CommandLine cli = new CommandLine(cmd);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute("--help");
+
+        assertThat(exitCode).isEqualTo(0);
+        String output = sw.toString();
+        assertThat(output).contains("Diagnose the local environment");
+        assertThat(output).contains("--data-dir");
+    }
+}

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/InitCommandTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/InitCommandTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InitCommandTest {
+
+    @Test
+    void initCommand_createsConfigAndDataDirectory(@TempDir Path tempDir) {
+        Path configDir = tempDir.resolve(".spector");
+        Path dataDir = configDir.resolve("data");
+
+        InitCommand cmd = new InitCommand();
+        CommandLine cli = new CommandLine(cmd);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute(
+                "--config-dir=" + configDir.toAbsolutePath(),
+                "--data-dir=" + dataDir.toAbsolutePath()
+        );
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(Files.exists(configDir)).isTrue();
+        assertThat(Files.exists(dataDir)).isTrue();
+        assertThat(Files.exists(configDir.resolve("spector.yml"))).isTrue();
+
+        String output = sw.toString();
+        assertThat(output).contains("Spector Environment Initialized");
+        assertThat(output).contains("Config File");
+        assertThat(output).contains("Next Steps:");
+    }
+
+    @Test
+    void initCommand_doesNotOverwriteExistingWithoutForce(@TempDir Path tempDir) throws Exception {
+        Path configDir = tempDir.resolve(".spector");
+        Path dataDir = configDir.resolve("data");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("spector.yml");
+        Files.writeString(configFile, "custom: config");
+
+        InitCommand cmd = new InitCommand();
+        CommandLine cli = new CommandLine(cmd);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute(
+                "--config-dir=" + configDir.toAbsolutePath(),
+                "--data-dir=" + dataDir.toAbsolutePath()
+        );
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(Files.readString(configFile)).isEqualTo("custom: config");
+        assertThat(sw.toString()).contains("already exists; use --force to overwrite");
+    }
+
+    @Test
+    void initCommand_overwritesWithForce(@TempDir Path tempDir) throws Exception {
+        Path configDir = tempDir.resolve(".spector");
+        Path dataDir = configDir.resolve("data");
+        Files.createDirectories(configDir);
+        Path configFile = configDir.resolve("spector.yml");
+        Files.writeString(configFile, "custom: config");
+
+        InitCommand cmd = new InitCommand();
+        CommandLine cli = new CommandLine(cmd);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute(
+                "--config-dir=" + configDir.toAbsolutePath(),
+                "--data-dir=" + dataDir.toAbsolutePath(),
+                "--force"
+        );
+
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(Files.readString(configFile)).contains("all-MiniLM-L6-v2");
+        assertThat(sw.toString()).contains("overwritten via --force");
+    }
+
+    @Test
+    void initCommand_jsonOutput(@TempDir Path tempDir) {
+        Path configDir = tempDir.resolve(".spector");
+        Path dataDir = configDir.resolve("data");
+
+        CommandLine.IFactory factory = new CommandLine.IFactory() {
+            @Override
+            public <K> K create(Class<K> cls) throws Exception {
+                if (cls == McpCommand.class) {
+                    return cls.cast(new McpCommand(org.mockito.Mockito.mock(org.springframework.beans.factory.ObjectProvider.class)));
+                }
+                if (cls == RememberCommand.class) {
+                    return cls.cast(new RememberCommand(org.mockito.Mockito.mock(org.springframework.beans.factory.ObjectProvider.class), org.mockito.Mockito.mock(org.springframework.beans.factory.ObjectProvider.class)));
+                }
+                return CommandLine.defaultFactory().create(cls);
+            }
+        };
+        CommandLine cli = new CommandLine(new SpectorCtl(), factory);
+        StringWriter sw = new StringWriter();
+        cli.setOut(new PrintWriter(sw));
+
+        int exitCode = cli.execute(
+                "--json", "init",
+                "--config-dir=" + configDir.toAbsolutePath(),
+                "--data-dir=" + dataDir.toAbsolutePath()
+        );
+
+        assertThat(exitCode).isEqualTo(0);
+        String output = sw.toString();
+        assertThat(output).contains("\"status\"");
+        assertThat(output).contains("\"SUCCESS\"");
+        assertThat(output).contains("\"configFile\"");
+    }
+}

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliApplicationTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCliApplicationTest.java
@@ -51,5 +51,26 @@ class SpectorCliApplicationTest {
         assertThat(context.containsBean("rememberCommand")).isTrue();
         assertThat(context.containsBean("recallCommand")).isTrue();
         assertThat(context.containsBean("memoryCommand")).isTrue();
+        assertThat(context.containsBean("doctorCommand")).isTrue();
+        assertThat(context.containsBean("initCommand")).isTrue();
+    }
+
+    @org.junit.jupiter.api.Nested
+    @SpringBootTest(classes = SpectorCliApplication.class, properties = {
+            "spring.main.lazy-initialization=true",
+            "spring.main.banner-mode=off"
+    })
+    @ActiveProfiles(value = "cli-embedded", inheritProfiles = false)
+    class EmbeddedProfileTest {
+
+        @Autowired
+        private ApplicationContext embeddedContext;
+
+        @Test
+        void contextLoads_inEmbeddedProfile_spectorMemoryBeanIsCreated() {
+            assertThat(embeddedContext).isNotNull();
+            assertThat(embeddedContext.getBeanNamesForType(SpectorMemory.class)).isNotEmpty();
+        }
     }
 }
+

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCtlTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/SpectorCtlTest.java
@@ -66,6 +66,8 @@ class SpectorCtlTest {
         assertThat(output).contains("recall");
         assertThat(output).contains("status");
         assertThat(output).contains("mcp");
+        assertThat(output).contains("doctor");
+        assertThat(output).contains("init");
     }
 
     @Test

--- a/synapse/spector-spring/pom.xml
+++ b/synapse/spector-spring/pom.xml
@@ -126,6 +126,10 @@
             <groupId>com.spectrayan</groupId>
             <artifactId>spector-providers</artifactId>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+        </dependency>
 
         <!-- ── Spring Boot Auto-Configuration ── -->
         <dependency>

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
@@ -17,14 +17,8 @@ package com.spectrayan.spector.spring.autoconfigure;
 
 import com.spectrayan.spector.provider.DefaultProviderRegistry;
 import com.spectrayan.spector.provider.DelegatingLlmProvider;
-import com.spectrayan.spector.provider.ProviderConfig;
 import com.spectrayan.spector.provider.ProviderRegistry;
-import com.spectrayan.spector.provider.anthropic.AnthropicProviderFactory;
-import com.spectrayan.spector.provider.azure.AzureOpenAiProviderFactory;
-import com.spectrayan.spector.provider.bedrock.BedrockProviderFactory;
-import com.spectrayan.spector.provider.embedding.EmbeddingConfig;
 import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
-import com.spectrayan.spector.provider.embedding.EmbeddingResult;
 import com.spectrayan.spector.provider.embedding.generic.DenseDerivedSparseProvider;
 import com.spectrayan.spector.provider.embedding.generic.DenseDerivedTokenProvider;
 import com.spectrayan.spector.provider.generation.LlmProvider;
@@ -38,13 +32,7 @@ import com.spectrayan.spector.memory.SpectorMemoryBuilder;
 import com.spectrayan.spector.metrics.MeteredSpectorMemory;
 import com.spectrayan.spector.metrics.SpectorMetrics;
 
-import com.spectrayan.spector.provider.google.GoogleProviderFactory;
 import com.spectrayan.spector.provider.langchain4j.LangChain4jHelper;
-import com.spectrayan.spector.provider.mistral.MistralProviderFactory;
-import com.spectrayan.spector.provider.ollama.OllamaEmbeddingProvider;
-import com.spectrayan.spector.provider.ollama.OllamaProviderFactory;
-import com.spectrayan.spector.provider.openai.OpenAiProviderFactory;
-import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import java.time.Duration;
@@ -85,7 +73,7 @@ import com.spectrayan.spector.memory.pathway.reflect.spi.ReflectSweepExecutors;
  *
  * <p>Automatically creates and wires the {@link SpectorMemory} bean when Spector is on the classpath.</p>
  */
-@AutoConfiguration
+@AutoConfiguration(after = SpectorEmbeddingAutoConfiguration.class)
 @EnableConfigurationProperties(SpectorConfigProperties.class)
 @ConditionalOnClass(SpectorMemory.class)
 public class SpectorAutoConfiguration {
@@ -131,101 +119,109 @@ public class SpectorAutoConfiguration {
      */
     @Bean
     @ConditionalOnBean(EmbeddingProvider.class)
+    @ConditionalOnMissingBean(SpectorMemory.class)
     @ConditionalOnProperty(prefix = "spector.memory", name = "enabled", havingValue = "true", matchIfMissing = true)
     SpectorMemory spectorMemory(SpectorConfigProperties props,
-                                 ObjectProvider<EmbeddingProvider> embedderProvider,
-                                 ObjectProvider<LlmProvider> textGenProvider,
-                                 ObjectProvider<MeterRegistry> registryProvider,
-                                 ObjectProvider<SalienceProfileProvider> salienceProvider,
-                                 ObjectProvider<SpectorCacheManager> cacheManagerProvider,
-                                 ObjectProvider<io.micrometer.observation.ObservationRegistry> observationRegistryProvider,
-                                 ObjectProvider<com.spectrayan.spector.config.ObservabilityConfig> observabilityConfigProvider) {
+                                     ObjectProvider<EmbeddingProvider> embedderProvider,
+                                     ObjectProvider<LlmProvider> textGenProvider,
+                                     ObjectProvider<MeterRegistry> registryProvider,
+                                     ObjectProvider<SalienceProfileProvider> salienceProvider,
+                                     ObjectProvider<SpectorCacheManager> cacheManagerProvider,
+                                     ObjectProvider<io.micrometer.observation.ObservationRegistry> observationRegistryProvider,
+                                     ObjectProvider<com.spectrayan.spector.config.ObservabilityConfig> observabilityConfigProvider) {
 
-        var spectorProps = props.toSpectorProperties();
-        var memoryProps = spectorProps.memory();
-        EmbeddingProvider embedder = embedderProvider.getIfAvailable();
+            var spectorProps = props.toSpectorProperties();
+            var memoryProps = spectorProps.memory();
+            EmbeddingProvider embedder = embedderProvider.getIfAvailable();
 
-        if (embedder == null) {
-            throw new SpectorInternalException(ErrorCode.ARGUMENT_NULL, "EmbeddingProvider bean (configure provider or set spector.memory.enabled=false)");
+            if (embedder == null) {
+                throw new SpectorInternalException(ErrorCode.ARGUMENT_NULL, "EmbeddingProvider bean (configure provider or set spector.memory.enabled=false)");
+            }
+
+            if (embedder.dimensions() > 0 && memoryProps.getDimensions() != embedder.dimensions()) {
+                log.info("[Spector] Aligning memory dimensions from {} to active embedder dimensions ({})",
+                        memoryProps.getDimensions(), embedder.dimensions());
+                memoryProps.setDimensions(embedder.dimensions());
+                props.getMemory().setDimensions(embedder.dimensions());
+            }
+
+            if (spectorProps.hardware() != null) {
+                AcceleratorRegistry.setBatchThreshold(
+                        spectorProps.hardware().getGpuBatchThreshold());
+            }
+            if (spectorProps.concurrency() != null) {
+                ConcurrentTasks.setStructuredEnabled(
+                        spectorProps.concurrency().isStructured());
+            }
+            if (spectorProps.memory() != null && spectorProps.memory().getCircadian() != null
+                    && spectorProps.memory().getCircadian().getOrchestrator() != null
+                    && !spectorProps.memory().getCircadian().getOrchestrator().isBlank()) {
+                ReflectSweepExecutors.setOrchestrator(
+                        spectorProps.memory().getCircadian().getOrchestrator());
+            }
+
+            var builder = SpectorMemoryBuilder.createEmpty()
+                    .fromProperties(spectorProps)
+                    .embeddingProvider(embedder);
+
+            //  Entity extraction (LLM if LlmProvider is present)
+            LlmProvider textGen = textGenProvider.getIfAvailable();
+            if (textGen != null) {
+                builder.entityExtractionMode(EntityExtractionMode.LLM);
+                builder.LlmProvider(textGen);
+            } else {
+                builder.entityExtractionMode(EntityExtractionMode.NONE);
+            }
+
+            //  Salience profile provider (user-driven importance modulation)
+            SalienceProfileProvider salience = salienceProvider.getIfAvailable();
+            if (salience != null) {
+                builder.salienceProfileProvider(salience);
+                log.info("SpectorMemory: user salience profile provider wired");
+            }
+
+            //  SPLADE + ColBERT providers (auto-created from embedding provider)
+            if (memoryProps.isSpladeEnabled()) {
+                builder.SparseEmbeddingProvider(
+                        new DenseDerivedSparseProvider(embedder));
+            }
+            if (memoryProps.isColbertEnabled()) {
+                builder.tokenEmbeddingProvider(
+                        new DenseDerivedTokenProvider(embedder));
+            }
+
+            SpectorCacheManager cacheManager = cacheManagerProvider.getIfAvailable();
+            if (cacheManager != null) {
+                builder.cacheManager(cacheManager);
+            }
+
+            io.micrometer.observation.ObservationRegistry obsRegistry = observationRegistryProvider.getIfAvailable();
+            com.spectrayan.spector.config.ObservabilityConfig obsConfig = observabilityConfigProvider.getIfAvailable();
+
+            if (obsRegistry != null && obsConfig != null) {
+                builder.observationHook(new com.spectrayan.spector.metrics.observation.MicrometerMemoryObservationHook(obsRegistry, obsConfig));
+            }
+
+            SpectorMemory raw = builder.build();
+            log.info("SpectorMemory auto-configured: dims={}, persistence={}, path={}, entity={}, SPLADE={}, ColBERT={}, salience={}",
+                    memoryProps.getDimensions(), memoryProps.getPersistenceMode(),
+                    memoryProps.getPersistencePath(), textGen != null ? "enabled" : "disabled",
+                    memoryProps.isSpladeEnabled(), memoryProps.isColbertEnabled(),
+                    salience != null);
+
+            MeterRegistry registry = registryProvider.getIfAvailable();
+            if (registry != null && props.getMetrics().isEnabled()) {
+                SpectorMetrics.init(registry);
+                log.info("Spector metrics enabled via Spring MeterRegistry");
+                new com.spectrayan.spector.metrics.observation.SpectorMemoryGauges(raw).bindTo(registry);
+            }
+
+            if (obsRegistry != null && obsConfig != null) {
+                return new com.spectrayan.spector.metrics.ObservedSpectorMemory(raw, obsRegistry, obsConfig);
+            }
+
+            return raw;
         }
-
-        if (spectorProps.hardware() != null) {
-            AcceleratorRegistry.setBatchThreshold(
-                    spectorProps.hardware().getGpuBatchThreshold());
-        }
-        if (spectorProps.concurrency() != null) {
-            ConcurrentTasks.setStructuredEnabled(
-                    spectorProps.concurrency().isStructured());
-        }
-        if (spectorProps.memory() != null && spectorProps.memory().getCircadian() != null
-                && spectorProps.memory().getCircadian().getOrchestrator() != null
-                && !spectorProps.memory().getCircadian().getOrchestrator().isBlank()) {
-            ReflectSweepExecutors.setOrchestrator(
-                    spectorProps.memory().getCircadian().getOrchestrator());
-        }
-
-        var builder = SpectorMemoryBuilder.createEmpty()
-                .fromProperties(spectorProps)
-                .embeddingProvider(embedder);
-
-        //  Entity extraction (LLM if LlmProvider is present)
-        LlmProvider textGen = textGenProvider.getIfAvailable();
-        if (textGen != null) {
-            builder.entityExtractionMode(EntityExtractionMode.LLM);
-            builder.LlmProvider(textGen);
-        } else {
-            builder.entityExtractionMode(EntityExtractionMode.NONE);
-        }
-
-        //  Salience profile provider (user-driven importance modulation)
-        SalienceProfileProvider salience = salienceProvider.getIfAvailable();
-        if (salience != null) {
-            builder.salienceProfileProvider(salience);
-            log.info("SpectorMemory: user salience profile provider wired");
-        }
-
-        //  SPLADE + ColBERT providers (auto-created from embedding provider)
-        if (memoryProps.isSpladeEnabled()) {
-            builder.SparseEmbeddingProvider(
-                    new DenseDerivedSparseProvider(embedder));
-        }
-        if (memoryProps.isColbertEnabled()) {
-            builder.tokenEmbeddingProvider(
-                    new DenseDerivedTokenProvider(embedder));
-        }
-
-        SpectorCacheManager cacheManager = cacheManagerProvider.getIfAvailable();
-        if (cacheManager != null) {
-            builder.cacheManager(cacheManager);
-        }
-
-        io.micrometer.observation.ObservationRegistry obsRegistry = observationRegistryProvider.getIfAvailable();
-        com.spectrayan.spector.config.ObservabilityConfig obsConfig = observabilityConfigProvider.getIfAvailable();
-
-        if (obsRegistry != null && obsConfig != null) {
-            builder.observationHook(new com.spectrayan.spector.metrics.observation.MicrometerMemoryObservationHook(obsRegistry, obsConfig));
-        }
-
-        SpectorMemory raw = builder.build();
-        log.info("SpectorMemory auto-configured: dims={}, persistence={}, path={}, entity={}, SPLADE={}, ColBERT={}, salience={}",
-                memoryProps.getDimensions(), memoryProps.getPersistenceMode(),
-                memoryProps.getPersistencePath(), textGen != null ? "enabled" : "disabled",
-                memoryProps.isSpladeEnabled(), memoryProps.isColbertEnabled(),
-                salience != null);
-
-        MeterRegistry registry = registryProvider.getIfAvailable();
-        if (registry != null && props.getMetrics().isEnabled()) {
-            SpectorMetrics.init(registry);
-            log.info("Spector metrics enabled via Spring MeterRegistry");
-            new com.spectrayan.spector.metrics.observation.SpectorMemoryGauges(raw).bindTo(registry);
-        }
-
-        if (obsRegistry != null && obsConfig != null) {
-            return new com.spectrayan.spector.metrics.ObservedSpectorMemory(raw, obsRegistry, obsConfig);
-        }
-
-        return raw;
-    }
 
     @Configuration
     static class SpringHttpClientAutoConfiguration {
@@ -273,24 +269,6 @@ public class SpectorAutoConfiguration {
     public List<McpToolHandler> coreMemoryTools(SpectorMemory memory) {
         return SpectorToolRegistry.handlers("1.0.0", memory);
     }
-    /**
-     * Autoconfigures a dedicated {@link OpenAiProviderFactory} when explicit
-     * Spector embedding properties are provided.
-     * <p>
-     * This bean takes precedence if 'spector.embedding.provider-name is set to 'Ollama'.
-     *
-     * @param props bound {@link SpectorConfigProperties} containing Spector configuration
-     * @return an instance of {@link EmbeddingProvider} initialized with Spector properties
-     */
-    @Bean(name = "openAiEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "OpenAi", matchIfMissing = false)
-    EmbeddingProvider spectorOpenAIEmbeddingProvider(SpectorConfigProperties props,
-                                                     ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        OpenAiProviderFactory openAiProviderFactory = new OpenAiProviderFactory(cacheManagerProvider.getIfAvailable());
-        return openAiProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(RuntimeException::new);
-    }
 
     @Bean
     @ConditionalOnMissingBean(ProviderRegistry.class)
@@ -329,106 +307,6 @@ public class SpectorAutoConfiguration {
         return new DelegatingLlmProvider(providerRegistry);
     }
 
-    @Bean(name = "ollamaEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Ollama", matchIfMissing = false)
-    EmbeddingProvider spectorOllamaEmbeddingProvider(SpectorConfigProperties props,
-                                                     ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        OllamaProviderFactory factory = new OllamaProviderFactory(cacheManagerProvider.getIfAvailable());
-        return factory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(() -> new IllegalStateException("Failed to create Ollama embedding provider"));
-    }
-
-    @Bean(name = "anthropicEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Anthropic", matchIfMissing = false)
-    EmbeddingProvider antrhopicEmbeddingProvider(SpectorConfigProperties props,
-                                                 ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        AnthropicProviderFactory anthropicProviderFactory = new AnthropicProviderFactory(cacheManagerProvider.getIfAvailable());
-        return anthropicProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(RuntimeException::new);
-    }
-
-    @Bean(name = "azureOpenAiEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "AzureOpenAi", matchIfMissing = false)
-    EmbeddingProvider spectorAzureOpenAiEmbeddingProvider(SpectorConfigProperties props,
-                                                          ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        AzureOpenAiProviderFactory azureOpenAiProviderFactory = new AzureOpenAiProviderFactory(cacheManagerProvider.getIfAvailable());
-        return azureOpenAiProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(RuntimeException::new);
-    }
-
-    @Bean(name = "bedrockEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Bedrock", matchIfMissing = false)
-    EmbeddingProvider spectorBedrockEmbeddingProvider(SpectorConfigProperties props,
-                                                      ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        BedrockProviderFactory bedrockProviderFactory = new BedrockProviderFactory(cacheManagerProvider.getIfAvailable());
-        return bedrockProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(RuntimeException::new);
-    }
-
-    @Bean(name = "googleEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Google", matchIfMissing = false)
-    EmbeddingProvider spectorGoogleEmbeddingProvider(SpectorConfigProperties props,
-                                                     ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        GoogleProviderFactory googleProviderFactory = new GoogleProviderFactory(cacheManagerProvider.getIfAvailable());
-        return googleProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(RuntimeException::new);
-    }
-
-    @Bean(name = "mistralEmbeddingProvider")
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Mistral", matchIfMissing = false)
-    EmbeddingProvider spectorMistralEmbeddingProvider(SpectorConfigProperties props,
-                                                      ObjectProvider<com.spectrayan.spector.commons.cache.SpectorCacheManager> cacheManagerProvider) {
-        MistralProviderFactory mistralProviderFactory = new MistralProviderFactory(cacheManagerProvider.getIfAvailable());
-        return mistralProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
-                .orElseThrow(RuntimeException::new);
-    }
-    /**
-     * Auto-configures an {@link EmbeddingProvider} by wrapping an existing Spring AI {@link EmbeddingModel} bean.
-     * <p>
-     * Serves as a fallback mechanism when no explicit Spector embedding configuration is provided,
-     * but an active Spring AI {@link EmbeddingModel} exists in the Spring application context.
-     *
-     * @param springEmbeddingModel the existing Spring AI {@link EmbeddingModel} bean
-     * @return an {@link EmbeddingProvider} delegating to the wrapped Spring AI model
-     */
-    @Bean
-    @ConditionalOnMissingBean(EmbeddingProvider.class)
-    @ConditionalOnBean(EmbeddingModel.class)
-    EmbeddingProvider embeddingProvider(EmbeddingModel springEmbeddingModel) {
-
-        /**
-         * Inner adapter class wrapping Spring AI's {@link EmbeddingModel}
-         * to satisfy Spector's {@link EmbeddingProvider} contract.
-         */
-        class SpringAIEmbeddedProviderWrapper implements EmbeddingProvider {
-            private final EmbeddingModel springAIEmbeddedModel;
-
-            SpringAIEmbeddedProviderWrapper(EmbeddingModel springAIEmbeddedModel) {
-                this.springAIEmbeddedModel = springAIEmbeddedModel;
-            }
-            @Override
-            public EmbeddingResult embed(String text) {
-                float[] vector = this.springAIEmbeddedModel.embed(text).content().vector();
-                return EmbeddingResult.of(vector, this.springAIEmbeddedModel.modelName());
-            }
-            @Override
-            public int dimensions() {
-                return this.springAIEmbeddedModel.dimension();
-            }
-            @Override
-            public String modelName() {
-                return this.springAIEmbeddedModel.modelName();
-            }
-        }
-
-        return new SpringAIEmbeddedProviderWrapper(springEmbeddingModel);
-    }
     /**
      * Auto-configures {@link SpectorVectorStore} using local {@link SpectorMemory}.
      *
@@ -441,48 +319,4 @@ public class SpectorAutoConfiguration {
     SpectorVectorStore spectorVectorMemoryStore(SpectorMemory memory){
         return new SpectorVectorStore(memory);
     }
-    /**
-     * Helper method to map {@link SpectorConfigProperties} to Spector's native {@link EmbeddingConfig}.
-     *
-     * @param props bound configuration properties
-     * @return an initialized {@link EmbeddingConfig} instance
-     */
-    EmbeddingConfig generateEmbeddingConfig(SpectorConfigProperties props) {
-        var embedding = props.getProvider().getEmbedding();
-        return new EmbeddingConfig(
-                embedding.getModel(),
-                embedding.getBaseUrl(),
-                embedding.getTimeout(),
-                embedding.getBatchSize(),
-                embedding.getMaxConcurrent()
-        );
-    }
-    /**
-     * Helper method to map {@link SpectorConfigProperties} to Spector's native {@link ProviderConfig}.
-     *
-     * @param props bound configuration properties
-     * @return an initialized {@link ProviderConfig} instance
-     */
-    ProviderConfig generateProviderConfig(SpectorConfigProperties props){
-        var embedding = props.getProvider().getEmbedding();
-        java.util.Map<String, String> properties = new java.util.HashMap<>(embedding.getProperties());
-        properties.put("cache.enabled", String.valueOf(embedding.isCacheEnabled()));
-        properties.put("cache.max-size", String.valueOf(embedding.getCacheMaxSize()));
-        if (embedding.getCacheTtl() != null) {
-            properties.put("cache.ttl-seconds", String.valueOf(embedding.getCacheTtl().toSeconds()));
-        }
-        if (embedding.getCacheStatsLogInterval() != null) {
-            properties.put("cache.stats-log-interval-seconds", String.valueOf(embedding.getCacheStatsLogInterval().toSeconds()));
-        }
-        return new ProviderConfig(
-                embedding.getType(),
-                embedding.getType(),
-                embedding.getModel(),
-                embedding.getApiKey(),
-                embedding.getBaseUrl(),
-                embedding.getDimensions(),
-                properties
-        );
-    }
-
 }

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfiguration.java
@@ -138,11 +138,19 @@ public class SpectorAutoConfiguration {
                 throw new SpectorInternalException(ErrorCode.ARGUMENT_NULL, "EmbeddingProvider bean (configure provider or set spector.memory.enabled=false)");
             }
 
-            if (embedder.dimensions() > 0 && memoryProps.getDimensions() != embedder.dimensions()) {
+            int embedderDims = props.getProvider().getEmbedding().getDimensions();
+            if (embedderDims <= 0) {
+                try {
+                    embedderDims = embedder.dimensions();
+                } catch (Exception e) {
+                    log.debug("[Spector] Could not probe embedder dimensions eagerly (provider offline): {}", e.getMessage());
+                }
+            }
+            if (embedderDims > 0 && memoryProps.getDimensions() != embedderDims) {
                 log.info("[Spector] Aligning memory dimensions from {} to active embedder dimensions ({})",
-                        memoryProps.getDimensions(), embedder.dimensions());
-                memoryProps.setDimensions(embedder.dimensions());
-                props.getMemory().setDimensions(embedder.dimensions());
+                        memoryProps.getDimensions(), embedderDims);
+                memoryProps.setDimensions(embedderDims);
+                props.getMemory().setDimensions(embedderDims);
             }
 
             if (spectorProps.hardware() != null) {

--- a/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorEmbeddingAutoConfiguration.java
+++ b/synapse/spector-spring/src/main/java/com/spectrayan/spector/spring/autoconfigure/SpectorEmbeddingAutoConfiguration.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.spring.autoconfigure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import com.spectrayan.spector.commons.cache.SpectorCacheManager;
+import com.spectrayan.spector.provider.ProviderConfig;
+import com.spectrayan.spector.provider.anthropic.AnthropicProviderFactory;
+import com.spectrayan.spector.provider.azure.AzureOpenAiProviderFactory;
+import com.spectrayan.spector.provider.bedrock.BedrockProviderFactory;
+import com.spectrayan.spector.provider.embedding.EmbeddingProvider;
+import com.spectrayan.spector.provider.embedding.EmbeddingResult;
+import com.spectrayan.spector.provider.google.GoogleProviderFactory;
+import com.spectrayan.spector.provider.mistral.MistralProviderFactory;
+import com.spectrayan.spector.provider.ollama.OllamaProviderFactory;
+import com.spectrayan.spector.provider.onnx.OnnxProviderFactory;
+import com.spectrayan.spector.provider.openai.OpenAiProviderFactory;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+
+/**
+ * Auto-configuration dedicated to resolving and registering {@link EmbeddingProvider} beans.
+ * <p>
+ * Executed prior to {@link SpectorAutoConfiguration} so downstream cognitive memory
+ * and vector store beans have access to an initialized embedder bean.
+ * </p>
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(SpectorConfigProperties.class)
+@ConditionalOnClass(EmbeddingProvider.class)
+public class SpectorEmbeddingAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(SpectorEmbeddingAutoConfiguration.class);
+
+    @Bean(name = "openAiEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "OpenAi", matchIfMissing = false)
+    EmbeddingProvider spectorOpenAIEmbeddingProvider(SpectorConfigProperties props,
+                                                     ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        OpenAiProviderFactory openAiProviderFactory = new OpenAiProviderFactory(cacheManagerProvider.getIfAvailable());
+        return openAiProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+
+    @Bean(name = "ollamaEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Ollama", matchIfMissing = false)
+    EmbeddingProvider spectorOllamaEmbeddingProvider(SpectorConfigProperties props,
+                                                     ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        OllamaProviderFactory factory = new OllamaProviderFactory(cacheManagerProvider.getIfAvailable());
+        return factory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(() -> new IllegalStateException("Failed to create Ollama embedding provider"));
+    }
+
+    @Bean(name = "anthropicEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Anthropic", matchIfMissing = false)
+    EmbeddingProvider anthropicEmbeddingProvider(SpectorConfigProperties props,
+                                                 ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        AnthropicProviderFactory anthropicProviderFactory = new AnthropicProviderFactory(cacheManagerProvider.getIfAvailable());
+        return anthropicProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+
+    @Bean(name = "azureOpenAiEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "AzureOpenAi", matchIfMissing = false)
+    EmbeddingProvider spectorAzureOpenAiEmbeddingProvider(SpectorConfigProperties props,
+                                                          ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        AzureOpenAiProviderFactory azureOpenAiProviderFactory = new AzureOpenAiProviderFactory(cacheManagerProvider.getIfAvailable());
+        return azureOpenAiProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+
+    @Bean(name = "bedrockEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Bedrock", matchIfMissing = false)
+    EmbeddingProvider spectorBedrockEmbeddingProvider(SpectorConfigProperties props,
+                                                      ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        BedrockProviderFactory bedrockProviderFactory = new BedrockProviderFactory(cacheManagerProvider.getIfAvailable());
+        return bedrockProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+
+    @Bean(name = "googleEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Google", matchIfMissing = false)
+    EmbeddingProvider spectorGoogleEmbeddingProvider(SpectorConfigProperties props,
+                                                     ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        GoogleProviderFactory googleProviderFactory = new GoogleProviderFactory(cacheManagerProvider.getIfAvailable());
+        return googleProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+
+    @Bean(name = "mistralEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Mistral", matchIfMissing = false)
+    EmbeddingProvider spectorMistralEmbeddingProvider(SpectorConfigProperties props,
+                                                      ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        MistralProviderFactory mistralProviderFactory = new MistralProviderFactory(cacheManagerProvider.getIfAvailable());
+        return mistralProviderFactory.createEmbeddingProvider(generateProviderConfig(props))
+                .orElseThrow(RuntimeException::new);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnBean(EmbeddingModel.class)
+    EmbeddingProvider embeddingProvider(EmbeddingModel springEmbeddingModel) {
+        class SpringAIEmbeddedProviderWrapper implements EmbeddingProvider {
+            private final EmbeddingModel springAIEmbeddedModel;
+
+            SpringAIEmbeddedProviderWrapper(EmbeddingModel springAIEmbeddedModel) {
+                this.springAIEmbeddedModel = springAIEmbeddedModel;
+            }
+
+            @Override
+            public EmbeddingResult embed(String text) {
+                float[] vector = this.springAIEmbeddedModel.embed(text).content().vector();
+                return EmbeddingResult.of(vector, this.springAIEmbeddedModel.modelName());
+            }
+
+            @Override
+            public int dimensions() {
+                return this.springAIEmbeddedModel.dimension();
+            }
+
+            @Override
+            public String modelName() {
+                return this.springAIEmbeddedModel.modelName();
+            }
+        }
+        return new SpringAIEmbeddedProviderWrapper(springEmbeddingModel);
+    }
+
+    @Bean(name = "onnxEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding", name = "type", havingValue = "Onnx", matchIfMissing = false)
+    EmbeddingProvider spectorOnnxEmbeddingProvider(SpectorConfigProperties props,
+                                                   ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        OnnxProviderFactory onnxProviderFactory = new OnnxProviderFactory(cacheManagerProvider.getIfAvailable());
+        var providerConfig = generateProviderConfig(props);
+        String model = providerConfig.model();
+        int dims = providerConfig.dimensions();
+        if (model == null || model.isBlank() || "nomic-embed-text".equalsIgnoreCase(model) || "default".equalsIgnoreCase(model)) {
+            model = "all-MiniLM-L6-v2";
+            dims = 384;
+        } else if (model.toLowerCase(java.util.Locale.ROOT).contains("minilm") || model.toLowerCase(java.util.Locale.ROOT).contains("bge-small")) {
+            dims = 384;
+        }
+        providerConfig = new ProviderConfig(
+                providerConfig.name(),
+                providerConfig.type(),
+                model,
+                providerConfig.apiKey(),
+                providerConfig.baseUrl(),
+                dims,
+                providerConfig.properties()
+        );
+        return onnxProviderFactory.createEmbeddingProvider(providerConfig)
+                .orElseThrow(() -> new IllegalStateException("Failed to create ONNX embedding provider"));
+    }
+
+    @Bean(name = "defaultFallbackOnnxEmbeddingProvider")
+    @ConditionalOnMissingBean(EmbeddingProvider.class)
+    @ConditionalOnProperty(prefix = "spector.provider.embedding.fallback", name = "enabled", havingValue = "true", matchIfMissing = true)
+    EmbeddingProvider defaultFallbackOnnxEmbeddingProvider(SpectorConfigProperties props,
+                                                           ObjectProvider<SpectorCacheManager> cacheManagerProvider) {
+        log.info("[Spector] No external EmbeddingProvider configured. Auto-configuring in-process fallback ONNX embedder (all-MiniLM-L6-v2-q, 384 dims).");
+        OnnxProviderFactory onnxProviderFactory = new OnnxProviderFactory(cacheManagerProvider.getIfAvailable());
+        var embedding = props.getProvider().getEmbedding();
+        java.util.Map<String, String> properties = new java.util.HashMap<>(embedding.getProperties());
+        properties.put("cache.enabled", String.valueOf(embedding.isCacheEnabled()));
+        properties.put("cache.max-size", String.valueOf(embedding.getCacheMaxSize()));
+        if (embedding.getCacheTtl() != null) {
+            properties.put("cache.ttl-seconds", String.valueOf(embedding.getCacheTtl().toSeconds()));
+        }
+        if (embedding.getCacheStatsLogInterval() != null) {
+            properties.put("cache.stats-log-interval-seconds", String.valueOf(embedding.getCacheStatsLogInterval().toSeconds()));
+        }
+        ProviderConfig fallbackConfig = new ProviderConfig(
+                "onnx",
+                "onnx",
+                "all-MiniLM-L6-v2",
+                null,
+                null,
+                384,
+                properties
+        );
+        return onnxProviderFactory.createEmbeddingProvider(fallbackConfig)
+                .orElseThrow(() -> new IllegalStateException("Failed to create fallback ONNX embedding provider"));
+    }
+
+    ProviderConfig generateProviderConfig(SpectorConfigProperties props) {
+        var embedding = props.getProvider().getEmbedding();
+        java.util.Map<String, String> properties = new java.util.HashMap<>(embedding.getProperties());
+        properties.put("cache.enabled", String.valueOf(embedding.isCacheEnabled()));
+        properties.put("cache.max-size", String.valueOf(embedding.getCacheMaxSize()));
+        if (embedding.getCacheTtl() != null) {
+            properties.put("cache.ttl-seconds", String.valueOf(embedding.getCacheTtl().toSeconds()));
+        }
+        if (embedding.getCacheStatsLogInterval() != null) {
+            properties.put("cache.stats-log-interval-seconds", String.valueOf(embedding.getCacheStatsLogInterval().toSeconds()));
+        }
+        return new ProviderConfig(
+                embedding.getType(),
+                embedding.getType(),
+                embedding.getModel(),
+                embedding.getApiKey(),
+                embedding.getBaseUrl(),
+                embedding.getDimensions(),
+                properties
+        );
+    }
+}

--- a/synapse/spector-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/synapse/spector-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
+com.spectrayan.spector.spring.autoconfigure.SpectorEmbeddingAutoConfiguration
 com.spectrayan.spector.spring.autoconfigure.SpectorAutoConfiguration

--- a/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
+++ b/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
@@ -41,7 +41,9 @@ class SpectorAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withPropertyValues("spector.memory.enabled=true")
-            .withConfiguration(AutoConfigurations.of(SpectorAutoConfiguration.class))
+            .withConfiguration(AutoConfigurations.of(
+                    SpectorEmbeddingAutoConfiguration.class,
+                    SpectorAutoConfiguration.class))
             ;
     @Configuration(proxyBeanMethods = false)
     static class TestDependenciesConfiguration {
@@ -108,10 +110,31 @@ class SpectorAutoConfigurationTest {
         });
     }
     @Test
-    void shouldNotCreateEmbeddingProviderBeanWithoutEmbeddingModelBean(){
+    void shouldCreateFallbackOnnxEmbeddingProviderByDefault() {
         contextRunner.run(context -> {
-            assertThat(context).doesNotHaveBean(EmbeddingProvider.class);
+            assertThat(context).hasSingleBean(EmbeddingProvider.class);
+            assertThat(context).hasBean("defaultFallbackOnnxEmbeddingProvider");
+            EmbeddingProvider provider = context.getBean("defaultFallbackOnnxEmbeddingProvider", EmbeddingProvider.class);
+            assertThat(provider.dimensions()).isEqualTo(384);
         });
+    }
+
+    @Test
+    void shouldNotCreateEmbeddingProviderBeanWhenFallbackDisabled() {
+        contextRunner.withPropertyValues("spector.provider.embedding.fallback.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(EmbeddingProvider.class);
+                });
+    }
+
+    @Test
+    void shouldCreateExplicitOnnxEmbeddingProvider() {
+        contextRunner.withPropertyValues("spector.provider.embedding.type=Onnx")
+                .run(context -> {
+                    assertThat(context).hasBean("onnxEmbeddingProvider");
+                    EmbeddingProvider provider = context.getBean("onnxEmbeddingProvider", EmbeddingProvider.class);
+                    assertThat(provider.dimensions()).isEqualTo(384);
+                });
     }
     @Test
     public void shouldCreateOllamaEmbeddingModelProvider(){

--- a/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
+++ b/synapse/spector-spring/src/test/java/com/spectrayan/spector/spring/autoconfigure/SpectorAutoConfigurationTest.java
@@ -322,4 +322,23 @@ class SpectorAutoConfigurationTest {
             assertThat(provider).isNotInstanceOf(CachingEmbeddingProvider.class);
         });
     }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestOfflineEmbeddingProviderConfiguration {
+        @Bean
+        EmbeddingProvider embeddingProvider() {
+            EmbeddingProvider mock = Mockito.mock(EmbeddingProvider.class);
+            Mockito.when(mock.dimensions()).thenThrow(new RuntimeException("Connection refused (provider offline)"));
+            Mockito.when(mock.modelName()).thenReturn("offline-embed");
+            return mock;
+        }
+    }
+
+    @Test
+    void shouldGracefullyHandleOfflineEmbeddingProviderDuringDimensionProbing() {
+        contextRunner.withUserConfiguration(TestOfflineEmbeddingProviderConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SpectorMemory.class);
+                });
+    }
 }

--- a/synapse/spector-synapse/pom.xml
+++ b/synapse/spector-synapse/pom.xml
@@ -122,6 +122,10 @@
             <artifactId>spector-memory</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.spectrayan</groupId>
             <artifactId>spector-connector</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary

Implements **Phase 1: Engine & CLI Stabilization** of the Spector Adoption Plan (#775) to achieve zero-config local developer adoption, offline cognitive memory capabilities, diagnostic tooling, and pure CLI discipline.

### Key Changes
1. **In-Process ONNX Fallback Embedder**:
   - Integrated LangChain4j \AllMiniLmL6V2QuantizedEmbeddingModel\ (384 dimensions) in \spector-providers\ and root POM.
   - Updated \OnnxProviderFactory\ to dynamically resolve default models to \ll-MiniLM-L6-v2\ with 384 dimensions.
   - Auto-configured \defaultFallbackOnnxEmbeddingProvider\ so Spector boots locally without Ollama or external API keys.

2. **Auto-Configuration Sequencing & Dimension Alignment**:
   - Extracted \SpectorEmbeddingAutoConfiguration\ to register all embedding providers prior to \SpectorAutoConfiguration\ via \@AutoConfigureAfter\.
   - Dynamically aligns memory index dimensions from the active embedder's reported dimensions.

3. **Pure CLI Diagnostics & Scaffolding (\spector-cli\)**:
   - \spector doctor\: Diagnoses JDK 25 runtime, Project Panama SIMD Vector API acceleration (\SimdCapability\), directory permissions, ONNX model presence, and daemon connectivity. Generates ready-to-use MCP configuration snippets for Claude Desktop and Cursor. Supports \--json\.
   - \spector init\: Generates zero-config \~/.spector/spector.yml\ configuration and scaffolding directories.
   - Preserves strict \WebApplicationType.NONE\ discipline on \spector-cli\.

### Verification
- All 77 tests pass in \synapse/spector-spring\.
- All 69 tests pass in \memory/spector-providers\.
- All 45 tests pass in \synapse/spector-cli\.
- All 812 tests pass in \synapse/spector-synapse\.
- Full reactor build (\mvn clean install -DskipTests\) succeeds across all 25 modules.
- License check (\mvn license:check\) succeeds across all files.

Closes #775

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>