### PR TITLE
fix(routing): address routing availability findings G38-G50

### DIFF
--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/OwnershipResolver.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/OwnershipResolver.java
@@ -96,6 +96,11 @@ public final class OwnershipResolver {
                 throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
                         "membership", "membership must not be empty for role " + identity.role() + " (Req R7.3, L2)");
             }
+            if (identity.role() == NodeRole.OWNER && !membership.members().contains(identity.nodeId())) {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                        "membership", "Node with role OWNER ('" + identity.nodeId()
+                                + "') must be present in membership members: " + membership.members() + " (G42)");
+            }
             ConsistentHashRing ring = ConsistentHashRing.of(membership.ringVersion(), membership.members());
             this.ringRef.set(ring);
             log.info("Initialized OwnershipResolver for cell '{}', node '{}', role '{}' with ring version {} and members: {}",
@@ -116,6 +121,11 @@ public final class OwnershipResolver {
         if (newMembership.members().isEmpty()) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
                     "membership", "membership must not be empty for role " + identity.role());
+        }
+        if (identity.role() == NodeRole.OWNER && !newMembership.members().contains(identity.nodeId())) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                    "membership", "Node with role OWNER ('" + identity.nodeId()
+                            + "') must be present in reloaded membership members: " + newMembership.members() + " (G42)");
         }
         ConsistentHashRing newRing = ConsistentHashRing.of(newMembership.ringVersion(), newMembership.members());
         ringRef.set(newRing);
@@ -221,5 +231,14 @@ public final class OwnershipResolver {
      */
     public Optional<ConsistentHashRing> ring() {
         return Optional.ofNullable(ringRef.get());
+    }
+
+    /**
+     * Returns the current hash ring, or null if standalone (G39).
+     *
+     * @return current hash ring
+     */
+    public ConsistentHashRing currentRing() {
+        return ringRef.get();
     }
 }

--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/ClusterValidation.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/ClusterValidation.java
@@ -51,7 +51,7 @@ public final class ClusterValidation {
         }
         for (int i = 0; i < namespaceId.length(); i++) {
             char c = namespaceId.charAt(i);
-            if (c == '/' || c == '\\' || c == '.' || c <= '\u001F') {
+            if (c == '/' || c == '\\' || c == '.' || c == '{' || c == '}' || c == ':' || c <= '\u001F') {
                 throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
                         "namespace identifier", "illegal character at index " + i
                                 + " (code point U+" + String.format("%04X", (int) c) + ")");
@@ -72,6 +72,32 @@ public final class ClusterValidation {
         if (!tenantId.equals(tenantId.toLowerCase(Locale.ROOT))) {
             throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
                     "namespace identifier", "tenant identifier must be lowercase");
+        }
+    }
+
+    /**
+     * Validates a cell identifier that is about to become a routing key component (G46).
+     *
+     * @param cellId the cell identifier to validate
+     * @throws SpectorValidationException if the identifier is invalid
+     */
+    public static void validateCellId(String cellId) {
+        if (cellId == null || cellId.isBlank()) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                    "cell identifier", "must not be null, empty, or whitespace-only");
+        }
+        if (cellId.length() > MAX_IDENTIFIER_LENGTH) {
+            throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                    "cell identifier", "length " + cellId.length()
+                            + " exceeds maximum of " + MAX_IDENTIFIER_LENGTH + " characters");
+        }
+        for (int i = 0; i < cellId.length(); i++) {
+            char c = cellId.charAt(i);
+            if (c == '/' || c == '\\' || c == '.' || c == '{' || c == '}' || c == ':' || c <= '\u001F') {
+                throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                        "cell identifier", "illegal character at index " + i
+                                + " (code point U+" + String.format("%04X", (int) c) + ")");
+            }
         }
     }
 }

--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/ConsistentHashRing.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/ConsistentHashRing.java
@@ -167,20 +167,32 @@ public final class ConsistentHashRing {
         return ringOwners[idx];
     }
 
+    private static final ThreadLocal<MessageDigest> SHA_256 = ThreadLocal.withInitial(() -> {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 message digest algorithm not found", e);
+        }
+    });
+
     /**
-     * Computes the 64-bit cryptographic digest using SHA-256 truncated to 8 bytes (Req R2.3, ADR §15.2).
+     * Computes the 64-bit cryptographic digest using SHA-256 truncated to 8 bytes (Req R2.3, ADR §15.2, G50).
      *
      * @param value input string
      * @return 64-bit integer hash
      */
     public static long hash64(String value) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
-            return ByteBuffer.wrap(digest).getLong();
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 message digest algorithm not found", e);
-        }
+        MessageDigest md = SHA_256.get();
+        md.reset();
+        byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
+        return (((long) digest[0] & 0xFF) << 56)
+                | (((long) digest[1] & 0xFF) << 48)
+                | (((long) digest[2] & 0xFF) << 40)
+                | (((long) digest[3] & 0xFF) << 32)
+                | (((long) digest[4] & 0xFF) << 24)
+                | (((long) digest[5] & 0xFF) << 16)
+                | (((long) digest[6] & 0xFF) << 8)
+                | (((long) digest[7] & 0xFF));
     }
 
     public int ringVersion() {

--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/RoutingKey.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/RoutingKey.java
@@ -39,6 +39,8 @@ public record RoutingKey(String cellId, String tenantId, String namespaceId) {
     public static final String NULL_TENANT_SENTINEL = "__NULL_TENANT__";
 
     public RoutingKey {
+        cellId = (cellId != null && !cellId.isBlank()) ? cellId.trim() : "default";
+        ClusterValidation.validateCellId(cellId);
         Objects.requireNonNull(namespaceId, "namespaceId must not be null");
         ClusterValidation.validateNamespaceId(namespaceId);
         if (tenantId != null) {

--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/cache/LettuceRedisRoutingCache.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/cache/LettuceRedisRoutingCache.java
@@ -32,11 +32,14 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 /**
  * Lettuce-based implementation of {@link RedisRoutingCache} with fast-fail timeout,
@@ -55,19 +58,38 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
             "  return 0\n" +
             "end";
 
+    public static final Duration DEFAULT_PROBE_INTERVAL = Duration.ofSeconds(5);
+
     private final RedisClient client;
+    private final boolean ownsClientLifecycle;
     private final StatefulRedisConnection<String, String> connection;
     private final RedisAsyncCommands<String, String> asyncCommands;
     private final long timeoutMs;
     private final RoutingMetricsListener metricsListener;
     private final String sanitizedUri;
     private final AtomicBoolean isDegraded = new AtomicBoolean(false);
+    private final AtomicLong degradedSinceNanos = new AtomicLong(0L);
+    private final long probeIntervalNanos;
+    private final LongSupplier nanoTimeSupplier;
 
     public LettuceRedisRoutingCache(String redisUri, long timeoutMs, RoutingMetricsListener metricsListener) {
+        this(redisUri, timeoutMs, metricsListener, DEFAULT_PROBE_INTERVAL, System::nanoTime);
+    }
+
+    public LettuceRedisRoutingCache(
+            String redisUri,
+            long timeoutMs,
+            RoutingMetricsListener metricsListener,
+            Duration probeInterval,
+            LongSupplier nanoTimeSupplier
+    ) {
         Objects.requireNonNull(redisUri, "redisUri must not be null");
         this.timeoutMs = Math.max(10L, timeoutMs);
         this.metricsListener = metricsListener != null ? metricsListener : RoutingMetricsListener.NOOP;
         this.sanitizedUri = sanitizeUri(redisUri);
+        this.probeIntervalNanos = (probeInterval != null ? probeInterval : DEFAULT_PROBE_INTERVAL).toNanos();
+        this.nanoTimeSupplier = nanoTimeSupplier != null ? nanoTimeSupplier : System::nanoTime;
+        this.ownsClientLifecycle = true;
 
         RedisURI uri = RedisURI.create(redisUri);
         uri.setTimeout(Duration.ofMillis(this.timeoutMs));
@@ -91,15 +113,67 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
     }
 
     /**
+     * Constructor using a shared RedisClient (G49).
+     */
+    public LettuceRedisRoutingCache(
+            RedisClient client,
+            String redisUri,
+            long timeoutMs,
+            RoutingMetricsListener metricsListener
+    ) {
+        this(client, redisUri, timeoutMs, metricsListener, DEFAULT_PROBE_INTERVAL, System::nanoTime);
+    }
+
+    public LettuceRedisRoutingCache(
+            RedisClient client,
+            String redisUri,
+            long timeoutMs,
+            RoutingMetricsListener metricsListener,
+            Duration probeInterval,
+            LongSupplier nanoTimeSupplier
+    ) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+        this.timeoutMs = Math.max(10L, timeoutMs);
+        this.metricsListener = metricsListener != null ? metricsListener : RoutingMetricsListener.NOOP;
+        this.sanitizedUri = redisUri != null ? sanitizeUri(redisUri) : "shared://redis";
+        this.probeIntervalNanos = (probeInterval != null ? probeInterval : DEFAULT_PROBE_INTERVAL).toNanos();
+        this.nanoTimeSupplier = nanoTimeSupplier != null ? nanoTimeSupplier : System::nanoTime;
+        this.ownsClientLifecycle = false;
+
+        StatefulRedisConnection<String, String> conn = null;
+        try {
+            conn = this.client.connect();
+        } catch (Exception e) {
+            handleFailure(e, "initial connection");
+        }
+
+        this.connection = conn;
+        this.asyncCommands = this.connection != null ? this.connection.async() : null;
+    }
+
+    /**
      * Package-private constructor for unit testing with a mock or existing connection.
      */
     LettuceRedisRoutingCache(StatefulRedisConnection<String, String> connection, long timeoutMs, RoutingMetricsListener metricsListener) {
+        this(connection, timeoutMs, metricsListener, DEFAULT_PROBE_INTERVAL, System::nanoTime);
+    }
+
+    LettuceRedisRoutingCache(
+            StatefulRedisConnection<String, String> connection,
+            long timeoutMs,
+            RoutingMetricsListener metricsListener,
+            Duration probeInterval,
+            LongSupplier nanoTimeSupplier
+    ) {
         this.client = null;
+        this.ownsClientLifecycle = false;
         this.connection = connection;
         this.asyncCommands = connection != null ? connection.async() : null;
         this.timeoutMs = Math.max(10L, timeoutMs);
         this.metricsListener = metricsListener != null ? metricsListener : RoutingMetricsListener.NOOP;
         this.sanitizedUri = "mock://redis";
+        this.probeIntervalNanos = (probeInterval != null ? probeInterval : DEFAULT_PROBE_INTERVAL).toNanos();
+        this.nanoTimeSupplier = nanoTimeSupplier != null ? nanoTimeSupplier : System::nanoTime;
     }
 
     @Override
@@ -117,9 +191,40 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
             }
 
             String ownerId = hash.get("owner");
-            long epoch = parseLongSafely(hash.get("epoch"), 1L);
-            String modeStr = hash.getOrDefault("mode", "HASH");
-            RouteMode mode = parseModeSafely(modeStr);
+            if (ownerId == null || ownerId.isBlank()) {
+                handleSuccess();
+                return Optional.empty();
+            }
+
+            // G47: treat missing or unparseable epoch/mode as cache miss
+            String epochStr = hash.get("epoch");
+            if (epochStr == null || epochStr.isBlank()) {
+                handleSuccess();
+                return Optional.empty();
+            }
+            long epoch;
+            try {
+                epoch = Long.parseLong(epochStr.trim());
+            } catch (NumberFormatException e) {
+                log.warn("Corrupt epoch '{}' for key {}; treating as cache miss (G47)", epochStr, key.keyMaterial());
+                handleSuccess();
+                return Optional.empty();
+            }
+
+            String modeStr = hash.get("mode");
+            if (modeStr == null || modeStr.isBlank()) {
+                handleSuccess();
+                return Optional.empty();
+            }
+            RouteMode mode;
+            try {
+                mode = RouteMode.valueOf(modeStr.trim().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                log.warn("Corrupt route mode '{}' for key {}; treating as cache miss (G47)", modeStr, key.keyMaterial());
+                handleSuccess();
+                return Optional.empty();
+            }
+
             String fence = hash.get("fence");
             Long hwm = hash.containsKey("hwm") ? parseLongSafely(hash.get("hwm"), 0L) : null;
 
@@ -196,10 +301,23 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
 
     @Override
     public boolean isAvailable() {
-        return connection != null && connection.isOpen() && !isDegraded.get();
+        if (connection == null || !connection.isOpen()) {
+            return false;
+        }
+        if (!isDegraded.get()) {
+            return true;
+        }
+        // G38: If degraded, allow a probe retry once probeInterval has elapsed
+        long since = degradedSinceNanos.get();
+        return since > 0 && (nanoTimeSupplier.getAsLong() - since) >= probeIntervalNanos;
+    }
+
+    public boolean isDegraded() {
+        return isDegraded.get();
     }
 
     private void handleSuccess() {
+        degradedSinceNanos.set(0L);
         if (isDegraded.compareAndSet(true, false)) {
             log.info("Redis routing cache connectivity restored ({}); resuming distributed L2 lookups", sanitizedUri);
             metricsListener.recordDegradationTransition(false);
@@ -207,6 +325,7 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
     }
 
     private void handleFailure(Exception e, String op) {
+        degradedSinceNanos.set(nanoTimeSupplier.getAsLong());
         if (isDegraded.compareAndSet(false, true)) {
             log.warn("Redis routing cache unreachable during {} ({}): {}; degrading to ConsistentHashRing fallback (Req R6.5)",
                     op, sanitizedUri, e.getMessage());
@@ -236,7 +355,7 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
     private static RouteMode parseModeSafely(String modeStr) {
         if (modeStr == null || modeStr.isBlank()) return RouteMode.HASH;
         try {
-            return RouteMode.valueOf(modeStr.trim().toUpperCase());
+            return RouteMode.valueOf(modeStr.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             return RouteMode.HASH;
         }
@@ -250,7 +369,7 @@ public class LettuceRedisRoutingCache implements RedisRoutingCache {
             }
         } catch (Exception ignored) {}
         try {
-            if (client != null) {
+            if (client != null && ownsClientLifecycle) {
                 client.shutdown();
             }
         } catch (Exception ignored) {}

--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/cache/WaterfallRoutingResolver.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/cache/WaterfallRoutingResolver.java
@@ -20,6 +20,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.spectrayan.spector.cluster.routing.ConsistentHashRing;
 import com.spectrayan.spector.cluster.routing.ResolvedRoute;
 import com.spectrayan.spector.cluster.routing.RouteBinding;
+import com.spectrayan.spector.cluster.routing.RouteMode;
 import com.spectrayan.spector.cluster.routing.RouteSource;
 import com.spectrayan.spector.cluster.routing.RoutingKey;
 import com.spectrayan.spector.cluster.routing.RoutingMetricsListener;
@@ -31,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Supplier;
 
 /**
  * Three-tier routing waterfall: L1 Caffeine → L2 Redis → L3 Ketama ConsistentHashRing
@@ -46,7 +48,7 @@ public class WaterfallRoutingResolver {
 
     private final Cache<RoutingKey, RouteBinding> caffeineCache;
     private final RedisRoutingCache redisCache;
-    private final ConsistentHashRing ring;
+    private final Supplier<ConsistentHashRing> ringSupplier;
     private final long redisTtlSeconds;
     private final RoutingMetricsListener metricsListener;
     private final Executor writeBehindExecutor;
@@ -60,7 +62,27 @@ public class WaterfallRoutingResolver {
             RoutingMetricsListener metricsListener,
             Executor writeBehindExecutor
     ) {
-        this.ring = Objects.requireNonNull(ring, "ring must not be null (K4)");
+        this(
+                () -> Objects.requireNonNull(ring, "ring must not be null (K4)"),
+                redisCache,
+                caffeineTtl,
+                caffeineMaxSize,
+                redisTtlSeconds,
+                metricsListener,
+                writeBehindExecutor
+        );
+    }
+
+    public WaterfallRoutingResolver(
+            Supplier<ConsistentHashRing> ringSupplier,
+            RedisRoutingCache redisCache,
+            Duration caffeineTtl,
+            long caffeineMaxSize,
+            long redisTtlSeconds,
+            RoutingMetricsListener metricsListener,
+            Executor writeBehindExecutor
+    ) {
+        this.ringSupplier = Objects.requireNonNull(ringSupplier, "ringSupplier must not be null (G39)");
         this.redisCache = redisCache;
         this.redisTtlSeconds = Math.max(1L, redisTtlSeconds);
         this.metricsListener = metricsListener != null ? metricsListener : RoutingMetricsListener.NOOP;
@@ -98,18 +120,27 @@ public class WaterfallRoutingResolver {
             return new ResolvedRoute(l1Hit, RouteSource.CAFFEINE);
         }
 
-        // ── Tier 2: Distributed L2 Redis ──
+        // ── Tier 2: Distributed L2 Redis (Structurally protected for G41) ──
         if (redisCache != null && redisCache.isAvailable()) {
-            Optional<RouteBinding> l2Hit = redisCache.get(key);
-            if (l2Hit.isPresent()) {
-                RouteBinding binding = l2Hit.get();
-                caffeineCache.put(key, binding);
-                metricsListener.recordLookup(RouteSource.REDIS);
-                return new ResolvedRoute(binding, RouteSource.REDIS);
+            try {
+                Optional<RouteBinding> l2Hit = redisCache.get(key);
+                if (l2Hit.isPresent()) {
+                    RouteBinding binding = l2Hit.get();
+                    caffeineCache.put(key, binding);
+                    metricsListener.recordLookup(RouteSource.REDIS);
+                    return new ResolvedRoute(binding, RouteSource.REDIS);
+                }
+            } catch (RuntimeException e) {
+                log.warn("Redis L2 lookup failed for {}; falling through to Tier 3 Ketama ring (G41): {}",
+                        key.keyMaterial(), e.getMessage());
             }
         }
 
         // ── Tier 3: Ketama Ring Fallback (Authoritative, Pure Computation, Invariant K4) ──
+        ConsistentHashRing ring = ringSupplier.get();
+        if (ring == null) {
+            throw new IllegalStateException("ConsistentHashRing is not available for routing key " + key.keyMaterial() + " (G39)");
+        }
         String ownerNodeId = ring.ownerOf(key);
         RouteBinding ringBinding = RouteBinding.ofHash(key, ownerNodeId, ring.ringVersion());
 
@@ -143,7 +174,30 @@ public class WaterfallRoutingResolver {
     }
 
     /**
-     * Invalidates the key from both local Caffeine and distributed Redis caches.
+     * Invalidates the key from local Caffeine cache, and if present in Redis as mode=HASH,
+     * evicts it from Redis without touching any OVERRIDE bindings (G40).
+     *
+     * @param key the routing key
+     */
+    public void invalidateIfHash(RoutingKey key) {
+        if (key != null) {
+            caffeineCache.invalidate(key);
+            if (redisCache != null && redisCache.isAvailable()) {
+                try {
+                    Optional<RouteBinding> cached = redisCache.get(key);
+                    if (cached.isPresent() && cached.get().mode() == RouteMode.HASH) {
+                        redisCache.invalidate(key);
+                    }
+                } catch (Exception e) {
+                    log.debug("Failed to check/evict hash route from Redis: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Invalidates the key from both local Caffeine and distributed Redis caches,
+     * and publishes cross-node invalidation (Req R4.1, G44).
      *
      * @param key the routing key
      */
@@ -152,6 +206,8 @@ public class WaterfallRoutingResolver {
             caffeineCache.invalidate(key);
             if (redisCache != null && redisCache.isAvailable()) {
                 redisCache.invalidate(key);
+                long ringVersion = ring() != null ? ring().ringVersion() : 1L;
+                redisCache.publishInvalidation(key.cellId(), key.keyMaterial(), ringVersion, "invalidateAll");
             }
         }
     }
@@ -160,7 +216,7 @@ public class WaterfallRoutingResolver {
      * @return the underlying consistent hash ring
      */
     public ConsistentHashRing ring() {
-        return ring;
+        return ringSupplier != null ? ringSupplier.get() : null;
     }
 
     /**

--- a/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/invalidation/RoutingInvalidationSubscriber.java
+++ b/cluster/spector-cluster/src/main/java/com/spectrayan/spector/cluster/routing/invalidation/RoutingInvalidationSubscriber.java
@@ -25,6 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -46,7 +49,8 @@ public class RoutingInvalidationSubscriber extends RedisPubSubAdapter<String, St
     private final RoutingMetricsListener metricsListener;
 
     private final RedisClient client;
-    private final StatefulRedisPubSubConnection<String, String> connection;
+    private volatile StatefulRedisPubSubConnection<String, String> connection;
+    private final ScheduledExecutorService retryScheduler;
 
     private final AtomicBoolean subscribed = new AtomicBoolean(false);
     private final AtomicLong unsubscribedSince = new AtomicLong(0L);
@@ -74,6 +78,7 @@ public class RoutingInvalidationSubscriber extends RedisPubSubAdapter<String, St
         this.resolver = Objects.requireNonNull(resolver, "resolver must not be null");
         this.metricsListener = metricsListener != null ? metricsListener : RoutingMetricsListener.NOOP;
         this.client = null;
+        this.retryScheduler = null;
 
         this.connection.addListener(this);
     }
@@ -109,19 +114,42 @@ public class RoutingInvalidationSubscriber extends RedisPubSubAdapter<String, St
             this.metricsListener.recordPubSubUnsubscribedTransition(true);
         }
         this.connection = conn;
+
+        this.retryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "routing-invalidation-subscriber-reconnect");
+            t.setDaemon(true);
+            return t;
+        });
+        this.retryScheduler.scheduleWithFixedDelay(this::ensureSubscribed, 5, 5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Attempts to connect and subscribe to the cell invalidation channel if currently unsubscribed.
+     */
+    public synchronized void ensureSubscribed() {
+        if (subscribed.get()) {
+            return;
+        }
+        try {
+            if (connection == null || !connection.isOpen()) {
+                if (client != null) {
+                    connection = client.connectPubSub();
+                    connection.addListener(this);
+                }
+            }
+            if (connection != null && connection.isOpen()) {
+                connection.async().subscribe(channelName);
+            }
+        } catch (Exception e) {
+            log.debug("Periodic reconnect/subscribe to channel {} failed: {}", channelName, e.getMessage());
+        }
     }
 
     /**
      * Subscribes to the cell invalidation channel.
      */
     public void start() {
-        if (connection != null && connection.isOpen()) {
-            try {
-                connection.async().subscribe(channelName);
-            } catch (Exception e) {
-                log.warn("Failed to subscribe to channel {}: {}", channelName, e.getMessage());
-            }
-        }
+        ensureSubscribed();
     }
 
     @Override
@@ -205,6 +233,9 @@ public class RoutingInvalidationSubscriber extends RedisPubSubAdapter<String, St
 
     @Override
     public void close() {
+        if (retryScheduler != null) {
+            retryScheduler.shutdownNow();
+        }
         try {
             if (connection != null && connection.isOpen()) {
                 connection.async().unsubscribe(channelName);

--- a/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/OwnershipResolverTest.java
+++ b/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/OwnershipResolverTest.java
@@ -125,4 +125,31 @@ class OwnershipResolverTest {
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("membershipSource must not be null");
     }
+
+    @Test
+    @DisplayName("G42: OWNER role fails closed when nodeId is not present in membership members")
+    void testOwnerRoleFailsClosedWhenNodeIdAbsentFromMembership() {
+        List<String> members = List.of("node-b", "node-c");
+        StaticMembershipSource membership = new StaticMembershipSource("cell-1", 1, members);
+        NodeIdentity ownerIdentity = new NodeIdentity("cell-1", "node-absent", NodeRole.OWNER);
+
+        assertThatThrownBy(() -> new OwnershipResolver(ownerIdentity, membership))
+                .isInstanceOf(SpectorValidationException.class)
+                .hasMessageContaining("must be present in membership members");
+    }
+
+    @Test
+    @DisplayName("G42: OWNER reloadRing fails closed when nodeId is missing from updated membership")
+    void testOwnerReloadRingFailsClosedWhenNodeIdMissing() {
+        List<String> members = List.of("node-a", "node-b");
+        StaticMembershipSource membership = new StaticMembershipSource("cell-1", 1, members);
+        OwnershipResolver resolver = new OwnershipResolver(new NodeIdentity("cell-1", "node-a", NodeRole.OWNER), membership);
+
+        com.spectrayan.spector.cluster.membership.CellMembership newMembership =
+                new com.spectrayan.spector.cluster.membership.CellMembership("cell-1", 2, List.of("node-b", "node-c"));
+
+        assertThatThrownBy(() -> resolver.reloadRing(newMembership))
+                .isInstanceOf(SpectorValidationException.class)
+                .hasMessageContaining("must be present in reloaded membership members");
+    }
 }

--- a/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/routing/RoutingKeyFormatTest.java
+++ b/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/routing/RoutingKeyFormatTest.java
@@ -80,5 +80,42 @@ class RoutingKeyFormatTest {
 
         assertThatThrownBy(() -> new RoutingKey("cell-1", "TENANT_UPPER", "ns-123"))
                 .isInstanceOf(com.spectrayan.spector.commons.error.SpectorValidationException.class);
+
+        // G46: Reject '{', '}', ':' in namespace, tenant, and cell
+        assertThatThrownBy(() -> new RoutingKey("cell-1", "tenant-1", "ns{123}"))
+                .isInstanceOf(com.spectrayan.spector.commons.error.SpectorValidationException.class);
+        assertThatThrownBy(() -> new RoutingKey("cell-1", "a}b", "ns-123"))
+                .isInstanceOf(com.spectrayan.spector.commons.error.SpectorValidationException.class);
+        assertThatThrownBy(() -> new RoutingKey("cell:1", "tenant-1", "ns-123"))
+                .isInstanceOf(com.spectrayan.spector.commons.error.SpectorValidationException.class);
+        assertThatThrownBy(() -> new RoutingKey("cell{1}", "tenant-1", "ns-123"))
+                .isInstanceOf(com.spectrayan.spector.commons.error.SpectorValidationException.class);
+        assertThatThrownBy(() -> new RoutingKey("cell/1", "tenant-1", "ns-123"))
+                .isInstanceOf(com.spectrayan.spector.commons.error.SpectorValidationException.class);
+    }
+
+    @Test
+    @DisplayName("G44: Null/blank cellId normalizes to 'default' and equals instance with 'default'")
+    void cellIdNormalizationAndEquality() {
+        RoutingKey keyNull = new RoutingKey(null, "tenant-1", "ns-123");
+        RoutingKey keyBlank = new RoutingKey("   ", "tenant-1", "ns-123");
+        RoutingKey keyExplicit = new RoutingKey("default", "tenant-1", "ns-123");
+
+        assertThat(keyNull.cellId()).isEqualTo("default");
+        assertThat(keyBlank.cellId()).isEqualTo("default");
+        assertThat(keyNull).isEqualTo(keyExplicit);
+        assertThat(keyBlank).isEqualTo(keyExplicit);
+    }
+
+    @Test
+    @DisplayName("G44: fromKeyMaterial round-trip preserves tenancy and namespace")
+    void fromKeyMaterialRoundTrip() {
+        RoutingKey tenanted = RoutingKey.ofTenanted("cell-1", "acme", "ns-99");
+        RoutingKey fromTenanted = RoutingKey.fromKeyMaterial("cell-1", tenanted.keyMaterial());
+        assertThat(fromTenanted).isEqualTo(tenanted);
+
+        RoutingKey untenanted = RoutingKey.ofUntenanted("cell-1", "ns-99");
+        RoutingKey fromUntenanted = RoutingKey.fromKeyMaterial("cell-1", untenanted.keyMaterial());
+        assertThat(fromUntenanted).isEqualTo(untenanted);
     }
 }

--- a/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/routing/cache/ChaosRedisOutageTest.java
+++ b/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/routing/cache/ChaosRedisOutageTest.java
@@ -143,7 +143,8 @@ class ChaosRedisOutageTest {
 
         @Override
         public boolean isAvailable() {
-            return isAlive.get();
+            // G41: Return true even when killed to simulate mid-flight failure during get()
+            return true;
         }
     }
 }

--- a/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/routing/cache/LettuceRedisRoutingCacheTest.java
+++ b/cluster/spector-cluster/src/test/java/com/spectrayan/spector/cluster/routing/cache/LettuceRedisRoutingCacheTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spectrayan.spector.cluster.routing.cache;
+
+import com.spectrayan.spector.cluster.routing.RouteBinding;
+import com.spectrayan.spector.cluster.routing.RouteMode;
+import com.spectrayan.spector.cluster.routing.RoutingKey;
+import com.spectrayan.spector.cluster.routing.RoutingMetricsListener;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Findings G38 & G47: LettuceRedisRoutingCache Recovery and Parse Hardening")
+class LettuceRedisRoutingCacheTest {
+
+    @SuppressWarnings("unchecked")
+    private RedisFuture<Map<String, String>> createMockRedisFuture(AtomicBoolean shouldFail, AtomicReference<Map<String, String>> responseHash) {
+        return (RedisFuture<Map<String, String>>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{RedisFuture.class},
+                (proxy, method, args) -> {
+                    if ("get".equals(method.getName())) {
+                        if (shouldFail != null && shouldFail.get()) {
+                            throw new ExecutionException(new RuntimeException("Redis connection timed out"));
+                        }
+                        return responseHash.get();
+                    }
+                    return null;
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("G38: Transient failure degrades cache but recovers after probe interval")
+    void testTransientFailureDegradesAndRecoversAfterProbeInterval() {
+        AtomicLong simulatedNanos = new AtomicLong(1_000_000_000L);
+        AtomicBoolean shouldFail = new AtomicBoolean(false);
+        AtomicReference<Map<String, String>> responseHash = new AtomicReference<>(
+                Map.of("owner", "node-1", "epoch", "2", "mode", "HASH")
+        );
+
+        @SuppressWarnings("unchecked")
+        RedisAsyncCommands<String, String> asyncCommands = (RedisAsyncCommands<String, String>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{RedisAsyncCommands.class},
+                (proxy, method, args) -> {
+                    if ("hgetall".equals(method.getName())) {
+                        return createMockRedisFuture(shouldFail, responseHash);
+                    }
+                    return null;
+                }
+        );
+
+        @SuppressWarnings("unchecked")
+        StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{StatefulRedisConnection.class},
+                (proxy, method, args) -> {
+                    if ("isOpen".equals(method.getName())) return true;
+                    if ("async".equals(method.getName())) return asyncCommands;
+                    return null;
+                }
+        );
+
+        Duration probeInterval = Duration.ofSeconds(5);
+        LettuceRedisRoutingCache cache = new LettuceRedisRoutingCache(
+                connection,
+                100L,
+                RoutingMetricsListener.NOOP,
+                probeInterval,
+                simulatedNanos::get
+        );
+
+        RoutingKey key = RoutingKey.ofUntenanted("cell-1", "ns-test");
+
+        // 1. Initial healthy state
+        assertThat(cache.isAvailable()).isTrue();
+        assertThat(cache.isDegraded()).isFalse();
+        Optional<RouteBinding> initial = cache.get(key);
+        assertThat(initial).isPresent();
+        assertThat(initial.get().ownerId()).isEqualTo("node-1");
+
+        // 2. Outage strikes: get() throws timeout exception
+        shouldFail.set(true);
+        Optional<RouteBinding> failed = cache.get(key);
+        assertThat(failed).isEmpty();
+        assertThat(cache.isDegraded()).isTrue();
+
+        // 3. Immediately after outage, cache is NOT available (probe interval has not elapsed)
+        simulatedNanos.addAndGet(Duration.ofSeconds(2).toNanos());
+        assertThat(cache.isAvailable()).isFalse();
+
+        // 4. Advance time past probe interval (5 seconds)
+        simulatedNanos.addAndGet(Duration.ofSeconds(4).toNanos()); // total 6 seconds elapsed
+        assertThat(cache.isAvailable()).isTrue(); // Probe window open!
+
+        // 5. Redis has recovered: probe call succeeds
+        shouldFail.set(false);
+        Optional<RouteBinding> recovered = cache.get(key);
+        assertThat(recovered).isPresent();
+        assertThat(recovered.get().ownerId()).isEqualTo("node-1");
+
+        // 6. Verification: degradation is cleared without restart!
+        assertThat(cache.isDegraded()).isFalse();
+        assertThat(cache.isAvailable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("G47: Missing or unparseable epoch or mode treated as cache miss")
+    void testCorruptHashTreatedAsCacheMiss() {
+        AtomicReference<Map<String, String>> responseHash = new AtomicReference<>();
+
+        @SuppressWarnings("unchecked")
+        RedisAsyncCommands<String, String> asyncCommands = (RedisAsyncCommands<String, String>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{RedisAsyncCommands.class},
+                (proxy, method, args) -> {
+                    if ("hgetall".equals(method.getName())) {
+                        return createMockRedisFuture(null, responseHash);
+                    }
+                    return null;
+                }
+        );
+
+        @SuppressWarnings("unchecked")
+        StatefulRedisConnection<String, String> connection = (StatefulRedisConnection<String, String>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{StatefulRedisConnection.class},
+                (proxy, method, args) -> {
+                    if ("isOpen".equals(method.getName())) return true;
+                    if ("async".equals(method.getName())) return asyncCommands;
+                    return null;
+                }
+        );
+
+        LettuceRedisRoutingCache cache = new LettuceRedisRoutingCache(
+                connection,
+                100L,
+                RoutingMetricsListener.NOOP
+        );
+
+        RoutingKey key = RoutingKey.ofUntenanted("cell-1", "ns-corrupt");
+
+        // Missing epoch -> cache miss
+        responseHash.set(Map.of("owner", "node-1", "mode", "HASH"));
+        assertThat(cache.get(key)).isEmpty();
+
+        // Malformed epoch -> cache miss
+        responseHash.set(Map.of("owner", "node-1", "epoch", "abc", "mode", "HASH"));
+        assertThat(cache.get(key)).isEmpty();
+
+        // Missing mode -> cache miss
+        responseHash.set(Map.of("owner", "node-1", "epoch", "1"));
+        assertThat(cache.get(key)).isEmpty();
+
+        // Malformed mode -> cache miss
+        responseHash.set(Map.of("owner", "node-1", "epoch", "1", "mode", "INVALID_MODE"));
+        assertThat(cache.get(key)).isEmpty();
+
+        // Valid hash -> cache hit
+        responseHash.set(Map.of("owner", "node-1", "epoch", "5", "mode", "OVERRIDE"));
+        Optional<RouteBinding> valid = cache.get(key);
+        assertThat(valid).isPresent();
+        assertThat(valid.get().ownerId()).isEqualTo("node-1");
+        assertThat(valid.get().epoch()).isEqualTo(5L);
+        assertThat(valid.get().mode()).isEqualTo(RouteMode.OVERRIDE);
+    }
+}

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/exception/NamespaceNotOwnedException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/exception/NamespaceNotOwnedException.java
@@ -57,4 +57,15 @@ public class NamespaceNotOwnedException extends SynapseException {
     public long epoch() {
         return epoch;
     }
+
+    /**
+     * Machine-readable error details for G45.
+     */
+    public java.util.Map<String, Object> details() {
+        return java.util.Map.of(
+                "namespace", namespaceId != null ? namespaceId : "",
+                "owner", ownerId != null ? ownerId : "",
+                "epoch", epoch
+        );
+    }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/exception/StaleRouteException.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/exception/StaleRouteException.java
@@ -64,4 +64,16 @@ public class StaleRouteException extends SynapseException {
     public long activeEpoch() {
         return activeEpoch;
     }
+
+    /**
+     * Machine-readable error details for G45.
+     */
+    public java.util.Map<String, Object> details() {
+        return java.util.Map.of(
+                "namespace", namespaceId != null ? namespaceId : "",
+                "owner", ownerId != null ? ownerId : "",
+                "epoch", activeEpoch,
+                "staleEpoch", staleEpoch
+        );
+    }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/gateway/GatewayForwarder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/gateway/GatewayForwarder.java
@@ -71,14 +71,29 @@ public class GatewayForwarder {
         Objects.requireNonNull(request, "request must not be null");
 
         int attempts = 0;
+        String explicitTargetOwner = null;
 
         while (true) {
             attempts++;
-            ResolvedRoute resolved = resolver.resolve(routingKey);
-            RouteBinding route = resolved.binding();
-            String ownerId = resolved.ownerId();
-            long epoch = resolved.epoch();
-            RouteSource source = resolved.source();
+            String ownerId;
+            long epoch;
+            RouteSource source;
+            String fence;
+
+            if (explicitTargetOwner != null) {
+                ownerId = explicitTargetOwner;
+                epoch = 0L;
+                fence = "";
+                source = RouteSource.REDIS;
+                explicitTargetOwner = null;
+            } else {
+                ResolvedRoute resolved = resolver.resolve(routingKey);
+                RouteBinding route = resolved.binding();
+                ownerId = resolved.ownerId();
+                epoch = resolved.epoch();
+                source = resolved.source();
+                fence = route.fence() != null ? route.fence() : "";
+            }
 
             String targetBaseUrl = nodeBaseUrlResolver.apply(ownerId);
 
@@ -88,7 +103,7 @@ public class GatewayForwarder {
                 routingHeaders.put(HEADER_TENANT, routingKey.tenantId());
             }
             routingHeaders.put(HEADER_EPOCH, String.valueOf(epoch));
-            routingHeaders.put(HEADER_FENCE, route.fence() != null ? route.fence() : "");
+            routingHeaders.put(HEADER_FENCE, fence);
 
             log.debug("Forwarding request {} to owner '{}' at {} with epoch {} (source={}, attempt={}/{})",
                     request.uriPath(), ownerId, targetBaseUrl, epoch, source, attempts, retryMax + 1);
@@ -97,13 +112,6 @@ public class GatewayForwarder {
 
             // Check for STALE_ROUTE / NOT_OWNER refusal (HTTP 421 Misdirected Request)
             if (response.statusCode() == 421) {
-                // Req R7.6: If route came from degraded path (HASH_FALLBACK), do NOT forward again!
-                if (source == RouteSource.HASH_FALLBACK) {
-                    log.warn("Target node '{}' refused request for namespace '{}' resolved via degraded HASH_FALLBACK; surfacing refusal immediately (Req R7.6)",
-                            ownerId, routingKey.namespaceId());
-                    return new ForwardResponse(response.statusCode(), response.headers(), response.body(), ownerId, attempts);
-                }
-
                 // Check retry bounds (Req R7.4)
                 if (attempts > retryMax) {
                     log.warn("Exhausted bounded retries ({}/{}) for namespace '{}' after node '{}' returned 421; surfacing refusal",
@@ -111,19 +119,51 @@ public class GatewayForwarder {
                     return new ForwardResponse(response.statusCode(), response.headers(), response.body(), ownerId, attempts);
                 }
 
-                // Bounded retry (Req R7.4):
-                // 1. Invalidate local Caffeine L1 cache
+                // G45: Check if refusing node reported the true authoritative owner
+                String reportedOwner = extractReportedOwner(response);
+                if (reportedOwner != null && !reportedOwner.isBlank() && !reportedOwner.equals(ownerId)) {
+                    log.info("Retargeting gateway forward for namespace '{}' directly to reported owner '{}' (was '{}', attempt {}/{})",
+                            routingKey.namespaceId(), reportedOwner, ownerId, attempts, retryMax);
+                    explicitTargetOwner = reportedOwner;
+                } else if (source == RouteSource.HASH_FALLBACK) {
+                    // Req R7.6: If route came from degraded path (HASH_FALLBACK) and node reported no alternative owner, do NOT forward again!
+                    log.warn("Target node '{}' refused request for namespace '{}' resolved via degraded HASH_FALLBACK; surfacing refusal immediately (Req R7.6)",
+                            ownerId, routingKey.namespaceId());
+                    return new ForwardResponse(response.statusCode(), response.headers(), response.body(), ownerId, attempts);
+                } else {
+                    log.info("Retrying gateway forward for namespace '{}' after 421 refusal from node '{}' (attempt {}/{})",
+                            routingKey.namespaceId(), ownerId, attempts, retryMax);
+                }
+
+                // Bounded retry (Req R7.4, G40):
+                // Invalidate local Caffeine L1 cache, and evict Redis ONLY if mode == HASH (never delete shared Redis overrides!)
                 resolver.invalidateLocal(routingKey);
-                // 2. Invalidate distributed Redis cache
-                resolver.invalidateAll(routingKey);
-                // 3. Loop re-resolves and retries, reusing the original idempotency key (Req R7.5, Invariant K7)!
-                log.info("Retrying gateway forward for namespace '{}' after 421 refusal from node '{}' (attempt {}/{})",
-                        routingKey.namespaceId(), ownerId, attempts, retryMax);
+                resolver.invalidateIfHash(routingKey);
                 continue;
             }
 
             return new ForwardResponse(response.statusCode(), response.headers(), response.body(), ownerId, attempts);
         }
+    }
+
+    private static String extractReportedOwner(ForwardResponse response) {
+        if (response.headers() != null) {
+            java.util.List<String> ownerHeaders = response.headers().get("X-Spector-Owner");
+            if (ownerHeaders != null && !ownerHeaders.isEmpty()) {
+                String val = ownerHeaders.get(0);
+                if (val != null && !val.isBlank()) {
+                    return val.trim();
+                }
+            }
+        }
+        if (response.body() != null && response.body().length > 0) {
+            String bodyStr = new String(response.body(), java.nio.charset.StandardCharsets.UTF_8);
+            java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("\"owner\"\\s*:\\s*\"([^\"]+)\"").matcher(bodyStr);
+            if (matcher.find()) {
+                return matcher.group(1).trim();
+            }
+        }
+        return null;
     }
 
     public static Function<String, String> defaultNodeUrlResolver(int defaultPort) {

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/gateway/GatewayForwardingFilter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/cluster/gateway/GatewayForwardingFilter.java
@@ -12,9 +12,12 @@
  */
 package com.spectrayan.spector.synapse.cluster.gateway;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.spectrayan.spector.cluster.node.NodeRole;
 import com.spectrayan.spector.cluster.routing.RoutingKey;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
+import com.spectrayan.spector.synapse.memory.MemoryDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -32,23 +34,40 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Servlet filter that intercepts requests on {@code role=gateway} nodes and forwards them
  * to the authoritative owner node (ADR-0034 §8, Req R7.1).
  */
-@Component
 @Order(Ordered.LOWEST_PRECEDENCE - 20)
 public class GatewayForwardingFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(GatewayForwardingFilter.class);
 
+    public static final int MAX_BUFFERED_BODY_BYTES = 10 * 1024 * 1024; // 10 MB limit (G48)
+    private static final Pattern NAMESPACE_PATH_PATTERN =
+            Pattern.compile("^/api/v1/namespaces/([^/?]+)(?:/.*)?$");
+
     private final SynapseProperties properties;
     private final GatewayForwarder forwarder;
+    private final ObjectMapper objectMapper;
 
     public GatewayForwardingFilter(SynapseProperties properties, GatewayForwarder forwarder) {
+        this(properties, forwarder, defaultObjectMapper());
+    }
+
+    public GatewayForwardingFilter(SynapseProperties properties, GatewayForwarder forwarder, ObjectMapper objectMapper) {
         this.properties = properties;
         this.forwarder = forwarder;
+        this.objectMapper = objectMapper != null ? objectMapper : defaultObjectMapper();
+    }
+
+    private static ObjectMapper defaultObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
     }
 
     @Override
@@ -81,12 +100,23 @@ public class GatewayForwardingFilter extends OncePerRequestFilter {
             return;
         }
 
-        String cellId = properties.getCell().getId();
+        String cellId = properties.getCell() != null ? properties.getCell().getId() : "default";
         String headerNs = request.getHeader(GatewayForwarder.HEADER_NAMESPACE);
         String paramNs = request.getParameter("namespace");
+        String pathNs = null;
+        String reqUri = request.getRequestURI();
+        if (reqUri != null) {
+            Matcher m = NAMESPACE_PATH_PATTERN.matcher(reqUri);
+            if (m.matches()) {
+                pathNs = m.group(1);
+            }
+        }
+
         String namespaceId = (headerNs != null && !headerNs.isBlank())
                 ? headerNs.trim()
-                : (paramNs != null && !paramNs.isBlank() ? paramNs.trim() : "default");
+                : (paramNs != null && !paramNs.isBlank()
+                        ? paramNs.trim()
+                        : (pathNs != null && !pathNs.isBlank() ? pathNs.trim() : "default"));
 
         String headerTenant = request.getHeader(GatewayForwarder.HEADER_TENANT);
         String paramTenant = request.getParameter("tenant");
@@ -112,7 +142,23 @@ public class GatewayForwardingFilter extends OncePerRequestFilter {
             }
         }
 
-        byte[] body = request.getInputStream().readAllBytes();
+        long contentLength = request.getContentLengthLong();
+        if (contentLength > MAX_BUFFERED_BODY_BYTES) {
+            log.warn("Gateway rejected request body: Content-Length {} exceeds max limit of {} bytes",
+                    contentLength, MAX_BUFFERED_BODY_BYTES);
+            writeError(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+                    "PAYLOAD_TOO_LARGE", "Request body exceeds maximum size of " + MAX_BUFFERED_BODY_BYTES + " bytes");
+            return;
+        }
+
+        byte[] body = request.getInputStream().readNBytes(MAX_BUFFERED_BODY_BYTES + 1);
+        if (body.length > MAX_BUFFERED_BODY_BYTES) {
+            log.warn("Gateway rejected request body: read bytes exceeded max limit of {} bytes", MAX_BUFFERED_BODY_BYTES);
+            writeError(response, HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+                    "PAYLOAD_TOO_LARGE", "Request body exceeds maximum size of " + MAX_BUFFERED_BODY_BYTES + " bytes");
+            return;
+        }
+
         String idempotencyKey = request.getHeader("Idempotency-Key");
         if (idempotencyKey == null || idempotencyKey.isBlank()) {
             idempotencyKey = request.getHeader("X-Idempotency-Key");
@@ -143,7 +189,18 @@ public class GatewayForwardingFilter extends OncePerRequestFilter {
             }
         } catch (Exception e) {
             log.error("Gateway forward failed for namespace '{}': {}", namespaceId, e.getMessage(), e);
-            response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Gateway routing failure: " + e.getMessage());
+            writeError(response, HttpServletResponse.SC_BAD_GATEWAY,
+                    "GATEWAY_ROUTING_FAILURE", "Gateway routing failure for namespace: " + namespaceId);
         }
+    }
+
+    private void writeError(HttpServletResponse response, int status, String errorCode, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        MemoryDto.ErrorResponse errorResponse = new MemoryDto.ErrorResponse(status, errorCode, message);
+        byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+        response.getOutputStream().write(bytes);
+        response.getOutputStream().flush();
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GlobalExceptionHandler.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/GlobalExceptionHandler.java
@@ -14,6 +14,8 @@ package com.spectrayan.spector.synapse.config;
 
 import com.spectrayan.spector.commons.error.ErrorCode;
 import com.spectrayan.spector.commons.error.SpectorException;
+import com.spectrayan.spector.synapse.cluster.exception.NamespaceNotOwnedException;
+import com.spectrayan.spector.synapse.cluster.exception.StaleRouteException;
 import com.spectrayan.spector.synapse.error.SynapseConflictException;
 import com.spectrayan.spector.synapse.error.SynapseDatabaseException;
 import com.spectrayan.spector.synapse.error.SynapseException;
@@ -21,6 +23,8 @@ import com.spectrayan.spector.synapse.error.SynapseNotFoundException;
 import com.spectrayan.spector.synapse.memory.MemoryDto.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -91,10 +95,22 @@ public class GlobalExceptionHandler {
             case SERVER -> HttpStatus.SERVICE_UNAVAILABLE;
             default -> HttpStatus.INTERNAL_SERVER_ERROR;
         };
+        Map<String, Object> details = null;
+        if (ex instanceof NamespaceNotOwnedException nnoe) {
+            details = nnoe.details();
+        } else if (ex instanceof StaleRouteException sre) {
+            details = sre.details();
+        }
         log.warn("[SynapseException] [{}] status={} message={}", code.id(), status.value(), ex.getMessage());
-        return ResponseEntity.status(status)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(new ErrorResponse(status.value(), code.id(), ex.getMessage()));
+        var responseBuilder = ResponseEntity.status(status)
+                .contentType(MediaType.APPLICATION_JSON);
+        if (details != null && details.containsKey("owner") && details.get("owner") != null) {
+            responseBuilder.header("X-Spector-Owner", String.valueOf(details.get("owner")));
+        }
+        if (details != null && details.containsKey("epoch") && details.get("epoch") != null) {
+            responseBuilder.header("X-Spector-Epoch", String.valueOf(details.get("epoch")));
+        }
+        return responseBuilder.body(new ErrorResponse(status.value(), code.id(), ex.getMessage(), details));
     }
 
     @ExceptionHandler(SpectorException.class)

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/cell/CellProperties.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/cell/CellProperties.java
@@ -96,6 +96,15 @@ public class CellProperties implements Serializable {
         if (nodeId != null && !nodeId.isBlank()) {
             return nodeId.trim();
         }
+        String envPodName = System.getenv("POD_NAME");
+        if (envPodName != null && !envPodName.isBlank()) {
+            return envPodName.trim();
+        }
+        NodeRole role = resolvedRole();
+        if (role != NodeRole.STANDALONE) {
+            throw new IllegalStateException("spector.cell.node-id (or $POD_NAME) must be explicitly configured for non-standalone role "
+                    + role + " (Req R4.5, G42)");
+        }
         return resolveHostname();
     }
 
@@ -153,7 +162,7 @@ public class CellProperties implements Serializable {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (Exception e) {
-            return "localhost";
+            throw new IllegalStateException("Failed to resolve hostname and no spector.cell.node-id or $POD_NAME configured (G42)", e);
         }
     }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/routing/ClusterRoutingConfiguration.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/routing/ClusterRoutingConfiguration.java
@@ -12,6 +12,7 @@
  */
 package com.spectrayan.spector.synapse.config.routing;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spectrayan.spector.cluster.OwnershipResolver;
 import com.spectrayan.spector.cluster.routing.ConsistentHashRing;
 import com.spectrayan.spector.cluster.routing.RoutingMetricsListener;
@@ -20,26 +21,51 @@ import com.spectrayan.spector.cluster.routing.cache.RedisRoutingCache;
 import com.spectrayan.spector.cluster.routing.cache.WaterfallRoutingResolver;
 import com.spectrayan.spector.cluster.routing.invalidation.RoutingInvalidationSubscriber;
 import com.spectrayan.spector.synapse.cluster.gateway.GatewayForwarder;
+import com.spectrayan.spector.synapse.cluster.gateway.GatewayForwardingFilter;
 import com.spectrayan.spector.synapse.config.SynapseProperties;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.TimeoutOptions;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import java.time.Duration;
-import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Spring auto-configuration for the three-tier routing cache, pub/sub invalidation bus,
  * and gateway forwarder (ADR-0034 §8, Req R1, R3, R5, R7).
+ *
+ * <p>Gated on {@link NonStandaloneCondition} to ensure zero cluster infrastructure
+ * is allocated in standalone mode (G43).</p>
  */
 @Configuration
+@Conditional(ClusterRoutingConfiguration.NonStandaloneCondition.class)
 public class ClusterRoutingConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(ClusterRoutingConfiguration.class);
+
+    public static class NonStandaloneCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            String role = context.getEnvironment().getProperty("spector.cell.role");
+            if (role == null || role.isBlank()) {
+                return false; // Standalone by default
+            }
+            return !"standalone".equalsIgnoreCase(role.trim());
+        }
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -51,16 +77,40 @@ public class ClusterRoutingConfiguration {
         return source -> registry.counter("spector.route.lookup", "tier", source.name().toLowerCase()).increment();
     }
 
+    @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean
+    public RedisClient redisClient(SynapseProperties properties) {
+        RoutingProperties routingProps = properties.getRouting();
+        if (routingProps != null && routingProps.getRedis() != null && routingProps.getRedis().isEnabled()) {
+            String redisUri = routingProps.getRedis().getUri();
+            long timeoutMs = Math.max(10L, routingProps.getRedis().getTimeoutMs());
+            RedisURI uri = RedisURI.create(redisUri);
+            uri.setTimeout(Duration.ofMillis(timeoutMs));
+
+            RedisClient client = RedisClient.create(uri);
+            client.setOptions(ClientOptions.builder()
+                    .autoReconnect(true)
+                    .socketOptions(SocketOptions.builder().connectTimeout(Duration.ofMillis(timeoutMs)).build())
+                    .timeoutOptions(TimeoutOptions.enabled(Duration.ofMillis(timeoutMs)))
+                    .build());
+            return client;
+        }
+        return null;
+    }
+
     @Bean(destroyMethod = "close")
     @ConditionalOnMissingBean
     public RedisRoutingCache redisRoutingCache(
             SynapseProperties properties,
+            ObjectProvider<RedisClient> redisClientProvider,
             RoutingMetricsListener metricsListener
     ) {
         RoutingProperties routingProps = properties.getRouting();
-        if (routingProps != null && routingProps.getRedis() != null && routingProps.getRedis().isEnabled()) {
+        RedisClient client = redisClientProvider.getIfAvailable();
+        if (client != null && routingProps != null && routingProps.getRedis() != null && routingProps.getRedis().isEnabled()) {
             log.info("Initializing Lettuce Redis routing cache at {}", routingProps.getRedis().getUri());
             return new LettuceRedisRoutingCache(
+                    client,
                     routingProps.getRedis().getUri(),
                     routingProps.getRedis().getTimeoutMs(),
                     metricsListener
@@ -78,9 +128,11 @@ public class ClusterRoutingConfiguration {
             RoutingMetricsListener metricsListener
     ) {
         OwnershipResolver ownershipResolver = ownershipResolverProvider.getIfAvailable();
-        ConsistentHashRing ring = (ownershipResolver != null && ownershipResolver.ring().isPresent())
-                ? ownershipResolver.ring().get()
-                : ConsistentHashRing.of(1, List.of("standalone"));
+        if (ownershipResolver == null) {
+            throw new IllegalStateException("OwnershipResolver must be present for non-standalone routing (G39)");
+        }
+        Supplier<ConsistentHashRing> ringSupplier = () -> ownershipResolver.ring()
+                .orElseThrow(() -> new IllegalStateException("Non-standalone node has no active ring (G39)"));
 
         RedisRoutingCache redisCache = redisCacheProvider.getIfAvailable();
         RoutingProperties routingProps = properties.getRouting() != null ? properties.getRouting() : new RoutingProperties();
@@ -90,7 +142,7 @@ public class ClusterRoutingConfiguration {
         long redisTtl = routingProps.getRedis().getTtlSeconds();
 
         return new WaterfallRoutingResolver(
-                ring,
+                ringSupplier,
                 redisCache,
                 caffeineTtl,
                 caffeineMaxSize,
@@ -112,28 +164,41 @@ public class ClusterRoutingConfiguration {
     }
 
     @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean
     public RoutingInvalidationSubscriber routingInvalidationSubscriber(
             SynapseProperties properties,
-            ObjectProvider<RedisRoutingCache> redisCacheProvider,
+            ObjectProvider<RedisClient> redisClientProvider,
             WaterfallRoutingResolver resolver,
             RoutingMetricsListener metricsListener
     ) {
-        RedisRoutingCache redisCache = redisCacheProvider.getIfAvailable();
-        if (redisCache instanceof LettuceRedisRoutingCache lettuceCache && lettuceCache.isAvailable()) {
+        RoutingProperties routingProps = properties.getRouting();
+        RedisClient client = redisClientProvider.getIfAvailable();
+        if (client != null && routingProps != null && routingProps.getRedis() != null && routingProps.getRedis().isEnabled()) {
             String cellId = properties.getCell() != null ? properties.getCell().getId() : "default";
             try {
                 RoutingInvalidationSubscriber subscriber = new RoutingInvalidationSubscriber(
                         cellId,
-                        io.lettuce.core.RedisClient.create(io.lettuce.core.RedisURI.create(properties.getRouting().getRedis().getUri())),
+                        client,
                         resolver,
                         metricsListener
                 );
                 subscriber.start();
                 return subscriber;
             } catch (Exception e) {
-                log.warn("Failed to start RoutingInvalidationSubscriber: {}", e.getMessage());
+                log.warn("Failed to create RoutingInvalidationSubscriber: {}", e.getMessage());
             }
         }
         return null;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GatewayForwardingFilter gatewayForwardingFilter(
+            SynapseProperties properties,
+            GatewayForwarder forwarder,
+            ObjectProvider<ObjectMapper> objectMapperProvider
+    ) {
+        ObjectMapper mapper = objectMapperProvider.getIfAvailable();
+        return new GatewayForwardingFilter(properties, forwarder, mapper);
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryDto.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryDto.java
@@ -14,6 +14,7 @@ package com.spectrayan.spector.synapse.memory;
 
 import com.spectrayan.spector.memory.cortex.index.IndexEntryMemory;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
@@ -567,10 +568,20 @@ public final class MemoryDto {
             int status,
             String error,
             String message,
-            Instant timestamp
+            Instant timestamp,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Map<String, Object> details
     ) {
         public ErrorResponse(int status, String error, String message) {
-            this(status, error, message, Instant.now());
+            this(status, error, message, Instant.now(), null);
+        }
+
+        public ErrorResponse(int status, String error, String message, Map<String, Object> details) {
+            this(status, error, message, Instant.now(), details);
+        }
+
+        public ErrorResponse(int status, String error, String message, Instant timestamp) {
+            this(status, error, message, timestamp, null);
         }
     }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/memory/MemoryRequestBinder.java
@@ -23,6 +23,8 @@ import com.spectrayan.spector.cluster.fencing.FenceTokenManager;
 import com.spectrayan.spector.cluster.node.NodeRole;
 import com.spectrayan.spector.cluster.routing.RouteBinding;
 import com.spectrayan.spector.cluster.routing.RoutingKey;
+import com.spectrayan.spector.commons.error.ErrorCode;
+import com.spectrayan.spector.commons.error.SpectorValidationException;
 import com.spectrayan.spector.synapse.cluster.exception.NamespaceNotOwnedException;
 import com.spectrayan.spector.synapse.cluster.exception.StaleRouteException;
 import com.spectrayan.spector.synapse.cluster.fencing.FencedException;
@@ -217,15 +219,18 @@ public class MemoryRequestBinder {
     }
 
     private Long extractIncomingEpoch() {
-        try {
-            RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
-            if (attrs instanceof ServletRequestAttributes servletAttrs) {
-                String epochHeader = servletAttrs.getRequest().getHeader("X-Spector-Epoch");
-                if (epochHeader != null && !epochHeader.isBlank()) {
+        RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof ServletRequestAttributes servletAttrs) {
+            String epochHeader = servletAttrs.getRequest().getHeader("X-Spector-Epoch");
+            if (epochHeader != null && !epochHeader.isBlank()) {
+                try {
                     return Long.parseLong(epochHeader.trim());
+                } catch (NumberFormatException e) {
+                    throw new SpectorValidationException(ErrorCode.ARGUMENT_INVALID,
+                            "X-Spector-Epoch", "Malformed epoch header: '" + epochHeader + "' (G47)");
                 }
             }
-        } catch (Exception ignored) {}
+        }
         return null;
     }
 

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/architecture/StandaloneParityRegressionTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/architecture/StandaloneParityRegressionTest.java
@@ -12,19 +12,30 @@
  */
 package com.spectrayan.spector.synapse.architecture;
 
+import com.spectrayan.spector.cluster.OwnershipResolver;
 import com.spectrayan.spector.cluster.node.NodeIdentity;
 import com.spectrayan.spector.cluster.node.NodeRole;
 import com.spectrayan.spector.cluster.routing.RoutingKey;
+import com.spectrayan.spector.cluster.routing.cache.RedisRoutingCache;
+import com.spectrayan.spector.cluster.routing.cache.WaterfallRoutingResolver;
+import com.spectrayan.spector.synapse.cluster.gateway.GatewayForwarder;
+import com.spectrayan.spector.synapse.cluster.gateway.GatewayForwardingFilter;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import com.spectrayan.spector.synapse.config.routing.ClusterRoutingConfiguration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Pins single-node and standalone behavior when {@code spector-cluster} is on the classpath (Req R11.1, R12.7).
+ * Pins single-node and standalone behavior when {@code spector-cluster} is on the classpath (Req R11.1, R12.7, G43).
  */
-@DisplayName("Task 0.1: Standalone Parity Regression Test")
+@DisplayName("Standalone Parity Regression Test (G43)")
 class StandaloneParityRegressionTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(ClusterRoutingConfiguration.class, SynapseProperties.class);
 
     @Test
     @DisplayName("Default node role is STANDALONE and requires no cell/node IDs")
@@ -45,5 +56,29 @@ class StandaloneParityRegressionTest {
 
         assertThat(key1.keyMaterial()).isEqualTo(key2.keyMaterial());
         assertThat(key1.keyMaterial()).isEqualTo(RoutingKey.NULL_TENANT_SENTINEL + "/ns-standalone-1");
+    }
+
+    @Test
+    @DisplayName("G43: Standalone boots with zero cluster routing beans and no ring")
+    void standaloneBootsWithZeroClusterRoutingInfrastructure() {
+        // Assert standalone OwnershipResolver has no ring
+        OwnershipResolver standaloneResolver = OwnershipResolver.standalone();
+        assertThat(standaloneResolver.ring()).isEmpty();
+
+        // Boot context with defaults (no spector.cell.role set, so standalone by default)
+        runner.run(context -> {
+            assertThat(context.getBeanNamesForType(WaterfallRoutingResolver.class)).isEmpty();
+            assertThat(context.getBeanNamesForType(GatewayForwarder.class)).isEmpty();
+            assertThat(context.getBeanNamesForType(GatewayForwardingFilter.class)).isEmpty();
+            assertThat(context.getBeanNamesForType(RedisRoutingCache.class)).isEmpty();
+        });
+
+        // Explicitly set spector.cell.role=standalone
+        runner.withPropertyValues("spector.cell.role=standalone").run(context -> {
+            assertThat(context.getBeanNamesForType(WaterfallRoutingResolver.class)).isEmpty();
+            assertThat(context.getBeanNamesForType(GatewayForwarder.class)).isEmpty();
+            assertThat(context.getBeanNamesForType(GatewayForwardingFilter.class)).isEmpty();
+            assertThat(context.getBeanNamesForType(RedisRoutingCache.class)).isEmpty();
+        });
     }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/cluster/GatewayForwardingTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/cluster/GatewayForwardingTest.java
@@ -148,4 +148,101 @@ class GatewayForwardingTest {
         // Verification of R7.5 and Invariant K7: exact same idempotency key was reused across retries!
         assertThat(seenIdempotencyKeys).containsExactly(clientUniqueIdempotencyKey, clientUniqueIdempotencyKey);
     }
+
+    @Test
+    @DisplayName("G40: 421 retry leaves OVERRIDE binding in Redis cache intact")
+    void test421RetryDoesNotDestroyClusterOverride() throws Exception {
+        String cellId = "cell-1";
+        ConsistentHashRing ring = ConsistentHashRing.of(1, List.of("node-1", "node-2", "node-3"));
+
+        RoutingKey key = RoutingKey.ofTenanted(cellId, "tenant-a", "ns-override");
+        RouteBinding overrideBinding = new RouteBinding(key, "node-override", 1L, null, null, RouteMode.OVERRIDE);
+
+        Map<RoutingKey, RouteBinding> fakeRedisStorage = new ConcurrentHashMap<>();
+        fakeRedisStorage.put(key, overrideBinding);
+
+        RedisRoutingCache mockRedis = new RedisRoutingCache() {
+            @Override
+            public Optional<RouteBinding> get(RoutingKey k) {
+                return Optional.ofNullable(fakeRedisStorage.get(k));
+            }
+
+            @Override
+            public boolean putIfAbsent(RoutingKey k, RouteBinding b, long ttl) {
+                return fakeRedisStorage.putIfAbsent(k, b) == null;
+            }
+
+            @Override
+            public void invalidate(RoutingKey k) {
+                fakeRedisStorage.remove(k);
+            }
+
+            @Override
+            public void publishInvalidation(String cell, String nsKey, long epoch, String reason) {}
+
+            @Override
+            public boolean isAvailable() {
+                return true;
+            }
+        };
+
+        WaterfallRoutingResolver resolver = new WaterfallRoutingResolver(
+                ring, mockRedis, Duration.ofMinutes(1), 1000L, 30L, null, Runnable::run
+        );
+
+        AtomicInteger dispatchCount = new AtomicInteger(0);
+        GatewayHttpTransport transport = (targetNodeId, targetUrl, req, routingHeaders) -> {
+            int attempt = dispatchCount.incrementAndGet();
+            if (attempt == 1) {
+                // Returns 421 on first attempt
+                return new ForwardResponse(421, Map.of(), "not_owner".getBytes(StandardCharsets.UTF_8), targetNodeId, 1);
+            }
+            return new ForwardResponse(200, Map.of(), "success".getBytes(StandardCharsets.UTF_8), targetNodeId, 2);
+        };
+
+        GatewayForwarder forwarder = new GatewayForwarder(resolver, 2, transport, nodeId -> "http://" + nodeId + ":7070");
+        ForwardRequest request = new ForwardRequest("GET", "/api/v1/memory", Map.of(), new byte[0], "idem-1");
+
+        forwarder.forward(key, request);
+
+        // Crucial invariant G40: The OVERRIDE in Redis must NOT have been destroyed by 421 retry!
+        assertThat(fakeRedisStorage.get(key)).isEqualTo(overrideBinding);
+    }
+
+    @Test
+    @DisplayName("G45: 421 retry retargets directly to reported owner from X-Spector-Owner header")
+    void test421RetryRetargetsToReportedOwner() throws Exception {
+        String cellId = "cell-1";
+        ConsistentHashRing ring = ConsistentHashRing.of(1, List.of("node-1", "node-2", "node-3"));
+        WaterfallRoutingResolver resolver = new WaterfallRoutingResolver(
+                ring, null, Duration.ofMinutes(1), 1000L, 30L, null, Runnable::run
+        );
+
+        List<String> targets = new ArrayList<>();
+        GatewayHttpTransport transport = (targetNodeId, targetUrl, req, routingHeaders) -> {
+            targets.add(targetNodeId);
+            if (targets.size() == 1) {
+                // First target reports 421 and directs forwarder to node-special
+                return new ForwardResponse(
+                        421,
+                        Map.of("X-Spector-Owner", List.of("node-special")),
+                        "{\"error\":\"NOT_OWNER\",\"details\":{\"owner\":\"node-special\"}}".getBytes(StandardCharsets.UTF_8),
+                        targetNodeId,
+                        1
+                );
+            }
+            return new ForwardResponse(200, Map.of(), "ok".getBytes(StandardCharsets.UTF_8), targetNodeId, 2);
+        };
+
+        GatewayForwarder forwarder = new GatewayForwarder(resolver, 2, transport, nodeId -> "http://" + nodeId + ":7070");
+        RoutingKey key = RoutingKey.ofTenanted(cellId, "tenant-a", "ns-retarget");
+        ForwardRequest request = new ForwardRequest("GET", "/api/v1/memory", Map.of(), new byte[0], "idem-2");
+
+        ForwardResponse response = forwarder.forward(key, request);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(targets).hasSize(2);
+        // Second attempt must be dispatched to the reported owner "node-special" rather than blind ring resolution
+        assertThat(targets.get(1)).isEqualTo("node-special");
+    }
 }

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/cluster/gateway/GatewayForwardingFilterTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/cluster/gateway/GatewayForwardingFilterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.cluster.gateway;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.spectrayan.spector.cluster.node.NodeRole;
+import com.spectrayan.spector.cluster.routing.RoutingKey;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import com.spectrayan.spector.synapse.config.cell.CellProperties;
+import com.spectrayan.spector.synapse.memory.MemoryDto;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("GatewayForwardingFilter Tests (G48, G54)")
+class GatewayForwardingFilterTest {
+
+    private SynapseProperties properties;
+    private GatewayForwarder forwarder;
+    private ObjectMapper objectMapper;
+    private GatewayForwardingFilter filter;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        properties = new SynapseProperties();
+        CellProperties cell = new CellProperties();
+        cell.setRole("gateway");
+        cell.setId("cell-test");
+        cell.setNodeId("gateway-node-1");
+        properties.setCell(cell);
+
+        forwarder = mock(GatewayForwarder.class);
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        filter = new GatewayForwardingFilter(properties, forwarder, objectMapper);
+        filterChain = mock(FilterChain.class);
+    }
+
+    @Test
+    @DisplayName("G48: Namespace is extracted from URI path when header and query parameter are missing")
+    void testExtractNamespaceFromPath() throws Exception {
+        AtomicReference<RoutingKey> routedKey = new AtomicReference<>();
+        when(forwarder.forward(any(), any())).thenAnswer(inv -> {
+            routedKey.set(inv.getArgument(0));
+            return new ForwardResponse(200, Map.of(), "{}".getBytes(StandardCharsets.UTF_8), "target-node", 1);
+        });
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/namespaces/team-alpha/reset");
+        request.setRequestURI("/api/v1/namespaces/team-alpha/reset");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(routedKey.get()).isNotNull();
+        assertThat(routedKey.get().namespaceId()).isEqualTo("team-alpha");
+    }
+
+    @Test
+    @DisplayName("G48: Request body exceeding 10MB limit is rejected with 413 Payload Too Large JSON envelope")
+    void testLargeBodyRejectedWith413() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/memory/remember");
+        request.setRequestURI("/api/v1/memory/remember");
+        // Over 10 MB
+        byte[] oversizedBody = new byte[GatewayForwardingFilter.MAX_BUFFERED_BODY_BYTES + 100];
+        request.setContent(oversizedBody);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(413);
+        assertThat(response.getContentType()).startsWith("application/json");
+
+        MemoryDto.ErrorResponse error = objectMapper.readValue(response.getContentAsString(), MemoryDto.ErrorResponse.class);
+        assertThat(error.status()).isEqualTo(413);
+        assertThat(error.error()).isEqualTo("PAYLOAD_TOO_LARGE");
+    }
+
+    @Test
+    @DisplayName("G54: Gateway forwarding failure returns 502 JSON ErrorResponse without leaking internal exception")
+    void testForwardingFailureReturns502JsonWithoutLeak() throws Exception {
+        when(forwarder.forward(any(), any())).thenThrow(new RuntimeException("Connection refused: redis://super-secret-host:6379"));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/memory");
+        request.setRequestURI("/api/v1/memory");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        assertThat(response.getContentType()).startsWith("application/json");
+
+        String responseBody = response.getContentAsString();
+        // Crucial G54 invariant: Must NOT leak internal Redis URL or hostname
+        assertThat(responseBody).doesNotContain("super-secret-host");
+        assertThat(responseBody).doesNotContain("6379");
+
+        MemoryDto.ErrorResponse error = objectMapper.readValue(responseBody, MemoryDto.ErrorResponse.class);
+        assertThat(error.status()).isEqualTo(502);
+        assertThat(error.error()).isEqualTo("GATEWAY_ROUTING_FAILURE");
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Addresses all routing availability, caching resilience, and standalone isolation findings **G38 through G50** (and **G54**) from the Cell HA review.

### Key Fixes

- **G38 (Redis Latch Self-Healing)**: Recorded `degradedSinceNanos` in `LettuceRedisRoutingCache` upon failure and added periodic probe retry (default 5s) in `isAvailable()`, enabling the cache to self-heal and clear degraded status upon successful response without requiring a node restart.
- **G39 (Dynamic Ring Propagation)**: Stored `Supplier<ConsistentHashRing>` in `WaterfallRoutingResolver` and resolved dynamically via `ownershipResolver.ring()`. Removed synthetic fallback to prevent silent misrouting; throws fail-closed `IllegalStateException` if a non-standalone node has no active ring.
- **G40 (Override Preservation on 421)**: Restricted 421 retry eviction strictly to `invalidateLocal` and conditional `invalidateIfHash`, preventing destruction of cluster-wide `RouteMode.OVERRIDE` bindings. Added regression test verifying overrides survive 421 responses.
- **G41 (Structural Tier 3 Protection)**: Wrapped Tier 2 Redis lookups in `try/catch (RuntimeException)` inside `WaterfallRoutingResolver` to guarantee uninterrupted Ketama ring computation even if Redis driver throws unexpectedly.
- **G42 (Node Identity Stability)**: Enforced explicit `spector.cell.node-id` or `$POD_NAME` for non-standalone roles; eliminated random container hostname derivation and `"localhost"` collision fallbacks. Enforced member presence in `OwnershipResolver` constructor and `reloadRing()`.
- **G43 (Standalone Parity Enforcement)**: Gated `ClusterRoutingConfiguration` with `NonStandaloneCondition` and registered `GatewayForwardingFilter` as an internal `@Bean`. Expanded `StandaloneParityRegressionTest` with `ApplicationContextRunner` asserting zero cluster routing beans and empty ring in standalone mode.
- **G44 (Invalidation Bus & Key Normalization)**: Wired `redisCache.publishInvalidation` into `WaterfallRoutingResolver.invalidateAll()`. Normalized `cellId` (`null` or blank -> `"default"`) in the canonical `RoutingKey` constructor and added `fromKeyMaterial` round-trip test.
- **G45 (Machine-Readable Refusals & Retargeting)**: Added `details` map to `MemoryDto.ErrorResponse` populated by `NamespaceNotOwnedException` and `StaleRouteException`. `GatewayForwarder` inspects `X-Spector-Owner` header and error details to retarget attempt 2 directly to the reported owner.
- **G46 (Hash Tag Delimiter Validation)**: Updated `ClusterValidation` to reject `{`, `}`, and `:`, preventing Redis hash slot collapse. Added `validateCellId()` and verified with `RoutingKeyFormatTest`.
- **G47 (Fail-Closed Epoch & Mode Parsing)**: `MemoryRequestBinder.extractIncomingEpoch()` throws `ARGUMENT_INVALID` (400) on malformed header values instead of swallowing `NumberFormatException`. `LettuceRedisRoutingCache` treats missing or malformed `epoch` or `mode` hash fields as cache misses.
- **G48 & G54 (Gateway Filter Hardening)**: Added path-based namespace extraction fallback to `GatewayForwardingFilter`. Enforced 10 MB request body buffer bound (`MAX_BUFFERED_BODY_BYTES`) returning 413 `PAYLOAD_TOO_LARGE` JSON envelope. Replaced HTML `sendError` with structured JSON `ErrorResponse` (502) without leaking internal Redis URIs or hostnames.
- **G49 (Shared Redis Client Lifecycle)**: Defined single shared `RedisClient` bean in `ClusterRoutingConfiguration` with explicit connect/socket/timeout options. `RoutingInvalidationSubscriber` automatically reconnects and resubscribes on a 5s schedule if Redis is offline at boot.
- **G50 (Allocation-Free Hash Ring)**: Refactored `ConsistentHashRing.hash64()` using `ThreadLocal<MessageDigest>` with `reset()` and bitwise long extraction, eliminating per-lookup allocations while preserving pinned golden SHA-256 values.

### Verification

- `cluster/spector-cluster`: 87/87 tests passing.
- `synapse/spector-synapse`: 195/195 tests passing (`GatewayForwardingTest`, `GatewayForwardingFilterTest`, `StandaloneParityRegressionTest`, `MemoryControllerTest`, etc.).
- Whole-repo `license:check`: 27/27 modules passing.

Closes #860
