### PR TITLE
fix(dr): address DR export and restore correctness findings G26-G29, G32-G35

### DIFF
--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/replication/SnapshotManifest.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/replication/SnapshotManifest.java
@@ -43,13 +43,54 @@ public record SnapshotManifest(
         List<SealedPartitionEntry> sealed,
         long walFrom,
         long walTo,
-        String encryptionKeyRef
+        String encryptionKeyRef,
+        List<FileEntry> files,
+        String namespaceMetadataJson
 ) {
 
     public static final String PLANE_NAMESPACE = "namespace";
     public static final int CURRENT_VERSION = 1;
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public SnapshotManifest(
+            String plane,
+            int manifestVersion,
+            String tenantId,
+            String namespaceId,
+            String pathHelper,
+            long epoch,
+            long hwm,
+            SnapshotKind kind,
+            RuntimeEntry runtime,
+            ActivePartitionEntry activePartition,
+            List<SealedPartitionEntry> sealed,
+            long walFrom,
+            long walTo,
+            String encryptionKeyRef
+    ) {
+        this(plane, manifestVersion, tenantId, namespaceId, pathHelper, epoch, hwm, kind, runtime, activePartition, sealed, walFrom, walTo, encryptionKeyRef, List.of(), null);
+    }
+
+    public SnapshotManifest(
+            String plane,
+            int manifestVersion,
+            String tenantId,
+            String namespaceId,
+            String pathHelper,
+            long epoch,
+            long hwm,
+            SnapshotKind kind,
+            RuntimeEntry runtime,
+            ActivePartitionEntry activePartition,
+            List<SealedPartitionEntry> sealed,
+            long walFrom,
+            long walTo,
+            String encryptionKeyRef,
+            List<FileEntry> files
+    ) {
+        this(plane, manifestVersion, tenantId, namespaceId, pathHelper, epoch, hwm, kind, runtime, activePartition, sealed, walFrom, walTo, encryptionKeyRef, files, null);
+    }
 
     public SnapshotManifest {
         // R1.3: Enforce plane == "namespace" (N4)
@@ -80,6 +121,7 @@ public record SnapshotManifest(
 
         Objects.requireNonNull(kind, "kind must not be null");
         sealed = sealed != null ? List.copyOf(sealed) : List.of();
+        files = files != null ? List.copyOf(files) : List.of();
 
         // Enforce identity plane separation on all contained references (N4)
         if (runtime != null) {
@@ -93,6 +135,17 @@ public record SnapshotManifest(
             if (s.objectRef() != null) {
                 ReplicationPathFilter.assertNotIdentityPlane(s.objectRef());
             }
+        }
+        for (FileEntry f : files) {
+            ReplicationPathFilter.assertNotIdentityPlane(f.path());
+        }
+    }
+
+    public record FileEntry(String path, String sha256) {
+        public FileEntry {
+            Objects.requireNonNull(path, "file path must not be null");
+            Objects.requireNonNull(sha256, "file sha256 must not be null");
+            ReplicationPathFilter.assertNotIdentityPlane(path);
         }
     }
 

--- a/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/replication/SnapshotVerifier.java
+++ b/memory/spector-memory/src/main/java/com/spectrayan/spector/memory/replication/SnapshotVerifier.java
@@ -157,6 +157,11 @@ public final class SnapshotVerifier {
                 ReplicationPathFilter.assertNotIdentityPlane(s.objectRef());
             }
         }
+        if (manifest.files() != null) {
+            for (SnapshotManifest.FileEntry f : manifest.files()) {
+                ReplicationPathFilter.assertNotIdentityPlane(f.path());
+            }
+        }
     }
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/AccountCatalog.java
@@ -80,6 +80,14 @@ public interface AccountCatalog {
 
     void tombstone(String accountId, String namespaceId);
 
+    /**
+     * Imports an authoritative NamespaceRecord into the catalog verbatim during disaster recovery
+     * or cross-cell replication, preserving original TSID, slug, status, bias, and legal hold.
+     *
+     * @param record authoritative namespace record
+     */
+    default void importNamespace(NamespaceRecord record) {}
+
     void recordAccess(String namespaceId);
 
     /**

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/file/FileAccountCatalog.java
@@ -409,6 +409,53 @@ public class FileAccountCatalog implements AccountCatalog {
     }
 
     @Override
+    public void importNamespace(NamespaceRecord record) {
+        Objects.requireNonNull(record, "record must not be null");
+        String accountId = record.ownerAccountId();
+        ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());
+        jvmLock.lock();
+        try {
+            Path accountDir = StoragePaths.accountDir(basePath, accountId);
+            Path lockFile = accountDir.resolve(FILE_LOCK);
+
+            try (FileChannel channel = FileChannel.open(lockFile,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock fileLock = channel.lock()) {
+
+                Path slugsFile = accountDir.resolve(FILE_SLUGS);
+                Map<String, String> slugs = new HashMap<>();
+                if (Files.exists(slugsFile)) {
+                    slugs = new HashMap<>(objectMapper.readValue(slugsFile.toFile(),
+                            new TypeReference<Map<String, String>>() {}));
+                }
+
+                Path namespacesFile = accountDir.resolve(FILE_NAMESPACES);
+                Map<String, NamespaceRecord> namespaces = new HashMap<>();
+                if (Files.exists(namespacesFile)) {
+                    namespaces = new HashMap<>(objectMapper.readValue(namespacesFile.toFile(),
+                            new TypeReference<Map<String, NamespaceRecord>>() {}));
+                }
+
+                slugs.put(record.slug(), record.namespaceId());
+                namespaces.put(record.namespaceId(), record);
+
+                atomicWrite(slugsFile, slugs);
+                atomicWrite(namespacesFile, namespaces);
+
+                snapshotCache.remove(accountId);
+                log.info("[FileAccountCatalog] imported namespace: {} (slug={}) for account {}",
+                        record.namespaceId(), record.slug(), accountId);
+            }
+        } catch (IOException e) {
+            log.error("[FileAccountCatalog] failed to import namespace {} for account {}",
+                    record.namespaceId(), record.ownerAccountId(), e);
+            throw new RuntimeException("Failed to import namespace into catalog", e);
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    @Override
     public NamespaceRecord updateNamespace(String accountId, String slugOrId,
             String displayName, String description, NamespaceType type, NamespaceBias bias) {
         ReentrantLock jvmLock = accountLocks.computeIfAbsent(accountId, k -> new ReentrantLock());

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/catalog/jdbc/JdbcAccountCatalog.java
@@ -316,6 +316,16 @@ public class JdbcAccountCatalog implements AccountCatalog {
     }
 
     @Override
+    @Transactional
+    public void importNamespace(NamespaceRecord record) {
+        Objects.requireNonNull(record, "record must not be null");
+        insertNamespaceRow(record);
+        insertImplicitOwnerGrant(record.ownerAccountId(), record.namespaceId());
+        log.info("[JdbcAccountCatalog] Imported namespace: slug={}, id={}, accountId={}",
+                record.slug(), record.namespaceId(), record.ownerAccountId());
+    }
+
+    @Override
     public Optional<NamespaceRecord> resolve(String accountId, String slugOrId) {
         Objects.requireNonNull(accountId, "accountId must not be null");
         Objects.requireNonNull(slugOrId, "slugOrId must not be null");

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporter.java
@@ -18,9 +18,12 @@ import com.spectrayan.spector.kernel.storage.StoragePaths;
 import com.spectrayan.spector.memory.replication.SnapshotKind;
 import com.spectrayan.spector.memory.replication.SnapshotManifest;
 import com.spectrayan.spector.memory.replication.SnapshotVerifier;
+import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
 import com.spectrayan.spector.synapse.config.dr.DisasterRecoveryProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
@@ -37,10 +41,13 @@ import java.util.stream.Stream;
  *
  * <p>Key Invariants:
  * <ul>
- *   <li>V1: RPO is the measured mutable-snapshot export interval (R2.1).</li>
+ *   <li>V1: RPO is the measured mutable-snapshot export interval (R2.1, G29).</li>
  *   <li>V5: Export never blocks the write path; throttled via BandwidthThrottler (R2.5, R2.7).</li>
  *   <li>V6: Residency verified before upload — strictly refuses on mismatch (R9.3).</li>
  *   <li>R2.4, R2.6: Payload objects uploaded first; {@code manifest.json} uploaded LAST for atomic visibility.</li>
+ *   <li>G27: Traverses directory tree recursively and preserves relative sub-paths in S3 keys.</li>
+ *   <li>G28: Enumerates all uploaded payload files into the manifest; refuses unverified fallback synthesis.</li>
+ *   <li>G35: Employs immutable export run prefixes {@code {epoch}-{runId}/} to eliminate in-place mutation.</li>
  *   <li>R2.9: Alerts when export lag exceeds multiple of {@code drExportInterval}.</li>
  *   <li>R2.10: Unhandled/failed namespaces explicitly recorded and auditable.</li>
  * </ul>
@@ -49,14 +56,17 @@ import java.util.stream.Stream;
 public class DisasterRecoveryExporter {
 
     private static final Logger log = LoggerFactory.getLogger(DisasterRecoveryExporter.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final ObjectStoreClient objectStoreClient;
     private final DisasterRecoveryProperties properties;
     private final String bucket;
+    private final AccountCatalog accountCatalog;
 
     private final Map<String, Long> lastExportTimestampMs = new ConcurrentHashMap<>();
     private final Map<String, Long> lastExportHwm = new ConcurrentHashMap<>();
     private final Map<String, String> unhandledNamespaces = new ConcurrentHashMap<>();
+    private final ConcurrentLinkedDeque<Long> measuredIntervalsSec = new ConcurrentLinkedDeque<>();
     private final AtomicLong successfulExportCount = new AtomicLong(0);
     private final AtomicLong failedExportCount = new AtomicLong(0);
 
@@ -71,14 +81,102 @@ public class DisasterRecoveryExporter {
             String failureReason
     ) {}
 
+    public record ActiveNamespaceTarget(
+            String tenantId,
+            String namespaceId,
+            Path directory,
+            String tenantJurisdiction,
+            long epoch,
+            long currentHwm
+    ) {}
+
     public DisasterRecoveryExporter(
             ObjectStoreClient objectStoreClient,
             DisasterRecoveryProperties properties,
             String bucket
     ) {
+        this(objectStoreClient, properties, bucket, null);
+    }
+
+    public DisasterRecoveryExporter(
+            ObjectStoreClient objectStoreClient,
+            DisasterRecoveryProperties properties,
+            String bucket,
+            AccountCatalog accountCatalog
+    ) {
         this.objectStoreClient = Objects.requireNonNull(objectStoreClient, "objectStoreClient must not be null");
         this.properties = Objects.requireNonNull(properties, "properties must not be null");
         this.bucket = bucket != null && !bucket.isBlank() ? bucket : properties.getObjectStoreBucket();
+        this.accountCatalog = accountCatalog;
+    }
+
+    /**
+     * Executes a scheduled export cycle across active targets (Req R2.1, G29).
+     * Automatically skips idle namespaces whose HWM has not advanced since the last export.
+     */
+    public List<ExportResult> exportCycle(List<ActiveNamespaceTarget> targets) {
+        long now = System.currentTimeMillis();
+        List<ExportResult> results = new ArrayList<>();
+        if (targets == null || targets.isEmpty()) {
+            return results;
+        }
+
+        for (ActiveNamespaceTarget target : targets) {
+            Long lastHwm = lastExportHwm.get(target.namespaceId());
+            // G29: Skip idle namespaces where HWM has not advanced
+            if (lastHwm != null && target.currentHwm() <= lastHwm) {
+                log.debug("[DRExporter] Namespace {} is idle (hwm={}, lastExportHwm={}), skipping export",
+                        target.namespaceId(), target.currentHwm(), lastHwm);
+                continue;
+            }
+
+            Long lastTime = lastExportTimestampMs.get(target.namespaceId());
+            if (lastTime != null) {
+                long intervalSec = Math.max(0, (now - lastTime) / 1000L);
+                recordExportInterval(target.namespaceId(), intervalSec);
+            }
+
+            ExportResult result = exportNamespace(
+                    target.directory(),
+                    target.tenantId(),
+                    target.namespaceId(),
+                    target.tenantJurisdiction(),
+                    target.epoch(),
+                    target.currentHwm()
+            );
+            results.add(result);
+        }
+        return results;
+    }
+
+    /**
+     * Records a measured export interval into the operational RPO tracking reservoir (G29).
+     */
+    public void recordExportInterval(String namespaceId, long intervalSec) {
+        measuredIntervalsSec.add(intervalSec);
+        while (measuredIntervalsSec.size() > 1000) {
+            measuredIntervalsSec.poll();
+        }
+        log.info("[DRExporter] Measured export interval for namespace {}: {}s (metric: spector.dr.export.interval)",
+                namespaceId, intervalSec);
+    }
+
+    /**
+     * Computes the measured 99th percentile RPO in seconds (G29).
+     */
+    public double getMeasuredP99RpoSeconds() {
+        List<Long> intervals = new ArrayList<>(measuredIntervalsSec);
+        if (intervals.isEmpty()) {
+            return properties.getExportIntervalSeconds();
+        }
+        Collections.sort(intervals);
+        int p99Index = (int) Math.ceil(0.99 * intervals.size()) - 1;
+        p99Index = Math.max(0, Math.min(p99Index, intervals.size() - 1));
+        return intervals.get(p99Index);
+    }
+
+    public long getMeasuredP99Rpo() {
+        return Math.round(getMeasuredP99RpoSeconds());
     }
 
     /**
@@ -127,40 +225,55 @@ public class DisasterRecoveryExporter {
         }
 
         String safeTenant = tenantId != null && !tenantId.isBlank() ? tenantId : "untenanted";
-        String s3Prefix = "snapshots/" + safeTenant + "/" + namespaceId + "/" + epoch + "/";
+        // G35: Immutable export directory per run: snapshots/{tenant}/{namespace}/{epoch}-{runId}/
+        String runId = Long.toHexString(System.currentTimeMillis()) + "-" + UUID.randomUUID().toString().substring(0, 8);
+        String s3Prefix = "snapshots/" + safeTenant + "/" + namespaceId + "/" + epoch + "-" + runId + "/";
 
         try {
-            // 3. Collect payload files and calculate hashes (Req R2.2, R2.6)
-            List<Path> payloadFiles = new ArrayList<>();
-            try (Stream<Path> stream = Files.list(namespaceDir)) {
+            // 3. Collect payload files recursively, preserving relative paths (G27, Req R2.2, R2.6)
+            List<Path> payloadFiles;
+            try (Stream<Path> stream = Files.walk(namespaceDir)) {
                 payloadFiles = stream
                         .filter(Files::isRegularFile)
                         .filter(p -> !p.getFileName().toString().equals(StoragePaths.FILE_LOCK))
                         .filter(p -> !p.getFileName().toString().equals("manifest.json"))
+                        .filter(p -> !p.getFileName().toString().equals("restore.failed"))
+                        .filter(p -> !p.getFileName().toString().endsWith(".tmp"))
                         .toList();
+            }
+
+            if (payloadFiles.isEmpty()) {
+                String err = "Namespace directory is empty: " + namespaceDir;
+                recordFailure(namespaceId, err);
+                return new ExportResult(namespaceId, tenantId, epoch, hwm, s3Prefix, 0, false, err);
             }
 
             SnapshotManifest.RuntimeEntry runtimeEntry = null;
             SnapshotManifest.ActivePartitionEntry activePartitionEntry = null;
             List<SnapshotManifest.SealedPartitionEntry> sealedEntries = new ArrayList<>();
+            List<SnapshotManifest.FileEntry> fileEntries = new ArrayList<>();
 
             // 4. Upload payload files FIRST (Req R2.4)
             int uploadedPayloadCount = 0;
             for (Path file : payloadFiles) {
+                String relPath = namespaceDir.relativize(file).toString().replace('\\', '/');
                 String fileName = file.getFileName().toString();
                 byte[] data = Files.readAllBytes(file);
                 String sha256 = AwsSigV4Signer.sha256Hex(data);
 
                 // Identify role and verify format
-                if (fileName.endsWith(".bundle") || fileName.equals("runtime.dat")) {
-                    runtimeEntry = new SnapshotManifest.RuntimeEntry(fileName, sha256, 1L);
+                if (fileName.endsWith(".bundle") || fileName.equals("runtime.dat") || relPath.startsWith(StoragePaths.DIR_RUNTIME + "/")) {
+                    runtimeEntry = new SnapshotManifest.RuntimeEntry(relPath, sha256, 1L);
                 } else if (fileName.startsWith("active-") || fileName.startsWith("part-active")) {
-                    activePartitionEntry = new SnapshotManifest.ActivePartitionEntry(fileName, sha256);
+                    activePartitionEntry = new SnapshotManifest.ActivePartitionEntry(relPath, sha256);
                 } else if (fileName.endsWith(".spct") || fileName.startsWith("sealed-")) {
-                    sealedEntries.add(new SnapshotManifest.SealedPartitionEntry(fileName, sha256, null));
+                    sealedEntries.add(new SnapshotManifest.SealedPartitionEntry(relPath, sha256, null));
                 }
 
-                String s3Key = s3Prefix + fileName;
+                // G28: Add every uploaded object to generic file entries
+                fileEntries.add(new SnapshotManifest.FileEntry(relPath, sha256));
+
+                String s3Key = s3Prefix + relPath;
                 objectStoreClient.putObject(bucket, s3Key, data, "application/octet-stream", Map.of(
                         "namespace-id", namespaceId,
                         "sha256", sha256
@@ -168,16 +281,20 @@ public class DisasterRecoveryExporter {
                 uploadedPayloadCount++;
             }
 
-            // If active partition was not specifically named, create fallback active entry
-            if (activePartitionEntry == null && !payloadFiles.isEmpty()) {
-                Path first = payloadFiles.get(0);
-                activePartitionEntry = new SnapshotManifest.ActivePartitionEntry(
-                        first.getFileName().toString(),
-                        AwsSigV4Signer.sha256Hex(Files.readAllBytes(first))
-                );
+            // G32: Extract authoritative catalog metadata if available
+            String namespaceMetadataJson = null;
+            if (accountCatalog != null) {
+                try {
+                    Optional<NamespaceRecord> recordOpt = accountCatalog.resolve(safeTenant, namespaceId);
+                    if (recordOpt.isPresent()) {
+                        namespaceMetadataJson = MAPPER.writeValueAsString(recordOpt.get());
+                    }
+                } catch (Exception e) {
+                    log.warn("[DRExporter] Could not resolve catalog record for {}: {}", namespaceId, e.getMessage());
+                }
             }
 
-            // 5. Build Phase 3 SnapshotManifest (Req R2.2, R2.6)
+            // 5. Build Phase 3 SnapshotManifest (Req R2.2, R2.6, G28, G32)
             SnapshotManifest manifest = new SnapshotManifest(
                     SnapshotManifest.PLANE_NAMESPACE,
                     SnapshotManifest.CURRENT_VERSION,
@@ -192,7 +309,9 @@ public class DisasterRecoveryExporter {
                     sealedEntries,
                     0L,
                     hwm,
-                    null
+                    null,
+                    fileEntries,
+                    namespaceMetadataJson
             );
 
             // 6. Upload manifest LAST for atomic visibility (Req R2.4, R2.6)
@@ -211,8 +330,8 @@ public class DisasterRecoveryExporter {
             unhandledNamespaces.remove(namespaceId);
             successfulExportCount.incrementAndGet();
 
-            log.info("[DRExporter] Exported namespace={} tenant={} epoch={} hwm={} payloadCount={}",
-                    namespaceId, tenantId, epoch, hwm, uploadedPayloadCount);
+            log.info("[DRExporter] Exported namespace={} tenant={} epoch={} hwm={} payloadCount={} prefix={}",
+                    namespaceId, tenantId, epoch, hwm, uploadedPayloadCount, s3Prefix);
 
             return new ExportResult(namespaceId, tenantId, epoch, hwm, s3Prefix, uploadedPayloadCount, true, null);
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryRestorer.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryRestorer.java
@@ -32,28 +32,29 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * Disaster recovery restorer that hydrates cognitive namespaces from S3 snapshot objects into
- * a standby cell (ADR-0034 §11.2, §14, §16, Phase 6, Req R3.1–R3.12).
+ * Disaster recovery restorer that hydrates cognitive namespaces from object storage
+ * into local NVMe file hierarchy (ADR-0034 §11.2, §14, §16, Phase 6, Req R3.1–R3.12).
  *
  * <p>Key Invariants:
  * <ul>
- *   <li>V4: Restored namespace is either verifiably complete or REFUSES TO SERVE (R3.2, R3.4).</li>
- *   <li>V6: Restores strictly refuse when standby cell is outside tenant residency jurisdiction (R9.4).</li>
- *   <li>R3.1: Pre-serving integrity verification — magic ('SMKM'), layout ID ('BUND'), and SHA-256.</li>
- *   <li>R3.3, R3.6: Restored namespace reports its snapshot HWM to disclose data loss.</li>
- *   <li>R3.5: Resumable and idempotent execution.</li>
- *   <li>R3.7: Supports prioritized restore ordering.</li>
- *   <li>R3.8, R3.10: Rebuilds catalog identity state so recovered namespaces are reachable.</li>
+ *   <li>V4: Pre-serving integrity verification — corrupt snapshots refuse to serve (R3.4).</li>
+ *   <li>V6: Data residency validation — cannot restore into non-compliant region (R9.4).</li>
+ *   <li>G26: Downloads and verifies into an isolated staging directory; atomically moves into place
+ *       only after complete validation; writes {@code restore.failed} sentinel on error.</li>
+ *   <li>G28, G33: Iterates manifest-declared artifacts and refuses unmanifested payloads ({@code UNMANIFESTED_ARTIFACT}).</li>
+ *   <li>G32: Refuses to restore erased namespaces marked with {@code .erased}; restores {@code NamespaceRecord} verbatim.</li>
+ *   <li>G33: Journaled/resumable download skipping verified files; error isolation in prioritized restore.</li>
+ *   <li>G35: Discovers immutable {@code {epoch}-{runId}/} snapshot directories and selects latest complete run.</li>
  * </ul>
  * </p>
  */
 public class DisasterRecoveryRestorer {
 
     private static final Logger log = LoggerFactory.getLogger(DisasterRecoveryRestorer.class);
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
 
     private final ObjectStoreClient objectStoreClient;
     private final String bucket;
@@ -67,7 +68,7 @@ public class DisasterRecoveryRestorer {
             long hwm,
             Path restoredDir,
             int verifiedArtifactCount,
-            long durationMs,
+            long elapsedMs,
             boolean success,
             String refusalReason
     ) {}
@@ -95,10 +96,17 @@ public class DisasterRecoveryRestorer {
     /**
      * Discovers selectable snapshot epochs under the tenant/namespace prefix.
      * Partial uploads lacking manifest.json are strictly unselectable (Req R2.6).
+     * Erased namespaces are unselectable (G32).
      */
     public List<Long> discoverSelectableEpochs(String tenantId, String namespaceId) {
         String safeTenant = tenantId != null && !tenantId.isBlank() ? tenantId : "untenanted";
         String searchPrefix = "snapshots/" + safeTenant + "/" + namespaceId + "/";
+
+        // G32: If namespace was erased, it is unselectable
+        if (isNamespaceErased(safeTenant, namespaceId)) {
+            log.warn("[DRRestorer] Namespace {} has been erased; discoverSelectableEpochs returning empty", namespaceId);
+            return List.of();
+        }
 
         List<String> allKeys = objectStoreClient.listKeysByPrefix(bucket, searchPrefix);
         Set<Long> epochsWithManifest = new TreeSet<>();
@@ -106,11 +114,15 @@ public class DisasterRecoveryRestorer {
         for (String key : allKeys) {
             if (key.endsWith("/manifest.json")) {
                 // key format: snapshots/{tenant}/{namespace}/{epoch}/manifest.json
+                // or immutable format: snapshots/{tenant}/{namespace}/{epoch}-{runId}/manifest.json
                 String sub = key.substring(searchPrefix.length());
                 int slash = sub.indexOf('/');
                 if (slash > 0) {
+                    String epochSegment = sub.substring(0, slash);
                     try {
-                        long epoch = Long.parseLong(sub.substring(0, slash));
+                        long epoch = epochSegment.contains("-")
+                                ? Long.parseLong(epochSegment.substring(0, epochSegment.indexOf('-')))
+                                : Long.parseLong(epochSegment);
                         epochsWithManifest.add(epoch);
                     } catch (NumberFormatException ignored) {}
                 }
@@ -137,8 +149,18 @@ public class DisasterRecoveryRestorer {
         DataResidencyEnforcer.validateRestoreResidency(tenantJurisdiction, standbyCellRegion);
 
         String safeTenant = tenantId != null && !tenantId.isBlank() ? tenantId : "untenanted";
-        String s3Prefix = "snapshots/" + safeTenant + "/" + namespaceId + "/" + epoch + "/";
-        String manifestKey = s3Prefix + "manifest.json";
+        String searchPrefix = "snapshots/" + safeTenant + "/" + namespaceId + "/";
+
+        // G32: Refuse restore if namespace has an erasure marker
+        if (isNamespaceErased(safeTenant, namespaceId)) {
+            String err = "Namespace " + namespaceId + " has been erased and cannot be restored from DR (G32).";
+            log.error("[DRRestorer] {}", err);
+            throw new IntegrityVerificationException(namespaceId, "erased.marker", "NAMESPACE_ALREADY_ERASED", err);
+        }
+
+        // G35: Resolve latest manifest-complete snapshot run prefix for the requested epoch
+        String chosenPrefix = resolveSnapshotPrefix(searchPrefix, namespaceId, epoch);
+        String manifestKey = chosenPrefix + "manifest.json";
 
         // 2. Fetch and Validate Manifest (Req R2.6, R3.4)
         Optional<byte[]> manifestBytes = objectStoreClient.getObject(bucket, manifestKey);
@@ -157,7 +179,7 @@ public class DisasterRecoveryRestorer {
             throw new IntegrityVerificationException(namespaceId, "manifest.json", "CORRUPT_MANIFEST", err);
         }
 
-        // 3. Reconstruct paths from layout markers (Req R2.3, R3.1, R3.4)
+        // 3. Resolve destination paths (Req R2.3, R3.1, R3.4)
         Path targetNamespaceDir;
         if ("tenant-rooted".equalsIgnoreCase(manifest.pathHelper()) && tenantId != null && !tenantId.isBlank()) {
             targetNamespaceDir = targetBaseDir.resolve("tenants").resolve(tenantId).resolve("namespaces").resolve(namespaceId);
@@ -165,131 +187,304 @@ public class DisasterRecoveryRestorer {
             targetNamespaceDir = targetBaseDir.resolve("namespaces").resolve(namespaceId);
         }
 
+        // G26: Download and verify into an isolated staging directory
+        Path stagingDir = targetNamespaceDir.resolveSibling(namespaceId + ".restoring");
         try {
-            Files.createDirectories(targetNamespaceDir);
+            Files.createDirectories(stagingDir);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to create destination directory: " + targetNamespaceDir, e);
+            throw new RuntimeException("Failed to create staging directory: " + stagingDir, e);
         }
 
         int verifiedCount = 0;
 
-        // 4. Download and verify payload artifacts
-        List<String> keys = objectStoreClient.listKeysByPrefix(bucket, s3Prefix);
-        for (String key : keys) {
-            if (key.endsWith("/manifest.json")) {
-                continue;
+        try {
+            // Build map of expected artifacts from manifest (G28, G33)
+            Map<String, String> expectedArtifacts = new LinkedHashMap<>();
+            if (manifest.files() != null && !manifest.files().isEmpty()) {
+                for (SnapshotManifest.FileEntry fe : manifest.files()) {
+                    expectedArtifacts.put(fe.path(), fe.sha256());
+                }
             }
-            String fileName = key.substring(key.lastIndexOf('/') + 1);
-            Optional<byte[]> fileDataOpt = objectStoreClient.getObject(bucket, key);
-            if (fileDataOpt.isEmpty()) {
-                throw new IntegrityVerificationException(namespaceId, fileName, "MISSING_PAYLOAD", "Payload missing: " + key);
+            if (manifest.runtime() != null) {
+                expectedArtifacts.putIfAbsent(manifest.runtime().file(), manifest.runtime().sha256());
             }
-            byte[] fileData = fileDataOpt.get();
-
-            // 4a. Verify SHA-256 Checksum against manifest
-            String actualSha = AwsSigV4Signer.sha256Hex(fileData);
-            String expectedSha = resolveExpectedSha(manifest, fileName);
-            if (expectedSha != null && !expectedSha.equalsIgnoreCase(actualSha)) {
-                String err = String.format("SHA-256 mismatch for %s: expected=%s, actual=%s. Refusing to serve (V4, R3.4).",
-                        fileName, expectedSha, actualSha);
-                log.error("[DRRestorer] {}", err);
-                throw new IntegrityVerificationException(namespaceId, fileName, "SHA_MISMATCH", err);
+            if (manifest.activePartition() != null) {
+                expectedArtifacts.putIfAbsent(manifest.activePartition().id(), manifest.activePartition().sha256());
+            }
+            for (SnapshotManifest.SealedPartitionEntry s : manifest.sealed()) {
+                expectedArtifacts.putIfAbsent(s.id(), s.sha256());
             }
 
-            // 4b. Verify Preamble Magic for bundle/region files (Req R3.1, V4)
-            verifyFileMagic(namespaceId, fileName, fileData);
+            // G33: Validate S3 contents against manifest — detect missing or unmanifested objects
+            List<String> s3Keys = objectStoreClient.listKeysByPrefix(bucket, chosenPrefix);
+            Set<String> s3RelPaths = new HashSet<>();
+            for (String key : s3Keys) {
+                if (key.endsWith("/manifest.json")) {
+                    continue;
+                }
+                String relPath = key.substring(chosenPrefix.length());
+                s3RelPaths.add(relPath);
 
-            // Write to destination
-            Path destFile = targetNamespaceDir.resolve(fileName);
-            try {
-                Path tempFile = targetNamespaceDir.resolve(fileName + ".tmp");
+                // G28: Check that this object is manifested
+                String expectedSha = resolveExpectedSha(manifest, relPath);
+                if (expectedSha == null) {
+                    String err = "Unmanifested artifact found in object store: " + relPath + ". Refusing unverified payload (G28).";
+                    log.error("[DRRestorer] {}", err);
+                    throw new IntegrityVerificationException(namespaceId, relPath, "UNMANIFESTED_ARTIFACT", err);
+                }
+            }
+
+            // Verify all manifested files are present in S3
+            for (String expPath : expectedArtifacts.keySet()) {
+                String expFileName = expPath.contains("/") ? expPath.substring(expPath.lastIndexOf('/') + 1) : expPath;
+                boolean presentInS3 = s3RelPaths.contains(expPath) || s3RelPaths.contains(expFileName);
+                if (!presentInS3) {
+                    String err = "Manifested artifact missing in object store: " + expPath + ". Refusing incomplete snapshot (G33).";
+                    log.error("[DRRestorer] {}", err);
+                    throw new IntegrityVerificationException(namespaceId, expPath, "MISSING_PAYLOAD", err);
+                }
+            }
+
+            // 4. Download and verify payload artifacts into stagingDir (G26, G33)
+            for (Map.Entry<String, String> entry : expectedArtifacts.entrySet()) {
+                String relPath = entry.getKey();
+                String expectedSha = entry.getValue();
+                String fileName = relPath.contains("/") ? relPath.substring(relPath.lastIndexOf('/') + 1) : relPath;
+
+                Path destFile = stagingDir.resolve(relPath);
+                Files.createDirectories(destFile.getParent());
+
+                // G33: Resumability check — if already verified in staging dir, skip re-download
+                if (Files.isRegularFile(destFile)) {
+                    byte[] existing = Files.readAllBytes(destFile);
+                    if (AwsSigV4Signer.sha256Hex(existing).equalsIgnoreCase(expectedSha)) {
+                        log.debug("[DRRestorer] Artifact {} already verified in staging journal, skipping download", relPath);
+                        verifiedCount++;
+                        continue;
+                    }
+                }
+
+                // Download from S3 (trying relative path first, then bare filename)
+                Optional<byte[]> fileDataOpt = objectStoreClient.getObject(bucket, chosenPrefix + relPath);
+                if (fileDataOpt.isEmpty()) {
+                    fileDataOpt = objectStoreClient.getObject(bucket, chosenPrefix + fileName);
+                }
+                if (fileDataOpt.isEmpty()) {
+                    throw new IntegrityVerificationException(namespaceId, relPath, "MISSING_PAYLOAD", "Payload missing: " + relPath);
+                }
+                byte[] fileData = fileDataOpt.get();
+
+                // 4a. Verify SHA-256 Checksum against manifest
+                String actualSha = AwsSigV4Signer.sha256Hex(fileData);
+                if (!expectedSha.equalsIgnoreCase(actualSha)) {
+                    String err = String.format("SHA-256 mismatch for %s: expected=%s, actual=%s. Refusing to serve (V4, R3.4).",
+                            relPath, expectedSha, actualSha);
+                    log.error("[DRRestorer] {}", err);
+                    throw new IntegrityVerificationException(namespaceId, relPath, "SHA_MISMATCH", err);
+                }
+
+                // 4b. Verify Preamble Magic for bundle/region files (Req R3.1, V4)
+                verifyFileMagic(namespaceId, fileName, fileData);
+
+                // Write to destination in stagingDir
+                Path tempFile = destFile.resolveSibling(destFile.getFileName().toString() + ".tmp");
                 Files.write(tempFile, fileData);
                 Files.move(tempFile, destFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to write restored artifact " + fileName, e);
+                verifiedCount++;
             }
-            verifiedCount++;
-        }
 
-        // 5. Write namespace.json marker if not already present (Req R2.3)
-        Path markerPath = targetNamespaceDir.resolve(StoragePaths.FILE_NAMESPACE);
-        if (!Files.exists(markerPath)) {
-            Map<String, Object> marker = new LinkedHashMap<>();
-            marker.put("namespaceId", namespaceId);
-            marker.put("tenantId", tenantId);
-            marker.put("pathHelper", manifest.pathHelper());
-            marker.put("layout", manifest.pathHelper());
-            marker.put("restoredAt", Instant.now().toString());
-            marker.put("snapshotEpoch", epoch);
-            marker.put("hwm", manifest.hwm());
-            try {
+            // 5. Write namespace.json marker inside stagingDir before atomic promotion (Req R2.3)
+            Path markerPath = stagingDir.resolve(StoragePaths.FILE_NAMESPACE);
+            if (!Files.exists(markerPath)) {
+                Map<String, Object> marker = new LinkedHashMap<>();
+                marker.put("namespaceId", namespaceId);
+                marker.put("tenantId", tenantId);
+                marker.put("pathHelper", manifest.pathHelper());
+                marker.put("layout", manifest.pathHelper());
+                marker.put("restoredAt", Instant.now().toString());
+                marker.put("snapshotEpoch", epoch);
+                marker.put("hwm", manifest.hwm());
                 Files.write(markerPath, MAPPER.writeValueAsBytes(marker));
-            } catch (IOException e) {
-                log.warn("[DRRestorer] Failed to write namespace marker: {}", e.getMessage());
             }
-        }
 
-        // 6. Rebuild Catalog Identity State Cross-Cell (Req R3.8, R3.10)
-        if (accountCatalog != null) {
-            try {
-                String ownerAccount = tenantId != null ? tenantId : "default-account";
-                accountCatalog.getOrCreateAccount(ownerAccount);
-                if (accountCatalog.resolve(ownerAccount, namespaceId).isEmpty()) {
-                    accountCatalog.createNamespace(
-                            ownerAccount,
-                            namespaceId,
-                            NamespaceType.PROJECT,
-                            "Restored-" + namespaceId,
-                            "Restored from DR snapshot epoch=" + epoch,
-                            null
-                    );
+            // 6. Rebuild Catalog Identity State Cross-Cell (Req R3.8, R3.10, G32)
+            if (accountCatalog != null) {
+                try {
+                    if (manifest.namespaceMetadataJson() != null && !manifest.namespaceMetadataJson().isBlank()) {
+                        NamespaceRecord record = MAPPER.readValue(manifest.namespaceMetadataJson(), NamespaceRecord.class);
+                        accountCatalog.getOrCreateAccount(record.ownerAccountId());
+                        accountCatalog.importNamespace(record);
+                        log.info("[DRRestorer] Imported authoritative catalog record for {} (slug={}, legalHold={})",
+                                namespaceId, record.slug(), record.legalHold());
+                    } else {
+                        String ownerAccount = tenantId != null ? tenantId : "default-account";
+                        accountCatalog.getOrCreateAccount(ownerAccount);
+                        if (accountCatalog.resolve(ownerAccount, namespaceId).isEmpty()) {
+                            accountCatalog.createNamespace(
+                                    ownerAccount,
+                                    namespaceId,
+                                    NamespaceType.PROJECT,
+                                    "Restored-" + namespaceId,
+                                    "Restored from DR snapshot epoch=" + epoch,
+                                    null
+                            );
+                        }
+                    }
+                } catch (Exception e) {
+                    String err = "Catalog registration failed for namespace " + namespaceId + ": " + e.getMessage();
+                    log.error("[DRRestorer] {}", err, e);
+                    throw new IntegrityVerificationException(namespaceId, "catalog", "CATALOG_REGISTRATION_FAILED", err);
                 }
-            } catch (Exception e) {
-                log.warn("[DRRestorer] Catalog registration noted: {}", e.getMessage());
             }
+
+            // G26: Promote staging directory to live serving directory with single atomic move
+            if (Files.exists(targetNamespaceDir)) {
+                Path oldDir = targetNamespaceDir.resolveSibling(namespaceId + ".old." + System.currentTimeMillis());
+                try {
+                    Files.move(targetNamespaceDir, oldDir, StandardCopyOption.ATOMIC_MOVE);
+                } catch (IOException e) {
+                    deleteDirectoryRecursively(targetNamespaceDir);
+                }
+                Files.move(stagingDir, targetNamespaceDir, StandardCopyOption.ATOMIC_MOVE);
+                deleteDirectoryRecursively(oldDir);
+            } else {
+                Files.createDirectories(targetNamespaceDir.getParent());
+                Files.move(stagingDir, targetNamespaceDir, StandardCopyOption.ATOMIC_MOVE);
+            }
+
+            // Remove any legacy restore.failed sentinel if present
+            Path sentinel = targetNamespaceDir.resolve("restore.failed");
+            Files.deleteIfExists(sentinel);
+
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("[DRRestorer] Successfully restored namespace={} tenant={} epoch={} hwm={} artifacts={} in {}ms",
+                    namespaceId, tenantId, epoch, manifest.hwm(), verifiedCount, duration);
+
+            return new RestoreResult(namespaceId, tenantId, epoch, manifest.hwm(), targetNamespaceDir, verifiedCount, duration, true, null);
+
+        } catch (Exception e) {
+            // G26: On failure, write a restore.failed sentinel so the namespace refuses to serve
+            try {
+                deleteDirectoryRecursively(stagingDir);
+                Files.createDirectories(targetNamespaceDir);
+                Files.writeString(targetNamespaceDir.resolve("restore.failed"),
+                        "Restore failed at " + Instant.now() + " for epoch=" + epoch + ": " + e.getMessage());
+            } catch (Exception writeSentinelEx) {
+                log.warn("[DRRestorer] Could not write restore.failed sentinel: {}", writeSentinelEx.getMessage());
+            }
+
+            if (e instanceof IntegrityVerificationException ive) {
+                throw ive;
+            }
+            throw new RuntimeException("Disaster recovery restore failed: " + e.getMessage(), e);
         }
-
-        long duration = System.currentTimeMillis() - startTime;
-        log.info("[DRRestorer] Successfully restored namespace={} tenant={} epoch={} hwm={} artifacts={} in {}ms",
-                namespaceId, tenantId, epoch, manifest.hwm(), verifiedCount, duration);
-
-        return new RestoreResult(namespaceId, tenantId, epoch, manifest.hwm(), targetNamespaceDir, verifiedCount, duration, true, null);
     }
 
     /**
-     * Executes restores in prioritized order (Req R3.7).
+     * Executes restores in prioritized order with per-namespace error isolation (Req R3.7, G33).
      */
     public List<RestoreResult> restorePrioritized(
             List<RestoreRequest> requests,
             Path targetBaseDir
     ) {
-        // High priority first (e.g. priority 10 before priority 1)
+        // High priority first (e.g. priority 100 before priority 1)
         List<RestoreRequest> sorted = requests.stream()
                 .sorted(Comparator.comparingInt(RestoreRequest::priority).reversed())
                 .toList();
 
         List<RestoreResult> results = new ArrayList<>();
         for (RestoreRequest req : sorted) {
-            results.add(restoreNamespace(
-                    req.tenantId(),
-                    req.namespaceId(),
-                    req.epoch(),
-                    targetBaseDir,
-                    req.tenantJurisdiction()
-            ));
+            try {
+                results.add(restoreNamespace(
+                        req.tenantId(),
+                        req.namespaceId(),
+                        req.epoch(),
+                        targetBaseDir,
+                        req.tenantJurisdiction()
+                ));
+            } catch (Exception e) {
+                // G33: Error isolation — collect per-namespace failure and continue
+                log.error("[DRRestorer] Prioritized restore failed for namespace={}: {}", req.namespaceId(), e.getMessage());
+                Path failedDir = targetBaseDir.resolve("namespaces").resolve(req.namespaceId());
+                results.add(new RestoreResult(
+                        req.namespaceId(),
+                        req.tenantId(),
+                        req.epoch(),
+                        0L,
+                        failedDir,
+                        0,
+                        0L,
+                        false,
+                        e.getMessage()
+                ));
+            }
         }
         return results;
     }
 
-    private static String resolveExpectedSha(SnapshotManifest manifest, String fileName) {
-        if (manifest.runtime() != null && fileName.equals(manifest.runtime().file())) {
+    private boolean isNamespaceErased(String tenantId, String namespaceId) {
+        if (objectStoreClient.getObject(bucket, "snapshots/.tombstones/" + namespaceId).isPresent()) {
+            return true;
+        }
+        String key1 = "snapshots/" + tenantId + "/" + namespaceId + "/.erased";
+        if (objectStoreClient.getObject(bucket, key1).isPresent()) {
+            return true;
+        }
+        String key2 = "snapshots/untenanted/" + namespaceId + "/.erased";
+        return objectStoreClient.getObject(bucket, key2).isPresent();
+    }
+
+    private String resolveSnapshotPrefix(String searchPrefix, String namespaceId, long epoch) {
+        List<String> allKeys = objectStoreClient.listKeysByPrefix(bucket, searchPrefix);
+        List<String> candidates = allKeys.stream()
+                .filter(k -> k.endsWith("/manifest.json"))
+                .map(k -> k.substring(searchPrefix.length()))
+                .filter(sub -> {
+                    int slash = sub.indexOf('/');
+                    if (slash <= 0) return false;
+                    String segment = sub.substring(0, slash);
+                    try {
+                        long ep = segment.contains("-")
+                                ? Long.parseLong(segment.substring(0, segment.indexOf('-')))
+                                : Long.parseLong(segment);
+                        return ep == epoch;
+                    } catch (NumberFormatException ignored) {
+                        return false;
+                    }
+                })
+                .map(sub -> sub.substring(0, sub.indexOf('/') + 1))
+                .distinct()
+                .sorted(Comparator.reverseOrder()) // latest run first
+                .toList();
+
+        if (candidates.isEmpty()) {
+            String legacyPrefix = searchPrefix + epoch + "/";
+            if (objectStoreClient.getObject(bucket, legacyPrefix + "manifest.json").isPresent()) {
+                return legacyPrefix;
+            }
+            throw new IntegrityVerificationException(namespaceId, "manifest.json", "ABSENT_MANIFEST",
+                    "No valid manifest found for namespace=" + namespaceId + " epoch=" + epoch);
+        }
+        return searchPrefix + candidates.get(0);
+    }
+
+    private static String resolveExpectedSha(SnapshotManifest manifest, String relPath) {
+        if (manifest.files() != null) {
+            for (SnapshotManifest.FileEntry fe : manifest.files()) {
+                if (fe.path().equals(relPath) || fe.path().equals(relPath.substring(relPath.lastIndexOf('/') + 1))) {
+                    return fe.sha256();
+                }
+            }
+        }
+        String fileName = relPath.contains("/") ? relPath.substring(relPath.lastIndexOf('/') + 1) : relPath;
+        if (manifest.runtime() != null && (relPath.equals(manifest.runtime().file()) || fileName.equals(manifest.runtime().file()))) {
             return manifest.runtime().sha256();
         }
-        if (manifest.activePartition() != null && fileName.equals(manifest.activePartition().id())) {
+        if (manifest.activePartition() != null && (relPath.equals(manifest.activePartition().id()) || fileName.equals(manifest.activePartition().id()))) {
             return manifest.activePartition().sha256();
         }
         for (SnapshotManifest.SealedPartitionEntry sealed : manifest.sealed()) {
-            if (fileName.equals(sealed.id())) {
+            if (relPath.equals(sealed.id()) || fileName.equals(sealed.id())) {
                 return sealed.sha256();
             }
         }
@@ -318,5 +513,19 @@ public class DisasterRecoveryRestorer {
                 throw new IntegrityVerificationException(namespaceId, fileName, "BAD_PREAMBLE_MAGIC", err);
             }
         }
+    }
+
+    private static void deleteDirectoryRecursively(Path dir) {
+        if (dir == null || !Files.exists(dir)) {
+            return;
+        }
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {}
+                    });
+        } catch (IOException ignored) {}
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/S3CompatibleObjectStoreClient.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/S3CompatibleObjectStoreClient.java
@@ -180,42 +180,66 @@ public class S3CompatibleObjectStoreClient implements ObjectStoreClient {
     public List<String> listKeysByPrefix(String bucket, String prefix) {
         Objects.requireNonNull(bucket, "bucket must not be null");
         String safePrefix = prefix != null ? prefix : "";
-        String query = "list-type=2&prefix=" + URLEncoder.encode(safePrefix, StandardCharsets.UTF_8);
-        URI targetUri = buildUri(bucket, null, query);
+        List<String> allKeys = new ArrayList<>();
+        String continuationToken = null;
+        boolean hasMore = true;
 
-        Map<String, String> sigHeaders = AwsSigV4Signer.sign(
-                "GET", targetUri, Map.of(), new byte[0], accessKey, secretKey, region, "s3");
-
-        HttpRequest.Builder builder = HttpRequest.newBuilder()
-                .uri(targetUri)
-                .timeout(DEFAULT_TIMEOUT)
-                .GET();
-
-        addNonRestrictedHeaders(builder, sigHeaders);
-
-        try {
-            HttpResponse<byte[]> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
-            int status = response.statusCode();
-            if (status < 200 || status >= 300) {
-                String body = new String(response.body(), StandardCharsets.UTF_8);
-                throw new ObjectStoreException(bucket, prefix, "HTTP " + status + ": " + body);
+        while (hasMore) {
+            StringBuilder query = new StringBuilder("list-type=2&prefix=")
+                    .append(URLEncoder.encode(safePrefix, StandardCharsets.UTF_8));
+            if (continuationToken != null && !continuationToken.isBlank()) {
+                query.append("&continuation-token=").append(URLEncoder.encode(continuationToken, StandardCharsets.UTF_8));
             }
+            URI targetUri = buildUri(bucket, null, query.toString());
 
-            return parseS3ListResponse(response.body());
-        } catch (ObjectStoreException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ObjectStoreException(bucket, prefix, "Failed to list objects by prefix: " + e.getMessage(), e);
+            Map<String, String> sigHeaders = AwsSigV4Signer.sign(
+                    "GET", targetUri, Map.of(), new byte[0], accessKey, secretKey, region, "s3");
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(targetUri)
+                    .timeout(DEFAULT_TIMEOUT)
+                    .GET();
+
+            addNonRestrictedHeaders(builder, sigHeaders);
+
+            try {
+                HttpResponse<byte[]> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+                int status = response.statusCode();
+                if (status < 200 || status >= 300) {
+                    String body = new String(response.body(), StandardCharsets.UTF_8);
+                    throw new ObjectStoreException(bucket, prefix, "HTTP " + status + ": " + body);
+                }
+
+                S3ListResult listResult = parseS3ListResponse(response.body());
+                allKeys.addAll(listResult.keys());
+                hasMore = listResult.isTruncated() && listResult.nextContinuationToken() != null && !listResult.nextContinuationToken().isBlank();
+                continuationToken = listResult.nextContinuationToken();
+            } catch (ObjectStoreException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ObjectStoreException(bucket, prefix, "Failed to list objects by prefix: " + e.getMessage(), e);
+            }
         }
+        return allKeys;
     }
 
     @Override
     public int deleteByPrefix(String bucket, String prefix) {
-        List<String> keys = listKeysByPrefix(bucket, prefix);
         int deleted = 0;
-        for (String key : keys) {
-            if (deleteObject(bucket, key)) {
-                deleted++;
+        while (true) {
+            List<String> keys = listKeysByPrefix(bucket, prefix);
+            if (keys.isEmpty()) {
+                break;
+            }
+            int deletedThisPass = 0;
+            for (String key : keys) {
+                if (deleteObject(bucket, key)) {
+                    deleted++;
+                    deletedThisPass++;
+                }
+            }
+            if (deletedThisPass == 0) {
+                break;
             }
         }
         return deleted;
@@ -314,8 +338,12 @@ public class S3CompatibleObjectStoreClient implements ObjectStoreClient {
         return URI.create(path.toString());
     }
 
-    private static List<String> parseS3ListResponse(byte[] xmlBytes) {
+    private record S3ListResult(List<String> keys, boolean isTruncated, String nextContinuationToken) {}
+
+    private static S3ListResult parseS3ListResponse(byte[] xmlBytes) {
         List<String> keys = new ArrayList<>();
+        boolean isTruncated = false;
+        String nextContinuationToken = null;
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             // Secure XML parser against XXE
@@ -330,10 +358,20 @@ public class S3CompatibleObjectStoreClient implements ObjectStoreClient {
             for (int i = 0; i < keyNodes.getLength(); i++) {
                 keys.add(keyNodes.item(i).getTextContent());
             }
+
+            NodeList truncNodes = doc.getElementsByTagName("IsTruncated");
+            if (truncNodes.getLength() > 0) {
+                isTruncated = Boolean.parseBoolean(truncNodes.item(0).getTextContent().trim());
+            }
+
+            NodeList tokenNodes = doc.getElementsByTagName("NextContinuationToken");
+            if (tokenNodes.getLength() > 0) {
+                nextContinuationToken = tokenNodes.item(0).getTextContent().trim();
+            }
         } catch (Exception e) {
             log.warn("[S3Client] Error parsing ListObjectsV2 response: {}", e.getMessage());
         }
-        return keys;
+        return new S3ListResult(keys, isTruncated, nextContinuationToken);
     }
 
     private static String normalizeEndpoint(String endpoint) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/TenantErasureService.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/TenantErasureService.java
@@ -21,10 +21,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -152,6 +155,15 @@ public class TenantErasureService {
                 }
             } catch (Exception e) {
                 log.debug("[Erasure] Prefix sweep for {} encountered: {}", namespaceId, e.getMessage());
+            }
+
+            // G32: Write erasure tombstone marker so DR restore refuses to resurrect erased data
+            try {
+                byte[] markerBytes = ("{\"erasedAt\":\"" + Instant.now() + "\",\"namespaceId\":\"" + namespaceId + "\",\"accountId\":\"" + accountId + "\"}").getBytes(StandardCharsets.UTF_8);
+                objectStoreClient.putObject(drBucket, "snapshots/.tombstones/" + namespaceId,
+                        markerBytes, "application/json", Map.of("erased", "true"));
+            } catch (Exception e) {
+                log.warn("[Erasure] Failed to write erasure marker in DR bucket for {}: {}", namespaceId, e.getMessage());
             }
         }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporterTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporterTest.java
@@ -114,10 +114,10 @@ class DisasterRecoveryExporterTest {
 
         // Verify objects uploaded to S3
         Map<String, byte[]> objects = s3Server.getBucketObjects(BUCKET);
-        String manifestKey = "snapshots/" + tenantId + "/" + namespaceId + "/1/manifest.json";
+        String manifestKey = result.prefix() + "manifest.json";
         assertThat(objects).containsKey(manifestKey);
-        assertThat(objects).containsKey("snapshots/" + tenantId + "/" + namespaceId + "/1/runtime.bundle");
-        assertThat(objects).containsKey("snapshots/" + tenantId + "/" + namespaceId + "/1/part-active.spct");
+        assertThat(objects).containsKey(result.prefix() + "runtime.bundle");
+        assertThat(objects).containsKey(result.prefix() + "part-active.spct");
 
         // Parse and verify manifest
         SnapshotManifest manifest = SnapshotManifest.fromJson(new String(objects.get(manifestKey), StandardCharsets.UTF_8));
@@ -197,5 +197,99 @@ class DisasterRecoveryExporterTest {
           .hasMessageContaining("us-east-1");
 
         assertThat(exporter.getUnhandledNamespaces()).containsKey(namespaceId);
+    }
+
+    @Test
+    @DisplayName("G27: Recursive export preserves relative paths in S3 keys for nested layouts")
+    void testExportNestedSubdirectoriesPreservesRelativePaths() throws IOException {
+        String tenantId = "ten-nested";
+        String namespaceId = "018f9b8c000070008000000000000044";
+        Path nsDir = tempDir.resolve("nested-ns-" + namespaceId);
+        Files.createDirectories(nsDir);
+
+        // Marker
+        String markerJson = String.format("{\"namespaceId\":\"%s\",\"tenantId\":\"%s\",\"pathHelper\":\"sharded\"}",
+                namespaceId, tenantId);
+        Files.writeString(nsDir.resolve(StoragePaths.FILE_NAMESPACE), markerJson);
+
+        // Nested runtime/
+        Path runtimeDir = nsDir.resolve(StoragePaths.DIR_RUNTIME);
+        Files.createDirectories(runtimeDir);
+        ByteBuffer rtBuf = ByteBuffer.allocate(64);
+        rtBuf.putInt(BundleFileLayout.LAYOUT_ID);
+        Files.write(runtimeDir.resolve(StoragePaths.FILE_RUNTIME_BUNDLE), rtBuf.array());
+
+        // Nested partitions/001_p/
+        Path partDir = nsDir.resolve(StoragePaths.DIR_PARTITIONS).resolve("001_p");
+        Files.createDirectories(partDir);
+        ByteBuffer ptBuf = ByteBuffer.allocate(128);
+        ptBuf.putInt(RegionPreamble.MAGIC);
+        Files.write(partDir.resolve("part-1.spct"), ptBuf.array());
+
+        DisasterRecoveryExporter.ExportResult result = exporter.exportNamespace(
+                nsDir, tenantId, namespaceId, REGION, 1L, 200L
+        );
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.payloadCount()).isEqualTo(3); // namespace.json, runtime.bundle, part-1.spct
+
+        Map<String, byte[]> objects = s3Server.getBucketObjects(BUCKET);
+        assertThat(objects).containsKey(result.prefix() + StoragePaths.DIR_RUNTIME + "/" + StoragePaths.FILE_RUNTIME_BUNDLE);
+        assertThat(objects).containsKey(result.prefix() + StoragePaths.DIR_PARTITIONS + "/001_p/part-1.spct");
+        assertThat(objects).containsKey(result.prefix() + StoragePaths.FILE_NAMESPACE);
+    }
+
+    @Test
+    @DisplayName("G29: exportCycle skips idle namespaces and measures RPO intervals")
+    void testExportCycleSkipsIdleNamespacesAndMeasuresRpo() throws IOException {
+        String tenantId = "ten-cycle";
+        String nsId1 = "018f9b8c000070008000000000000031";
+        String nsId2 = "018f9b8c000070008000000000000032";
+
+        Path nsDir1 = createSampleNamespace(tenantId, nsId1, "flat");
+        Path nsDir2 = createSampleNamespace(tenantId, nsId2, "flat");
+
+        // Cycle 1: both namespaces exported
+        var target1 = new DisasterRecoveryExporter.ActiveNamespaceTarget(tenantId, nsId1, nsDir1, REGION, 1L, 100L);
+        var target2 = new DisasterRecoveryExporter.ActiveNamespaceTarget(tenantId, nsId2, nsDir2, REGION, 1L, 50L);
+
+        List<DisasterRecoveryExporter.ExportResult> results1 = exporter.exportCycle(List.of(target1, target2));
+        assertThat(results1).hasSize(2);
+        assertThat(exporter.getLastExportHwm()).containsEntry(nsId1, 100L).containsEntry(nsId2, 50L);
+
+        // Cycle 2: nsId1 is idle (HWM unchanged at 100L), nsId2 has advanced (HWM 75L)
+        var target1Idle = new DisasterRecoveryExporter.ActiveNamespaceTarget(tenantId, nsId1, nsDir1, REGION, 2L, 100L);
+        var target2Active = new DisasterRecoveryExporter.ActiveNamespaceTarget(tenantId, nsId2, nsDir2, REGION, 2L, 75L);
+
+        List<DisasterRecoveryExporter.ExportResult> results2 = exporter.exportCycle(List.of(target1Idle, target2Active));
+        assertThat(results2).hasSize(1);
+        assertThat(results2.get(0).namespaceId()).isEqualTo(nsId2);
+        assertThat(exporter.getLastExportHwm().get(nsId2)).isEqualTo(75L);
+
+        // Measured RPO tracking
+        exporter.recordExportInterval(nsId2, 30L);
+        assertThat(exporter.getMeasuredP99RpoSeconds()).isGreaterThan(0.0);
+        assertThat(exporter.getMeasuredP99Rpo()).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("G35: Re-exporting at the same epoch creates distinct immutable prefixes")
+    void testReExportAtSameEpochProducesDistinctImmutablePrefixes() throws IOException {
+        String tenantId = "ten-immutable";
+        String namespaceId = "018f9b8c000070008000000000000022";
+        Path nsDir = createSampleNamespace(tenantId, namespaceId, "flat");
+
+        DisasterRecoveryExporter.ExportResult run1 = exporter.exportNamespace(nsDir, tenantId, namespaceId, REGION, 5L, 100L);
+        DisasterRecoveryExporter.ExportResult run2 = exporter.exportNamespace(nsDir, tenantId, namespaceId, REGION, 5L, 100L);
+
+        assertThat(run1.success()).isTrue();
+        assertThat(run2.success()).isTrue();
+        assertThat(run1.prefix()).isNotEqualTo(run2.prefix());
+        assertThat(run1.prefix()).contains("/5-");
+        assertThat(run2.prefix()).contains("/5-");
+
+        Map<String, byte[]> objects = s3Server.getBucketObjects(BUCKET);
+        assertThat(objects).containsKey(run1.prefix() + "manifest.json");
+        assertThat(objects).containsKey(run2.prefix() + "manifest.json");
     }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryRestorerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryRestorerTest.java
@@ -19,6 +19,8 @@ import com.spectrayan.spector.kernel.storage.StoragePaths;
 import com.spectrayan.spector.memory.replication.SnapshotKind;
 import com.spectrayan.spector.memory.replication.SnapshotManifest;
 import com.spectrayan.spector.synapse.catalog.AccountCatalog;
+import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
+import com.spectrayan.spector.synapse.catalog.NamespaceType;
 import com.spectrayan.spector.synapse.catalog.file.FileAccountCatalog;
 import com.spectrayan.spector.synapse.config.dr.DisasterRecoveryProperties;
 import org.junit.jupiter.api.AfterEach;
@@ -32,7 +34,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -284,5 +288,195 @@ class DisasterRecoveryRestorerTest {
         )).isInstanceOf(ResidencyViolationException.class)
           .hasMessageContaining("eu-central-1")
           .hasMessageContaining("us-west-2");
+    }
+
+    @Test
+    @DisplayName("G26: Checksum failure leaves target directory quarantined with restore.failed sentinel")
+    void testPartialFailureLeavesNoCorruptedFilesAndWritesSentinel() {
+        String tenantId = "ten-fail";
+        String namespaceId = "018f9b8c000070008000000000000091";
+        String s3Prefix = "snapshots/" + tenantId + "/" + namespaceId + "/1/";
+
+        // Runtime bundle with valid checksum
+        ByteBuffer rtBuf = ByteBuffer.allocate(64);
+        rtBuf.putInt(BundleFileLayout.LAYOUT_ID);
+        byte[] rtData = rtBuf.array();
+        String rtSha = AwsSigV4Signer.sha256Hex(rtData);
+        s3Client.putObject(BUCKET, s3Prefix + "runtime.bundle", rtData, null, null);
+
+        // Partition with invalid checksum (corrupted in S3)
+        ByteBuffer ptBuf = ByteBuffer.allocate(128);
+        ptBuf.putInt(RegionPreamble.MAGIC);
+        byte[] ptData = ptBuf.array();
+        s3Client.putObject(BUCKET, s3Prefix + "part-active.spct", ptData, null, null);
+
+        // Manifest declares expected partition hash as "badbadbad..."
+        SnapshotManifest manifest = new SnapshotManifest(
+                SnapshotManifest.PLANE_NAMESPACE,
+                SnapshotManifest.CURRENT_VERSION,
+                tenantId,
+                namespaceId,
+                "flat",
+                1L,
+                100L,
+                SnapshotKind.FULL,
+                new SnapshotManifest.RuntimeEntry("runtime.bundle", rtSha, 1L),
+                new SnapshotManifest.ActivePartitionEntry("part-active.spct", "badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad0"),
+                List.of(),
+                0L,
+                100L,
+                null
+        );
+        s3Client.putObject(BUCKET, s3Prefix + "manifest.json", manifest.toJson().getBytes(StandardCharsets.UTF_8), null, null);
+
+        Path restoreBase = tempDir.resolve("quarantine-test");
+        Path targetDir = restoreBase.resolve("namespaces").resolve(namespaceId);
+
+        assertThatThrownBy(() -> restorer.restoreNamespace(
+                tenantId, namespaceId, 1L, restoreBase, STANDBY_REGION
+        )).isInstanceOf(IntegrityVerificationException.class)
+          .hasMessageContaining("SHA-256 mismatch");
+
+        // G26 Assertions: target directory has sentinel, and NO payload files are present
+        assertThat(Files.exists(targetDir.resolve("restore.failed"))).isTrue();
+        assertThat(Files.exists(targetDir.resolve("runtime.bundle"))).isFalse();
+        assertThat(Files.exists(targetDir.resolve("part-active.spct"))).isFalse();
+    }
+
+    @Test
+    @DisplayName("G28, G33: S3 contains unmanifested artifact — restorer strictly REFUSES to serve")
+    void testUnmanifestedArtifactInS3RefusesToServe() {
+        String tenantId = "ten-unman";
+        String namespaceId = "018f9b8c000070008000000000000092";
+        stageValidSnapshot(tenantId, namespaceId, 1L, 50L, "flat");
+
+        // Plant an unmanifested payload in the snapshot prefix
+        String s3Prefix = "snapshots/" + tenantId + "/" + namespaceId + "/1/";
+        s3Client.putObject(BUCKET, s3Prefix + "rogue-unmanifested.bin", "rogue-bytes".getBytes(StandardCharsets.UTF_8), null, null);
+
+        Path restoreBase = tempDir.resolve("unman-test");
+        assertThatThrownBy(() -> restorer.restoreNamespace(
+                tenantId, namespaceId, 1L, restoreBase, STANDBY_REGION
+        )).isInstanceOf(IntegrityVerificationException.class)
+          .satisfies(e -> {
+              IntegrityVerificationException ive = (IntegrityVerificationException) e;
+              assertThat(ive.getFailureMode()).isEqualTo("UNMANIFESTED_ARTIFACT");
+          });
+    }
+
+    @Test
+    @DisplayName("G32: Erased namespace with tombstone marker in DR bucket REFUSES restore and discovery")
+    void testErasedNamespaceRefusesRestoreAndDiscovery() {
+        String tenantId = "ten-erased";
+        String namespaceId = "018f9b8c000070008000000000000093";
+        stageValidSnapshot(tenantId, namespaceId, 1L, 100L, "flat");
+
+        // Plant tombstone marker in DR bucket
+        s3Client.putObject(BUCKET, "snapshots/.tombstones/" + namespaceId,
+                "{\"erased\":true}".getBytes(StandardCharsets.UTF_8), null, null);
+
+        // 1. Discovery returns empty
+        List<Long> epochs = restorer.discoverSelectableEpochs(tenantId, namespaceId);
+        assertThat(epochs).isEmpty();
+
+        // 2. Restore throws IntegrityVerificationException
+        Path restoreBase = tempDir.resolve("erased-test");
+        assertThatThrownBy(() -> restorer.restoreNamespace(
+                tenantId, namespaceId, 1L, restoreBase, STANDBY_REGION
+        )).isInstanceOf(IntegrityVerificationException.class)
+          .satisfies(e -> {
+              IntegrityVerificationException ive = (IntegrityVerificationException) e;
+              assertThat(ive.getFailureMode()).isEqualTo("NAMESPACE_ALREADY_ERASED");
+          });
+    }
+
+    @Test
+    @DisplayName("G33: restorePrioritized provides error isolation across requests")
+    void testPrioritizedRestoreErrorIsolation() {
+        String tenantGood = "ten-good";
+        String nsGood = "018f9b8c000070008000000000000094";
+        stageValidSnapshot(tenantGood, nsGood, 1L, 100L, "flat");
+
+        String tenantBad = "ten-bad";
+        String nsBad = "018f9b8c000070008000000000000095"; // No snapshot staged in S3
+
+        List<DisasterRecoveryRestorer.RestoreRequest> requests = List.of(
+                new DisasterRecoveryRestorer.RestoreRequest(tenantBad, nsBad, 1L, 100, STANDBY_REGION),
+                new DisasterRecoveryRestorer.RestoreRequest(tenantGood, nsGood, 1L, 50, STANDBY_REGION)
+        );
+
+        Path restoreBase = tempDir.resolve("prioritized-isolation");
+        List<DisasterRecoveryRestorer.RestoreResult> results = restorer.restorePrioritized(requests, restoreBase);
+
+        assertThat(results).hasSize(2);
+        // Bad request failed
+        assertThat(results.get(0).namespaceId()).isEqualTo(nsBad);
+        assertThat(results.get(0).success()).isFalse();
+        assertThat(results.get(0).refusalReason()).isNotNull();
+
+        // Good request succeeded despite bad request running first
+        assertThat(results.get(1).namespaceId()).isEqualTo(nsGood);
+        assertThat(results.get(1).success()).isTrue();
+    }
+
+    @Test
+    @DisplayName("G32: Full NamespaceRecord metadata and legalHold restored verbatim cross-cell")
+    void testCatalogMetadataRestoredVerbatim() throws IOException {
+        String tenantId = "ten-meta";
+        String namespaceId = "018f9b8c000070008000000000000096";
+
+        Path sourceDir = tempDir.resolve("meta-source").resolve("namespaces").resolve(namespaceId);
+        Files.createDirectories(sourceDir);
+        Files.writeString(sourceDir.resolve(StoragePaths.FILE_NAMESPACE), "{\"namespaceId\":\"" + namespaceId + "\",\"pathHelper\":\"flat\"}");
+
+        ByteBuffer ptBuf = ByteBuffer.allocate(64);
+        ptBuf.putInt(RegionPreamble.MAGIC);
+        Files.write(sourceDir.resolve("part-active.spct"), ptBuf.array());
+
+        // Create authoritative catalog entry with legalHold=true and custom description in source catalog
+        accountCatalog.getOrCreateAccount(tenantId);
+        NamespaceRecord sourceRecord = new NamespaceRecord(
+                namespaceId,
+                "vault-slug",
+                tenantId,
+                NamespaceType.PROJECT,
+                com.spectrayan.spector.synapse.catalog.NamespaceStatus.ACTIVE,
+                "Classified Vault",
+                "Mission-critical namespace",
+                null,
+                Instant.now(),
+                Instant.now(),
+                true // legalHold = true!
+        );
+        accountCatalog.importNamespace(sourceRecord);
+
+        // Export with catalog metadata
+        DisasterRecoveryProperties props = new DisasterRecoveryProperties();
+        DisasterRecoveryExporter exporter = new DisasterRecoveryExporter(s3Client, props, BUCKET, accountCatalog);
+        DisasterRecoveryExporter.ExportResult expResult = exporter.exportNamespace(
+                sourceDir, tenantId, namespaceId, STANDBY_REGION, 1L, 500L
+        );
+        assertThat(expResult.success()).isTrue();
+
+        // Standby cell with fresh catalog
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        AccountCatalog standbyCatalog = new FileAccountCatalog(tempDir.resolve("standby-catalog"), mapper);
+        DisasterRecoveryRestorer standbyRestorer = new DisasterRecoveryRestorer(s3Client, BUCKET, STANDBY_REGION, standbyCatalog);
+
+        Path standbyBase = tempDir.resolve("meta-standby");
+        DisasterRecoveryRestorer.RestoreResult resResult = standbyRestorer.restoreNamespace(
+                tenantId, namespaceId, 1L, standbyBase, STANDBY_REGION
+        );
+
+        assertThat(resResult.success()).isTrue();
+
+        // Verify catalog record restored verbatim
+        Optional<NamespaceRecord> restoredOpt = standbyCatalog.resolve(tenantId, "vault-slug");
+        assertThat(restoredOpt).isPresent();
+        NamespaceRecord restored = restoredOpt.get();
+        assertThat(restored.namespaceId()).isEqualTo(namespaceId);
+        assertThat(restored.displayName()).isEqualTo("Classified Vault");
+        assertThat(restored.description()).isEqualTo("Mission-critical namespace");
+        assertThat(restored.legalHold()).as("Legal hold must be preserved cross-cell").isTrue();
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses all Disaster Recovery (DR) export and restore correctness findings (G26–G29, G32–G35) from the Phase 6 Code Review across `spector-memory` and `spector-synapse`.

### Key Changes
1. **G26: Atomic Directory Swap on Restore**:
   - `DisasterRecoveryRestorer` stages downloaded and verified artifacts into an isolated `{namespaceId}.restoring/` staging directory.
   - Upon full verification, performs an atomic directory swap into the target live directory (safely swapping out any existing target into `.old.<timestamp>` before promotion).
   - In case of failure, writes a `restore.failed` sentinel and purges corrupt partial files.
2. **G27: Recursive Subdirectory Traversal for Exports**:
   - `DisasterRecoveryExporter` replaced shallow `Files.list` with `Files.walk`, preserving relative hierarchy (`DIR_RUNTIME/FILE_RUNTIME_BUNDLE`, `DIR_PARTITIONS/...`) in S3 keys.
3. **G28 & G33: Manifest Verification & Unmanifested Artifact Rejection**:
   - Populates manifest with all exported payload files and SHA-256 digests; removed fallback fabricating active partition.
   - Restorer validates object store files against manifest entries and strictly throws `IntegrityVerificationException("UNMANIFESTED_ARTIFACT")` when rogue/unmanifested files exist.
   - Staging resumability: skips re-downloading files in staging that already match manifest SHA-256 digests.
4. **G29: Dynamic Export Cycle & RPO Measurement**:
   - Added `exportCycle(List<ActiveNamespaceTarget>)` that skips idle namespaces where current HWM matches last exported HWM.
   - Measures per-namespace wall-clock elapsed export duration and exposes `getMeasuredP99RpoSeconds()`.
5. **G32: Cross-Cell Catalog Sync & Erasure Tombstones**:
   - `AccountCatalog` interface and implementations (`FileAccountCatalog`, `JdbcAccountCatalog`) extended with `importNamespace(NamespaceRecord)`, restoring full authoritative records (including `legalHold`, `displayName`, `description`, timestamps) cross-cell.
   - DR restore deserializes `NamespaceRecord` and restores it verbatim into the standby cell catalog; catalog failure halts restore with fatal error.
   - `TenantErasureService` places a tombstone marker in the DR bucket at `snapshots/.tombstones/{namespaceId}` upon namespace erasure; `DisasterRecoveryRestorer` refuses restore with `NAMESPACE_ALREADY_ERASED` and excludes erased namespaces from selectable epoch discovery.
6. **G34: S3 Object Listing Continuation Pagination**:
   - `S3CompatibleObjectStoreClient` now parses `<IsTruncated>` and `<NextContinuationToken>` in `parseS3ListResponse`.
   - `listKeysByPrefix` paginates using `&continuation-token=`.
   - `deleteByPrefix` performs multi-pass deletion until the prefix is completely drained.
7. **G35: Immutable Export Prefix Isolation**:
   - Snapshot export prefixes use immutable run keys `snapshots/{tenant}/{ns}/{epoch}-{runId}/` to prevent overwriting prior runs at the same epoch. Restorer selects the highest-epoch, latest-completed run.

## Validation
- `S3CompatibleObjectStoreClientTest`: verified continuation token pagination and multi-pass deletion.
- `DisasterRecoveryExporterTest`: verified recursive export, idle namespace skipping, RPO measurement, and immutable run prefixes.
- `DisasterRecoveryRestorerTest`: verified atomic swap, unmanifested artifact rejection, erased namespace refusal, error isolation across prioritized requests, and verbatim catalog metadata restoration.
- All unit and integration test suites pass cleanly.

Fixes #856
