### PR TITLE
fix(ci): harden release workflows for maven, npm, pypi, and binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,11 +11,12 @@
 .vscode
 *.iml
 
-# Node (cortex source not needed — we copy pre-built dist)
+# Node
 **/node_modules
 cortex/spector-cortex/.angular
-cortex/spector-cortex/src
-cortex/spector-cortex/public
+
+# Windows-specific Maven config
+.mvn/
 
 # Maven build output (rebuilt in container)
 **/target

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag (e.g. 0.1.0-beta.0 or latest). Leave empty to use latest'
+        required: false
+        default: 'latest'
+        type: string
 
 permissions:
   contents: read
@@ -42,6 +48,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch' }}
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v5
@@ -57,7 +65,9 @@ jobs:
 
       - name: Smoke test Docker image on amd64
         run: |
-          docker run -d --name spector-smoke -p 7070:7070 ghcr.io/spectrayan/spector:latest || true
+          PRIMARY_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
+          echo "Smoke testing image: $PRIMARY_TAG"
+          docker run -d --name spector-smoke -p 7070:7070 "$PRIMARY_TAG" || true
           for i in {1..30}; do
             if curl -sf http://127.0.0.1:7070/actuator/health >/dev/null 2>&1; then
               echo "Healthcheck /actuator/health passed!"

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Chart version override (e.g. 0.1.0-beta.0). Leave empty to use tag or Chart.yaml'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -28,9 +34,18 @@ jobs:
 
       - name: Package Chart
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ] && [[ "$GITHUB_REF_NAME" =~ ^v?[0-9] ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+
+          EXTRA_ARGS=""
+          if [ -n "$VERSION" ]; then
+            EXTRA_ARGS="--version $VERSION --app-version $VERSION"
+          fi
+
           mkdir -p .cr-release-packages
-          helm package deploy/helm/spector --version "$VERSION" --app-version "$VERSION" --destination .cr-release-packages
+          helm package deploy/helm/spector $EXTRA_ARGS --destination .cr-release-packages
 
       - name: Log in to GHCR
         run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.1.0-beta.0). Required when running manually'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -20,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -28,8 +34,16 @@ jobs:
 
       - name: Build spector.jar
         run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION_ARG=""
+          if [ -n "$TAG" ] && [ "$TAG" != "main" ]; then
+            VERSION_ARG="-Drevision=${TAG#v}"
+          fi
           # Build fat JAR with all synapse dependencies
-          mvn -B clean package -DskipTests -pl synapse/spector-cli -am --no-transfer-progress
+          mvn -B clean package -DskipTests $VERSION_ARG -pl synapse/spector-cli -am --no-transfer-progress
           cp synapse/spector-cli/target/spector.jar ./spector.jar
           sha256sum spector.jar > spector.jar.sha256
           echo "Generated spector.jar checksum:"
@@ -44,7 +58,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          if [ "$TAG" = "main" ] || [ -z "$TAG" ]; then
+            echo "Error: Must specify a valid release tag (e.g. v0.1.0-beta.0) when running manually." >&2
+            exit 1
+          fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; uploading assets..."
             gh release upload "$TAG" spector.jar spector.jar.sha256 --clobber

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -11,6 +11,16 @@ on:
         required: false
         default: false
         type: boolean
+      version:
+        description: 'Override version (e.g. 0.1.0-beta.1). Leave empty to use tag or pom.xml revision'
+        required: false
+        default: ''
+        type: string
+      modules:
+        description: 'Maven modules to deploy (default: :spector,sdks/java/spector-client)'
+        required: false
+        default: ':spector,sdks/java/spector-client'
+        type: string
       channel:
         description: 'Release channel (release, rc, milestone)'
         required: false
@@ -35,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -78,6 +88,26 @@ jobs:
             GOAL="verify"
           fi
           CHANNEL="${{ github.event.inputs.channel || 'rc' }}"
+          MODULES="${{ github.event.inputs.modules || ':spector,sdks/java/spector-client' }}"
+
+          DEPLOY_VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$DEPLOY_VERSION" ] && [[ "$GITHUB_REF_NAME" =~ ^v?[0-9] ]]; then
+            DEPLOY_VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          if [ -z "$DEPLOY_VERSION" ]; then
+            DEPLOY_VERSION=$(sed -n 's/.*<revision>\(.*\)<\/revision>.*/\1/p' pom.xml | head -n 1)
+          fi
+
+          echo "Target deployment version: ${DEPLOY_VERSION}"
+
+          # Maven Central Portal is immutable; check if artifact already exists to avoid fatal 400 rejection
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://repo1.maven.org/maven2/com/spectrayan/spector/${DEPLOY_VERSION}/spector-${DEPLOY_VERSION}.pom" || true)
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "::warning::Version ${DEPLOY_VERSION} is already published on Maven Central. Skipping deployment."
+            exit 0
+          fi
+
           mvn -B $GOAL -P $CHANNEL -DskipTests \
-            -pl :spector,sdks/java/spector-client \
+            -Drevision="${DEPLOY_VERSION}" \
+            -pl "$MODULES" \
             --no-transfer-progress

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -58,7 +58,12 @@ jobs:
           if [ "${{ github.event.inputs.dryRun }}" = "true" ]; then
             EXTRA_FLAGS="--dry-run"
           fi
-          npm publish --access public $EXTRA_FLAGS
+          CURRENT_VER=$(node -p "require('./package.json').version")
+          if [ "${{ github.event.inputs.dryRun }}" != "true" ] && npm view "@spectrayan/spector-client@$CURRENT_VER" version >/dev/null 2>&1; then
+            echo "Version $CURRENT_VER of @spectrayan/spector-client is already published on npm. Skipping publish."
+          else
+            npm publish --access public $EXTRA_FLAGS
+          fi
 
       # 2. Publish Zero-Install MCP Runner (@spectrayan/spector)
       - name: Publish @spectrayan/spector (NPX Runner)
@@ -80,4 +85,9 @@ jobs:
           if [ "${{ github.event.inputs.dryRun }}" = "true" ]; then
             EXTRA_FLAGS="--dry-run"
           fi
-          npm publish --access public $EXTRA_FLAGS
+          CURRENT_VER=$(node -p "require('./package.json').version")
+          if [ "${{ github.event.inputs.dryRun }}" != "true" ] && npm view "@spectrayan/spector@$CURRENT_VER" version >/dev/null 2>&1; then
+            echo "Version $CURRENT_VER of @spectrayan/spector is already published on npm. Skipping publish."
+          else
+            npm publish --access public $EXTRA_FLAGS
+          fi

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -48,10 +48,15 @@ jobs:
           cd sdks/python
           if [ -n "${{ github.event.inputs.version }}" ]; then
             VERSION="${{ github.event.inputs.version }}"
-            sed -i -E "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
           elif [[ "$GITHUB_REF_NAME" =~ ^v?[0-9] ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
-            sed -i -E "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          else
+            VERSION=""
+          fi
+          if [ -n "$VERSION" ]; then
+            # Normalize semver pre-release to PEP 440 (e.g. 0.1.0-beta.1 -> 0.1.0b1, 0.1.0-alpha.1 -> 0.1.0a1, 0.1.0-rc.1 -> 0.1.0rc1)
+            PEP440_VERSION=$(echo "$VERSION" | sed -E 's/-beta\.?([0-9]*)/b\1/' | sed -E 's/-alpha\.?([0-9]*)/a\1/' | sed -E 's/-rc\.?([0-9]*)/rc\1/')
+            sed -i -E "s/^version = .*/version = \"$PEP440_VERSION\"/" pyproject.toml
           fi
           python -m build
           twine check dist/*
@@ -61,3 +66,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdks/python/dist/
+          skip-existing: true

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -52,8 +52,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user spector (UID/GID 1000)
-RUN groupadd -g 1000 spector && \
-    useradd -u 1000 -g spector -m -s /bin/bash spector
+RUN (userdel -r ubuntu 2>/dev/null || true) && \
+    (groupdel ubuntu 2>/dev/null || true) && \
+    (groupadd -g 1000 spector 2>/dev/null || true) && \
+    (id -u 1000 >/dev/null 2>&1 || useradd -u 1000 -g 1000 -m -s /bin/bash spector)
 
 WORKDIR /app
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -6,7 +6,7 @@
 # ═══════════════════════════════════════════════════════════════════
 
 # ── Stage 1: Build Angular Cortex Dashboard ───────────────────────────
-FROM node:22-alpine AS builder-cortex
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder-cortex
 
 WORKDIR /build
 COPY cortex/spector-cortex/package*.json ./
@@ -16,50 +16,21 @@ COPY cortex/spector-cortex/ ./
 RUN npm run build -- --configuration production
 
 # ── Stage 2: Build Java Synapse Backend ───────────────────────────────
-FROM maven:3.9-eclipse-temurin-25 AS builder-synapse
+FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-25 AS builder-synapse
 
 WORKDIR /build
 
-# Copy root and all module POMs to leverage Docker layer caching
+# Copy Maven reactor modules
 COPY pom.xml .
-COPY nucleus/pom.xml nucleus/
-COPY nucleus/spector-core/pom.xml nucleus/spector-core/
-COPY nucleus/spector-events/pom.xml nucleus/spector-events/
-COPY nucleus/spector-index/pom.xml nucleus/spector-index/
-COPY nucleus/spector-metrics/pom.xml nucleus/spector-metrics/
-COPY nucleus/spector-simd/pom.xml nucleus/spector-simd/
-COPY nucleus/spector-config/pom.xml nucleus/spector-config/
-COPY nucleus/spector-benchmark/pom.xml nucleus/spector-benchmark/
-COPY memory/pom.xml memory/
-COPY memory/spector-memory/pom.xml memory/spector-memory/
-COPY memory/spector-providers/pom.xml memory/spector-providers/
-COPY cortex/pom.xml cortex/
-COPY synapse/pom.xml synapse/
-COPY synapse/spector-spring/pom.xml synapse/spector-spring/
-COPY synapse/spector-synapse/pom.xml synapse/spector-synapse/
-COPY synapse/spector-cli/pom.xml synapse/spector-cli/
-COPY synapse/spector-mcp/pom.xml synapse/spector-mcp/
-COPY synapse/spector-connectors/pom.xml synapse/spector-connectors/
-COPY sdks/pom.xml sdks/
-COPY sdks/java/pom.xml sdks/java/
-COPY sdks/java/spector-client/pom.xml sdks/java/spector-client/
-COPY tools/pom.xml tools/
-COPY tools/spector-analyzer/pom.xml tools/spector-analyzer/
-COPY plugins/pom.xml plugins/
-COPY plugins/odysseus/pom.xml plugins/odysseus/
-COPY plugins/odysseus/odysseus-core/pom.xml plugins/odysseus/odysseus-core/
-COPY plugins/odysseus/odysseus-spring/pom.xml plugins/odysseus/odysseus-spring/
-
-# Copy sources
 COPY nucleus/ nucleus/
 COPY memory/ memory/
 COPY synapse/ synapse/
-COPY sdks/ sdks/
-COPY tools/ tools/
-COPY plugins/ plugins/
+COPY sdks/java/ sdks/java/
+COPY bench/ bench/
 
 # Package Synapse executable fat JAR
-RUN mvn -B package -pl synapse/spector-synapse -am -DskipTests --no-transfer-progress
+RUN mvn -B package -pl synapse/spector-synapse -am -DskipTests --no-transfer-progress && \
+    cp /build/synapse/spector-synapse/target/spector-synapse-*-exec.jar /build/spector-synapse.jar
 
 # ── Stage 3: Runtime (glibc Debian Bookworm base) ─────────────────────
 FROM eclipse-temurin:25-jre AS runtime
@@ -87,7 +58,7 @@ RUN groupadd -g 1000 spector && \
 WORKDIR /app
 
 # Copy backend fat JAR from Stage 2
-COPY --from=builder-synapse /build/synapse/spector-synapse/target/spector-synapse-*-exec.jar /app/spector-synapse.jar
+COPY --from=builder-synapse /build/spector-synapse.jar /app/spector-synapse.jar
 
 # Copy frontend distribution from Stage 1
 COPY --from=builder-cortex /build/dist/spector-cortex/browser/ /usr/share/nginx/html/


### PR DESCRIPTION
## Summary
Hardens the release workflows across Maven Central, NPM, PyPI, and GitHub Releases to prevent publishing pipeline failures:

1. **Maven Central (elease-maven.yml)**:
   - Added \ersion\ and \modules\ inputs to \workflow_dispatch\.
   - Added pre-check against Maven Central (\epo1.maven.org\) to cleanly skip already-published coordinates instead of failing with HTTP 400.
   - Dynamic \-Drevision\ injection from tag or input.
   - Migrated to \ctions/setup-java@v5\.

2. **NPM Packages (elease-npm.yml)**:
   - Added \
pm view\ idempotency checks before \
pm publish\ for both packages (\@spectrayan/spector-client\ and \@spectrayan/spector\).
   - Gracefully skips already published versions instead of aborting the workflow, unblocking \@spectrayan/spector\ (NPX runner).

3. **PyPI SDK (\elease-pypi.yml\)**:
   - Added \skip-existing: true\ to \pypa/gh-action-pypi-publish\.
   - Added PEP 440 semver normalization (\