### PR TITLE
docs: renumber cell HA ADR to ADR-0034 in code references (#819)

### DIFF
--- a/docs/docs/configuration/parameters.md
+++ b/docs/docs/configuration/parameters.md
@@ -217,7 +217,7 @@ SPECTOR_API_KEY=my-secret-key mvn -Psynapse -pl synapse/spector-synapse spring-b
 
 | Parameter | Default | Range | Description |
 |-----------|---------|-------|-------------|
-| `spector.namespace.tenant-rooted.enabled` | `true` | true/false | Enables tenant-rooted namespace sharding layout (`tenants/XX/YY/tenantId/namespaces/ZZ/WW/namespaceId`) for tenanted accounts (ADR-0033). Untenanted accounts (`tenantId == null`) always resolve to legacy flat sharded path (`namespaces/XX/YY/namespaceId`). |
+| `spector.namespace.tenant-rooted.enabled` | `true` | true/false | Enables tenant-rooted namespace sharding layout (`tenants/XX/YY/tenantId/namespaces/ZZ/WW/namespaceId`) for tenanted accounts (ADR-0034). Untenanted accounts (`tenantId == null`) always resolve to legacy flat sharded path (`namespaces/XX/YY/namespaceId`). |
 | `spector.namespace.dual-read.enabled` | `true` | true/false | Enables dual-read fallback from layout B (tenant-rooted) to layout A (flat) during migration window (Req R5.3). Never dual-writes (I6). Fallbacks increment `spector.namespace.layout.fallback`. |
 
 > [!NOTE]

--- a/memory/spector-kernel/src/main/java/com/spectrayan/spector/kernel/storage/NamespacePathResolver.java
+++ b/memory/spector-kernel/src/main/java/com/spectrayan/spector/kernel/storage/NamespacePathResolver.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 /**
  * Resolves rememberer directories. The ONLY sanctioned source of a namespace path
- * (ADR-0033 §9.2, Phase 0.1, Req R1.1, R1.2, R4, R9).
+ * (ADR-0034 §9.2, Phase 0.1, Req R1.1, R1.2, R4, R9).
  */
 public final class NamespacePathResolver {
 
@@ -31,7 +31,7 @@ public final class NamespacePathResolver {
     }
 
     /**
-     * Identity recorded in {@code namespace.json} (Req R8) and in ADR-0033 §9.7 manifests (Req R8.3).
+     * Identity recorded in {@code namespace.json} (Req R8) and in ADR-0034 §9.7 manifests (Req R8.3).
      */
     public enum Layout {
         FLAT_SHA256("StoragePaths.namespaceDirSharded"),

--- a/memory/spector-kernel/src/main/java/com/spectrayan/spector/kernel/storage/StoragePaths.java
+++ b/memory/spector-kernel/src/main/java/com/spectrayan/spector/kernel/storage/StoragePaths.java
@@ -361,7 +361,7 @@ public final class StoragePaths {
 
     /**
      * Resolves a tenant-rooted namespace path with SHA-256 sharding for both tenant and namespace
-     * (ADR-0033 §9.2, Phase 0.1, Req R4.2, R4.3, R4.5).
+     * (ADR-0034 §9.2, Phase 0.1, Req R4.2, R4.3, R4.5).
      *
      * <pre>
      *   basePath/tenants/XX/YY/tenantId/namespaces/ZZ/WW/namespaceId/
@@ -386,7 +386,7 @@ public final class StoragePaths {
      *
      * @deprecated Use {@link #tenantRootedNamespaceDir(Path, String, String)} instead.
      *             This helper placed tenants directly under {@code namespaces/} instead of the tenant-rooted
-     *             hierarchy defined by ADR-0033 §9.2 (Req R6.4).
+     *             hierarchy defined by ADR-0034 §9.2 (Req R6.4).
      * @param basePath     root persistence path
      * @param tenantId     the tenant (org) identifier — sharded on this
      * @param namespaceId  the namespace (user/agent) identifier within the tenant

--- a/memory/spector-kernel/src/test/java/com/spectrayan/spector/kernel/storage/NamespacePathResolverTest.java
+++ b/memory/spector-kernel/src/test/java/com/spectrayan/spector/kernel/storage/NamespacePathResolverTest.java
@@ -70,7 +70,7 @@ class NamespacePathResolverTest {
         }
 
         @Test
-        @DisplayName("Tenanted hierarchy matches ADR-0033 §9.2 structure")
+        @DisplayName("Tenanted hierarchy matches ADR-0034 §9.2 structure")
         void verifyPathStructure() {
             var placement = NamespacePathResolver.resolve(ROOT, "acme", "ns-project-1");
             Path relative = ROOT.relativize(placement.dir());

--- a/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
+++ b/nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java
@@ -51,7 +51,7 @@ public final class SpectorPropertyConstants {
 
     // Namespace Storage Layout & Routing
     /**
-     * Enables the tenant-rooted rememberer layout (ADR-0033 §9.2 layout B).
+     * Enables the tenant-rooted rememberer layout (ADR-0034 §9.2 layout B).
      *
      * <p><strong>Defaults to {@code false} deliberately.</strong> With the flag off, namespace
      * resolution is bit-identical to the pre-unification flat layout, which is what lets the

--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/MigrateNamespacesCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/MigrateNamespacesCommand.java
@@ -35,7 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * CLI command to migrate flat namespace directories to tenant-rooted layout (ADR-0033 D3=C, Task 4.5, Requirements R5.7).
+ * CLI command to migrate flat namespace directories to tenant-rooted layout (ADR-0034 D3=C, Task 4.5, Requirements R5.7).
  */
 @Component
 @Command(

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TenantReassignmentException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TenantReassignmentException.java
@@ -16,8 +16,8 @@ import com.spectrayan.spector.commons.error.ErrorCode;
 
 /**
  * Thrown when an attempt is made to reassign an account's tenantId while the account owns
- * namespaces (ADR-0033 D4, Req R2.6). Data movement across tenant trees is deferred to
- * ADR-0033 Phase 1 rebalance.
+ * namespaces (ADR-0034 D4, Req R2.6). Data movement across tenant trees is deferred to
+ * ADR-0034 Phase 4, where the namespace mover is needed for failover anyway.
  */
 public class TenantReassignmentException extends NamespaceException {
 
@@ -27,7 +27,7 @@ public class TenantReassignmentException extends NamespaceException {
 
     public TenantReassignmentException(String accountId, String currentTenantId, String targetTenantId) {
         super(ErrorCode.API_CONFLICT, "TENANT_REASSIGNMENT_REFUSED",
-                "Cannot reassign tenant for account %s from '%s' to '%s': account owns namespaces. Data movement is deferred to ADR-0033 Phase 1."
+                "Cannot reassign tenant for account %s from '%s' to '%s': account owns namespaces. Data movement is deferred to ADR-0034 Phase 4."
                         .formatted(accountId, currentTenantId, targetTenantId));
         this.accountId = accountId;
         this.currentTenantId = currentTenantId;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java
@@ -88,7 +88,7 @@ public class SynapseProperties extends SpectorConfigProperties {
     public void setCache(com.spectrayan.spector.synapse.config.cache.SynapseCacheProperties cache) { if (cache != null) this.cache = cache; }
 
     // ══════════════════════════════════════════════════════════════
-    // Canonical storage roots (ADR-0033 D1, Req R3.1, R3.4)
+    // Canonical storage roots (ADR-0034 D1, Req R3.1, R3.4)
     // ══════════════════════════════════════════════════════════════
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java
@@ -70,7 +70,7 @@ import org.springframework.beans.factory.ObjectProvider;
  * 2. Catalog:      AccountCatalog.getOrCreateAccount(accountId)
  *                  → account.defaultNamespaceId → namespaceId
  * 3. Authorize:    catalog.authorize(accountId, namespaceId, minimumRole)
- * 4. Place:        owner account → tenantId → NamespacePathResolver (ADR-0033 §9.2)
+ * 4. Place:        owner account → tenantId → NamespacePathResolver (ADR-0034 §9.2)
  * 5. Bind:         cache.getOrOpen(namespaceId, () → buildInstance(tenantId, namespaceId, owner))
  * </pre>
  *

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/migration/TenantNamespaceMigrator.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/migration/TenantNamespaceMigrator.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 
 /**
  * Migrates existing flat namespace directories (layout A) to the tenant-rooted layout (layout B)
- * for tenanted accounts (ADR-0033, Tasks 4.1–4.3, Requirements R5.1–R5.8).
+ * for tenanted accounts (ADR-0034, Tasks 4.1–4.3, Requirements R5.1–R5.8).
  *
  * <p>Key properties:
  * <ul>
@@ -457,7 +457,7 @@ public class TenantNamespaceMigrator {
         // name rather than the layout id, and "tenantNamespaceDirSharded" names the *deprecated*
         // helper, which shards tenants under namespaces/ and is incompatible with this layout. A
         // Phase 3 replica reading that manifest would pick the wrong resolver — exactly the failure
-        // ADR-0033 KI-3 warns about (Req R8.1, R8.3).
+        // ADR-0034 KI-3 warns about (Req R8.1, R8.3).
         String layoutId = NamespacePathResolver.Layout.TENANT_SHA256.id();
         manifest.put("layout", layoutId);
         manifest.put("pathHelper", layoutId);

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/migration/TenantNamespaceStartupDetector.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/migration/TenantNamespaceStartupDetector.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 
 /**
  * Startup detector verifying that all tenanted namespaces have been migrated to the tenant-rooted
- * layout when {@code spector.namespace.tenant-rooted.enabled=true} (ADR-0033 D3=C, Task 4.5, Requirements R5.8).
+ * layout when {@code spector.namespace.tenant-rooted.enabled=true} (ADR-0034 D3=C, Task 4.5, Requirements R5.8).
  *
  * <p>Fails readiness by throwing an {@link IllegalStateException} if unmigrated tenanted namespaces
  * are detected. Automatically cleans up leftover {@code .migrating-*} staging directories on boot (R5.5).</p>

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/CellHaNamespaceExitCriteriaIntegrationTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/CellHaNamespaceExitCriteriaIntegrationTest.java
@@ -49,7 +49,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**
- * ADR-0033 KI-5 Exit-Criteria Integration Tests (Task 4.8, Reqs R10.1–R10.4, R9).
+ * ADR-0034 KI-5 Exit-Criteria Integration Tests (Task 4.8, Reqs R10.1–R10.4, R9).
  *
  * <p>Verifies the end-to-end multi-tenant cell HA layout guarantees:
  * <ul>
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.*;
  * </ul>
  * </p>
  */
-@DisplayName("Task 4.8: ADR-0033 KI-5 Exit Criteria Integration Tests")
+@DisplayName("Task 4.8: ADR-0034 KI-5 Exit Criteria Integration Tests")
 class CellHaNamespaceExitCriteriaIntegrationTest {
 
     private static final String TENANT_ACME = "018f9b8c000070008000000000000001";


### PR DESCRIPTION
## Summary

Follow-up to #821. This PR incorporates commit `c316b953`, which was authored immediately after #821 was merged, disambiguating ADR references across code and documentation.

Three documents claimed `ADR-0033`:
1. RnD 'Engine & CLI Stabilization' (Accepted, #775)
2. 'Cognitive and Mathematical Kernel Decoupling to Spector Core' (Proposed, Phases 0 and 1 shipped as #809 / #810)
3. 'Cell Topology, Namespace Ownership and Checkpoint Snapshot HA'

Git history already used 'ADR-0033 Phase 0/Phase 1' to mean kernel decoupling, so the cell HA references were ambiguous.

The cell HA document is renumbered to **ADR-0034** as the newest of the three. This PR updates only the 12 files whose references are cell-HA in sense, identified by their markers (§9.2, §9.7, KI-3, KI-5, D1/D3/D4, layout B, Phase 0.1). The 38 files referencing kernel decoupling by its markers (Principle 3, Principle 6, §4) are deliberately left on ADR-0033.

Also corrects `TenantReassignmentException`, which pointed the deferred namespace mover at 'Phase 1 rebalance'. The mover lands in Phase 4, where failover needs it anyway; Phase 1 is ring plus local ownership only.

## Affected Files (12 files, +18 / -18)

- `docs/docs/configuration/parameters.md`
- `memory/spector-kernel/src/main/java/com/spectrayan/spector/kernel/storage/NamespacePathResolver.java`
- `memory/spector-kernel/src/main/java/com/spectrayan/spector/kernel/storage/StoragePaths.java`
- `memory/spector-kernel/src/test/java/com/spectrayan/spector/kernel/storage/NamespacePathResolverTest.java`
- `nucleus/spector-config/src/main/java/com/spectrayan/spector/config/SpectorPropertyConstants.java`
- `synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/MigrateNamespacesCommand.java`
- `synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/exception/TenantReassignmentException.java`
- `synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/SynapseProperties.java`
- `synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/NamespaceResolver.java`
- `synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/migration/TenantNamespaceMigrator.java`
- `synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/migration/TenantNamespaceStartupDetector.java`
- `synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/memory/CellHaNamespaceExitCriteriaIntegrationTest.java`

## Verification

- `mvn test -pl memory/spector-kernel,synapse/spector-synapse -Dtest=NamespacePathResolverTest,CellHaNamespaceExitCriteriaIntegrationTest` passed (45 tests).
- `mvn test -pl synapse/spector-synapse -Dtest=StorageRootDerivationGuardTest,NoRawPathHelperGuardTest` passed (5 tests).

Relates to #819.
Follow-up to #821.
