### PR TITLE
fix(dr): address DR CLI, measured RPO, residency, and throttler accounting findings G29-G31, G61

### DIFF
--- a/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/DisasterRecoveryCommand.java
+++ b/synapse/spector-cli/src/main/java/com/spectrayan/spector/cli/DisasterRecoveryCommand.java
@@ -15,17 +15,32 @@
  */
 package com.spectrayan.spector.cli;
 
+import com.spectrayan.spector.config.SpectorPropertyConstants;
+import com.spectrayan.spector.synapse.config.SynapseProperties;
+import com.spectrayan.spector.synapse.config.dr.DisasterRecoveryProperties;
+import com.spectrayan.spector.synapse.dr.DisasterRecoveryExporter;
+import com.spectrayan.spector.synapse.dr.DisasterRecoveryRestorer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 
 /**
  * CLI command group for Cell Disaster Recovery, standby cell promotion, and snapshot rehydration
- * (ADR-0034 §11.2, §14, §16, Phase 6, Req R4.1, R3.1).
+ * (ADR-0034 §11.2, §14, §16, Phase 6, Req R4.1, R3.1, G30).
  *
  * <p>Invariant V3: Cell promotion is an explicit HUMAN decision requiring an auditable trigger.
  * Automatic promotion across cells is strictly forbidden to prevent undetectable multi-region split-brain.</p>
@@ -43,6 +58,8 @@ import java.util.Map;
 )
 public class DisasterRecoveryCommand extends BaseCommand {
 
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
     @Override
     public void run() {
         spec.commandLine().usage(out());
@@ -51,7 +68,7 @@ public class DisasterRecoveryCommand extends BaseCommand {
     @Component
     @Command(
             name = "promote",
-            description = "Promote this standby cell to primary authority (AUDITABLE HUMAN DECISION, Req R4.1).",
+            description = "Promote this standby cell to primary authority (AUDITABLE HUMAN DECISION, Req R4.1, G30).",
             mixinStandardHelpOptions = true
     )
     public static class PromoteCellSubcommand extends BaseCommand {
@@ -64,6 +81,13 @@ public class DisasterRecoveryCommand extends BaseCommand {
 
         @Option(names = {"--force"}, description = "Acknowledge that promotion is irreversible without data migration.")
         private boolean force;
+
+        @Option(
+                names = {"--audit-file"},
+                description = "Append-only file path to persist promotion audit records (G30).",
+                defaultValue = "dr-promotion-audit.log"
+        )
+        private String auditFile = "dr-promotion-audit.log";
 
         @Override
         public void run() {
@@ -81,17 +105,33 @@ public class DisasterRecoveryCommand extends BaseCommand {
             audit.put("authority", "ACTIVE_PRIMARY");
             audit.put("warning", "Dead cell must be decommissioned or isolated to avoid split-brain upon network reconnection (Req R4.7).");
 
+            // G30: Persist promote audit record to an append-only store before acknowledging
+            Path auditPath = Path.of(auditFile);
+            try {
+                if (auditPath.getParent() != null) {
+                    Files.createDirectories(auditPath.getParent());
+                }
+                String auditJson = MAPPER.writeValueAsString(audit) + System.lineSeparator();
+                Files.writeString(auditPath, auditJson, StandardCharsets.UTF_8,
+                        StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+                audit.put("auditPersistedTo", auditPath.toAbsolutePath().toString());
+            } catch (IOException e) {
+                err().println("ERROR: Failed to persist promotion audit record to " + auditPath + ": " + e.getMessage());
+                return;
+            }
+
             if (isJson()) {
                 OutputFormatter.printJson(out(), audit);
             } else {
                 out().println("================================================================================");
-                out().println("               CELL PROMOTION AUDIT RECORD (Req R4.1, V3)                       ");
+                out().println("               CELL PROMOTION AUDIT RECORD (Req R4.1, V3, G30)                  ");
                 out().println("================================================================================");
                 out().println("Cell ID:     " + cellId);
                 out().println("Reason:      " + reason);
                 out().println("Operator:    " + audit.get("operator"));
                 out().println("Timestamp:   " + audit.get("promotedAt"));
                 out().println("Authority:   ACTIVE_PRIMARY");
+                out().println("Audit Log:   " + audit.get("auditPersistedTo"));
                 out().println("WARNING:     Reverse path requires a structured data migration, not symmetric undo.");
                 out().println("================================================================================");
             }
@@ -101,51 +141,170 @@ public class DisasterRecoveryCommand extends BaseCommand {
     @Component
     @Command(
             name = "restore",
-            description = "Hydrate and restore a namespace from S3 disaster recovery snapshots.",
+            description = "Hydrate and restore a namespace from S3 disaster recovery snapshots (G30).",
             mixinStandardHelpOptions = true
     )
     public static class RestoreNamespaceSubcommand extends BaseCommand {
 
         @Option(names = {"--tenant"}, description = "Tenant ID.", defaultValue = "untenanted")
-        private String tenantId;
+        private String tenantId = "untenanted";
 
         @Option(names = {"--namespace"}, description = "Namespace ID to restore.", required = true)
         private String namespaceId;
 
-        @Option(names = {"--epoch"}, description = "Snapshot epoch sequence.", defaultValue = "latest")
-        private String epoch;
+        @Option(names = {"--epoch"}, description = "Snapshot epoch sequence or 'latest'.", defaultValue = "latest")
+        private String epoch = "latest";
+
+        @Option(names = {"--target-dir"}, description = "Target directory to rehydrate namespace into.")
+        private String targetDir;
+
+        @Option(names = {"--jurisdiction"}, description = "Tenant jurisdiction for data residency validation.")
+        private String jurisdiction;
+
+        @Autowired(required = false)
+        private DisasterRecoveryRestorer restorer;
+
+        @Autowired(required = false)
+        private SynapseProperties synapseProperties;
+
+        public RestoreNamespaceSubcommand() {}
+
+        public RestoreNamespaceSubcommand(DisasterRecoveryRestorer restorer) {
+            this.restorer = restorer;
+        }
+
+        public RestoreNamespaceSubcommand(DisasterRecoveryRestorer restorer, SynapseProperties synapseProperties) {
+            this.restorer = restorer;
+            this.synapseProperties = synapseProperties;
+        }
 
         @Override
         public void run() {
-            out().printf("Rehydration initiated for tenant=%s, namespace=%s, epoch=%s (Req R3.1–R3.8)%n",
-                    tenantId, namespaceId, epoch);
+            if (restorer == null) {
+                err().println("ERROR: Disaster recovery restorer is not configured or unavailable (Req R3.1–R3.8, G30).");
+                return;
+            }
+
+            Path targetBaseDir;
+            if (targetDir != null && !targetDir.isBlank()) {
+                targetBaseDir = Path.of(targetDir);
+            } else if (synapseProperties != null) {
+                targetBaseDir = synapseProperties.remembererRoot();
+            } else {
+                targetBaseDir = SpectorPropertyConstants.DEFAULT_MEMORY_PERSISTENCE_PATH;
+            }
+
+            long targetEpoch;
+            if ("latest".equalsIgnoreCase(epoch)) {
+                List<Long> selectable = restorer.discoverSelectableEpochs(tenantId, namespaceId);
+                if (selectable.isEmpty()) {
+                    err().printf("ERROR: No selectable snapshot epochs found for tenant=%s, namespace=%s (G32, Req R2.6)%n",
+                            tenantId, namespaceId);
+                    return;
+                }
+                targetEpoch = selectable.get(selectable.size() - 1);
+            } else {
+                try {
+                    targetEpoch = Long.parseLong(epoch);
+                } catch (NumberFormatException e) {
+                    err().println("ERROR: Invalid epoch sequence parameter: " + epoch);
+                    return;
+                }
+            }
+
+            try {
+                DisasterRecoveryRestorer.RestoreResult result = restorer.restoreNamespace(
+                        tenantId,
+                        namespaceId,
+                        targetEpoch,
+                        targetBaseDir,
+                        jurisdiction
+                );
+
+                if (!result.success()) {
+                    err().printf("ERROR: Restore refused for namespace %s: %s%n", namespaceId, result.refusalReason());
+                    return;
+                }
+
+                if (isJson()) {
+                    OutputFormatter.printJson(out(), result);
+                } else {
+                    out().println("================================================================================");
+                    out().println("               DISASTER RECOVERY RESTORE COMPLETE (Req R3.1–R3.8, G30)          ");
+                    out().println("================================================================================");
+                    out().println("Namespace ID: " + result.namespaceId());
+                    out().println("Tenant ID:    " + result.tenantId());
+                    out().println("Epoch:        " + result.epoch());
+                    out().println("Restored HWM: " + result.hwm());
+                    out().println("Artifacts:    " + result.verifiedArtifactCount() + " verified");
+                    out().println("Location:     " + result.restoredDir());
+                    out().println("Elapsed:      " + result.elapsedMs() + " ms");
+                    out().println("================================================================================");
+                }
+            } catch (Exception e) {
+                err().println("ERROR: Restore execution failed: " + e.getMessage());
+            }
         }
     }
 
     @Component
     @Command(
             name = "status",
-            description = "Show DR export lag, backup counts, and disaster readiness posture.",
+            description = "Show DR export lag, backup counts, and disaster readiness posture (G30).",
             mixinStandardHelpOptions = true
     )
     public static class StatusSubcommand extends BaseCommand {
 
+        @Autowired(required = false)
+        private DisasterRecoveryProperties drProperties;
+
+        @Autowired(required = false)
+        private DisasterRecoveryExporter drExporter;
+
+        public StatusSubcommand() {}
+
+        public StatusSubcommand(DisasterRecoveryProperties drProperties, DisasterRecoveryExporter drExporter) {
+            this.drProperties = drProperties;
+            this.drExporter = drExporter;
+        }
+
         @Override
         public void run() {
+            boolean drConfigured = drProperties != null;
+            boolean drEnabled = drConfigured && drProperties.isExportEnabled();
+            String standbyMode = drConfigured ? drProperties.getStandbyMode() : "NOT_CONFIGURED";
+            Long exportIntervalSeconds = drConfigured ? drProperties.getExportIntervalSeconds() : null;
+
+            OptionalLong measuredRpo = (drExporter != null) ? drExporter.getMeasuredP99Rpo() : OptionalLong.empty();
+
+            String posture;
+            if (!drConfigured) {
+                posture = "NOT_CONFIGURED";
+            } else if (!drEnabled) {
+                posture = "DISABLED";
+            } else if (measuredRpo.isPresent()) {
+                posture = "READY";
+            } else {
+                posture = "UNMEASURED (no export intervals recorded yet)";
+            }
+
             Map<String, Object> status = new LinkedHashMap<>();
-            status.put("drEnabled", true);
-            status.put("standbyMode", "COLD_AT_ZERO");
-            status.put("exportIntervalSeconds", 900);
-            status.put("rpoSlaSeconds", 900);
+            status.put("drConfigured", drConfigured);
+            status.put("drEnabled", drEnabled);
+            status.put("standbyMode", standbyMode);
+            status.put("exportIntervalSeconds", exportIntervalSeconds != null ? exportIntervalSeconds : "NOT_CONFIGURED");
+            status.put("measuredP99RpoSeconds", measuredRpo.isPresent() ? measuredRpo.getAsLong() : "UNKNOWN");
+            status.put("posture", posture);
             status.put("rtoTargetMinutes", 30);
             status.put("residencyControl", "ORG_TO_CELL_PIN");
 
             if (isJson()) {
                 OutputFormatter.printJson(out(), status);
             } else {
-                out().println("Disaster Recovery Posture: READY");
-                out().println("Standby Posture:          COLD_AT_ZERO (scalable in 5-10m)");
-                out().println("Export Interval:          15m (RPO SLA)");
+                out().println("Disaster Recovery Posture: " + posture);
+                out().println("Standby Posture:          " + standbyMode);
+                out().println("Export Interval:          " + (exportIntervalSeconds != null ? exportIntervalSeconds + "s" : "NOT_CONFIGURED"));
+                out().println("Measured RPO:             " + (measuredRpo.isPresent() ? measuredRpo.getAsLong() + "s" : "UNKNOWN"));
                 out().println("RTO Target:               0-30m (Rehearsed Drill)");
             }
         }

--- a/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/DisasterRecoveryCommandTest.java
+++ b/synapse/spector-cli/src/test/java/com/spectrayan/spector/cli/DisasterRecoveryCommandTest.java
@@ -15,16 +15,28 @@
  */
 package com.spectrayan.spector.cli;
 
+import com.spectrayan.spector.synapse.config.dr.DisasterRecoveryProperties;
+import com.spectrayan.spector.synapse.dr.DisasterRecoveryExporter;
+import com.spectrayan.spector.synapse.dr.DisasterRecoveryRestorer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.OptionalLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@DisplayName("spectorctl dr Command Specification (ADR-0034 §11.2, Req R4.1)")
+@DisplayName("spectorctl dr Command Specification (ADR-0034 §11.2, Req R4.1, G30)")
 class DisasterRecoveryCommandTest {
 
     @Test
@@ -44,8 +56,10 @@ class DisasterRecoveryCommandTest {
     }
 
     @Test
-    @DisplayName("dr promote with --force records auditable human promotion event (Req R4.1, V3)")
-    void testPromoteWithForceSucceedsAndAudits() {
+    @DisplayName("dr promote with --force records auditable human promotion event and persists to file (Req R4.1, V3, G30)")
+    void testPromoteWithForceSucceedsAndAudits(@TempDir Path tempDir) throws IOException {
+        Path auditFile = tempDir.resolve("dr-promotion-audit.log");
+
         DisasterRecoveryCommand cmdObj = new DisasterRecoveryCommand();
         CommandLine cmd = new CommandLine(cmdObj);
         StringWriter out = new StringWriter();
@@ -53,7 +67,13 @@ class DisasterRecoveryCommandTest {
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
 
-        int exitCode = cmd.execute("promote", "--cell", "cell-standby-02", "--reason", "Cloud region outage", "--force");
+        int exitCode = cmd.execute(
+                "promote",
+                "--cell", "cell-standby-02",
+                "--reason", "Cloud region outage",
+                "--force",
+                "--audit-file", auditFile.toString()
+        );
 
         assertThat(exitCode).isEqualTo(0);
         String output = out.toString();
@@ -62,12 +82,21 @@ class DisasterRecoveryCommandTest {
                 .contains("cell-standby-02")
                 .contains("Cloud region outage")
                 .contains("ACTIVE_PRIMARY")
-                .contains("Reverse path requires a structured data migration");
+                .contains("Reverse path requires a structured data migration")
+                .contains(auditFile.toAbsolutePath().toString());
+
+        // G30: Verify audit record is persisted to disk
+        assertThat(Files.exists(auditFile)).isTrue();
+        String auditContent = Files.readString(auditFile);
+        assertThat(auditContent)
+                .contains("CELL_PROMOTION")
+                .contains("cell-standby-02")
+                .contains("Cloud region outage");
     }
 
     @Test
-    @DisplayName("dr status displays disaster recovery readiness posture")
-    void testDrStatus() {
+    @DisplayName("dr status in unconfigured environment prints NOT_CONFIGURED and UNKNOWN (G30)")
+    void testDrStatusUnconfigured() {
         DisasterRecoveryCommand cmdObj = new DisasterRecoveryCommand();
         CommandLine cmd = new CommandLine(cmdObj);
         StringWriter out = new StringWriter();
@@ -78,8 +107,86 @@ class DisasterRecoveryCommandTest {
         assertThat(exitCode).isEqualTo(0);
         String output = out.toString();
         assertThat(output)
+                .contains("Disaster Recovery Posture: NOT_CONFIGURED")
+                .contains("Standby Posture:          NOT_CONFIGURED")
+                .contains("Export Interval:          NOT_CONFIGURED")
+                .contains("Measured RPO:             UNKNOWN");
+    }
+
+    @Test
+    @DisplayName("dr status with live exporter reporting measured RPO shows READY and measured interval (G30)")
+    void testDrStatusWithMeasuredRpo() {
+        DisasterRecoveryProperties props = new DisasterRecoveryProperties();
+        props.setExportEnabled(true);
+        props.setExportIntervalSeconds(900);
+        props.setStandbyMode("WARM_SYNC");
+
+        DisasterRecoveryExporter exporter = mock(DisasterRecoveryExporter.class);
+        when(exporter.getMeasuredP99Rpo()).thenReturn(OptionalLong.of(42L));
+
+        DisasterRecoveryCommand.StatusSubcommand statusCmd = new DisasterRecoveryCommand.StatusSubcommand(props, exporter);
+        CommandLine cmd = new CommandLine(statusCmd);
+        StringWriter out = new StringWriter();
+        cmd.setOut(new PrintWriter(out));
+
+        int exitCode = cmd.execute();
+        assertThat(exitCode).isEqualTo(0);
+        String output = out.toString();
+        assertThat(output)
                 .contains("Disaster Recovery Posture: READY")
-                .contains("COLD_AT_ZERO")
-                .contains("15m (RPO SLA)");
+                .contains("Standby Posture:          WARM_SYNC")
+                .contains("Export Interval:          900s")
+                .contains("Measured RPO:             42s");
+    }
+
+    @Test
+    @DisplayName("dr restore without restorer reports error (G30)")
+    void testRestoreWithoutRestorerFails() {
+        DisasterRecoveryCommand.RestoreNamespaceSubcommand restoreCmd = new DisasterRecoveryCommand.RestoreNamespaceSubcommand(null);
+        CommandLine cmd = new CommandLine(restoreCmd);
+        StringWriter err = new StringWriter();
+        cmd.setErr(new PrintWriter(err));
+
+        int exitCode = cmd.execute("--namespace", "018f9b8c000070008000000000000042");
+        assertThat(exitCode).isEqualTo(0);
+        assertThat(err.toString()).contains("ERROR: Disaster recovery restorer is not configured");
+    }
+
+    @Test
+    @DisplayName("dr restore with restorer executes and prints restored HWM (G30)")
+    void testRestoreWithRestorerSucceeds() {
+        DisasterRecoveryRestorer restorer = mock(DisasterRecoveryRestorer.class);
+        when(restorer.discoverSelectableEpochs("untenanted", "018f9b8c000070008000000000000042"))
+                .thenReturn(List.of(1L, 2L));
+
+        DisasterRecoveryRestorer.RestoreResult mockResult = new DisasterRecoveryRestorer.RestoreResult(
+                "018f9b8c000070008000000000000042",
+                "untenanted",
+                2L,
+                450L,
+                Path.of("/tmp/restore/018f9b8c000070008000000000000042"),
+                5,
+                120L,
+                true,
+                null
+        );
+
+        when(restorer.restoreNamespace(eq("untenanted"), eq("018f9b8c000070008000000000000042"), eq(2L), any(), isNull()))
+                .thenReturn(mockResult);
+
+        DisasterRecoveryCommand.RestoreNamespaceSubcommand restoreCmd = new DisasterRecoveryCommand.RestoreNamespaceSubcommand(restorer);
+        CommandLine cmd = new CommandLine(restoreCmd);
+        StringWriter out = new StringWriter();
+        cmd.setOut(new PrintWriter(out));
+
+        int exitCode = cmd.execute("--namespace", "018f9b8c000070008000000000000042");
+        assertThat(exitCode).isEqualTo(0);
+        String output = out.toString();
+        assertThat(output)
+                .contains("DISASTER RECOVERY RESTORE COMPLETE")
+                .contains("018f9b8c000070008000000000000042")
+                .contains("Epoch:        2")
+                .contains("Restored HWM: 450")
+                .contains("Artifacts:    5 verified");
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/dr/DisasterRecoveryProperties.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/config/dr/DisasterRecoveryProperties.java
@@ -15,6 +15,8 @@ package com.spectrayan.spector.synapse.config.dr;
 import com.spectrayan.spector.config.SpectorPropertyConstants;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Configuration properties for Cell Disaster Recovery, mutable snapshot cloud export, and standby restore
@@ -34,6 +36,8 @@ public class DisasterRecoveryProperties implements Serializable {
     private String objectStoreRegion = SpectorPropertyConstants.DEFAULT_DR_OBJECT_STORE_REGION;
     private int alertLagMultiplier = SpectorPropertyConstants.DEFAULT_DR_ALERT_LAG_MULTIPLIER;
     private String standbyMode = SpectorPropertyConstants.DEFAULT_DR_STANDBY_MODE;
+    private Map<String, String> tenantJurisdictions = new HashMap<>();
+    private boolean requireTenantJurisdiction = false;
 
     public DisasterRecoveryProperties() {}
 
@@ -99,5 +103,21 @@ public class DisasterRecoveryProperties implements Serializable {
 
     public void setStandbyMode(String standbyMode) {
         this.standbyMode = standbyMode;
+    }
+
+    public Map<String, String> getTenantJurisdictions() {
+        return tenantJurisdictions;
+    }
+
+    public void setTenantJurisdictions(Map<String, String> tenantJurisdictions) {
+        this.tenantJurisdictions = tenantJurisdictions != null ? new HashMap<>(tenantJurisdictions) : new HashMap<>();
+    }
+
+    public boolean isRequireTenantJurisdiction() {
+        return requireTenantJurisdiction;
+    }
+
+    public void setRequireTenantJurisdiction(boolean requireTenantJurisdiction) {
+        this.requireTenantJurisdiction = requireTenantJurisdiction;
     }
 }

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/BandwidthThrottler.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/BandwidthThrottler.java
@@ -12,21 +12,47 @@
  */
 package com.spectrayan.spector.synapse.dr;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 /**
  * Token-bucket bandwidth rate limiter to throttle DR snapshot exports and prevent starvations
  * of replication links (ADR-0034 §11.2, §14, Req R1.6, W10).
+ *
+ * <p>Invariant: Window accounting accounts for multi-window allocations and carries over
+ * deficit bytes to prevent single oversized payloads from blowing the limit (G61).</p>
  */
 public class BandwidthThrottler {
 
+    @FunctionalInterface
+    public interface Sleeper {
+        void sleepNanos(long nanos) throws InterruptedException;
+    }
+
+    public static final Sleeper DEFAULT_SLEEPER = nanos -> {
+        if (nanos > 0) {
+            TimeUnit.NANOSECONDS.sleep(nanos);
+        }
+    };
+
     private final long maxBytesPerSecond;
-    private final AtomicLong transferredInWindow = new AtomicLong(0);
-    private final AtomicLong windowStartTime = new AtomicLong(System.nanoTime());
+    private final LongSupplier nanoClock;
+    private final Sleeper sleeper;
+    private final AtomicLong transferredInWindow;
+    private final AtomicLong windowStartTime;
 
     public BandwidthThrottler(long maxBytesPerSecond) {
+        this(maxBytesPerSecond, System::nanoTime, DEFAULT_SLEEPER);
+    }
+
+    public BandwidthThrottler(long maxBytesPerSecond, LongSupplier nanoClock, Sleeper sleeper) {
         this.maxBytesPerSecond = maxBytesPerSecond;
+        this.nanoClock = Objects.requireNonNull(nanoClock, "nanoClock must not be null");
+        this.sleeper = Objects.requireNonNull(sleeper, "sleeper must not be null");
+        this.transferredInWindow = new AtomicLong(0);
+        this.windowStartTime = new AtomicLong(nanoClock.getAsLong());
     }
 
     /**
@@ -39,28 +65,41 @@ public class BandwidthThrottler {
             return;
         }
 
-        long now = System.nanoTime();
+        long now = nanoClock.getAsLong();
         long start = windowStartTime.get();
         long elapsedNanos = now - start;
+        long oneSecondNanos = TimeUnit.SECONDS.toNanos(1);
 
-        if (elapsedNanos >= TimeUnit.SECONDS.toNanos(1)) {
-            windowStartTime.set(now);
-            transferredInWindow.set(bytes);
-            return;
+        if (elapsedNanos >= oneSecondNanos) {
+            long fullWindowsElapsed = elapsedNanos / oneSecondNanos;
+            windowStartTime.addAndGet(fullWindowsElapsed * oneSecondNanos);
+            transferredInWindow.set(0);
+            elapsedNanos = now - windowStartTime.get();
         }
 
         long total = transferredInWindow.addAndGet(bytes);
         if (total > maxBytesPerSecond) {
-            long remainingNanosInWindow = TimeUnit.SECONDS.toNanos(1) - elapsedNanos;
-            if (remainingNanosInWindow > 0) {
+            // G61: Accurately compute duration required for total transferred bytes
+            long fullSeconds = total / maxBytesPerSecond;
+            long remainderBytes = total % maxBytesPerSecond;
+            long requiredNanos = fullSeconds * oneSecondNanos + (remainderBytes * oneSecondNanos) / maxBytesPerSecond;
+
+            long sleepNanos = requiredNanos - elapsedNanos;
+            if (sleepNanos > 0) {
                 try {
-                    TimeUnit.NANOSECONDS.sleep(remainingNanosInWindow);
+                    sleeper.sleepNanos(sleepNanos);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
             }
-            windowStartTime.set(System.nanoTime());
-            transferredInWindow.set(0);
+
+            // Advance window start time by the full seconds consumed by this allocation
+            long fullWindowsConsumed = requiredNanos / oneSecondNanos;
+            windowStartTime.addAndGet(fullWindowsConsumed * oneSecondNanos);
+
+            // Carry over any residual bytes into the new current window
+            long carriedOver = total - (fullWindowsConsumed * maxBytesPerSecond);
+            transferredInWindow.set(Math.max(0, carriedOver));
         }
     }
 
@@ -68,3 +107,4 @@ public class BandwidthThrottler {
         return maxBytesPerSecond;
     }
 }
+

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DataResidencyEnforcer.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DataResidencyEnforcer.java
@@ -17,10 +17,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Enforces geographic and jurisdictional boundaries for tenant data export and standby recovery
- * based on org-to-cell pin policies (ADR-0034 §16, Req R9.1–R9.5, V6).
+ * based on org-to-cell pin policies (ADR-0034 §16, Req R9.1–R9.5, V6, G31).
  *
  * <p>Invariant V6: A tenant's data does not leave its pinned region. Violations strictly
  * refuse operations rather than proceeding with warnings.</p>
@@ -28,6 +29,10 @@ import java.util.Objects;
 public final class DataResidencyEnforcer {
 
     private static final Logger log = LoggerFactory.getLogger(DataResidencyEnforcer.class);
+
+    private static final Set<String> GEO_CONTINENT_PREFIXES = Set.of(
+            "eu", "us", "ap", "sa", "ca", "af", "me", "global"
+    );
 
     private DataResidencyEnforcer() {}
 
@@ -39,8 +44,29 @@ public final class DataResidencyEnforcer {
      * @throws ResidencyViolationException if jurisdiction bounds are violated
      */
     public static void validateExportResidency(String tenantJurisdiction, String targetBucketRegion) {
+        validateExportResidency(tenantJurisdiction, targetBucketRegion, false);
+    }
+
+    /**
+     * Validates that tenant geographic residency admits export to the target bucket region,
+     * with optional requirement for explicit jurisdiction (G31).
+     *
+     * @param tenantJurisdiction pinned jurisdiction/region for the tenant
+     * @param targetBucketRegion region where the DR object-store bucket is located
+     * @param requireExplicitJurisdiction whether unassigned jurisdiction is treated as a violation
+     * @throws ResidencyViolationException if jurisdiction bounds are violated
+     */
+    public static void validateExportResidency(String tenantJurisdiction, String targetBucketRegion, boolean requireExplicitJurisdiction) {
         if (tenantJurisdiction == null || tenantJurisdiction.isBlank()) {
-            return; // No geographic pin declared
+            if (requireExplicitJurisdiction) {
+                String msg = String.format(
+                        "Data residency refusal: Explicit tenant jurisdiction is required but unassigned/unknown for target region '%s' (Req R9.3, V6, G31).",
+                        targetBucketRegion
+                );
+                log.error("[DataResidency] {}", msg);
+                throw new ResidencyViolationException("UNDEFINED", targetBucketRegion, msg);
+            }
+            return; // No geographic pin declared and explicit jurisdiction not mandated
         }
         Objects.requireNonNull(targetBucketRegion, "targetBucketRegion must not be null");
 
@@ -62,8 +88,29 @@ public final class DataResidencyEnforcer {
      * @throws ResidencyViolationException if jurisdiction bounds are violated
      */
     public static void validateRestoreResidency(String tenantJurisdiction, String standbyCellRegion) {
+        validateRestoreResidency(tenantJurisdiction, standbyCellRegion, false);
+    }
+
+    /**
+     * Validates that tenant geographic residency admits restore into the standby cell,
+     * with optional requirement for explicit jurisdiction (G31).
+     *
+     * @param tenantJurisdiction pinned jurisdiction/region for the tenant
+     * @param standbyCellRegion region where the standby recovery cell is running
+     * @param requireExplicitJurisdiction whether unassigned jurisdiction is treated as a violation
+     * @throws ResidencyViolationException if jurisdiction bounds are violated
+     */
+    public static void validateRestoreResidency(String tenantJurisdiction, String standbyCellRegion, boolean requireExplicitJurisdiction) {
         if (tenantJurisdiction == null || tenantJurisdiction.isBlank()) {
-            return; // No geographic pin declared
+            if (requireExplicitJurisdiction) {
+                String msg = String.format(
+                        "Data residency refusal: Explicit tenant jurisdiction is required but unassigned/unknown for standby region '%s' (Req R9.4, V6, G31).",
+                        standbyCellRegion
+                );
+                log.error("[DataResidency] {}", msg);
+                throw new ResidencyViolationException("UNDEFINED", standbyCellRegion, msg);
+            }
+            return; // No geographic pin declared and explicit jurisdiction not mandated
         }
         Objects.requireNonNull(standbyCellRegion, "standbyCellRegion must not be null");
 
@@ -80,6 +127,7 @@ public final class DataResidencyEnforcer {
     /**
      * Matches tenant jurisdiction against target region.
      * Supports exact matches ("us-east-1" == "us-east-1") and prefix/geo matches ("eu" matches "eu-central-1", "eu-west-1").
+     * Arbitrary substring matches (e.g. "us-east-1" matching "us-east-19" or "us-east-1-fips") are rejected (G31).
      */
     public static boolean isCompatible(String tenantJurisdiction, String region) {
         if (tenantJurisdiction == null || tenantJurisdiction.isBlank()) {
@@ -96,8 +144,9 @@ public final class DataResidencyEnforcer {
             return true;
         }
 
-        // Broad geographic matching, e.g. "eu" prefix matches "eu-west-1", "us" matches "us-east-1"
-        if (normRegion.startsWith(normPin + "-") || normRegion.startsWith(normPin)) {
+        // Broad geographic prefix matching only for known geo prefixes (e.g. "eu" matches "eu-west-1", "us" matches "us-east-1")
+        // Hyphen boundary prevents "us-east-1" from matching "us-east-19" or "us-east-1-fips" (G31)
+        if (GEO_CONTINENT_PREFIXES.contains(normPin) && normRegion.startsWith(normPin + "-")) {
             return true;
         }
 

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporter.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporter.java
@@ -163,20 +163,26 @@ public class DisasterRecoveryExporter {
 
     /**
      * Computes the measured 99th percentile RPO in seconds (G29).
+     * Returns empty when no export intervals have been measured yet.
      */
-    public double getMeasuredP99RpoSeconds() {
+    public OptionalDouble getMeasuredP99RpoSeconds() {
         List<Long> intervals = new ArrayList<>(measuredIntervalsSec);
         if (intervals.isEmpty()) {
-            return properties.getExportIntervalSeconds();
+            return OptionalDouble.empty();
         }
         Collections.sort(intervals);
         int p99Index = (int) Math.ceil(0.99 * intervals.size()) - 1;
         p99Index = Math.max(0, Math.min(p99Index, intervals.size() - 1));
-        return intervals.get(p99Index);
+        return OptionalDouble.of(intervals.get(p99Index));
     }
 
-    public long getMeasuredP99Rpo() {
-        return Math.round(getMeasuredP99RpoSeconds());
+    public OptionalLong getMeasuredP99Rpo() {
+        OptionalDouble p99 = getMeasuredP99RpoSeconds();
+        return p99.isPresent() ? OptionalLong.of(Math.round(p99.getAsDouble())) : OptionalLong.empty();
+    }
+
+    public int getMeasuredIntervalCount() {
+        return measuredIntervalsSec.size();
     }
 
     /**
@@ -201,9 +207,16 @@ public class DisasterRecoveryExporter {
         Objects.requireNonNull(namespaceDir, "namespaceDir must not be null");
         Objects.requireNonNull(namespaceId, "namespaceId must not be null");
 
-        // 1. Data Residency Validation (Req R9.3, V6)
+        // G31: Resolve effective jurisdiction from configuration if not explicitly provided
+        String effectiveJurisdiction = tenantJurisdiction;
+        if ((effectiveJurisdiction == null || effectiveJurisdiction.isBlank()) && properties != null && tenantId != null) {
+            effectiveJurisdiction = properties.getTenantJurisdictions().get(tenantId);
+        }
+        boolean requireExplicitJurisdiction = properties != null && properties.isRequireTenantJurisdiction();
+
+        // 1. Data Residency Validation (Req R9.3, V6, G31)
         try {
-            DataResidencyEnforcer.validateExportResidency(tenantJurisdiction, objectStoreClient.getRegion());
+            DataResidencyEnforcer.validateExportResidency(effectiveJurisdiction, objectStoreClient.getRegion(), requireExplicitJurisdiction);
         } catch (ResidencyViolationException e) {
             recordFailure(namespaceId, "Residency violation: " + e.getMessage());
             throw e;

--- a/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryRestorer.java
+++ b/synapse/spector-synapse/src/main/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryRestorer.java
@@ -21,6 +21,7 @@ import com.spectrayan.spector.synapse.catalog.AccountCatalog;
 import com.spectrayan.spector.synapse.catalog.NamespaceRecord;
 import com.spectrayan.spector.synapse.catalog.NamespaceStatus;
 import com.spectrayan.spector.synapse.catalog.NamespaceType;
+import com.spectrayan.spector.synapse.config.dr.DisasterRecoveryProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +61,7 @@ public class DisasterRecoveryRestorer {
     private final String bucket;
     private final String standbyCellRegion;
     private final AccountCatalog accountCatalog;
+    private final DisasterRecoveryProperties properties;
 
     public record RestoreResult(
             String namespaceId,
@@ -87,10 +89,21 @@ public class DisasterRecoveryRestorer {
             String standbyCellRegion,
             AccountCatalog accountCatalog
     ) {
+        this(objectStoreClient, bucket, standbyCellRegion, accountCatalog, null);
+    }
+
+    public DisasterRecoveryRestorer(
+            ObjectStoreClient objectStoreClient,
+            String bucket,
+            String standbyCellRegion,
+            AccountCatalog accountCatalog,
+            DisasterRecoveryProperties properties
+    ) {
         this.objectStoreClient = Objects.requireNonNull(objectStoreClient, "objectStoreClient must not be null");
         this.bucket = Objects.requireNonNull(bucket, "bucket must not be null");
         this.standbyCellRegion = Objects.requireNonNull(standbyCellRegion, "standbyCellRegion must not be null");
         this.accountCatalog = accountCatalog;
+        this.properties = properties;
     }
 
     /**
@@ -145,8 +158,15 @@ public class DisasterRecoveryRestorer {
         Objects.requireNonNull(namespaceId, "namespaceId must not be null");
         Objects.requireNonNull(targetBaseDir, "targetBaseDir must not be null");
 
-        // 1. Data Residency Validation (Req R9.4, V6)
-        DataResidencyEnforcer.validateRestoreResidency(tenantJurisdiction, standbyCellRegion);
+        // G31: Resolve effective jurisdiction from configuration if not explicitly provided
+        String effectiveJurisdiction = tenantJurisdiction;
+        if ((effectiveJurisdiction == null || effectiveJurisdiction.isBlank()) && properties != null && tenantId != null) {
+            effectiveJurisdiction = properties.getTenantJurisdictions().get(tenantId);
+        }
+        boolean requireExplicitJurisdiction = properties != null && properties.isRequireTenantJurisdiction();
+
+        // 1. Data Residency Validation (Req R9.4, V6, G31)
+        DataResidencyEnforcer.validateRestoreResidency(effectiveJurisdiction, standbyCellRegion, requireExplicitJurisdiction);
 
         String safeTenant = tenantId != null && !tenantId.isBlank() ? tenantId : "untenanted";
         String searchPrefix = "snapshots/" + safeTenant + "/" + namespaceId + "/";

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/BandwidthThrottlerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/BandwidthThrottlerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.dr;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("BandwidthThrottler Window Accounting (ADR-0034 §11.2, Req R1.6, G61)")
+class BandwidthThrottlerTest {
+
+    @Test
+    @DisplayName("G61: Transfer within rate limit does not sleep")
+    void testTransferWithinRateLimitDoesNotSleep() {
+        AtomicLong simulatedNanos = new AtomicLong(1_000_000_000L);
+        List<Long> sleeps = new ArrayList<>();
+
+        BandwidthThrottler throttler = new BandwidthThrottler(
+                1000,
+                simulatedNanos::get,
+                sleeps::add
+        );
+
+        throttler.throttle(500);
+
+        assertThat(sleeps).isEmpty();
+    }
+
+    @Test
+    @DisplayName("G61: Second transfer exceeding limit sleeps for exact remainder")
+    void testSecondTransferExceedingLimitSleeps() {
+        AtomicLong simulatedNanos = new AtomicLong(1_000_000_000L);
+        List<Long> sleeps = new ArrayList<>();
+
+        BandwidthThrottler throttler = new BandwidthThrottler(
+                1000,
+                simulatedNanos::get,
+                nanos -> {
+                    sleeps.add(nanos);
+                    simulatedNanos.addAndGet(nanos);
+                }
+        );
+
+        throttler.throttle(600);
+        assertThat(sleeps).isEmpty();
+
+        // Advance simulated time by 200ms
+        simulatedNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(200));
+
+        // Transfer another 600 bytes -> total 1200 bytes for 1000 B/s limit
+        // Required time: 1.2s (1200ms). Elapsed so far: 200ms. Sleep should be 1000ms.
+        throttler.throttle(600);
+
+        assertThat(sleeps).hasSize(1);
+        assertThat(sleeps.get(0)).isEqualTo(TimeUnit.MILLISECONDS.toNanos(1000));
+    }
+
+    @Test
+    @DisplayName("G61: Single oversized payload consumes multiple windows and carries over remainder")
+    void testOversizedPayloadConsumesMultipleWindows() {
+        AtomicLong simulatedNanos = new AtomicLong(1_000_000_000L);
+        List<Long> sleeps = new ArrayList<>();
+
+        BandwidthThrottler throttler = new BandwidthThrottler(
+                1000, // 1000 bytes per sec
+                simulatedNanos::get,
+                nanos -> {
+                    sleeps.add(nanos);
+                    simulatedNanos.addAndGet(nanos);
+                }
+        );
+
+        // Send 5500 bytes (5.5x the rate limit)
+        // Required time: 5.5s (5500ms). Sleep should be 5500ms.
+        throttler.throttle(5500);
+
+        assertThat(sleeps).hasSize(1);
+        assertThat(sleeps.get(0)).isEqualTo(TimeUnit.MILLISECONDS.toNanos(5500));
+
+        // Now, 500 bytes are carried over into the current window, and 500ms have elapsed (since 5.5s - 5.0s = 0.5s).
+        // Sending another 600 bytes results in total 1100 bytes (> 1000 limit).
+        // Required for 1100 bytes is 1.1s. Since 0.5s already elapsed, remaining sleep is 0.6s (600ms).
+        throttler.throttle(600);
+        assertThat(sleeps).hasSize(2);
+        assertThat(sleeps.get(1)).isEqualTo(TimeUnit.MILLISECONDS.toNanos(600));
+    }
+
+    @Test
+    @DisplayName("G61: Zero or negative bytes do not sleep")
+    void testZeroOrNegativeBytesDoNotSleep() {
+        AtomicLong simulatedNanos = new AtomicLong(1_000_000_000L);
+        List<Long> sleeps = new ArrayList<>();
+
+        BandwidthThrottler throttler = new BandwidthThrottler(
+                1000,
+                simulatedNanos::get,
+                sleeps::add
+        );
+
+        throttler.throttle(0);
+        throttler.throttle(-10);
+
+        assertThat(sleeps).isEmpty();
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DataResidencyEnforcerTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DataResidencyEnforcerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Spectrayan
+ *
+ * Licensed under the Business Source License 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/spectrayan/spector/blob/main/spector-synapse/LICENSE
+ *
+ * Change Date: July 6, 2030
+ * Change License: Apache License, Version 2.0
+ */
+package com.spectrayan.spector.synapse.dr;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Data Residency Enforcer Specification (ADR-0034 §16, Req R9.1–R9.5, V6, G31)")
+class DataResidencyEnforcerTest {
+
+    @Test
+    @DisplayName("G31: Exact match is compatible")
+    void testExactMatch() {
+        assertThat(DataResidencyEnforcer.isCompatible("us-east-1", "us-east-1")).isTrue();
+        assertThat(DataResidencyEnforcer.isCompatible("eu-west-1", "eu-west-1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("G31: Broad continent geo prefix is compatible with child regions")
+    void testBroadGeoContinentPrefix() {
+        assertThat(DataResidencyEnforcer.isCompatible("eu", "eu-central-1")).isTrue();
+        assertThat(DataResidencyEnforcer.isCompatible("eu", "eu-west-1")).isTrue();
+        assertThat(DataResidencyEnforcer.isCompatible("us", "us-east-1")).isTrue();
+        assertThat(DataResidencyEnforcer.isCompatible("us", "us-west-2")).isTrue();
+        assertThat(DataResidencyEnforcer.isCompatible("ap", "ap-southeast-1")).isTrue();
+
+        // Incompatible geo
+        assertThat(DataResidencyEnforcer.isCompatible("eu", "us-east-1")).isFalse();
+        assertThat(DataResidencyEnforcer.isCompatible("us", "eu-west-1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("G31: Loose substring matching without boundary is strictly rejected")
+    void testLooseSubstringMatchingRejected() {
+        // "us-east-1" must NOT match "us-east-19" or "us-east-1-fips"
+        assertThat(DataResidencyEnforcer.isCompatible("us-east-1", "us-east-19")).isFalse();
+        assertThat(DataResidencyEnforcer.isCompatible("us-east-1", "us-east-1-fips")).isFalse();
+        assertThat(DataResidencyEnforcer.isCompatible("eu-west-1", "eu-west-10")).isFalse();
+    }
+
+    @Test
+    @DisplayName("G31: Blank jurisdiction is admitted when explicit jurisdiction is not required")
+    void testBlankJurisdictionAdmittedWhenNotRequired() {
+        assertThat(DataResidencyEnforcer.isCompatible(null, "us-east-1")).isTrue();
+        assertThat(DataResidencyEnforcer.isCompatible("", "us-east-1")).isTrue();
+
+        DataResidencyEnforcer.validateExportResidency(null, "us-east-1", false);
+        DataResidencyEnforcer.validateRestoreResidency(null, "us-east-1", false);
+    }
+
+    @Test
+    @DisplayName("G31: Blank jurisdiction is refused when explicit jurisdiction is required")
+    void testBlankJurisdictionRefusedWhenRequired() {
+        assertThatThrownBy(() -> DataResidencyEnforcer.validateExportResidency(null, "us-east-1", true))
+                .isInstanceOf(ResidencyViolationException.class)
+                .hasMessageContaining("Explicit tenant jurisdiction is required");
+
+        assertThatThrownBy(() -> DataResidencyEnforcer.validateRestoreResidency("", "us-east-1", true))
+                .isInstanceOf(ResidencyViolationException.class)
+                .hasMessageContaining("Explicit tenant jurisdiction is required");
+    }
+
+    @Test
+    @DisplayName("G31: Incompatible jurisdiction throws ResidencyViolationException")
+    void testIncompatibleJurisdictionThrows() {
+        assertThatThrownBy(() -> DataResidencyEnforcer.validateExportResidency("eu-central-1", "us-east-1"))
+                .isInstanceOf(ResidencyViolationException.class)
+                .hasMessageContaining("Tenant pinned to jurisdiction 'eu-central-1' cannot export to target region 'us-east-1'");
+
+        assertThatThrownBy(() -> DataResidencyEnforcer.validateRestoreResidency("us-east-1", "us-east-19"))
+                .isInstanceOf(ResidencyViolationException.class)
+                .hasMessageContaining("Tenant pinned to jurisdiction 'us-east-1' cannot be restored into standby cell in region 'us-east-19'");
+    }
+}

--- a/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporterTest.java
+++ b/synapse/spector-synapse/src/test/java/com/spectrayan/spector/synapse/dr/DisasterRecoveryExporterTest.java
@@ -249,6 +249,10 @@ class DisasterRecoveryExporterTest {
         Path nsDir1 = createSampleNamespace(tenantId, nsId1, "flat");
         Path nsDir2 = createSampleNamespace(tenantId, nsId2, "flat");
 
+        // G29: Initial state before any cycle runs has NO measured RPO
+        assertThat(exporter.getMeasuredP99RpoSeconds()).isEmpty();
+        assertThat(exporter.getMeasuredP99Rpo()).isEmpty();
+
         // Cycle 1: both namespaces exported
         var target1 = new DisasterRecoveryExporter.ActiveNamespaceTarget(tenantId, nsId1, nsDir1, REGION, 1L, 100L);
         var target2 = new DisasterRecoveryExporter.ActiveNamespaceTarget(tenantId, nsId2, nsDir2, REGION, 1L, 50L);
@@ -268,8 +272,8 @@ class DisasterRecoveryExporterTest {
 
         // Measured RPO tracking
         exporter.recordExportInterval(nsId2, 30L);
-        assertThat(exporter.getMeasuredP99RpoSeconds()).isGreaterThan(0.0);
-        assertThat(exporter.getMeasuredP99Rpo()).isGreaterThanOrEqualTo(0L);
+        assertThat(exporter.getMeasuredP99RpoSeconds()).hasValue(30.0);
+        assertThat(exporter.getMeasuredP99Rpo()).hasValue(30L);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Addresses code review findings G29, G30, G31, and G61 (DR CLI, measured RPO, data residency, and throttler accounting) across `spector-synapse` and `spector-cli`.

### Findings Resolved:
1. **G61 · S3 · `BandwidthThrottler` window accounting**:
   - Accurately computes duration required for total transferred bytes (`requiredNanos = fullSeconds * 1s + (remainderBytes * 1s) / maxBytesPerSecond`).
   - Carries over deficit bytes into the new current window and advances window start time by the consumed full seconds.
   - Added constructor supporting injected `LongSupplier nanoClock` and `Sleeper` for deterministic unit testing.
   - Added unit test `BandwidthThrottlerTest`.

2. **G31 · S1 · Residency is unenforced by construction, and the region matcher is too loose**:
   - `DataResidencyEnforcer.isCompatible` rejects arbitrary prefix/substring matches (e.g. `us-east-1` matching `us-east-19` or `us-east-1-fips`), admitting only exact matches or recognized geo continent prefixes (`eu`, `us`, `ap`, `sa`, `ca`, `af`, `me`, `global`) with hyphen boundary.
   - Added `requireExplicitJurisdiction` parameter overload to `validateExportResidency` and `validateRestoreResidency`.
   - `DisasterRecoveryProperties` now supports `tenantJurisdictions` mapping and `requireTenantJurisdiction`.
   - `DisasterRecoveryExporter` and `DisasterRecoveryRestorer` automatically resolve tenant jurisdiction from configured properties.
   - Added unit test `DataResidencyEnforcerTest`.

3. **G29 · S1 · Export interval and measured RPO**:
   - `DisasterRecoveryExporter.getMeasuredP99RpoSeconds()` and `getMeasuredP99Rpo()` return `OptionalDouble` and `OptionalLong`.
   - When no intervals have been recorded, they return empty instead of falsely claiming the configured SLA interval as a measured value.

4. **G30 · S1 · DR CLI operator surface honesty & actuation**:
   - `DisasterRecoveryCommand.StatusSubcommand` reports live status: if unconfigured, prints `NOT_CONFIGURED` and `UNKNOWN` measured RPO; if configured but without recorded intervals, prints `UNMEASURED`; if live intervals exist, reports measured p99 RPO.
   - `DisasterRecoveryCommand.PromoteCellSubcommand` persists promotion audit records to an append-only file (`--audit-file`, default `dr-promotion-audit.log`) before completing.
   - `DisasterRecoveryCommand.RestoreNamespaceSubcommand` actuates restore through `DisasterRecoveryRestorer`, resolves latest selectable epoch, and outputs verified restored HWM and artifact count.
   - Updated `DisasterRecoveryCommandTest` to test all scenarios.

Closes #862

Co-authored-by: Bharat Joshi <bharatjoshi@spectrayan.com>
Signed-off-by: Forge <forge@spectrayan.com>
