### PR TITLE
feat(core): ADR-0033 Phase 0 — Prerequisites and Safety Scaffolding

### DIFF
--- a/memory/spector-kernel/pom.xml
+++ b/memory/spector-kernel/pom.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright (c) 2026 Spectrayan. All rights reserved.
-    Business Source License 1.1 (BSL-1.1)
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/memory/spector-providers/pom.xml
+++ b/memory/spector-providers/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>com.spectrayan</groupId>
+            <artifactId>spector-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.spectrayan</groupId>
             <artifactId>spector-commons</artifactId>
         </dependency>
 

--- a/nucleus/spector-core/pom.xml
+++ b/nucleus/spector-core/pom.xml
@@ -24,6 +24,48 @@
             <groupId>com.spectrayan</groupId>
             <artifactId>spector-commons</artifactId>
         </dependency>
+
+        <!-- ── Test Dependencies ── -->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <bannedDependencies>
+                            <excludes>
+                                <exclude>com.spectrayan:spector-kernel</exclude>
+                                <exclude>com.spectrayan:spector-memory</exclude>
+                                <exclude>com.spectrayan:spector-index</exclude>
+                                <exclude>com.spectrayan:spector-config</exclude>
+                                <exclude>com.spectrayan:spector-events</exclude>
+                                <exclude>com.spectrayan:spector-providers</exclude>
+                                <exclude>com.spectrayan:spector-synapse</exclude>
+                            </excludes>
+                            <message>ADR-0033 Principle 1 violation: spector-core must not depend on upstream storage, memory, config, index, or provider modules.</message>
+                        </bannedDependencies>
+                    </rules>
+                    <fail>true</fail>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/CosineSimilarity.java
+++ b/nucleus/spector-core/src/main/java/com/spectrayan/spector/core/similarity/CosineSimilarity.java
@@ -107,7 +107,7 @@ public final class CosineSimilarity {
         float normB = sumNormB.reduceLanes(VectorOperators.ADD);
 
         float denom = (float) Math.sqrt((double) normA * normB);
-        return denom == 0.0f ? 0.0f : dot / denom;
+        return (denom <= 0.0f || Float.isNaN(denom)) ? 0.0f : dot / denom;
     }
 
 

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/CosineSimilarityTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/CosineSimilarityTest.java
@@ -63,6 +63,13 @@ class CosineSimilarityTest {
     }
 
     @Test
+    void nanInputReturnsZero() {
+        float[] a = {Float.NaN, 0f, 0f};
+        float[] b = {1f, 2f, 3f};
+        assertThat(CosineSimilarity.compute(a, b)).isEqualTo(0.0f);
+    }
+
+    @Test
     void scalingDoesNotAffectResult() {
         float[] a = {1f, 2f, 3f};
         float[] b = {10f, 20f, 30f};

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/arch/CoreBoundaryRulesTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/arch/CoreBoundaryRulesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.arch;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Enforces the architectural boundary rules established by ADR-0033 (Principles 1 &amp; 5).
+ *
+ * <p>Validates that {@code spector-core} remains a pure mathematical library with zero
+ * domain model infiltration and no dependencies on upstream modules.</p>
+ */
+@DisplayName("ADR-0033 Principle 1 & 5: Spector Core Architectural Boundary Enforcement")
+class CoreBoundaryRulesTest {
+
+    private static final String CORE_PKG = "com.spectrayan.spector.core";
+    private static final String COGNITIVE_PKG = "com.spectrayan.spector.core.cognitive..";
+    private static JavaClasses coreClasses;
+
+    @BeforeAll
+    static void importCoreClasses() {
+        coreClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages(CORE_PKG);
+
+        // Subject-count guard against issue #734 (ArchUnit importing 0 classes on class-file major 69)
+        assertThat(coreClasses)
+                .as("Core classes imported by ArchUnit must not be empty (guarding against issue #734)")
+                .hasSizeGreaterThan(50);
+    }
+
+    @Test
+    @DisplayName("spector-core must never depend on upstream storage, memory, config, index, or provider modules (Principle 1)")
+    void coreMustNotDependOnUpstreamModules() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("com.spectrayan.spector.core..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "..spector.kernel..",
+                        "..spector.memory..",
+                        "..spector.index..",
+                        "..spector.config..",
+                        "..spector.events..",
+                        "..spector.provider..",
+                        "..spector.providers..",
+                        "..spector.synapse..")
+                .because("ADR-0033 Principle 1 mandates zero domain model infiltration into spector-core");
+
+        rule.check(coreClasses);
+    }
+
+    @Test
+    @DisplayName("spector-core cognitive kernels must be pure math free of java.lang.foreign (Principle 1)")
+    void cognitiveKernelsMustNotDependOnForeign() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage(COGNITIVE_PKG)
+                .should().dependOnClassesThat().resideInAnyPackage("java.lang.foreign..")
+                .because("cognitive kernels must operate solely on primitive scalars and arrays, free of off-heap handles");
+
+        rule.check(coreClasses);
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/parity/ParityHarness.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/parity/ParityHarness.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.parity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * ADR-0033 Principle 6: Behavioural Parity Harness.
+ *
+ * <p>Provides deterministic parity assertions across migrated mathematical algorithms,
+ * ensuring migrated kernels maintain bit-exact or documented epsilon equivalence against
+ * baseline implementations and golden-value corpora.</p>
+ */
+public final class ParityHarness {
+
+    private ParityHarness() {
+        // utility class
+    }
+
+    /**
+     * Asserts bit-exact equivalence between two IEEE 754 float values.
+     *
+     * @param actual   the actual result from the migrated kernel
+     * @param expected the baseline golden value
+     * @param context  description of the formula or test vector
+     */
+    public static void assertBitExact(float actual, float expected, String context) {
+        int actualBits = Float.floatToRawIntBits(actual);
+        int expectedBits = Float.floatToRawIntBits(expected);
+
+        if (Float.isNaN(actual) && Float.isNaN(expected)) {
+            return;
+        }
+
+        assertThat(actualBits)
+                .as("Bit-exact parity failed for '%s': expected %f (0x%08X), got %f (0x%08X)",
+                        context, expected, expectedBits, actual, actualBits)
+                .isEqualTo(expectedBits);
+    }
+
+    /**
+     * Asserts bit-exact equivalence between two float arrays.
+     *
+     * @param actual   the actual result array
+     * @param expected the baseline golden array
+     * @param context  description of the formula or test vector
+     */
+    public static void assertBitExact(float[] actual, float[] expected, String context) {
+        assertThat(actual)
+                .as("Array length mismatch for '%s'", context)
+                .hasSameSizeAs(expected);
+
+        for (int i = 0; i < actual.length; i++) {
+            assertBitExact(actual[i], expected[i], context + "[" + i + "]");
+        }
+    }
+
+    /**
+     * Asserts numerical equivalence within a documented tolerance epsilon.
+     *
+     * @param actual   the actual result from the migrated kernel
+     * @param expected the baseline golden value
+     * @param epsilon  maximum allowed absolute delta
+     * @param context  description of the formula or test vector
+     */
+    public static void assertWithinEpsilon(float actual, float expected, float epsilon, String context) {
+        if (Float.isNaN(actual) && Float.isNaN(expected)) {
+            return;
+        }
+        assertThat(actual)
+                .as("Epsilon parity failed for '%s' (tolerance=%e)", context, epsilon)
+                .isCloseTo(expected, within(epsilon));
+    }
+
+    /**
+     * Asserts numerical equivalence within a documented tolerance epsilon for float arrays.
+     *
+     * @param actual   the actual result array
+     * @param expected the baseline golden array
+     * @param epsilon  maximum allowed absolute delta
+     * @param context  description of the formula or test vector
+     */
+    public static void assertWithinEpsilon(float[] actual, float[] expected, float epsilon, String context) {
+        assertThat(actual)
+                .as("Array length mismatch for '%s'", context)
+                .hasSameSizeAs(expected);
+
+        for (int i = 0; i < actual.length; i++) {
+            assertWithinEpsilon(actual[i], expected[i], epsilon, context + "[" + i + "]");
+        }
+    }
+
+    /**
+     * Asserts that a struct-of-arrays batch computation matches sequential scalar invocations.
+     *
+     * @param batchOut  output array produced by the batch SIMD seam
+     * @param scalarOut output array produced by per-record scalar evaluations
+     * @param epsilon   maximum permitted discrepancy
+     * @param context   description of the benchmark/parity run
+     */
+    public static void assertBatchMatchesScalar(float[] batchOut, float[] scalarOut, float epsilon, String context) {
+        assertThat(batchOut)
+                .as("Batch vs Scalar output count mismatch for '%s'", context)
+                .hasSameSizeAs(scalarOut);
+
+        assertWithinEpsilon(batchOut, scalarOut, epsilon, "Batch vs Scalar parity: " + context);
+    }
+}

--- a/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/parity/ParityHarnessTest.java
+++ b/nucleus/spector-core/src/test/java/com/spectrayan/spector/core/parity/ParityHarnessTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.core.parity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ADR-0033 ParityHarness Validation")
+class ParityHarnessTest {
+
+    @Test
+    @DisplayName("Bit-exact parity succeeds for identical values and NaNs")
+    void bitExactSuccess() {
+        ParityHarness.assertBitExact(1.2345f, 1.2345f, "identical float");
+        ParityHarness.assertBitExact(Float.NaN, Float.NaN, "NaN matches NaN");
+
+        float[] a = {1.0f, 2.5f, -0.75f};
+        float[] b = {1.0f, 2.5f, -0.75f};
+        ParityHarness.assertBitExact(a, b, "float array");
+    }
+
+    @Test
+    @DisplayName("Bit-exact parity fails on slightest mantissa difference")
+    void bitExactFailure() {
+        float a = 1.0f;
+        float b = Math.nextUp(1.0f);
+
+        assertThatThrownBy(() -> ParityHarness.assertBitExact(a, b, "nextUp float"))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Bit-exact parity failed");
+    }
+
+    @Test
+    @DisplayName("Epsilon parity succeeds within tolerance")
+    void epsilonSuccess() {
+        float actual = 1.000001f;
+        float expected = 1.000000f;
+        ParityHarness.assertWithinEpsilon(actual, expected, 1e-5f, "close float");
+
+        float[] a = {1.000001f, 2.000002f};
+        float[] b = {1.000000f, 2.000000f};
+        ParityHarness.assertWithinEpsilon(a, b, 1e-5f, "close float array");
+    }
+
+    @Test
+    @DisplayName("Batch matches scalar helper functions properly")
+    void batchMatchesScalar() {
+        float[] batch = {0.1f, 0.2f, 0.3f};
+        float[] scalar = {0.1f, 0.2f, 0.3f};
+        ParityHarness.assertBatchMatchesScalar(batch, scalar, 1e-6f, "test scan");
+    }
+}

--- a/nucleus/spector-core/src/test/resources/fixtures/parity/.gitkeep
+++ b/nucleus/spector-core/src/test/resources/fixtures/parity/.gitkeep
@@ -1,0 +1,2 @@
+# Parity golden-value fixtures directory for ADR-0033
+# Populated per-phase with baseline values captured from pre-migration implementations.


### PR DESCRIPTION
## Summary
This PR executes **Phase 0** of [ADR-0033 Revision 2](https://github.com/spectrayan/spectrayan/blob/main/docs/adr/ADR-0033-cognitive-and-mathematical-kernel-decoupling-to-spector-core.md) establishing all prerequisites, boundary rules, licensing reconciliation, and verification harnesses before the 34 cognitive algorithms are decoupled into \spector-core\.

### Changes Included
1. **Licensing Reconciliation (L1/L2)**:
   - Removed stale BSL-1.1 XML comment from \memory/spector-kernel/pom.xml\ to match the Apache 2.0 headers present across all module source files.
2. **Reactor Edge (Cluster D1 Enablement)**:
   - Added direct dependency from \memory/spector-providers\ to \spector-core\ in \pom.xml\, unblocking SIMD similarity and quantization usage for provider classes.
3. **Core Boundary Rules & Enforcement (Principle 1 & 5)**:
   - Added \maven-enforcer-plugin\ \annedDependencies\ rule in \
ucleus/spector-core/pom.xml\ preventing any compile-time dependency on \spector-kernel\, \spector-memory\, \spector-index\, \spector-config\, \spector-events\, or \spector-providers\.
   - Created \CoreBoundaryRulesTest.java\ enforcing zero domain-model infiltration and pure math across \spector-core\, guarded against empty imports on Java 25 (issue #734).
4. **Cosine Similarity Zero-Guard Standardization (OD3)**:
   - Hardened \CosineSimilarity.compute\ to safely return \